### PR TITLE
Apply serialRxBytesWaiting-related optimization to /src/main/telemetry

### DIFF
--- a/src/main/drivers/serial.h
+++ b/src/main/drivers/serial.h
@@ -134,6 +134,7 @@ struct serialPortVTable {
 };
 
 void serialWrite(serialPort_t *instance, uint8_t ch);
+// prefer snapshotting the returned value to calling this function in while loops
 uint32_t serialRxBytesWaiting(const serialPort_t *instance);
 uint32_t serialTxBytesFree(const serialPort_t *instance);
 void serialWriteBuf(serialPort_t *instance, const uint8_t *data, int count);

--- a/src/main/telemetry/hott.c
+++ b/src/main/telemetry/hott.c
@@ -357,7 +357,8 @@ void initHoTTTelemetry(void)
 
 static void flushHottRxBuffer(void)
 {
-    while (serialRxBytesWaiting(hottPort) > 0) {
+    uint32_t rxBytesWaiting = serialRxBytesWaiting(hottPort);
+    while (rxBytesWaiting-- > 0) {
         serialRead(hottPort);
     }
 }

--- a/src/main/telemetry/ibus.c
+++ b/src/main/telemetry/ibus.c
@@ -104,7 +104,8 @@ void handleIbusTelemetry(void)
         return;
     }
 
-    while (serialRxBytesWaiting(ibusSerialPort) > 0) {
+    uint32_t rxBytesWaiting = serialRxBytesWaiting(ibusSerialPort);
+    while (rxBytesWaiting-- > 0) {
         uint8_t c = serialRead(ibusSerialPort);
 
         if (outboundBytesToIgnoreOnRxCount) {

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -520,7 +520,8 @@ static void mavlinkProcessIncoming(void)
     }
     // Bound the drain so a flooded link cannot starve the telemetry task.
     uint16_t rxBudget = 64;
-    while (rxBudget-- && serialRxBytesWaiting(mavlinkPort)) {
+    uint32_t rxBytesWaiting = serialRxBytesWaiting(mavlinkPort);
+    while (rxBudget-- && rxBytesWaiting-- > 0) {
         const uint8_t c = serialRead(mavlinkPort);
         if (mavlink_parse_char(MAVLINK_COMM_1, c, &mavRxMsg, &mavRxStatus) == MAVLINK_FRAMING_OK) {
             mavlinkDispatch(&mavRxMsg);

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -914,12 +914,13 @@ void handleSmartPortTelemetry(void)
     if (telemetryState == TELEMETRY_STATE_INITIALIZED_SERIAL && smartPortSerialPort) {
         smartPortPayload_t *payload = NULL;
         bool clearToSend = false;
-        while (serialRxBytesWaiting(smartPortSerialPort) > 0 && !payload) {
+        uint32_t rxBytesWaiting = serialRxBytesWaiting(smartPortSerialPort);
+        while (rxBytesWaiting-- > 0 && !payload) {
             uint8_t c = serialRead(smartPortSerialPort);
             payload = smartPortDataReceive(c, &clearToSend, serialReadyToSend, true);
         }
 
-            processSmartPortTelemetry(payload, &clearToSend, &requestTimeout);
+        processSmartPortTelemetry(payload, &clearToSend, &requestTimeout);
     }
 }
 #endif


### PR DESCRIPTION
Snapshotting of the value returned from `serialRxBytesWaiting()`  was a good optimization in scope of https://github.com/betaflight/betaflight/pull/15020; I think we could apply the same for other applicable code snippets. In this PR I've applied it to the code of /src/main/telemetry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced efficiency of telemetry data reception across multiple protocols (HoTT, iBus, MAVLink, SmartPort) through internal optimization of processing routines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->