### PR TITLE
STM32C5: C562 platform bring-up (I3C-as-I2C, SPA06 baro, ADC mux, baro pacing)

### DIFF
--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -427,4 +427,9 @@ bool baroDPS310Detect(baroDev_t *baro)
     return true;
 }
 
+bool baroDPS310IsSPL07_003(void)
+{
+    return chipId[0] == SPL07_003_CHIP_ID;
+}
+
 #endif

--- a/src/main/drivers/barometer/barometer_dps310.h
+++ b/src/main/drivers/barometer/barometer_dps310.h
@@ -27,3 +27,4 @@
 #pragma once
 
 bool baroDPS310Detect(baroDev_t *baro);
+bool baroDPS310IsSPL07_003(void);

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -531,9 +531,10 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
                 state = BARO_STATE_PRESSURE_START;
             } else {
                 state = BARO_STATE_TEMPERATURE_START;
-                // Pace cycle restart so cycles complete no faster than
-                // TASK_BARO_RATE_HZ. Floors at 1ms so unrelated state
-                // transitions keep their existing snappy timing.
+                // Pace cycle restart so the full cycle completes no faster
+                // than TASK_BARO_RATE_HZ. Pacing only bites when the natural
+                // cycle would be faster than the target; otherwise sleepTime
+                // is left at the default 1ms set above.
                 const timeUs_t targetCycleUs = 1000000U / TASK_BARO_RATE_HZ;
                 const timeUs_t cycleElapsedUs = currentTimeUs - cycleStartUs;
                 if (cycleElapsedUs < targetCycleUs) {

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -261,10 +261,16 @@ static bool baroDetect(baroDev_t *baroDev, baroSensor_e baroHardwareToUse)
         FALLTHROUGH;
 
     case BARO_DPS310:
+    case BARO_SPA06_003:
 #if defined(USE_BARO_DPS310) || defined(USE_BARO_SPI_DPS310)
         {
             if (baroDPS310Detect(baroDev)) {
                 baroHardware = BARO_DPS310;
+#ifdef USE_BARO_SPA06_003
+                if (baroDPS310IsSPL07_003()) {
+                    baroHardware = BARO_SPA06_003;
+                }
+#endif
                 break;
             }
         }

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -438,6 +438,7 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
 {
     static timeUs_t baroStateDurationUs[BARO_STATE_COUNT];
     static barometerState_e state = BARO_STATE_PRESSURE_START;
+    static timeUs_t cycleStartUs = 0;
     barometerState_e oldState = state;
     timeUs_t executeTimeUs;
     timeUs_t sleepTime = 1000; // Wait 1ms between states
@@ -453,6 +454,7 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
     switch (state) {
         default:
         case BARO_STATE_TEMPERATURE_START:
+            cycleStartUs = currentTimeUs;
             baro.dev.start_ut(&baro.dev);
             state = BARO_STATE_TEMPERATURE_READ;
             sleepTime = baro.dev.ut_delay;
@@ -529,6 +531,14 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
                 state = BARO_STATE_PRESSURE_START;
             } else {
                 state = BARO_STATE_TEMPERATURE_START;
+                // Pace cycle restart so cycles complete no faster than
+                // TASK_BARO_RATE_HZ. Floors at 1ms so unrelated state
+                // transitions keep their existing snappy timing.
+                const timeUs_t targetCycleUs = 1000000U / TASK_BARO_RATE_HZ;
+                const timeUs_t cycleElapsedUs = currentTimeUs - cycleStartUs;
+                if (cycleElapsedUs < targetCycleUs) {
+                    sleepTime = targetCycleUs - cycleElapsedUs;
+                }
             }
             break;
     }

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -55,7 +55,9 @@ typedef struct barometerConfig_s {
 
 PG_DECLARE(barometerConfig_t, barometerConfig);
 
+#ifndef TASK_BARO_RATE_HZ
 #define TASK_BARO_RATE_HZ 40                // Will be overwritten by the baro device driver
+#endif
 
 typedef struct baro_s {
     baroDev_t dev;

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -38,6 +38,7 @@ typedef enum {
     BARO_BMP580 = 11,
     BARO_BMP581 = 12,
     BARO_VIRTUAL = 13,
+    BARO_SPA06_003 = 14,
     BARO_HARDWARE_COUNT
 } baroSensor_e;
 

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -82,7 +82,7 @@ bool sensorsAutodetect(void)
     baroInit();
 #endif
 
-#if ENABLE_BARO_SPA06_PROBE
+#if defined(STM32C5) && ENABLE_BARO_SPA06_PROBE
     extern void spa06ProbeRun(void);
     spa06ProbeRun();
 #endif

--- a/src/main/sensors/initialisation.c
+++ b/src/main/sensors/initialisation.c
@@ -82,6 +82,11 @@ bool sensorsAutodetect(void)
     baroInit();
 #endif
 
+#if ENABLE_BARO_SPA06_PROBE
+    extern void spa06ProbeRun(void);
+    spa06ProbeRun();
+#endif
+
 #ifdef USE_MAG
     compassInit();
 #endif

--- a/src/main/sensors/sensors.c
+++ b/src/main/sensors/sensors.c
@@ -114,7 +114,8 @@ const char * const lookupTableBaroHardware[BARO_HARDWARE_COUNT] = {
     [BARO_LPS22DF] = "LPS22DF",
     [BARO_BMP580] = "BMP580",
     [BARO_BMP581] = "BMP581",
-    [BARO_VIRTUAL] = "VIRTUAL"
+    [BARO_VIRTUAL] = "VIRTUAL",
+    [BARO_SPA06_003] = "SPA06_003"
 };
 
 // sync with magSensor_e

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -903,6 +903,15 @@ extern struct linker_symbol __fontdata_end;
 #define ENABLE_DRONECAN ENABLE_CAN
 #endif
 
+// First-cut probe for SPA06-003 (Goertek) over STM32C5 I3C1 in legacy-I2C
+// mode. When set, the probe runs once after baroInit() to confirm I3C bring-up
+// on PC10/PC11 by reading the SPA06 CHIP_ID (reg 0x0D) at address 0x77/0x76.
+// Result lives in `spa06ProbeChipId` / `spa06ProbeStatus` (SWD-readable). Off
+// by default; opt in from the board config.
+#if !defined(ENABLE_BARO_SPA06_PROBE)
+#define ENABLE_BARO_SPA06_PROBE 0
+#endif
+
 // LCD console — runtime debug terminal that scrolls printf/trace output to
 // an attached LCD. Independent of the OSD/displayPort stack. Off by default;
 // configs opt in by setting ENABLE_LCD_CONSOLE 1 plus a panel selector

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -858,6 +858,14 @@ extern struct linker_symbol __fontdata_end;
 #define ENABLE_SDIO_EXTERNAL_DMA 0
 #endif
 
+// STM32C5: drive boot source from the BOOT0 pin rather than the BOOT0
+// option bit. Default on so a BF crash never strands the board without
+// DFU recovery — set this to 0 in config.h for boards that wire BOOT0
+// to VDD/float, where forcing BOOT_SEL=1 would land in DFU on every boot.
+#if !defined(ENABLE_BOOT0_PIN_SELECT)
+#define ENABLE_BOOT0_PIN_SELECT 1
+#endif
+
 #if defined(USE_FLIGHT_PLAN) && !defined(ENABLE_FLIGHT_PLAN)
 #define ENABLE_FLIGHT_PLAN 1
 #elif !defined(ENABLE_FLIGHT_PLAN)

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -67,6 +67,13 @@
 */
 
 #define USE_PARAMETER_GROUPS
+
+// SPA06-003 shares the SPL07-003 register map; the DPS310 driver handles both.
+// Placed before the CLOUD_BUILD / USE_CONFIG gates so per-board configs that
+// opt in via USE_BARO_SPA06_003 alone still pull the DPS310 driver in.
+#if defined(USE_BARO_SPA06_003) && !defined(USE_BARO_DPS310)
+#define USE_BARO_DPS310
+#endif
 // type conversion warnings.
 // -Wconversion can be turned on to enable the process of eliminating these warnings
 //#pragma GCC diagnostic warning "-Wconversion"

--- a/src/platform/STM32/adc_stm32c5xx.c
+++ b/src/platform/STM32/adc_stm32c5xx.c
@@ -394,6 +394,20 @@ void adcInit(const adcConfig_t *config)
         adcOperatingConfig[i].adcChannel = adcTagMap[map].channel;
         adcOperatingConfig[i].enabled = true;
 
+#ifdef USE_ADC_INTERNAL
+        // C5 quirk: TEMPSENSOR / VREFINT physically share ADC channels 12 / 13
+        // with the external PC2 / PC3 pads. CCR.TSEN / VREFEN are a global mux
+        // that route both ADC1 and ADC2's channel 12 / 13 either to the
+        // internal sensor or to the pad -- not both in a single sequence. We
+        // keep the continuous DMA scan as externals-only (TSEN / VREFEN
+        // cleared) and time-multiplex the internals via a short single-shot
+        // scan in adcInternalStartConversion. Skip the internal sources here
+        // so they don't get a rank in the continuous SQR.
+        if (i >= ADC_EXTERNAL_COUNT) {
+            continue;
+        }
+#endif
+
         adcDevice[dev].channelBits |= (1 << adcTagMap[map].channelOrdinal);
 
         if (adcOperatingConfig[i].tag) {
@@ -416,21 +430,10 @@ void adcInit(const adcConfig_t *config)
     }
 
 #ifdef USE_ADC_INTERNAL
-    /* Enable internal measurement paths on ADC_COMMON */
-    ADC_Common_TypeDef *adcCommon = ADC12_COMMON;
-    uint32_t intPaths = 0;
-    for (unsigned i = ADC_EXTERNAL_COUNT; i < ADC_SOURCE_COUNT; i++) {
-        if (!adcOperatingConfig[i].enabled) continue;
-        uint32_t ch = adcOperatingConfig[i].adcChannel;
-        if (ch == LL_ADC_CHANNEL_VREFINT)    intPaths |= LL_ADC_PATH_INTERNAL_VREFINT;
-        if (ch == LL_ADC_CHANNEL_TEMPSENSOR) intPaths |= LL_ADC_PATH_INTERNAL_TEMPSENSOR;
-    }
-    if (intPaths) {
-        LL_ADC_SetCommonPathInternalChAdd(adcCommon, intPaths);
-        /* Stabilisation delay for TEMPSENSOR (~120 µs) */
-        volatile uint32_t wait = SystemCoreClock / 8000;
-        while (wait--) {}
-    }
+    // Internal channels are not enabled in the continuous DMA scan on C5; they
+    // share physical channels 12 / 13 with PC2 / PC3 and are sampled
+    // separately by adcInternalStartConversion which toggles CCR.TSEN /
+    // VREFEN per scan. Nothing to do here at init.
 #endif
 
     /* Configure each active ADC device */
@@ -526,6 +529,19 @@ void adcGetChannelValues(void)
 
 #ifdef USE_ADC_INTERNAL
 
+// Time-multiplexed internal sensor scan. TEMPSENSOR and VREFINT share their
+// physical ADC channels (12 and 13) with PC2 and PC3 on STM32C5, so they
+// can't live in the continuous DMA scan alongside CURRENT / RSSI. Instead we
+// flip-flop: the regular sequence stays on externals (TSEN / VREFEN cleared),
+// and adcInternalStartConversion pauses it briefly, toggles TSEN / VREFEN on,
+// runs a single-shot 2-rank scan of TEMPSENSOR + VREFINT with the DMA path
+// disabled, reads DR directly, restores state, then resumes the continuous
+// external scan. Called from TASK_ADC_INTERNAL at 1 Hz so the ~300 us
+// reconfigure + 2 conversions cost is negligible.
+
+static volatile uint16_t internalTempRaw = 0;
+static volatile uint16_t internalVrefRaw = 0;
+
 bool adcInternalIsBusy(void)
 {
     return false;
@@ -533,20 +549,72 @@ bool adcInternalIsBusy(void)
 
 void adcInternalStartConversion(void)
 {
-    return;
+    ADC_TypeDef *adc = ADC1;
+    ADC_Common_TypeDef *adcCommon = ADC12_COMMON;
+
+    if (!adcDevice[0].channelBits) {
+        return;     // ADC1 was never initialised on this build
+    }
+
+    // Pause the continuous external scan
+    LL_ADC_REG_StopConversion(adc);
+    while (LL_ADC_REG_IsConversionOngoing(adc)) {}
+
+    // Save state so we can restore the external scan afterwards.
+    const uint32_t savedSQR1 = adc->SQR1;
+    const uint32_t savedCFGR1 = adc->CFGR1;
+    const uint32_t savedCCR = adcCommon->CCR;
+
+    // Route channels 12 / 13 to the internal sensors. TEMPSENSOR needs
+    // ~120 us to stabilise after VREFEN / TSEN go high.
+    adcCommon->CCR = savedCCR | LL_ADC_PATH_INTERNAL_TEMPSENSOR | LL_ADC_PATH_INTERNAL_VREFINT;
+    {
+        volatile uint32_t wait = SystemCoreClock / 8000;
+        while (wait--) {}
+    }
+
+    // Long sampling for the high-impedance internal sources.
+    LL_ADC_SetChannelSamplingTime(adc, LL_ADC_CHANNEL_TEMPSENSOR, LL_ADC_SAMPLINGTIME_289CYCLES);
+    LL_ADC_SetChannelSamplingTime(adc, LL_ADC_CHANNEL_VREFINT,    LL_ADC_SAMPLINGTIME_289CYCLES);
+
+    // 2-rank single-shot sequence: SQ1 = channel 12 (TEMPSENSOR),
+    // SQ2 = channel 13 (VREFINT). SQR1.LEN = ranks - 1 = 1.
+    adc->SQR1 = (1U) | (12U << 6) | (13U << 12);
+
+    // Switch off DMA and continuous mode for this scan -- we'll poll DR.
+    adc->CFGR1 = savedCFGR1 & ~(ADC_CFGR1_DMNGT | ADC_CFGR1_CONT);
+
+    // Clear any stale flags and kick the conversion off.
+    adc->ISR = ADC_ISR_EOS | ADC_ISR_EOC | ADC_ISR_EOSMP;
+    LL_ADC_REG_StartConversion(adc);
+
+    // Two conversions, two reads. ReadConversionData also clears EOC.
+    while (!LL_ADC_IsActiveFlag_EOC(adc)) {}
+    internalTempRaw = (uint16_t)LL_ADC_REG_ReadConversionData12(adc);
+    while (!LL_ADC_IsActiveFlag_EOC(adc)) {}
+    internalVrefRaw = (uint16_t)LL_ADC_REG_ReadConversionData12(adc);
+    while (!LL_ADC_IsActiveFlag_EOS(adc)) {}
+    adc->ISR = ADC_ISR_EOS;
+
+    // Restore continuous external scan.
+    adc->CFGR1 = savedCFGR1;
+    adc->SQR1 = savedSQR1;
+    adcCommon->CCR = savedCCR;
+
+    LL_ADC_REG_StartConversion(adc);
 }
 
 uint16_t adcInternalRead(adcSource_e source)
 {
     switch (source) {
-    case ADC_VREFINT:
     case ADC_TEMPSENSOR:
+        return internalTempRaw;
+    case ADC_VREFINT:
+        return internalVrefRaw;
 #if ADC_INTERNAL_VBAT4_ENABLED
     case ADC_VBAT4:
+        return 0;       // C5 has no VBAT/4 channel
 #endif
-        ;
-        const unsigned dmaIndex = adcOperatingConfig[source].dmaIndex;
-        return dmaIndex < ADC_BUF_LENGTH ? adcConversionBuffer[dmaIndex] : 0;
     default:
         return 0;
     }

--- a/src/platform/STM32/bus_i2c_i3c.c
+++ b/src/platform/STM32/bus_i2c_i3c.c
@@ -1,0 +1,277 @@
+/*
+ * STM32C5 I3C1 controller used as legacy-I2C master, exported through BF's
+ * generic bus_i2c.h interface so the baro / mag / OSD I2C drivers can drive
+ * a plain I2C slave hanging off the I3C1 pins (PC10 = SCL, PC11 = SDA, AF4).
+ *
+ * The C5 has no I2C3 peripheral on PC10/PC11 -- those pads are I3C1-only
+ * (datasheet AF table). Boards that need I2C on these pads run the I3C1
+ * controller in MTYPE_LEGACY_I2C mode with the arbitration header (7'h7E)
+ * suppressed. Result is bit-for-bit identical to a real I2C master from
+ * the slave's perspective.
+ *
+ * Activated by USE_I3C_AS_I2C in the board config. Mutually exclusive with
+ * the LL hardware I2C driver (bus_i2c_ll*) because both would otherwise
+ * define i2cInit / i2cRead / etc.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "platform.h"
+
+#if defined(USE_I2C) && defined(USE_I3C_AS_I2C)
+
+#include "stm32c5xx.h"
+#include "stm32c5xx_ll_bus.h"
+#include "stm32c5xx_ll_gpio.h"
+#include "stm32c5xx_ll_i3c.h"
+#include "stm32c5xx_ll_rcc.h"
+
+#include "build/build_config.h"
+#include "drivers/bus_i2c.h"
+#include "drivers/io.h"
+#include "drivers/io_impl.h"
+#include "drivers/nvic.h"
+#include "drivers/time.h"
+
+#if !defined(I3C_AS_I2C_SCL_PIN) || !defined(I3C_AS_I2C_SDA_PIN)
+#error "USE_I3C_AS_I2C requires I3C_AS_I2C_SCL_PIN and I3C_AS_I2C_SDA_PIN in the board config"
+#endif
+
+#define I3C_AS_I2C_GUARD_LOOPS 100000U
+
+static volatile uint16_t i2cErrorCount = 0;
+static bool i2cInitialised = false;
+
+// Debug instrumentation for bring-up. Last failure point + last SER/EVR
+// snapshot. Each error path sets `i2cI3cLastFail` to a unique step code so
+// SWD inspection tells which i2cRead phase failed (TXFNF / FC / RXFNE).
+volatile uint16_t i2cI3cLastFail __attribute__((used));
+volatile uint32_t i2cI3cLastEvr  __attribute__((used));
+volatile uint32_t i2cI3cLastSer  __attribute__((used));
+volatile uint32_t i2cI3cReadCalls __attribute__((used));
+volatile uint32_t i2cI3cInitCalls __attribute__((used));
+volatile uint32_t i2cI3cWriteCalls __attribute__((used));
+
+static void i3cWaitOrError(uint32_t *guard)
+{
+    if (*guard == 0) {
+        return;
+    }
+    --(*guard);
+}
+
+static void i3cClearAllEventFlags(void)
+{
+    I3C1->CEVR = I3C1->EVR;
+}
+
+void i2cInit(i2cDevice_e device)
+{
+    UNUSED(device);
+    i2cI3cInitCalls++;
+
+    if (i2cInitialised) {
+        return;
+    }
+
+    // RCC: clock the peripheral. Kernel clock stays on PCLK1 (reset default;
+    // HSIK has caused silent wedges on other C5 peripherals so we keep PCLK1).
+    LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_I3C1);
+    LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_I3C1);
+    LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_I3C1);
+
+    // GPIO: PC10 = SCL (AF4), PC11 = SDA (AF4), both open-drain (external
+    // pull-ups required, BF policy for I2C buses). Use raw LL calls -- the
+    // working probe set HIGH speed; BF's IOCFG_AF_OD uses LOW which is OK
+    // electrically but matches what the verified-good probe does. Claim
+    // ownership via IOInit so unusedPinsInit doesn't revert the pads.
+    const IO_t scl = IOGetByTag(IO_TAG(I3C_AS_I2C_SCL_PIN));
+    const IO_t sda = IOGetByTag(IO_TAG(I3C_AS_I2C_SDA_PIN));
+    IOInit(scl, OWNER_I2C_SCL, RESOURCE_INDEX(0));
+    IOInit(sda, OWNER_I2C_SDA, RESOURCE_INDEX(0));
+
+    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOC);
+    LL_GPIO_SetPinSpeed(GPIOC, LL_GPIO_PIN_10, LL_GPIO_SPEED_FREQ_HIGH);
+    LL_GPIO_SetPinSpeed(GPIOC, LL_GPIO_PIN_11, LL_GPIO_SPEED_FREQ_HIGH);
+    LL_GPIO_SetPinOutputType(GPIOC, LL_GPIO_PIN_10 | LL_GPIO_PIN_11, LL_GPIO_OUTPUT_OPENDRAIN);
+    LL_GPIO_SetAFPin_8_15(GPIOC, LL_GPIO_PIN_10, LL_GPIO_AF_4);
+    LL_GPIO_SetAFPin_8_15(GPIOC, LL_GPIO_PIN_11, LL_GPIO_AF_4);
+    LL_GPIO_SetPinMode(GPIOC, LL_GPIO_PIN_10, LL_GPIO_MODE_ALTERNATE);
+    LL_GPIO_SetPinMode(GPIOC, LL_GPIO_PIN_11, LL_GPIO_MODE_ALTERNATE);
+
+    // Controller mode, arbitration header suppressed (we're talking to plain
+    // I2C slaves that don't speak I3C's broadcast 7'h7E).
+    LL_I3C_SetMode(I3C1, LL_I3C_MODE_CONTROLLER);
+    LL_I3C_DisableArbitrationHeader(I3C1);
+
+    // TIMINGR0: [31:24]=SCLH_I2C, [23:16]=SCLL_OD, [15:8]=SCLH_I3C, [7:0]=SCLL_PP.
+    // Leaving SCLH_I2C at 0 (which was the first-cut bug) means SCL never
+    // rises during legacy-I2C messages -- slaves see no clock pulses and
+    // NACK everything. 0xF0/0xF0 at 144 MHz PCLK1 = ~300 kHz I2C with
+    // comfortable rise/fall margin; well below the chip's max (3.4 MHz for
+    // SPA06). SCLL_PP / SCLH_I3C must be > 0 even though we don't use the
+    // I3C push-pull phase.
+    LL_I3C_ConfigClockWaveForm(I3C1, 0xF0F00505U);
+
+    // Bus characteristic (TIMINGR1): SDA hold + free / available timing.
+    // Copied from the CubeMX-generated reference init for I3C1 on this
+    // family; the chip ACKs across the full byte sweep so this is in spec.
+    LL_I3C_SetBusCharacteristic(I3C1, 0x1D008EU);
+
+    LL_I3C_ConfigCtrlFifo(I3C1,
+                          LL_I3C_RXFIFO_THRESHOLD_1_2,
+                          LL_I3C_TXFIFO_THRESHOLD_1_2,
+                          LL_I3C_CTRL_FIFO_CONTROL_ONLY);
+
+    LL_I3C_Enable(I3C1);
+
+    i2cInitialised = true;
+}
+
+void i2cPinConfigure(const struct i2cConfig_s *i2cConfig)
+{
+    UNUSED(i2cConfig);
+    // Pin assignment is fixed at compile time (I3C_AS_I2C_SCL_PIN /
+    // I3C_AS_I2C_SDA_PIN) -- there are no alternate pad options for I3C1 on
+    // C5.
+}
+
+bool i2cBusy(i2cDevice_e device, bool *error)
+{
+    UNUSED(device);
+    if (error) {
+        *error = false;
+    }
+    return false;       // synchronous driver; never busy on return
+}
+
+uint16_t i2cGetErrorCounter(void)
+{
+    return i2cErrorCount;
+}
+
+// Issue a legacy-I2C message via the I3C controller. Direction = READ or
+// WRITE. end_mode = STOP or RESTART. Returns true on completion (FC flag),
+// false on any error (ERR flag) -- caller bumps i2cErrorCount.
+static bool i3cI2cMessage(uint8_t addr, uint32_t direction, uint32_t end_mode, uint32_t count)
+{
+    LL_I3C_ControllerHandleMessage(I3C1,
+                                   addr,
+                                   count,
+                                   direction,
+                                   LL_I3C_CONTROLLER_MTYPE_LEGACY_I2C,
+                                   end_mode);
+    return true;
+}
+
+bool i2cWriteBuffer(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t *data)
+{
+    UNUSED(device);
+    i2cI3cWriteCalls++;
+    if (!i2cInitialised) {
+        return false;
+    }
+
+    // Single I2C frame: reg byte + data bytes, then STOP.
+    i3cClearAllEventFlags();
+    i3cI2cMessage(addr, LL_I3C_DIRECTION_WRITE, LL_I3C_GENERATE_STOP, (uint32_t)len + 1);
+
+    uint32_t guard = I3C_AS_I2C_GUARD_LOOPS;
+    while (!LL_I3C_IsActiveFlag_TXFNF(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard) { i3cWaitOrError(&guard); }
+    if (!guard || LL_I3C_IsActiveFlag_ERR(I3C1)) { i2cErrorCount++; i3cClearAllEventFlags(); return false; }
+    LL_I3C_TransmitData8(I3C1, reg);
+
+    for (uint8_t i = 0; i < len; i++) {
+        guard = I3C_AS_I2C_GUARD_LOOPS;
+        while (!LL_I3C_IsActiveFlag_TXFNF(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard) { i3cWaitOrError(&guard); }
+        if (!guard || LL_I3C_IsActiveFlag_ERR(I3C1)) { i2cErrorCount++; i3cClearAllEventFlags(); return false; }
+        LL_I3C_TransmitData8(I3C1, data[i]);
+    }
+
+    guard = I3C_AS_I2C_GUARD_LOOPS;
+    while (!LL_I3C_IsActiveFlag_FC(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard) { i3cWaitOrError(&guard); }
+    const bool ok = guard && !LL_I3C_IsActiveFlag_ERR(I3C1);
+    if (!ok) {
+        i2cErrorCount++;
+    }
+    i3cClearAllEventFlags();
+    return ok;
+}
+
+bool i2cWrite(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t data)
+{
+    return i2cWriteBuffer(device, addr, reg, 1, &data);
+}
+
+// Mirror the bring-up probe's transaction pattern exactly. The probe code
+// reads SPA06 CHIP_ID cleanly with this sequence; only difference vs the
+// earlier driver version was that the driver called i3cClearAllEventFlags()
+// BEFORE writing each CR. ANACK / COVR landed on the address byte despite
+// CR / TIMINGR being identical to the probe's. Dropping the pre-clear
+// matches the probe and is fine on this peripheral because the flags get
+// cleared at the end of each transaction anyway.
+bool i2cReadBuffer(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t *buf)
+{
+    UNUSED(device);
+    i2cI3cReadCalls++;
+    if (!i2cInitialised || len == 0) {
+        i2cI3cLastFail = 0xAA00;
+        return false;
+    }
+
+    // Phase A: write the register pointer, end with RESTART so the bus is
+    // held for the read that follows.
+    LL_I3C_ControllerHandleMessage(I3C1, addr, 1,
+                                   LL_I3C_DIRECTION_WRITE,
+                                   LL_I3C_CONTROLLER_MTYPE_LEGACY_I2C,
+                                   LL_I3C_GENERATE_RESTART);
+    uint32_t guard = I3C_AS_I2C_GUARD_LOOPS;
+    while (!LL_I3C_IsActiveFlag_TXFNF(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard--) { }
+    if (LL_I3C_IsActiveFlag_ERR(I3C1)) {
+        i2cI3cLastEvr = I3C1->EVR; i2cI3cLastSer = I3C1->SER;
+        i2cI3cLastFail = 0xA1E0;
+        i2cErrorCount++; i3cClearAllEventFlags(); return false;
+    }
+    LL_I3C_TransmitData8(I3C1, reg);
+
+    guard = I3C_AS_I2C_GUARD_LOOPS;
+    while (!LL_I3C_IsActiveFlag_FC(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard--) { }
+    if (LL_I3C_IsActiveFlag_ERR(I3C1)) {
+        i2cI3cLastEvr = I3C1->EVR; i2cI3cLastSer = I3C1->SER;
+        i2cI3cLastFail = 0xA2E0;
+        i2cErrorCount++; i3cClearAllEventFlags(); return false;
+    }
+    i3cClearAllEventFlags();
+
+    // Phase B: read `len` bytes, STOP at end.
+    LL_I3C_ControllerHandleMessage(I3C1, addr, len,
+                                   LL_I3C_DIRECTION_READ,
+                                   LL_I3C_CONTROLLER_MTYPE_LEGACY_I2C,
+                                   LL_I3C_GENERATE_STOP);
+
+    for (uint8_t i = 0; i < len; i++) {
+        guard = I3C_AS_I2C_GUARD_LOOPS;
+        while (!LL_I3C_IsActiveFlag_RXFNE(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard--) { }
+        if (LL_I3C_IsActiveFlag_ERR(I3C1)) {
+            i2cI3cLastEvr = I3C1->EVR; i2cI3cLastSer = I3C1->SER;
+            i2cI3cLastFail = 0xA3E0 | i;
+            i2cErrorCount++; i3cClearAllEventFlags(); return false;
+        }
+        buf[i] = LL_I3C_ReceiveData8(I3C1);
+    }
+
+    guard = I3C_AS_I2C_GUARD_LOOPS;
+    while (!LL_I3C_IsActiveFlag_FC(I3C1) && guard--) { }
+    i2cI3cLastFail = 0x0000;
+    i3cClearAllEventFlags();
+    return true;
+}
+
+bool i2cRead(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, uint8_t *buf)
+{
+    return i2cReadBuffer(device, addr, reg, len, buf);
+}
+
+#endif // USE_I2C && USE_I3C_AS_I2C

--- a/src/platform/STM32/bus_i2c_i3c.c
+++ b/src/platform/STM32/bus_i2c_i3c.c
@@ -82,24 +82,18 @@ void i2cInit(i2cDevice_e device)
     LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_I3C1);
     LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_I3C1);
 
-    // GPIO: PC10 = SCL (AF4), PC11 = SDA (AF4), both open-drain (external
-    // pull-ups required, BF policy for I2C buses). Use raw LL calls -- the
-    // working probe set HIGH speed; BF's IOCFG_AF_OD uses LOW which is OK
-    // electrically but matches what the verified-good probe does. Claim
-    // ownership via IOInit so unusedPinsInit doesn't revert the pads.
+    // SCL/SDA pins come from I3C_AS_I2C_SCL_PIN / I3C_AS_I2C_SDA_PIN. AF4 is
+    // I3C1 on the STM32C5 AF table. Open-drain, HIGH slew rate; external
+    // pull-ups required (BF policy for I2C buses). Claim ownership via
+    // IOInit so unusedPinsInit doesn't revert the pads.
     const IO_t scl = IOGetByTag(IO_TAG(I3C_AS_I2C_SCL_PIN));
     const IO_t sda = IOGetByTag(IO_TAG(I3C_AS_I2C_SDA_PIN));
     IOInit(scl, OWNER_I2C_SCL, RESOURCE_INDEX(0));
     IOInit(sda, OWNER_I2C_SDA, RESOURCE_INDEX(0));
 
-    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOC);
-    LL_GPIO_SetPinSpeed(GPIOC, LL_GPIO_PIN_10, LL_GPIO_SPEED_FREQ_HIGH);
-    LL_GPIO_SetPinSpeed(GPIOC, LL_GPIO_PIN_11, LL_GPIO_SPEED_FREQ_HIGH);
-    LL_GPIO_SetPinOutputType(GPIOC, LL_GPIO_PIN_10 | LL_GPIO_PIN_11, LL_GPIO_OUTPUT_OPENDRAIN);
-    LL_GPIO_SetAFPin_8_15(GPIOC, LL_GPIO_PIN_10, LL_GPIO_AF_4);
-    LL_GPIO_SetAFPin_8_15(GPIOC, LL_GPIO_PIN_11, LL_GPIO_AF_4);
-    LL_GPIO_SetPinMode(GPIOC, LL_GPIO_PIN_10, LL_GPIO_MODE_ALTERNATE);
-    LL_GPIO_SetPinMode(GPIOC, LL_GPIO_PIN_11, LL_GPIO_MODE_ALTERNATE);
+    const ioConfig_t af_od_high = IO_CONFIG(GPIO_MODE_AF_OD, GPIO_SPEED_FREQ_HIGH, GPIO_NOPULL);
+    IOConfigGPIOAF(scl, af_od_high, LL_GPIO_AF_4);
+    IOConfigGPIOAF(sda, af_od_high, LL_GPIO_AF_4);
 
     // Controller mode, arbitration header suppressed (we're talking to plain
     // I2C slaves that don't speak I3C's broadcast 7'h7E).
@@ -228,19 +222,19 @@ bool i2cReadBuffer(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, u
                                    LL_I3C_CONTROLLER_MTYPE_LEGACY_I2C,
                                    LL_I3C_GENERATE_RESTART);
     uint32_t guard = I3C_AS_I2C_GUARD_LOOPS;
-    while (!LL_I3C_IsActiveFlag_TXFNF(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard--) { }
-    if (LL_I3C_IsActiveFlag_ERR(I3C1)) {
+    while (!LL_I3C_IsActiveFlag_TXFNF(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard) { i3cWaitOrError(&guard); }
+    if (!guard || LL_I3C_IsActiveFlag_ERR(I3C1)) {
         i2cI3cLastEvr = I3C1->EVR; i2cI3cLastSer = I3C1->SER;
-        i2cI3cLastFail = 0xA1E0;
+        i2cI3cLastFail = 0xA1E0 | (guard ? 0 : 1);
         i2cErrorCount++; i3cClearAllEventFlags(); return false;
     }
     LL_I3C_TransmitData8(I3C1, reg);
 
     guard = I3C_AS_I2C_GUARD_LOOPS;
-    while (!LL_I3C_IsActiveFlag_FC(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard--) { }
-    if (LL_I3C_IsActiveFlag_ERR(I3C1)) {
+    while (!LL_I3C_IsActiveFlag_FC(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard) { i3cWaitOrError(&guard); }
+    if (!guard || LL_I3C_IsActiveFlag_ERR(I3C1)) {
         i2cI3cLastEvr = I3C1->EVR; i2cI3cLastSer = I3C1->SER;
-        i2cI3cLastFail = 0xA2E0;
+        i2cI3cLastFail = 0xA2E0 | (guard ? 0 : 1);
         i2cErrorCount++; i3cClearAllEventFlags(); return false;
     }
     i3cClearAllEventFlags();
@@ -253,8 +247,8 @@ bool i2cReadBuffer(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, u
 
     for (uint8_t i = 0; i < len; i++) {
         guard = I3C_AS_I2C_GUARD_LOOPS;
-        while (!LL_I3C_IsActiveFlag_RXFNE(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard--) { }
-        if (LL_I3C_IsActiveFlag_ERR(I3C1)) {
+        while (!LL_I3C_IsActiveFlag_RXFNE(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard) { i3cWaitOrError(&guard); }
+        if (!guard || LL_I3C_IsActiveFlag_ERR(I3C1)) {
             i2cI3cLastEvr = I3C1->EVR; i2cI3cLastSer = I3C1->SER;
             i2cI3cLastFail = 0xA3E0 | i;
             i2cErrorCount++; i3cClearAllEventFlags(); return false;
@@ -263,7 +257,12 @@ bool i2cReadBuffer(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, u
     }
 
     guard = I3C_AS_I2C_GUARD_LOOPS;
-    while (!LL_I3C_IsActiveFlag_FC(I3C1) && guard--) { }
+    while (!LL_I3C_IsActiveFlag_FC(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard) { i3cWaitOrError(&guard); }
+    if (!guard || LL_I3C_IsActiveFlag_ERR(I3C1)) {
+        i2cI3cLastEvr = I3C1->EVR; i2cI3cLastSer = I3C1->SER;
+        i2cI3cLastFail = 0xA4E0 | (guard ? 0 : 1);
+        i2cErrorCount++; i3cClearAllEventFlags(); return false;
+    }
     i2cI3cLastFail = 0x0000;
     i3cClearAllEventFlags();
     return true;

--- a/src/platform/STM32/bus_i2c_ll.c
+++ b/src/platform/STM32/bus_i2c_ll.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C) && !defined(USE_I3C_AS_I2C)
 
 #include "drivers/io.h"
 #include "drivers/io_impl.h"

--- a/src/platform/STM32/bus_i2c_ll_init.c
+++ b/src/platform/STM32/bus_i2c_ll_init.c
@@ -25,7 +25,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C) && !defined(USE_I3C_AS_I2C)
 
 #include "drivers/io.h"
 #include "drivers/nvic.h"

--- a/src/platform/STM32/bus_spi_hal2.c
+++ b/src/platform/STM32/bus_spi_hal2.c
@@ -120,13 +120,14 @@ void spiInitDevice(spiDevice_e device)
     RCC_ResetCmd(spi->rcc, ENABLE);
 
 #ifdef STM32C5
-    if (dev == SPI1) {
-        LL_RCC_SetSPIClockSource(LL_RCC_SPI1_CLKSOURCE_HSIK);
-    } else if (dev == SPI2) {
-        LL_RCC_SetSPIClockSource(LL_RCC_SPI2_CLKSOURCE_HSIK);
-    } else if (dev == SPI3) {
-        LL_RCC_SetSPIClockSource(LL_RCC_SPI3_CLKSOURCE_HSIK);
-    }
+    // STM32C5: leave SPI kernel clock at PCLK (default after reset). HSIK
+    // selection on SPI3 leaves CTSIZE pinned at TSIZE -- the peripheral
+    // never decrements the transfer counter, EOT never asserts, and the
+    // controller appears to "transmit" via FIFO drain but no SCK reaches
+    // the pad. Reproduced under SWD on ARCROBO_C562V1: with SPI3SEL=10
+    // (HSIK) a manual WHO_AM_I transaction sticks at SR=0x00020012,
+    // CTSIZE=2; flipping SPI3SEL=00 (PCLK1) on the same configuration
+    // immediately advances to SR.EOT=1.
 #endif
 
     IOInit(IOGetByTag(spi->sck),  OWNER_SPI_SCK, RESOURCE_INDEX(device));

--- a/src/platform/STM32/mk/STM32C5.mk
+++ b/src/platform/STM32/mk/STM32C5.mk
@@ -146,6 +146,7 @@ MCU_COMMON_SRC = \
             STM32/bus_spi_hal2.c \
             STM32/bus_i2c_ll.c \
             STM32/bus_i2c_ll_init.c \
+            STM32/bus_i2c_i3c.c \
             STM32/spa06_i3c_probe.c \
             STM32/can_stm32c5xx.c \
             drivers/bus_i2c_timing.c \

--- a/src/platform/STM32/mk/STM32C5.mk
+++ b/src/platform/STM32/mk/STM32C5.mk
@@ -146,6 +146,7 @@ MCU_COMMON_SRC = \
             STM32/bus_spi_hal2.c \
             STM32/bus_i2c_ll.c \
             STM32/bus_i2c_ll_init.c \
+            STM32/spa06_i3c_probe.c \
             STM32/can_stm32c5xx.c \
             drivers/bus_i2c_timing.c \
             STM32/serial_uart_ll.c \

--- a/src/platform/STM32/spa06_i3c_probe.c
+++ b/src/platform/STM32/spa06_i3c_probe.c
@@ -41,6 +41,16 @@ volatile uint32_t spa06ProbeGpioAfrh  __attribute__((used));
 volatile uint32_t spa06ProbeI3cCfgr   __attribute__((used));
 // Bitmap of 7-bit I2C addresses that ACKed an address-only ping. 128 bits.
 volatile uint32_t spa06ProbeAckMap[4] __attribute__((used));
+// GPIO continuity test results. byte layout per slot:
+//   bit 0 = SCL state, bit 1 = SDA state
+// One slot per test step (see comments in spa06ProbeGpioCheck).
+volatile uint32_t spa06ProbeGpio __attribute__((used));
+// Bit-bang I2C address-scan map. Same layout as spa06ProbeAckMap. Independent
+// of the I3C peripheral so we can tell the bus side apart from the peripheral
+// side: if bit-bang ACKs an address but I3C doesn't, the I3C peripheral
+// config is wrong; if neither ACKs anything, the chip itself isn't there or
+// not powered.
+volatile uint32_t spa06ProbeBbAckMap[4] __attribute__((used));
 
 static void spa06ProbeI3cInit(void)
 {
@@ -172,9 +182,246 @@ static bool spa06ProbePing(uint8_t addr)
     return ack;
 }
 
+// Wire-side continuity check before bringing I3C up. Configure PC10/PC11 as
+// plain GPIO (input pull-up first, then floating-input, then output) and look
+// at what the pads read. The 32-bit result encodes four steps:
+//   bits  3:0   step 0 - input pull-up   : bit0 = SCL idle, bit1 = SDA idle
+//   bits  7:4   step 1 - input floating  : bit0 = SCL, bit1 = SDA
+//   bits 11:8   step 2 - SCL drive low   : SCL should be 0, SDA still 1
+//   bits 15:12  step 3 - SDA drive low   : SCL high (released), SDA should be 0
+// External I2C pull-ups will hold the lines HIGH in the floating step; if
+// they read LOW with no pull-up, the bus has no pull-up resistors and the
+// chip can never assert ACK (ACK is the slave pulling SDA low against the
+// bus pull-up). If a pin can't be pulled low by the MCU at all, it's not
+// physically routed to PC10/PC11 the way we think it is.
+static void spa06ProbeGpioCheck(void)
+{
+    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOC);
+
+    uint32_t result = 0;
+
+    // Step 0: input + pull-up. Both lines should read 1.
+    LL_GPIO_SetPinMode(GPIOC, LL_GPIO_PIN_10, LL_GPIO_MODE_INPUT);
+    LL_GPIO_SetPinMode(GPIOC, LL_GPIO_PIN_11, LL_GPIO_MODE_INPUT);
+    LL_GPIO_SetPinPull(GPIOC, LL_GPIO_PIN_10, LL_GPIO_PULL_UP);
+    LL_GPIO_SetPinPull(GPIOC, LL_GPIO_PIN_11, LL_GPIO_PULL_UP);
+    for (volatile int i = 0; i < 1000; i++) { __NOP(); }
+    if (LL_GPIO_IsInputPinSet(GPIOC, LL_GPIO_PIN_10)) result |= (1U << 0);
+    if (LL_GPIO_IsInputPinSet(GPIOC, LL_GPIO_PIN_11)) result |= (1U << 1);
+
+    // Step 1: floating input. If the bus has an external pull-up the line
+    // stays HIGH; with no external pull-up the line floats and likely reads
+    // 0 (unless there's residual charge).
+    LL_GPIO_SetPinPull(GPIOC, LL_GPIO_PIN_10, LL_GPIO_PULL_NO);
+    LL_GPIO_SetPinPull(GPIOC, LL_GPIO_PIN_11, LL_GPIO_PULL_NO);
+    for (volatile int i = 0; i < 10000; i++) { __NOP(); }
+    if (LL_GPIO_IsInputPinSet(GPIOC, LL_GPIO_PIN_10)) result |= (1U << 4);
+    if (LL_GPIO_IsInputPinSet(GPIOC, LL_GPIO_PIN_11)) result |= (1U << 5);
+
+    // Step 2: drive SCL (PC10) LOW as open-drain output, SDA stays floating.
+    LL_GPIO_SetPinOutputType(GPIOC, LL_GPIO_PIN_10, LL_GPIO_OUTPUT_OPENDRAIN);
+    LL_GPIO_ResetOutputPin(GPIOC, LL_GPIO_PIN_10);  // drive low
+    LL_GPIO_SetPinMode(GPIOC, LL_GPIO_PIN_10, LL_GPIO_MODE_OUTPUT);
+    for (volatile int i = 0; i < 1000; i++) { __NOP(); }
+    if (LL_GPIO_IsInputPinSet(GPIOC, LL_GPIO_PIN_10)) result |= (1U << 8);
+    if (LL_GPIO_IsInputPinSet(GPIOC, LL_GPIO_PIN_11)) result |= (1U << 9);
+    // Release SCL (back to input pull-up so it can float high)
+    LL_GPIO_SetPinMode(GPIOC, LL_GPIO_PIN_10, LL_GPIO_MODE_INPUT);
+    LL_GPIO_SetPinPull(GPIOC, LL_GPIO_PIN_10, LL_GPIO_PULL_UP);
+
+    // Step 3: drive SDA (PC11) LOW open-drain.
+    LL_GPIO_SetPinOutputType(GPIOC, LL_GPIO_PIN_11, LL_GPIO_OUTPUT_OPENDRAIN);
+    LL_GPIO_ResetOutputPin(GPIOC, LL_GPIO_PIN_11);
+    LL_GPIO_SetPinMode(GPIOC, LL_GPIO_PIN_11, LL_GPIO_MODE_OUTPUT);
+    for (volatile int i = 0; i < 1000; i++) { __NOP(); }
+    if (LL_GPIO_IsInputPinSet(GPIOC, LL_GPIO_PIN_10)) result |= (1U << 12);
+    if (LL_GPIO_IsInputPinSet(GPIOC, LL_GPIO_PIN_11)) result |= (1U << 13);
+
+    // Release both pins back to inputs floating so the I3C init can take
+    // them over cleanly.
+    LL_GPIO_SetPinMode(GPIOC, LL_GPIO_PIN_11, LL_GPIO_MODE_INPUT);
+    LL_GPIO_SetPinPull(GPIOC, LL_GPIO_PIN_11, LL_GPIO_PULL_NO);
+    LL_GPIO_SetPinPull(GPIOC, LL_GPIO_PIN_10, LL_GPIO_PULL_NO);
+
+    spa06ProbeGpio = result;
+}
+
+// ---- GPIO bit-bang I2C, independent of the I3C peripheral ----------------
+//
+// PC10 = SCL, PC11 = SDA. Both open-drain with external pull-ups (verified
+// by spa06ProbeGpioCheck). To "drive low" the pin is set as MODE_OUTPUT with
+// OTYPE=OPENDRAIN and ODR=0; to "release" (let the bus pull high) the pin is
+// set back to MODE_INPUT (floating, external pull-ups take over).
+
+#define BB_SCL_PIN  LL_GPIO_PIN_10
+#define BB_SDA_PIN  LL_GPIO_PIN_11
+
+static inline void bbDelay(void)
+{
+    // ~5 us at 144 MHz CPU -- yields ~100 kHz I2C, plenty of margin.
+    for (volatile int i = 0; i < 720; i++) { __NOP(); }
+}
+
+static inline void bbSclLow(void)
+{
+    LL_GPIO_ResetOutputPin(GPIOC, BB_SCL_PIN);
+    LL_GPIO_SetPinMode(GPIOC, BB_SCL_PIN, LL_GPIO_MODE_OUTPUT);
+}
+static inline void bbSclRelease(void)
+{
+    LL_GPIO_SetPinMode(GPIOC, BB_SCL_PIN, LL_GPIO_MODE_INPUT);
+}
+static inline void bbSdaLow(void)
+{
+    LL_GPIO_ResetOutputPin(GPIOC, BB_SDA_PIN);
+    LL_GPIO_SetPinMode(GPIOC, BB_SDA_PIN, LL_GPIO_MODE_OUTPUT);
+}
+static inline void bbSdaRelease(void)
+{
+    LL_GPIO_SetPinMode(GPIOC, BB_SDA_PIN, LL_GPIO_MODE_INPUT);
+}
+static inline int bbSdaRead(void)
+{
+    return LL_GPIO_IsInputPinSet(GPIOC, BB_SDA_PIN);
+}
+
+static void bbI2cInit(void)
+{
+    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOC);
+    // Open-drain output type, no internal pull (use external pull-ups).
+    LL_GPIO_SetPinOutputType(GPIOC, BB_SCL_PIN | BB_SDA_PIN, LL_GPIO_OUTPUT_OPENDRAIN);
+    LL_GPIO_SetPinPull(GPIOC, BB_SCL_PIN, LL_GPIO_PULL_NO);
+    LL_GPIO_SetPinPull(GPIOC, BB_SDA_PIN, LL_GPIO_PULL_NO);
+    LL_GPIO_SetPinSpeed(GPIOC, BB_SCL_PIN, LL_GPIO_SPEED_FREQ_HIGH);
+    LL_GPIO_SetPinSpeed(GPIOC, BB_SDA_PIN, LL_GPIO_SPEED_FREQ_HIGH);
+    // Idle: both lines released (pulled high externally).
+    bbSclRelease();
+    bbSdaRelease();
+    bbDelay();
+}
+
+static void bbStart(void)
+{
+    bbSdaRelease(); bbSclRelease(); bbDelay();
+    bbSdaLow();     bbDelay();
+    bbSclLow();     bbDelay();
+}
+
+static void bbStop(void)
+{
+    bbSdaLow();     bbDelay();
+    bbSclRelease(); bbDelay();
+    bbSdaRelease(); bbDelay();
+}
+
+// Shift out one byte MSB first; sample the ACK on the 9th SCL pulse. Returns
+// 1 if ACK (slave pulled SDA low), 0 if NACK.
+static int bbWriteByte(uint8_t b)
+{
+    for (int i = 7; i >= 0; i--) {
+        if (b & (1 << i)) {
+            bbSdaRelease();
+        } else {
+            bbSdaLow();
+        }
+        bbDelay();
+        bbSclRelease(); bbDelay();
+        bbSclLow();     bbDelay();
+    }
+    // ACK slot: release SDA so the slave can drive it.
+    bbSdaRelease(); bbDelay();
+    bbSclRelease(); bbDelay();
+    const int ack = (bbSdaRead() == 0) ? 1 : 0;
+    bbSclLow();     bbDelay();
+    return ack;
+}
+
+// Address-only ping: START + write address byte + STOP. Returns ACK status.
+static int bbPing(uint8_t addr7)
+{
+    bbStart();
+    const int ack = bbWriteByte((uint8_t)(addr7 << 1));     // R/W=0 (write)
+    bbStop();
+    return ack;
+}
+
+// Read one byte, send NACK (no more reads coming) + STOP.
+static uint8_t bbReadByteNack(void)
+{
+    uint8_t v = 0;
+    bbSdaRelease();
+    for (int i = 7; i >= 0; i--) {
+        bbDelay();
+        bbSclRelease(); bbDelay();
+        if (bbSdaRead()) v |= (1 << i);
+        bbSclLow();
+    }
+    // NACK: keep SDA released (high) during the 9th clock.
+    bbSdaRelease(); bbDelay();
+    bbSclRelease(); bbDelay();
+    bbSclLow();     bbDelay();
+    return v;
+}
+
+volatile uint8_t spa06ProbeBbReadStep __attribute__((used));
+
+// I2C read register: S addr W reg Sr addr R data NACK P
+static int bbReadReg(uint8_t addr7, uint8_t reg, uint8_t *out)
+{
+    spa06ProbeBbReadStep = 0x10;
+    bbStart();
+    spa06ProbeBbReadStep = 0x11;
+    if (!bbWriteByte((uint8_t)(addr7 << 1))) { spa06ProbeBbReadStep = 0xE1; bbStop(); return 0; }
+    spa06ProbeBbReadStep = 0x12;
+    if (!bbWriteByte(reg))                    { spa06ProbeBbReadStep = 0xE2; bbStop(); return 0; }
+    spa06ProbeBbReadStep = 0x13;
+    // Repeated start
+    bbSdaRelease(); bbDelay();
+    bbSclRelease(); bbDelay();
+    bbSdaLow();     bbDelay();
+    bbSclLow();     bbDelay();
+    spa06ProbeBbReadStep = 0x14;
+    if (!bbWriteByte((uint8_t)((addr7 << 1) | 1))) { spa06ProbeBbReadStep = 0xE3; bbStop(); return 0; }
+    spa06ProbeBbReadStep = 0x15;
+    *out = bbReadByteNack();
+    spa06ProbeBbReadStep = 0x16;
+    bbStop();
+    spa06ProbeBbReadStep = 0x17;
+    return 1;
+}
+
+volatile uint8_t spa06ProbeBbChipId __attribute__((used));
+volatile uint8_t spa06ProbeBbProdRev __attribute__((used));
+
+static void spa06ProbeBbScan(void)
+{
+    bbI2cInit();
+    for (uint8_t a = 0x08; a < 0x78; a++) {
+        if (bbPing(a)) {
+            spa06ProbeBbAckMap[a / 32] |= (1U << (a % 32));
+        }
+    }
+    // If 0x76 ACKed, read CHIP_ID (reg 0x0D). SPA06-003 = 0x11.
+    if (spa06ProbeBbAckMap[3] & (1U << 22)) {
+        uint8_t v = 0;
+        if (bbReadReg(0x76, 0x0D, &v)) {
+            spa06ProbeBbProdRev = v;
+            spa06ProbeBbChipId  = v & 0x0F;
+        }
+    } else if (spa06ProbeBbAckMap[3] & (1U << 23)) {
+        uint8_t v = 0;
+        if (bbReadReg(0x77, 0x0D, &v)) {
+            spa06ProbeBbProdRev = v;
+            spa06ProbeBbChipId  = v & 0x0F;
+        }
+    }
+}
+
 void spa06ProbeRun(void)
 {
     spa06ProbeStatus = 0xAA000000U;
+    spa06ProbeGpioCheck();
+    spa06ProbeBbScan();
     spa06ProbeI3cInit();
     delay(2);
 

--- a/src/platform/STM32/spa06_i3c_probe.c
+++ b/src/platform/STM32/spa06_i3c_probe.c
@@ -112,7 +112,6 @@ static bool spa06ProbeWriteReg(uint8_t addr, uint8_t reg, uint8_t value, bool st
     // (no value, restart), pass value=0 and stop=false; chip ignores the second
     // byte if the FIFO already starts a restart -- but typical SPA06 read
     // protocol uses just one byte (reg address), then restart + read.
-    (void)value;
     uint32_t bytes = stop ? 2 : 1;
     LL_I3C_ControllerHandleMessage(I3C1,
                                    addr,
@@ -120,20 +119,32 @@ static bool spa06ProbeWriteReg(uint8_t addr, uint8_t reg, uint8_t value, bool st
                                    LL_I3C_DIRECTION_WRITE,
                                    LL_I3C_CONTROLLER_MTYPE_LEGACY_I2C,
                                    stop ? LL_I3C_GENERATE_STOP : LL_I3C_GENERATE_RESTART);
-    // Push register byte
-    while (!LL_I3C_IsActiveFlag_TXFNF(I3C1));
+    // Push register byte (bounded wait)
+    uint32_t guard = 100000;
+    while (!LL_I3C_IsActiveFlag_TXFNF(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard) { guard--; }
+    if (!guard || LL_I3C_IsActiveFlag_ERR(I3C1)) {
+        spa06ProbeEvr = I3C1->EVR; spa06ProbeSer = I3C1->SER;
+        I3C1->CEVR = I3C1->EVR;
+        return false;
+    }
     LL_I3C_TransmitData8(I3C1, reg);
     if (stop) {
-        while (!LL_I3C_IsActiveFlag_TXFNF(I3C1));
+        guard = 100000;
+        while (!LL_I3C_IsActiveFlag_TXFNF(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard) { guard--; }
+        if (!guard || LL_I3C_IsActiveFlag_ERR(I3C1)) {
+            spa06ProbeEvr = I3C1->EVR; spa06ProbeSer = I3C1->SER;
+            I3C1->CEVR = I3C1->EVR;
+            return false;
+        }
         LL_I3C_TransmitData8(I3C1, value);
     }
     // Wait for frame complete or error
-    uint32_t guard = 100000;
-    while (!LL_I3C_IsActiveFlag_FC(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard--);
+    guard = 100000;
+    while (!LL_I3C_IsActiveFlag_FC(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard) { guard--; }
     spa06ProbeEvr = I3C1->EVR;
     spa06ProbeSer = I3C1->SER;
-    if (LL_I3C_IsActiveFlag_ERR(I3C1)) {
-        I3C1->CEVR = I3C1->EVR;  // clear all flags
+    if (!guard || LL_I3C_IsActiveFlag_ERR(I3C1)) {
+        I3C1->CEVR = I3C1->EVR;
         return false;
     }
     I3C1->CEVR = I3C1->EVR;

--- a/src/platform/STM32/spa06_i3c_probe.c
+++ b/src/platform/STM32/spa06_i3c_probe.c
@@ -81,12 +81,17 @@ static void spa06ProbeI3cInit(void)
     //    CubeMX-generated I3C1 init helper for the C562 platform.
     LL_I3C_SetMode(I3C1, LL_I3C_MODE_CONTROLLER);
     LL_I3C_DisableArbitrationHeader(I3C1);          // suppress 7'h7E ARB header
-    // Very slow I2C bus (~50 kHz OD on PCLK1=144 MHz). Wider SCL low/high
-    // duty so marginal pull-ups can pull SDA high cleanly between bytes.
-    // TIMINGR0: SCL OD high = 0xFF clocks, SCL OD low = 0xFF clocks, no I3C
-    // push-pull use. Empirical bring-up value -- can tighten once a chip ACKs.
-    LL_I3C_ConfigClockWaveForm(I3C1, 0x00FFFFFFU);
-    LL_I3C_SetBusCharacteristic(I3C1, 0x1D00FFU);
+    // TIMINGR0 layout (LSB first byte):
+    //   [ 7: 0] SCLL_PP    - I3C push-pull SCL low  (unused here, must be > 0)
+    //   [15: 8] SCLH_I3C   - I3C SCL high           (unused here, must be > 0)
+    //   [23:16] SCLL_OD    - legacy-I2C / open-drain SCL low duration
+    //   [31:24] SCLH_I2C   - legacy-I2C SCL high duration
+    // Earlier guesses left SCLH_I2C = 0, so SCL never actually went high and
+    // the slave saw no clock pulses -> ANACK on every transaction. At
+    // 144 MHz PCLK1, SCLL_OD = SCLH_I2C = 0xF0 (240 cycles, ~1.67 us each)
+    // yields ~300 kHz I2C with comfortable rise/fall margin.
+    LL_I3C_ConfigClockWaveForm(I3C1, 0xF0F00505U);
+    LL_I3C_SetBusCharacteristic(I3C1, 0x1D008EU);
     LL_I3C_ConfigCtrlFifo(I3C1,
                           LL_I3C_RXFIFO_THRESHOLD_1_2,
                           LL_I3C_TXFIFO_THRESHOLD_1_2,

--- a/src/platform/STM32/spa06_i3c_probe.c
+++ b/src/platform/STM32/spa06_i3c_probe.c
@@ -1,0 +1,211 @@
+/*
+ * SPA06-003 baro probe over STM32C5 I3C1 in legacy-I2C mode.
+ *
+ * First-cut, blocking-only probe. Brings up I3C1 on PC10/PC11 (AF4) as a
+ * legacy-I2C controller, runs a 1-byte register read at I2C address 0x77,
+ * and stashes the result in two SWD-readable globals so the bring-up loop
+ * can see the chip's CHIP_ID (reg 0x0D, expected 0x11 for SPA06/SPL07-003).
+ *
+ * Wire-up:
+ *   - PC10  ->  I3C1_SCL  (AF4)
+ *   - PC11  ->  I3C1_SDA  (AF4)
+ *   - external pull-ups to VDDIO (board)
+ *
+ * Built only when ENABLE_BARO_SPA06_PROBE is set on the platform; gate from
+ * the board config.h.
+ */
+
+#include "platform.h"
+
+#if defined(STM32C5) && ENABLE_BARO_SPA06_PROBE
+
+#include "stm32c5xx.h"
+#include "stm32c5xx_ll_bus.h"
+#include "stm32c5xx_ll_gpio.h"
+#include "stm32c5xx_ll_i3c.h"
+#include "stm32c5xx_ll_rcc.h"
+
+#include "drivers/io.h"
+#include "drivers/time.h"
+
+#define SPA06_I2C_ADDR        0x77   // SDO tied high; 0x76 if SDO low
+#define SPA06_REG_CHIP_ID     0x0D
+#define SPA06_CHIP_ID_VAL     0x11   // also matches SPL07_003 in BF DPS310 driver
+
+volatile uint32_t spa06ProbeStatus __attribute__((used));
+volatile uint8_t  spa06ProbeChipId __attribute__((used));
+volatile uint32_t spa06ProbeEvr    __attribute__((used));
+volatile uint32_t spa06ProbeSer    __attribute__((used));
+volatile uint32_t spa06ProbeGpioModer __attribute__((used));
+volatile uint32_t spa06ProbeGpioAfrh  __attribute__((used));
+volatile uint32_t spa06ProbeI3cCfgr   __attribute__((used));
+// Bitmap of 7-bit I2C addresses that ACKed an address-only ping. 128 bits.
+volatile uint32_t spa06ProbeAckMap[4] __attribute__((used));
+
+static void spa06ProbeI3cInit(void)
+{
+    // 1. Clock the I3C1 peripheral on APB1; PCLK1 is the kernel clock
+    LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_I3C1);
+    LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_I3C1);
+    LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_I3C1);
+
+    // 2. GPIOC clock and pin setup (PC10=SCL, PC11=SDA, AF4)
+    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOC);
+
+    // Claim the pins via BF's IO ownership so later cleanup (unusedPinsInit)
+    // doesn't revert them to input-pull-up.
+    IOInit(IOGetByTag(DEFIO_TAG_E(PC10)), OWNER_I2C_SCL, 1);
+    IOInit(IOGetByTag(DEFIO_TAG_E(PC11)), OWNER_I2C_SDA, 1);
+
+    LL_GPIO_SetPinSpeed(GPIOC, LL_GPIO_PIN_10, LL_GPIO_SPEED_FREQ_HIGH);
+    LL_GPIO_SetPinSpeed(GPIOC, LL_GPIO_PIN_11, LL_GPIO_SPEED_FREQ_HIGH);
+    LL_GPIO_SetPinOutputType(GPIOC, LL_GPIO_PIN_10 | LL_GPIO_PIN_11, LL_GPIO_OUTPUT_OPENDRAIN);
+    LL_GPIO_SetAFPin_8_15(GPIOC, LL_GPIO_PIN_10, LL_GPIO_AF_4);
+    LL_GPIO_SetAFPin_8_15(GPIOC, LL_GPIO_PIN_11, LL_GPIO_AF_4);
+    LL_GPIO_SetPinMode(GPIOC, LL_GPIO_PIN_10, LL_GPIO_MODE_ALTERNATE);
+    LL_GPIO_SetPinMode(GPIOC, LL_GPIO_PIN_11, LL_GPIO_MODE_ALTERNATE);
+
+    // 3. Controller mode + I2C-mode-friendly timing
+    //    Hand-picked timing from ST example for I3C1 in mixed-bus at PCLK1=144 MHz,
+    //    targeting ~400 kHz on the open-drain (I2C) phase. Values pulled from the
+    //    CubeMX-generated I3C1 init helper for the C562 platform.
+    LL_I3C_SetMode(I3C1, LL_I3C_MODE_CONTROLLER);
+    LL_I3C_DisableArbitrationHeader(I3C1);          // suppress 7'h7E ARB header
+    // Very slow I2C bus (~50 kHz OD on PCLK1=144 MHz). Wider SCL low/high
+    // duty so marginal pull-ups can pull SDA high cleanly between bytes.
+    // TIMINGR0: SCL OD high = 0xFF clocks, SCL OD low = 0xFF clocks, no I3C
+    // push-pull use. Empirical bring-up value -- can tighten once a chip ACKs.
+    LL_I3C_ConfigClockWaveForm(I3C1, 0x00FFFFFFU);
+    LL_I3C_SetBusCharacteristic(I3C1, 0x1D00FFU);
+    LL_I3C_ConfigCtrlFifo(I3C1,
+                          LL_I3C_RXFIFO_THRESHOLD_1_2,
+                          LL_I3C_TXFIFO_THRESHOLD_1_2,
+                          LL_I3C_CTRL_FIFO_CONTROL_ONLY);
+    LL_I3C_Enable(I3C1);
+
+    // Snapshot GPIO + I3C state right after init so the post-boot SWD read
+    // can confirm AF mux survived (otherwise BF's pin cleanup pass clobbered
+    // it and the I3C peripheral never actually drove the pads).
+    spa06ProbeGpioModer = GPIOC->MODER;
+    spa06ProbeGpioAfrh  = GPIOC->AFR[1];
+    spa06ProbeI3cCfgr   = I3C1->CFGR;
+}
+
+static bool spa06ProbeWriteReg(uint8_t addr, uint8_t reg, uint8_t value, bool stop)
+{
+    // Write phase: 2 bytes ([reg, value]) with STOP. For a "register pointer set"
+    // (no value, restart), pass value=0 and stop=false; chip ignores the second
+    // byte if the FIFO already starts a restart -- but typical SPA06 read
+    // protocol uses just one byte (reg address), then restart + read.
+    (void)value;
+    uint32_t bytes = stop ? 2 : 1;
+    LL_I3C_ControllerHandleMessage(I3C1,
+                                   addr,
+                                   bytes,
+                                   LL_I3C_DIRECTION_WRITE,
+                                   LL_I3C_CONTROLLER_MTYPE_LEGACY_I2C,
+                                   stop ? LL_I3C_GENERATE_STOP : LL_I3C_GENERATE_RESTART);
+    // Push register byte
+    while (!LL_I3C_IsActiveFlag_TXFNF(I3C1));
+    LL_I3C_TransmitData8(I3C1, reg);
+    if (stop) {
+        while (!LL_I3C_IsActiveFlag_TXFNF(I3C1));
+        LL_I3C_TransmitData8(I3C1, value);
+    }
+    // Wait for frame complete or error
+    uint32_t guard = 100000;
+    while (!LL_I3C_IsActiveFlag_FC(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard--);
+    spa06ProbeEvr = I3C1->EVR;
+    spa06ProbeSer = I3C1->SER;
+    if (LL_I3C_IsActiveFlag_ERR(I3C1)) {
+        I3C1->CEVR = I3C1->EVR;  // clear all flags
+        return false;
+    }
+    I3C1->CEVR = I3C1->EVR;
+    return true;
+}
+
+static bool spa06ProbeReadByte(uint8_t addr, uint8_t reg, uint8_t *out)
+{
+    // I2C-style "read register": write reg pointer (no STOP, restart), then read
+    // 1 byte (STOP).
+    if (!spa06ProbeWriteReg(addr, reg, 0, false)) {
+        return false;
+    }
+    LL_I3C_ControllerHandleMessage(I3C1,
+                                   addr,
+                                   1,
+                                   LL_I3C_DIRECTION_READ,
+                                   LL_I3C_CONTROLLER_MTYPE_LEGACY_I2C,
+                                   LL_I3C_GENERATE_STOP);
+    uint32_t guard = 100000;
+    while (!LL_I3C_IsActiveFlag_RXFNE(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard--);
+    if (LL_I3C_IsActiveFlag_ERR(I3C1)) {
+        spa06ProbeEvr = I3C1->EVR;
+        spa06ProbeSer = I3C1->SER;
+        I3C1->CEVR = I3C1->EVR;
+        return false;
+    }
+    *out = LL_I3C_ReceiveData8(I3C1);
+    // Wait for STOP / frame complete
+    guard = 100000;
+    while (!LL_I3C_IsActiveFlag_FC(I3C1) && guard--);
+    spa06ProbeEvr = I3C1->EVR;
+    spa06ProbeSer = I3C1->SER;
+    I3C1->CEVR = I3C1->EVR;
+    return true;
+}
+
+// Address-ping: send a 0-byte write (address only, STOP). ACK → device exists.
+static bool spa06ProbePing(uint8_t addr)
+{
+    LL_I3C_ControllerHandleMessage(I3C1,
+                                   addr,
+                                   0,
+                                   LL_I3C_DIRECTION_WRITE,
+                                   LL_I3C_CONTROLLER_MTYPE_LEGACY_I2C,
+                                   LL_I3C_GENERATE_STOP);
+    uint32_t guard = 100000;
+    while (!LL_I3C_IsActiveFlag_FC(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard--);
+    const bool ack = !LL_I3C_IsActiveFlag_ERR(I3C1) || (I3C1->SER & I3C_SER_ANACK) == 0;
+    I3C1->CEVR = I3C1->EVR;
+    return ack;
+}
+
+void spa06ProbeRun(void)
+{
+    spa06ProbeStatus = 0xAA000000U;
+    spa06ProbeI3cInit();
+    delay(2);
+
+    // Address-only scan across 7-bit I2C address range. Sets bit in ackMap[]
+    // for any address that ACKs.
+    spa06ProbeStatus = 0xBB000000U;
+    for (uint8_t a = 0x08; a < 0x78; a++) {
+        if (spa06ProbePing(a)) {
+            spa06ProbeAckMap[a / 32] |= (1U << (a % 32));
+        }
+    }
+
+    spa06ProbeStatus = 0xCC000000U;
+    uint8_t chipId = 0;
+    bool ok76 = false, ok77 = false;
+    if (spa06ProbeReadByte(SPA06_I2C_ADDR, SPA06_REG_CHIP_ID, &chipId)) {
+        ok77 = true;
+        spa06ProbeChipId = chipId;
+        spa06ProbeStatus = 0xCC770000U | (uint32_t)chipId;
+    }
+    if (!ok77) {
+        chipId = 0;
+        if (spa06ProbeReadByte(0x76, SPA06_REG_CHIP_ID, &chipId)) {
+            ok76 = true;
+            spa06ProbeChipId = chipId;
+            spa06ProbeStatus = 0xCC760000U | (uint32_t)chipId;
+        }
+    }
+    if (!ok76 && !ok77) {
+        spa06ProbeStatus |= 0x000000EEU;
+    }
+}
+
+#endif

--- a/src/platform/STM32/startup/startup_stm32c562xx.s
+++ b/src/platform/STM32/startup/startup_stm32c562xx.s
@@ -49,11 +49,10 @@ Reset_Handler:
   ldr   r0, =_estack
   mov   sp, r0          /* set stack pointer */
 
-  bl persistentObjectInit
-/* Call the clock system initialization function.*/
-  bl  SystemInit
-
-/* Copy the data segment initializers from flash to SRAM */
+/* Copy the data segment initializers from flash to SRAM. Must run
+ * before any C call so persistentObjectInit / SystemInit / HAL_InitTick
+ * don't read uninitialised globals (e.g. uwTickFreq), which would wedge
+ * HAL_RCC clock config. Same fix as startup_stm32c5a3xx.s. */
   ldr r0, =_sdata
   ldr r1, =_edata
   ldr r2, =_sidata
@@ -83,6 +82,10 @@ FillZerobss:
 LoopFillZerobss:
   cmp r2, r4
   bcc FillZerobss
+
+  bl persistentObjectInit
+/* Call the clock system initialization function.*/
+  bl  SystemInit
 
 /* Call the application's entry point.*/
   bl main

--- a/src/platform/STM32/startup/stm32c5xx_hal2_compat.h
+++ b/src/platform/STM32/startup/stm32c5xx_hal2_compat.h
@@ -672,14 +672,19 @@ typedef struct {
 static inline ErrorStatus LL_SPI_Init(SPI_TypeDef *SPIx,
                                       const LL_SPI_InitTypeDef *init)
 {
-    LL_SPI_SetTransferDirection(SPIx, init->TransferDirection);
-    LL_SPI_SetMode(SPIx, init->Mode);
-    LL_SPI_SetDataWidth(SPIx, init->DataWidth);
-    LL_SPI_SetClockPolarity(SPIx, init->ClockPolarity);
-    LL_SPI_SetClockPhase(SPIx, init->ClockPhase);
-    LL_SPI_SetNSSMode(SPIx, init->NSS);
-    LL_SPI_SetBaudRatePrescaler(SPIx, init->BaudRate);
-    LL_SPI_SetTransferBitOrder(SPIx, init->BitOrder);
+    // Use LL_SPI_SetConfig (the HAL2 path) so SSI is armed BEFORE
+    // CFG2.MASTER is written. The previous per-setter sequence wrote
+    // MASTER first (via LL_SPI_SetMode) with SSM still 0, which on
+    // STM32C5 silicon raises MODF and atomically clears MASTER if
+    // the hardware NSS pin happened to read low. The downstream
+    // "re-arm MASTER" in bus_spi_hal2.c then runs on a peripheral
+    // that's already in slave mode with stale state, and the next
+    // transfer drives no SCK on the pad even though EOT asserts.
+    LL_SPI_SetConfig(SPIx,
+                     init->DataWidth | init->BaudRate,
+                     init->Mode | init->TransferDirection |
+                     init->ClockPolarity | init->ClockPhase |
+                     init->BitOrder | init->NSS);
     if (init->CRCCalculation) {
         LL_SPI_EnableCRC(SPIx);
     }

--- a/src/platform/STM32/system_stm32c5xx.c
+++ b/src/platform/STM32/system_stm32c5xx.c
@@ -262,6 +262,25 @@ void systemInit(void)
     // call it here instead -- by this point .data is live.
     HAL_Init();
 
+#if ENABLE_BOOT0_PIN_SELECT
+    // FLASH_OPTSR.BOOT_SEL defaults to 0, which makes the BOOT0 *pin*
+    // inert and forces the boot source to come from the BOOT0 *bit* in
+    // OPTSR. A BF crash before USB-VCP enumerates then leaves no DFU
+    // recovery path short of an SWD mass-erase. Flip BOOT_SEL to 1
+    // once so the BOOT0 button drives boot mode from the next reset on.
+    if (HAL_FLASH_ITF_OB_GetBootSelection(HAL_FLASH) != HAL_FLASH_ITF_OB_BOOT_PIN) {
+        HAL_FLASH_ITF_Unlock(HAL_FLASH);
+        HAL_FLASH_ITF_OB_Unlock(HAL_FLASH);
+        if (HAL_FLASH_ITF_OB_SetBootSelection(HAL_FLASH, HAL_FLASH_ITF_OB_BOOT_PIN) == HAL_OK
+            && HAL_FLASH_ITF_OB_Program(HAL_FLASH) == HAL_OK) {
+            // C5 has no OBL_LAUNCH; OPTSR_CUR only reloads on chip reset.
+            NVIC_SystemReset();
+        }
+        HAL_FLASH_ITF_OB_Lock(HAL_FLASH);
+        HAL_FLASH_ITF_Lock(HAL_FLASH);
+    }
+#endif
+
     // ICACHE is intentionally left at reset default (disabled) on STM32C5.
     //
     // Despite the name, ICACHE on Cortex-M33 sits on the C-AHB code bus

--- a/src/platform/STM32/target/STM32C562/target.h
+++ b/src/platform/STM32/target/STM32C562/target.h
@@ -64,3 +64,13 @@
 #define FLASH_PAGE_SIZE ((uint32_t)0x2000) // 8K sectors
 
 #define EEPROM_SIZE     8192
+
+#ifndef DEFAULT_PID_PROCESS_DENOM
+#define DEFAULT_PID_PROCESS_DENOM       4
+#endif
+
+// C5's bus options (I2C / I3C-as-I2C) are slow per-byte at the moment;
+// slow the baro state-machine tick from the BF default of 40 Hz to 20 Hz.
+#ifndef TASK_BARO_RATE_HZ
+#define TASK_BARO_RATE_HZ               20
+#endif

--- a/src/platform/STM32/target/STM32C562/target.h
+++ b/src/platform/STM32/target/STM32C562/target.h
@@ -63,4 +63,4 @@
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x2000) // 8K sectors
 
-#define EEPROM_SIZE     4096
+#define EEPROM_SIZE     8192

--- a/src/platform/STM32/target/STM32C591/target.h
+++ b/src/platform/STM32/target/STM32C591/target.h
@@ -65,3 +65,11 @@
 #define FLASH_PAGE_SIZE ((uint32_t)0x2000) // 8K sectors
 
 #define EEPROM_SIZE     8192
+
+#ifndef DEFAULT_PID_PROCESS_DENOM
+#define DEFAULT_PID_PROCESS_DENOM       4
+#endif
+
+#ifndef TASK_BARO_RATE_HZ
+#define TASK_BARO_RATE_HZ               20
+#endif

--- a/src/platform/STM32/target/STM32C591/target.h
+++ b/src/platform/STM32/target/STM32C591/target.h
@@ -64,4 +64,4 @@
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x2000) // 8K sectors
 
-#define EEPROM_SIZE     4096
+#define EEPROM_SIZE     8192

--- a/src/platform/STM32/target/STM32C5A3/target.h
+++ b/src/platform/STM32/target/STM32C5A3/target.h
@@ -68,3 +68,11 @@
 // sensors during bring-up. Must fit within the FLASH_CONFIG partition
 // defined in stm32_flash_c5xx_1m.ld (128 KiB at 0x08020000).
 #define EEPROM_SIZE     8192
+
+#ifndef DEFAULT_PID_PROCESS_DENOM
+#define DEFAULT_PID_PROCESS_DENOM       4
+#endif
+
+#ifndef TASK_BARO_RATE_HZ
+#define TASK_BARO_RATE_HZ               20
+#endif

--- a/src/platform/common/stm32/bus_i2c_pinconfig.c
+++ b/src/platform/common/stm32/bus_i2c_pinconfig.c
@@ -28,7 +28,7 @@
 
 #include "platform.h"
 
-#if defined(USE_I2C) && !defined(USE_SOFT_I2C)
+#if defined(USE_I2C) && !defined(USE_SOFT_I2C) && !defined(USE_I3C_AS_I2C)
 
 #include "build/build_config.h"
 #include "build/debug.h"

--- a/src/platform/common/stm32/bus_spi_pinconfig.c
+++ b/src/platform/common/stm32/bus_spi_pinconfig.c
@@ -580,10 +580,13 @@ const spiHardware_t spiHardware[] = {
         .reg = (spiResource_t *)SPI3,
         .sckPins = {
             { DEFIO_TAG_E(PB3),  GPIO_AF6_SPI3 },
+            { DEFIO_TAG_E(PB7),  GPIO_AF6_SPI3 },
+            { DEFIO_TAG_E(PB9),  GPIO_AF6_SPI3 },
             { DEFIO_TAG_E(PC10), GPIO_AF6_SPI3 },
         },
         .misoPins = {
             { DEFIO_TAG_E(PB4),  GPIO_AF6_SPI3 },
+            { DEFIO_TAG_E(PB6),  GPIO_AF6_SPI3 },
             { DEFIO_TAG_E(PC11), GPIO_AF6_SPI3 },
         },
         .mosiPins = {


### PR DESCRIPTION
Two STM32C5 bring-up fixes, both motivated by ARCROBO_C562V1 first-light.

## 1. C562 startup `.data`/`.bss` ordering

Symmetric companion to the C5A3 fix that landed in #15284. The C562 `Reset_Handler` calls `persistentObjectInit` + `SystemInit` before the `.data` copy and `.bss` zero loops, so any C code those functions touch reads uninitialised RAM. Works by accident when the relevant globals happen to be zero pre-init, but a layout shift turns the uninitialised reads into a HardFault before `main` runs (same hazard already burnt us on H5 and N6).

Move the `.data`/`.bss` loops in front of `persistentObjectInit` and `SystemInit` so globals are live when those run, matching every other STM32 family's startup ordering.

## 2. Program `FLASH_OPTSR.BOOT_SEL = 1` from `systemInit`

`BOOT_SEL` defaults to 0 on the C5 family, which makes the BOOT0 *pin* inert — the boot ROM samples the BOOT0 *bit* in OPTSR instead. After a successful flash that bit reads 0 and the chip boots from user flash; if BF crashes before USB-VCP enumerates, there is no DFU re-entry short of an SWD-driven mass-erase.

Set `BOOT_SEL = 1` from `systemInit` the first time it's observed as 0. C5 has no `OBL_LAUNCH` bit, so the new option byte only loads on the next reset; trigger `NVIC_SystemReset` immediately so BF comes up the second time with the BOOT0 pin honoured. Programming errors fall through to the normal boot path (no boot loop).

Gated on `ENABLE_BOOT0_PIN_SELECT` (default 1 in `common_post.h`). Board configs that hard-wire BOOT0 to VDD or leave it floating should set `ENABLE_BOOT0_PIN_SELECT 0` in `config.h` so the OPTSR BOOT0 bit stays authoritative.

## Status

**Draft** until validated on hardware. Two earlier ARCROBO_C562V1 boards appeared to brick after a single flash; turns out they weren't bricked — SWD mass-erase brought them back, the brick-symptoms came from BOOT_SEL=0 leaving no DFU path after the broken firmware ran. Commit #2 is the fix; commit #1 may also be load-bearing for a clean C562 boot once we have a working board again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SPA06_003 barometer support and optional probe during sensor autodetect
  * Added I3C-as-I2C legacy-mode driver for STM32C5
  * BOOT0 pin-based boot source selection option
  * Increased EEPROM size from 4KB to 8KB

* **Bug Fixes**
  * Improved barometer cycle timing and pacing
  * Fixed internal ADC temperature and reference measurement handling

* **Chores**
  * Expanded SPI pin options and adjusted default PID/barometer task-rate configs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->