### PR TITLE
Fix DPS310 coefficient read bound

### DIFF
--- a/src/main/drivers/barometer/barometer_dps310.c
+++ b/src/main/drivers/barometer/barometer_dps310.c
@@ -174,13 +174,13 @@ static bool deviceConfigure(const extDevice_t *dev)
     // 1. Read the pressure calibration coefficients (c00, c10, c20, c30, c01, c11, and c21, c31, c40) from the Calibration Coefficient register.
     //   Note: The coefficients read from the coefficient register are 2's complement numbers.
     // Do the read of the coefficients in multiple parts, as the chip will return a read failure when trying to read all at once over I2C.
-    unsigned coefficientLength = chipId[0] == SPL07_003_CHIP_ID ? 22 : 18;
-    uint8_t coef[coefficientLength];
+    const unsigned coefficientLength = chipId[0] == SPL07_003_CHIP_ID ? 22 : 18;
+    uint8_t coef[22];
 
 #define READ_LENGTH 9
 
-    for (unsigned i = 0; i < sizeof(coef); ) {
-        int chunk = MIN((unsigned)READ_LENGTH, (sizeof(coef) - i));
+    for (unsigned i = 0; i < coefficientLength; ) {
+        int chunk = MIN((unsigned)READ_LENGTH, (coefficientLength - i));
         if (!busReadBuf(dev, DPS310_REG_COEF + i,  coef + i, chunk)) {
             return false;
         }


### PR DESCRIPTION
Fixes #15265

Replaces the DPS310/SPL07 coefficient VLA with a fixed max-size buffer and uses the explicit coefficient length as the read bound.

DPS310 still reads 18 coefficient bytes, while SPL07-003 reads 22 bytes. This removes the fragile dependency on sizeof(VLA) behavior without changing intended runtime behavior.

Tested:
- make CONFIG=SPEEDYBEEF405WING
- make TARGET=SITL
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized barometer calibration coefficient handling to enhance data reliability and consistency during sensor initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->