### PR TITLE
Fix OSD RTC short timezone offset

### DIFF
--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -253,6 +253,12 @@ static uint32_t blinkBits[(OSD_ITEM_COUNT + 31) / 32];
 
 // Current element and render status
 static osdElementParms_t activeElement;
+#ifdef UNIT_TEST
+void osdSetActiveElementTypeForTest(osdElementType_e type)
+{
+    activeElement.type = type;
+}
+#endif
 static bool displayPendingForeground;
 static bool displayPendingBackground;
 static char elementBuff[OSD_ELEMENT_BUFFER_LENGTH];
@@ -482,12 +488,15 @@ bool osdFormatRtcDateTime(char *buffer)
         return false;
     }
 
+    dateTime_t localDateTime;
+    dateTimeUTCToLocal(&dateTime, &localDateTime);
+
     switch (activeElement.type) {
     case OSD_ELEMENT_TYPE_3: 
-        tfp_sprintf(buffer, "%02d:%02d:%02d", dateTime.hours, dateTime.minutes, dateTime.seconds); 
+        tfp_sprintf(buffer, "%02d:%02d:%02d", localDateTime.hours, localDateTime.minutes, localDateTime.seconds);
         break;
     case OSD_ELEMENT_TYPE_2:
-        tfp_sprintf(buffer, "%02d.%02d %02d:%02d", dateTime.month, dateTime.day, dateTime.hours, dateTime.minutes);
+        tfp_sprintf(buffer, "%02d.%02d %02d:%02d", localDateTime.month, localDateTime.day, localDateTime.hours, localDateTime.minutes);
         break;
     case OSD_ELEMENT_TYPE_1:
     default:

--- a/src/main/osd/osd_elements.h
+++ b/src/main/osd/osd_elements.h
@@ -50,6 +50,9 @@ typedef void (*osdElementDrawFn)(osdElementParms_t *element);
 int osdConvertTemperatureToSelectedUnit(int tempInDegreesCelcius);
 void osdFormatDistanceString(char *result, int distance, char leadingSymbol);
 bool osdFormatRtcDateTime(char *buffer);
+#ifdef UNIT_TEST
+void osdSetActiveElementTypeForTest(osdElementType_e type);
+#endif
 void osdFormatTime(char * buff, osd_timer_precision_e precision, timeUs_t time);
 void osdFormatTimer(char *buff, bool showSymbol, bool usePrecision, int timerIndex);
 float osdGetMetersToSelectedUnit(int32_t meters);

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -560,6 +560,8 @@ TEST_F(OsdTest, TestRtcDateTimeVariantsUseTimezoneOffset)
     // then
     // the time-only variant uses local time
     EXPECT_STREQ("00:30:15", buffer);
+
+    osdSetActiveElementTypeForTest(OSD_ELEMENT_TYPE_1);
 }
 
 /*

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -124,8 +124,12 @@ void setDefaultSimulationState()
 {
     memset(osdElementConfigMutable(), 0, sizeof(osdElementConfig_t));
 
+    rtcTime_t rtcTime = simulationTime / 1000;
+    rtcSet(&rtcTime);
+
     osdConfigMutable()->enabled_stats = 0;
     osdConfigMutable()->framerate_hz = 12;
+    timeConfigMutable()->tz_offsetMinutes = 0;
 
     rssi = 1024;
 
@@ -521,6 +525,41 @@ TEST_F(OsdTest, TestStatsTiming)
     displayPortTestBufferSubstring(2, row++, "2017-11-19 10:12:");
     displayPortTestBufferSubstring(2, row++, "TOTAL ARM         : 00:13.60");
     displayPortTestBufferSubstring(2, row++, "LAST ARM          : 00:01");
+}
+
+TEST_F(OsdTest, TestRtcDateTimeVariantsUseTimezoneOffset)
+{
+    // given
+    // this RTC time and timezone offset
+    dateTime_t dateTime;
+    dateTime.year = 2026;
+    dateTime.month = 5;
+    dateTime.day = 30;
+    dateTime.hours = 22;
+    dateTime.minutes = 30;
+    dateTime.seconds = 15;
+    dateTime.millis = 0;
+    rtcSetDateTime(&dateTime);
+    timeConfigMutable()->tz_offsetMinutes = 120;
+
+    // when
+    // the short date/time variant is formatted
+    char buffer[FORMATTED_DATE_TIME_BUFSIZE];
+    osdSetActiveElementTypeForTest(OSD_ELEMENT_TYPE_2);
+    EXPECT_TRUE(osdFormatRtcDateTime(buffer));
+
+    // then
+    // the short date/time variant uses local time
+    EXPECT_STREQ("05.31 00:30", buffer);
+
+    // when
+    // the time-only variant is formatted
+    osdSetActiveElementTypeForTest(OSD_ELEMENT_TYPE_3);
+    EXPECT_TRUE(osdFormatRtcDateTime(buffer));
+
+    // then
+    // the time-only variant uses local time
+    EXPECT_STREQ("00:30:15", buffer);
 }
 
 /*


### PR DESCRIPTION
Fixes #15278

Applies timezone_offset_minutes consistently to OSD RTC Date/Time element variants.

Type 1 already used dateTimeFormatLocalShort(). Types 2 (short date/time) and 3 (time only) formatted the raw RTC value directly, so they displayed UTC when a timezone offset was configured. This converts the RTC value to local time before formatting those variants.

Tested:
- make CC=gcc CXX=g++ test_osd_unittest
- make CONFIG=SPEEDYBEEF405WING
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OSD date/time display now converts UTC timestamps to local time using the configured timezone offset, fixing incorrect time-only and short date+time displays.

* **Tests**
  * Added unit tests to verify timezone-adjusted OSD date/time formatting across display variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->