### PR TITLE
Share common/stm32 source list across STM32-style families

### DIFF
--- a/src/platform/APM32/mk/APM32F4.mk
+++ b/src/platform/APM32/mk/APM32F4.mk
@@ -163,18 +163,17 @@ else
 $(error TARGET_MCU [$(TARGET_MCU)] is not supported)
 endif
 
-MCU_COMMON_SRC = \
-        common/stm32/system.c \
-        common/stm32/io_impl.c \
-        common/stm32/config_flash.c \
+# Portable common/stm32 sources shared with the STM32/AT32/X32 families.
+include $(PLATFORM_DIR)/common/stm32/mcu_common_src.mk
+
+MCU_COMMON_SRC += \
         common/stm32/mco.c \
+        common/stm32/bus_spi_hw.c \
+        common/stm32/camera_control.c \
+        common/stm32/rx_pwm_hw.c \
         APM32/startup/system_apm32f4xx.c \
         drivers/inverter.c \
         drivers/dshot_bitbang_decode.c \
-        common/stm32/pwm_output_beeper.c \
-        common/stm32/pwm_output_dshot_shared.c \
-        common/stm32/dshot_dpwm.c \
-        common/stm32/dshot_bitbang_shared.c \
         APM32/bus_spi_apm32.c \
         APM32/bus_i2c_apm32.c \
         APM32/bus_i2c_apm32_init.c \
@@ -189,7 +188,6 @@ MCU_COMMON_SRC = \
         APM32/persistent_apm32.c \
         APM32/pwm_output_apm32.c \
         APM32/pwm_output_dshot_apm32.c \
-        common/stm32/rx_pwm_hw.c \
         APM32/rcm_apm32.c \
         APM32/serial_uart_apm32.c \
         APM32/timer_apm32.c \
@@ -200,20 +198,9 @@ MCU_COMMON_SRC = \
         APM32/serial_uart_apm32f4xx.c \
         drivers/adc.c \
         drivers/bus_spi_config.c \
-        common/stm32/bus_i2c_pinconfig.c \
-        common/stm32/bus_spi_hw.c \
-        common/stm32/camera_control.c \
-        common/stm32/bus_spi_pinconfig.c \
-        common/stm32/serial_uart_hw.c \
-        common/stm32/serial_uart_pinconfig.c \
         drivers/serial_escserial.c \
         drivers/serial_pinconfig.c \
-        APM32/system_apm32f4xx.c \
-        common/stm32/ledstrip_ws2811_stm32.c \
-        common/stm32/debug_pin.c \
-        common/stm32/adc_impl.c \
-        common/stm32/expresslrs_driver_hw.c \
-        common/stm32/fault_handlers.c
+        APM32/system_apm32f4xx.c
 
 VCP_SRC = \
         APM32/usb/vcp/usbd_cdc_descriptor.c \

--- a/src/platform/AT32/mk/AT32F4.mk
+++ b/src/platform/AT32/mk/AT32F4.mk
@@ -83,11 +83,13 @@ endif
 ARCH_FLAGS      = -std=c99 -mthumb -mcpu=cortex-m4 -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16
 DEVICE_FLAGS   += -DUSE_ATBSP_DRIVER -DAT32F43x -DHSE_VALUE=$(HSE_VALUE) -DAT32 -DUSE_OTG_HOST_MODE
 
-MCU_COMMON_SRC = \
-            common/stm32/system.c \
-            common/stm32/io_impl.c \
-            common/stm32/config_flash.c \
+# Portable common/stm32 sources shared with the STM32/APM32/X32 families.
+include $(PLATFORM_DIR)/common/stm32/mcu_common_src.mk
+
+MCU_COMMON_SRC += \
             common/stm32/mco.c \
+            common/stm32/bus_spi_hw.c \
+            common/stm32/camera_control.c \
             AT32/startup/at32f435_437_clock.c \
             AT32/startup/system_at32f435_437.c \
             AT32/adc_at32f43x.c \
