### PR TITLE
Fix GPS distance calculation and sign of accelEast

### DIFF
--- a/src/main/common/vector.h
+++ b/src/main/common/vector.h
@@ -43,6 +43,20 @@ typedef union vector3_u {
     };
 } vector3_t;
 
+// NED (North-East-Down) framed vector.  The union member u allows the same
+// storage to be addressed either as a plain vector3_t (for passing to math
+// routines) or with named geographic axes (for readability at call sites).
+typedef struct {
+    union {
+        vector3_t v;
+        struct {
+            float N;  // North
+            float E;  // East
+            float D;  // Down
+        } ef;
+    } u;
+} vectorNED_t;
+
 typedef struct matrix33_s {
     float m[3][3];
 } matrix33_t;

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -467,8 +467,8 @@ bool positionControl(void)
         const float angle = DECIDEGREES_TO_RADIANS(attitude.values.yaw - 900);
         vector2_t pidBodyFrame;
         vector2Rotate(&pidBodyFrame, &pidSumEF, angle);
-        anglesBF.v[AI_ROLL]  = -pidBodyFrame.y;
-        anglesBF.v[AI_PITCH] = -pidBodyFrame.x;
+        anglesBF.v[AI_ROLL]  = -pidBodyFrame.y; // negate: body Y is leftward, positive roll is rightward
+        anglesBF.v[AI_PITCH] = -pidBodyFrame.x; // negate: body X is forward, positive pitch is nose-up (rearward)
 
         const float mag = vector2Norm(&anglesBF);
         if (mag > ap.maxAngle && mag > 0.0f) {

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -291,8 +291,8 @@ static void getLinearAccelENU(float *accelEast, float *accelNorth, float *accelU
     matrixVectorMul(&accEF_NEU, &rMat, &accBF);
 
     // NED -> ENU, subtract gravity (NED gravity = [0,0,+1g]), convert G -> cm/s^2
-    *accelEast  =  accEF_NEU.y * GRAVITY_CMSS;
-    *accelNorth =  accEF_NEU.x * GRAVITY_CMSS;
+    *accelEast  = -accEF_NEU.y * GRAVITY_CMSS; // rMat Y is West (NWD earth frame); East = -Y
+    *accelNorth =  accEF_NEU.x * GRAVITY_CMSS; // rMat X is North
     *accelUp    = (accEF_NEU.z - 1.0f) * GRAVITY_CMSS;
 }
 
@@ -366,8 +366,8 @@ static void feedGPSMeasurements(timeUs_t nowUs)
     // XY position + velocity measurements
     if (xyEnabled && gpsXYAllowed && gpsArmLocationSet) {
         vector2_t gpsDistCm;
-        GPS_distance2d(&gpsSol.llh, &armLocationGps, &gpsDistCm);
-        // gpsDistCm: X = East-West (lon), Y = North-South (lat) relative to arm position
+        GPS_distance2d(&armLocationGps, &gpsSol.llh, &gpsDistCm);
+        // gpsDistCm: X = East-West (lon), Y = North-South (lat) of craft relative to arm position
 
         const uint16_t xyDop = gpsDopOrFallback(gpsSol.dop.hdop, gpsSol.dop.pdop);
         const float rPos = gpsR(R_GPS_POS_BASE, xyDop);

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -286,14 +286,14 @@ static void getLinearAccelENU(float *accelEast, float *accelNorth, float *accelU
                          acc.accADC.y * accScale,
                          acc.accADC.z * accScale }};
 
-    // rMat rotates body -> earth NWD (North-West-Down)
-    vector3_t accEF_NWD;
-    matrixVectorMul(&accEF_NWD, &rMat, &accBF);
+    // rMat^T rotates body -> earth NED (North-East-Down)
+    vectorNED_t accEF_NED;
+    matrixTrnVectorMul(&accEF_NED.u.v, &rMat, &accBF);
 
-    // NWD -> ENU: X=North stays, Y=West negates to East, Z=Down inverts and loses 1g
-    *accelEast  = -accEF_NWD.y * GRAVITY_CMSS; // West = -East
-    *accelNorth =  accEF_NWD.x * GRAVITY_CMSS; // North unchanged
-    *accelUp    = (accEF_NWD.z - 1.0f) * GRAVITY_CMSS;
+    // NED -> ENU named outputs
+    *accelEast  =  accEF_NED.u.ef.E * GRAVITY_CMSS;
+    *accelNorth =  accEF_NED.u.ef.N * GRAVITY_CMSS;
+    *accelUp    = (accEF_NED.u.ef.D - 1.0f) * GRAVITY_CMSS;
 }
 
 #ifdef USE_GPS

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -528,23 +528,22 @@ static void feedOpticalFlowMeasurements(timeUs_t nowUs)
     }
 
     // Convert flow rates (rad/s) to velocity (cm/s) in body frame, scaled by rangefinder height.
