### PR TITLE
STM32C5: enable SPI DMA on the STM32C562 target

### DIFF
--- a/src/platform/STM32/target/STM32C562/target.h
+++ b/src/platform/STM32/target/STM32C562/target.h
@@ -56,6 +56,10 @@
 #define USE_SPI
 #define SPI_FULL_RECONFIGURABILITY
 
+// Run SPI transfers over LPDMA. Allocated late (after motor timers) so DShot
+// bitbang claims its LPDMA channels first; SPI takes what remains.
+#define USE_SPI_DMA_ENABLE_LATE
+
 #define USE_ADC
 #define USE_EXTI
 


### PR DESCRIPTION
Enables LPDMA for SPI on the STM32C562 target via `USE_SPI_DMA_ENABLE_LATE`, so SPI transfers of 8 bytes or more run over DMA instead of CPU-polled blocking transfers.

The C5 LPDMA SPI path was already implemented but no C5 target had opted in. Allocated late (after motor timers) so DShot bitbang claims its LPDMA channels first; SPI takes the remainder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized DMA allocation sequencing for the STM32C562 target platform, improving resource management efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->