@@ -118,33 +120,18 @@ MCU_COMMON_SRC = \
             drivers/accgyro/accgyro_mpu.c \
             drivers/dshot_bitbang_decode.c \
             drivers/inverter.c \
-            common/stm32/pwm_output_beeper.c \
-            common/stm32/pwm_output_dshot_shared.c \
-            common/stm32/dshot_dpwm.c \
-            common/stm32/dshot_bitbang_shared.c \
             $(MIDDLEWARES_DIR)/i2c_application_library/i2c_application.c \
             drivers/bus_i2c_timing.c \
             drivers/usb_msc_common.c \
             drivers/adc.c \
             drivers/bus_spi_config.c \
-            common/stm32/bus_i2c_pinconfig.c \
-            common/stm32/bus_spi_pinconfig.c \
-            common/stm32/bus_spi_hw.c \
-            common/stm32/camera_control.c \
-            common/stm32/serial_uart_hw.c \
-            common/stm32/serial_uart_pinconfig.c \
             drivers/serial_escserial.c \
             drivers/serial_pinconfig.c \
             msc/usbd_storage.c \
             msc/usbd_storage_emfat.c \
             msc/emfat.c \
             msc/emfat_file.c \
-            msc/usbd_storage_sd_spi.c \
-            common/stm32/ledstrip_ws2811_stm32.c \
-            common/stm32/debug_pin.c \
-            common/stm32/adc_impl.c \
-            common/stm32/expresslrs_driver_hw.c \
-            common/stm32/fault_handlers.c
+            msc/usbd_storage_sd_spi.c
 
 SPEED_OPTIMISED_SRC += \
             common/stm32/dshot_bitbang_shared.c \

--- a/src/platform/STM32/mk/STM32_COMMON.mk
+++ b/src/platform/STM32/mk/STM32_COMMON.mk
@@ -1,33 +1,21 @@
 
 INCLUDE_DIRS += $(PLATFORM_DIR)/common/stm32
 
+# Portable common/stm32 sources shared with the APM32/AT32/X32 families.
+include $(PLATFORM_DIR)/common/stm32/mcu_common_src.mk
+
+# ST-only additions on top of the shared set.
 MCU_COMMON_SRC += \
-            common/stm32/system.c \
-            common/stm32/config_flash.c \
-            common/stm32/bus_spi_pinconfig.c \
             common/stm32/can_hw.c \
             common/stm32/can_pinconfig.c \
             common/stm32/mco.c \
-            drivers/bus_spi_config.c \
-            drivers/serial_pinconfig.c \
-            common/stm32/bus_i2c_pinconfig.c \
             common/stm32/bus_spi_hw.c \
             common/stm32/camera_control.c \
-            common/stm32/io_impl.c \
-            common/stm32/serial_uart_hw.c \
-            common/stm32/serial_uart_pinconfig.c \
-            common/stm32/dshot_dpwm.c \
-            STM32/pwm_output_hw.c \
-            STM32/gyro_clkin_stm32.c \
             common/stm32/rx_pwm_hw.c \
-            common/stm32/pwm_output_dshot_shared.c \
-            common/stm32/pwm_output_beeper.c \
-            common/stm32/dshot_bitbang_shared.c \
-            common/stm32/ledstrip_ws2811_stm32.c \
-            common/stm32/debug_pin.c \
-            common/stm32/adc_impl.c \
-            common/stm32/expresslrs_driver_hw.c \
-            common/stm32/fault_handlers.c
+            drivers/bus_spi_config.c \
+            drivers/serial_pinconfig.c \
+            STM32/pwm_output_hw.c \
+            STM32/gyro_clkin_stm32.c
 
 SIZE_OPTIMISED_SRC += \
             drivers/bus_spi_config.c \

--- a/src/platform/X32/mk/X32M7.mk
+++ b/src/platform/X32/mk/X32M7.mk
@@ -129,24 +129,11 @@ VCP_SRC = \
             X32/usbhs/vcp/usbd_cdc_vcp.c \
             drivers/usb_io.c
 