-    // Flow sensor X axis measures leftward motion (positive = left); Y axis measures forward motion.
-    const float flowLeft    = flow->processedFlowRates.x * altitudeCm;
+    // Flow sensor X axis measures rightward motion; Y axis measures forward motion.
+    const float flowRight   = flow->processedFlowRates.x * altitudeCm;
     const float flowForward = flow->processedFlowRates.y * altitudeCm;
 
     // Project to the horizontal plane by removing the tilt-induced component.
     const float cosPitch = cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch));
     const float cosRoll  = cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll));
-    const float velLeft    = flowLeft    * cosRoll;
+    const float velRight   = flowRight   * cosRoll;
     const float velForward = flowForward * cosPitch;
 
     // Rotate from body heading frame to ENU earth frame.
-    // Left is the negative of East when heading North, so velLeft terms are negated.
     const float yawRad = DECIDEGREES_TO_RADIANS(attitude.values.yaw);
     const float cosYaw = cos_approx(yawRad);
     const float sinYaw = sin_approx(yawRad);
-    const float velEast  =  velForward * sinYaw - velLeft * cosYaw;
-    const float velNorth =  velForward * cosYaw + velLeft * sinYaw;
+    const float velEast  =  velForward * sinYaw - velRight * cosYaw;
+    const float velNorth =  velForward * cosYaw + velRight * sinYaw;
 
     kalmanUpdateVelocity(&kfX, velEast, flowR);
     kalmanUpdateVelocity(&kfY, velNorth, flowR);

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -286,14 +286,14 @@ static void getLinearAccelENU(float *accelEast, float *accelNorth, float *accelU
                          acc.accADC.y * accScale,
                          acc.accADC.z * accScale }};
 
-    // rMat rotates body -> earth NED
-    vector3_t accEF_NEU;
-    matrixVectorMul(&accEF_NEU, &rMat, &accBF);
+    // rMat rotates body -> earth NWD (North-West-Down)
+    vector3_t accEF_NWD;
+    matrixVectorMul(&accEF_NWD, &rMat, &accBF);
 
-    // NED -> ENU, subtract gravity (NED gravity = [0,0,+1g]), convert G -> cm/s^2
-    *accelEast  = -accEF_NEU.y * GRAVITY_CMSS; // rMat Y is West (NWD earth frame); East = -Y
-    *accelNorth =  accEF_NEU.x * GRAVITY_CMSS; // rMat X is North
-    *accelUp    = (accEF_NEU.z - 1.0f) * GRAVITY_CMSS;
+    // NWD -> ENU: X=North stays, Y=West negates to East, Z=Down inverts and loses 1g
+    *accelEast  = -accEF_NWD.y * GRAVITY_CMSS; // West = -East
+    *accelNorth =  accEF_NWD.x * GRAVITY_CMSS; // North unchanged
+    *accelUp    = (accEF_NWD.z - 1.0f) * GRAVITY_CMSS;
 }
 
 #ifdef USE_GPS

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -527,28 +527,24 @@ static void feedOpticalFlowMeasurements(timeUs_t nowUs)
         return;  // quality too low
     }
 