-MCU_COMMON_SRC = \
+# Portable common/stm32 sources shared with the STM32/APM32/AT32 families.
+include $(PLATFORM_DIR)/common/stm32/mcu_common_src.mk
+
+MCU_COMMON_SRC += \
             X32/startup/soc.c \
-            common/stm32/system.c \
-            common/stm32/io_impl.c \
-            common/stm32/adc_impl.c \
-            common/stm32/bus_i2c_pinconfig.c \
-            common/stm32/config_flash.c \
-            common/stm32/debug_pin.c \
-            common/stm32/expresslrs_driver_hw.c \
-            common/stm32/fault_handlers.c \
-            common/stm32/ledstrip_ws2811_stm32.c \
-            common/stm32/pwm_output_beeper.c \
-            common/stm32/pwm_output_dshot_shared.c \
-            common/stm32/dshot_dpwm.c \
-            common/stm32/dshot_bitbang_shared.c \
-            common/stm32/serial_uart_hw.c \
-            common/stm32/serial_uart_pinconfig.c \
-            common/stm32/bus_spi_pinconfig.c \
             drivers/adc.c \
             drivers/bus_i2c_timing.c \
             drivers/bus_spi_config.c \

--- a/src/platform/common/stm32/mcu_common_src.mk
+++ b/src/platform/common/stm32/mcu_common_src.mk
@@ -1,0 +1,35 @@
+#
+# Source files under common/stm32 that are portable across every STM32-style
+# MCU family — the genuine ST parts (STM32*) and the ST-derivative vendors
+# (APM32, AT32, X32). These used to be hand-listed in each family's MCU_COMMON_SRC,
+# which meant a newly added common/stm32 driver had to be remembered in every
+# family or it would silently go missing on some boards. Centralise them here so
+# every family that includes this file picks them up automatically.
+#
+# Files that are NOT universal (e.g. can_hw.c, mco.c, bus_spi_hw.c,
+# camera_control.c, rx_pwm_hw.c) stay in the per-family .mk that actually needs
+# them. SPEED/SIZE optimisation lists also stay per-family because those sets
+# legitimately differ between MCUs.
+
+ifndef MCU_COMMON_STM32_SRC_INCLUDED
+MCU_COMMON_STM32_SRC_INCLUDED := 1
+
+MCU_COMMON_SRC += \
+            common/stm32/system.c \
+            common/stm32/io_impl.c \
+            common/stm32/config_flash.c \
+            common/stm32/adc_impl.c \
+            common/stm32/bus_i2c_pinconfig.c \
+            common/stm32/bus_spi_pinconfig.c \
+            common/stm32/serial_uart_hw.c \
+            common/stm32/serial_uart_pinconfig.c \
+            common/stm32/pwm_output_beeper.c \
+            common/stm32/pwm_output_dshot_shared.c \
+            common/stm32/dshot_dpwm.c \
+            common/stm32/dshot_bitbang_shared.c \
+            common/stm32/ledstrip_ws2811_stm32.c \
+            common/stm32/debug_pin.c \
+            common/stm32/expresslrs_driver_hw.c \
+            common/stm32/fault_handlers.c
+
+endif


### PR DESCRIPTION
The 16 portable `common/stm32` driver sources were hand-listed in `STM32_COMMON.mk` and duplicated again in the APM32, AT32 and X32 family makefiles. A newly added `common/stm32` file had to be remembered in each one, or it silently went missing on some boards.

This moves the shared set into `common/stm32/mcu_common_src.mk` and includes it from every family. Family-specific extras (`can_hw`, `mco`, `bus_spi_hw`, `camera_control`, `rx_pwm_hw`) and the SPEED/SIZE optimisation lists stay per-family, since those sets legitimately differ per MCU.

No build change intended: the resolved `MCU_COMMON_SRC` / `SPEED_OPTIMISED_SRC` / `SIZE_OPTIMISED_SRC` sets are identical before and after for all ten families (STM32 F4/F7/G4/H5/H7/C5/N6, APM32, AT32, X32).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated common source file management across multiple STM32-compatible platforms to reduce build configuration duplication and improve build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->