-    // Convert flow rates (rad/s) to velocity (cm/s) in body frame, scaled by rangefinder height
-    const float vBFx = flow->processedFlowRates.x * altitudeCm;
-    const float vBFy = flow->processedFlowRates.y * altitudeCm;
+    // Convert flow rates (rad/s) to velocity (cm/s) in body frame, scaled by rangefinder height.
+    // Flow sensor X axis measures leftward motion (positive = left); Y axis measures forward motion.
+    const float flowLeft    = flow->processedFlowRates.x * altitudeCm;
+    const float flowForward = flow->processedFlowRates.y * altitudeCm;
 
-    // Project body-frame velocity to earth frame using heading
-    // Flow X (roll axis) corresponds to lateral movement, flow Y (pitch axis) to longitudinal
+    // Project to the horizontal plane by removing the tilt-induced component.
+    const float cosPitch = cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch));
+    const float cosRoll  = cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll));
+    const float velLeft    = flowLeft    * cosRoll;
+    const float velForward = flowForward * cosPitch;
+
+    // Rotate from body heading frame to ENU earth frame.
+    // Left is the negative of East when heading North, so velLeft terms are negated.
     const float yawRad = DECIDEGREES_TO_RADIANS(attitude.values.yaw);
     const float cosYaw = cos_approx(yawRad);
     const float sinYaw = sin_approx(yawRad);
-
-    // Also project through pitch/roll to horizontal plane
-    const float cosPitch = cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.pitch));
-    const float cosRoll  = cos_approx(DECIDEGREES_TO_RADIANS(attitude.values.roll));
-    const float vBodyX = vBFx * cosRoll;   // lateral velocity, tilt-corrected
-    const float vBodyY = vBFy * cosPitch;  // longitudinal velocity, tilt-corrected
-
-    // Rotate body-heading-frame velocity to ENU
-    // Body X (roll) = rightward, Body Y (pitch) = forward
-    // ENU East  =  bodyY * sinYaw + bodyX * cosYaw
-    // ENU North =  bodyY * cosYaw - bodyX * sinYaw
-    const float velEast  =  vBodyY * sinYaw + vBodyX * cosYaw;
-    const float velNorth =  vBodyY * cosYaw - vBodyX * sinYaw;
+    const float velEast  =  velForward * sinYaw - velLeft * cosYaw;
+    const float velNorth =  velForward * cosYaw + velLeft * sinYaw;
 
     kalmanUpdateVelocity(&kfX, velEast, flowR);
     kalmanUpdateVelocity(&kfY, velNorth, flowR);

--- a/src/main/sensors/opticalflow.c
+++ b/src/main/sensors/opticalflow.c
@@ -185,17 +185,17 @@ void opticalflowProcess(void) {
         // There is a delay between a detected gyro motion and this
         // being seen in the optical flow output
         static uint8_t gyroSampleIndex = 0;
-        static float xRotation[MAX_GYRO_SAMPLE_DELAY];
-        static float yRotation[MAX_GYRO_SAMPLE_DELAY];
+        static float rollRate[MAX_GYRO_SAMPLE_DELAY];
+        static float pitchRate[MAX_GYRO_SAMPLE_DELAY];
 
         const uint8_t sampleDelay = (uint8_t)constrain((int)opticalflow.dev.gyroSampleDelay, 1, MAX_GYRO_SAMPLE_DELAY);
         gyroSampleIndex = (gyroSampleIndex + 1) % sampleDelay;
-        xRotation[gyroSampleIndex] = (float)gyroGetFilteredDownsampled(X);
-        yRotation[gyroSampleIndex] = -(float)gyroGetFilteredDownsampled(Y);
+        rollRate[gyroSampleIndex] = (float)gyroGetFilteredDownsampled(X);
+        pitchRate[gyroSampleIndex] = -(float)gyroGetFilteredDownsampled(Y);
         delayedGyroSampleIndex = (gyroSampleIndex + 1) % sampleDelay;
         vector2_t delayedGyroRaw = {{
-            xRotation[delayedGyroSampleIndex],
-            yRotation[delayedGyroSampleIndex]
+            rollRate[delayedGyroSampleIndex],
+            pitchRate[delayedGyroSampleIndex]
         }};
         vector2_t delayedGyroRotated;
         applySensorRotation(&delayedGyroRotated, &delayedGyroRaw);

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -155,29 +155,34 @@ TEST_F(PositionEstimatorTest, GPSPositionEastOfArmIsPositive)
 }
 
 // Regression test: forward thrust when heading East must produce a positive East velocity
-// estimate.  rMat Y points West in Betaflight's earth frame, so accelEast must be
-// -accEF_NEU.y (not +accEF_NEU.y).  The bug used the wrong sign, causing the IMU
-// prediction to oppose GPS-measured East motion.
+// estimate even when the craft is rolled.  A level-only rMat does not distinguish
+// matrixVectorMul from matrixTrnVectorMul because the off-diagonal z terms vanish.
+// With roll the gravity components in body Y and Z create cross-coupling that
+// matrixVectorMul handles incorrectly (yielding zero East acceleration here) while
+// matrixTrnVectorMul correctly cancels them and recovers the full forward thrust.
 TEST_F(PositionEstimatorTest, EastThrustProducesPositiveEastVelocity)
 {
     // Run a couple of steps so XY fusion is established with the arm at origin.
     stepEstimator(2);
 
-    // Set rMat for heading East (attitude yaw = 90 deg).
-    // Row pattern: row0 = (cosYaw, sinYaw, 0) = (0, 1, 0)
-    //              row1 = (-sinYaw, cosYaw, 0) = (-1, 0, 0)
+    // rMat = Cbn for heading East (yaw 90 deg) + 30 deg right roll.
+    // Cbn = Cbn_roll(30) * Cbn_yaw(90):
+    //   row0 = (0,       1,        0      )
+    //   row1 = (-cos30,  0,        sin30  )
+    //   row2 = ( sin30,  0,        cos30  )
     memset(&rMat, 0, sizeof(rMat));
-    rMat.m[0][1] = 1.0f;
-    rMat.m[1][0] = -1.0f;
-    rMat.m[2][2] = 1.0f;
+    rMat.m[0][1] =  1.0f;
+    rMat.m[1][0] = -0.866f;  rMat.m[1][2] = 0.5f;
+    rMat.m[2][0] =  0.5f;    rMat.m[2][2] = 0.866f;
 
-    // Apply forward (East) thrust of 0.5 g alongside the steady-state gravity component.
+    // Forward (East) thrust of 0.5 g; gravity projects onto body Y and Z due to the roll.
     acc.accADC.x = 0.5f;
-    acc.accADC.z = 1.0f;
+    acc.accADC.y = 0.5f;    // sin(30) * 1g
+    acc.accADC.z = 0.866f;  // cos(30) * 1g
 
-    // GPS position and velocity remain zero (craft stationary in GPS frame) so any
-    // non-zero velocity estimate is purely driven by the IMU acceleration prediction.
-    // After many steps the sign of the steady-state velocity reflects the sign of accelEast.
+    // GPS position and velocity remain zero so any non-zero velocity estimate is
+    // driven purely by the IMU prediction.  The gravity cross-terms cancel exactly
+    // and only the 0.5 g forward thrust contributes to East, giving velocity.x > 0.
     stepEstimator(100);
 
     EXPECT_GT(positionEstimatorGetEstimate()->velocity.x, 0.0f);

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -63,10 +63,9 @@ bool gpsHasNewData(uint16_t *gpsStamp)
 
 void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *dest)
 {
-    UNUSED(from);
-    UNUSED(to);
-    dest->x = 0.0f;
-    dest->y = 0.0f;
+    // Simplified (no Earth-scale projection): return integer-unit deltas so sign tests work.
+    dest->x = (float)(to->lon - from->lon);
+    dest->y = (float)(to->lat - from->lat);
 }
 }
 
@@ -136,5 +135,51 @@ TEST_F(PositionEstimatorTest, RangefinderPreferFallsBackAndRecovers)
     // In RANGEFINDER_PREFER, recovered altitude should be pulled down toward RF value.
     EXPECT_LT(recoveredAltitude, fallbackAltitude - 5.0f);
     EXPECT_TRUE(positionEstimatorIsValidZ());
+}
+
+// Regression test: GPS_distance2d must be called as (arm, current) so that a craft
+// East of the arm position produces a positive kfX (East) position estimate.
+// The bug had the arguments reversed — (current, arm) — giving a negative East estimate.
+TEST_F(PositionEstimatorTest, GPSPositionEastOfArmIsPositive)
+{
+    // Run a couple of steps so the arm location is captured from the initial gpsSol (lon=0).
+    stepEstimator(2);
+
+    // Place the craft East of the arm (positive longitude delta).
+    gpsSol.llh.lon = 100000;
+
+    // Let the Kalman filter converge toward the GPS position measurement.
+    stepEstimator(30);
+
+    EXPECT_GT(positionEstimatorGetEstimate()->position.x, 0.0f);
+}
+
+// Regression test: forward thrust when heading East must produce a positive East velocity
+// estimate.  rMat Y points West in Betaflight's earth frame, so accelEast must be
+// -accEF_NEU.y (not +accEF_NEU.y).  The bug used the wrong sign, causing the IMU
+// prediction to oppose GPS-measured East motion.
+TEST_F(PositionEstimatorTest, EastThrustProducesPositiveEastVelocity)
+{
+    // Run a couple of steps so XY fusion is established with the arm at origin.
+    stepEstimator(2);
+
+    // Set rMat for heading East (attitude yaw = 90 deg).
+    // Row pattern: row0 = (cosYaw, sinYaw, 0) = (0, 1, 0)
+    //              row1 = (-sinYaw, cosYaw, 0) = (-1, 0, 0)
+    memset(&rMat, 0, sizeof(rMat));
+    rMat.m[0][1] = 1.0f;
+    rMat.m[1][0] = -1.0f;
+    rMat.m[2][2] = 1.0f;
+
+    // Apply forward (East) thrust of 0.5 g alongside the steady-state gravity component.
+    acc.accADC.x = 0.5f;
+    acc.accADC.z = 1.0f;
+
+    // GPS position and velocity remain zero (craft stationary in GPS frame) so any
+    // non-zero velocity estimate is purely driven by the IMU acceleration prediction.
+    // After many steps the sign of the steady-state velocity reflects the sign of accelEast.
+    stepEstimator(100);
+
+    EXPECT_GT(positionEstimatorGetEstimate()->velocity.x, 0.0f);
 }
 


### PR DESCRIPTION
Prompted by @ctzsnooze (and all credit to him) who is debugging the GPS position hold code following the addition of optical flow sensor support, I asked Fable 5:

_Please validate the relationship between East and earthframe y and North and earthframe x. There's a suspicion that something is wrong here leading to issues with GPS._

It found a sign reversal in the calculation of `accelEast` confirming @ctzsnooze findings.

In addition the argument order to `GPS_distance2d()` was incorrect breaking the convention of positive East and positive North.

This PR fixes both issues and adds some comments clarifying sign on some calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected acceleration coordinate-frame conversion for consistent attitude and position estimates.
  * Fixed GPS distance sign/origin handling so East/North positions are accurate.
  * Improved optical-flow heading/tilt handling for more accurate horizontal velocity estimation.
  * Clarified autopilot roll/pitch sign convention to avoid misinterpreting body-frame commands.

* **Tests**
  * Added regression tests and updated GPS test stub to validate East/North behavior and estimator responses.

* **Chores**
  * Added explicit NED-vector support for clearer internal consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->