### PR TITLE
[2025.12] fix(uart): clear ORE when RXNEIE is enabled in HAL uartIrqHandler (fixes #15317, #15306)

### DIFF
--- a/src/platform/STM32/serial_uart_hal.c
+++ b/src/platform/STM32/serial_uart_hal.c
@@ -429,7 +429,12 @@ FAST_IRQ_HANDLER void uartIrqHandler(uartPort_t *s)
     }
 
     /* UART Over-Run interrupt occurred -----------------------------------------*/
-    if ((cr3 & USART_CR3_EIE) && (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET)) {
+    // ORE asserts the USART IRQ when CR1.RXNEIE is set even with CR3.EIE clear
+    // (RM0433/RM0410; ST HAL gates ORE on RXNEIE || EIE). Betaflight's RXNE path
+    // clears CR3.EIE on every received byte, so gating the clear on EIE alone
+    // leaves ORE permanently set -> unbounded IRQ re-entry (FC freeze on save).
+    if (((cr1 & USART_CR1_RXNEIE) || (cr3 & USART_CR3_EIE)) &&
+        (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET)) {
         __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
     }
 


### PR DESCRIPTION
## Summary

Fixes the FC lock-up on configuration save reported in #15317 and #15306 (2025.12.1/2025.12.2 fine, 2025.12.3/2025.12.4 freeze).

## Root cause

The #15258 backport rewrote `uartIrqHandler()` in `src/platform/STM32/serial_uart_hal.c` to gate every `__HAL_UART_GET_IT` branch on the corresponding interrupt-enable bit cached at IRQ entry. The ORE (overrun) clear branch was gated on `CR3.EIE` only:

```c
if ((cr3 & USART_CR3_EIE) && (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET)) {
    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
}
```

However, Betaflight's RXNE branch executes `CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE)` on every received byte, so on any active IRQ-driven RX port `CR3.EIE` is always 0 — the ORE clear can never execute.

Per RM0433/RM0410 (and ST's own HAL `UART_IRQHandler`, e.g. `stm32h7xx_hal_uart.c` ORE handling), **ORE asserts the USART interrupt when `CR1.RXNEIE` is set even with `CR3.EIE` clear**. Neither reading RDR nor `RQR.RXFRQ` clears ORE — only `ICR.ORECF` does.

Failure sequence (deterministic during EEPROM save):
1. `writeEEPROM()` flash erase/program blocks the CPU; CRSF/GPS/OSD UART bytes keep arriving → hardware sets ORE.
2. On the next IRQ entry RXNE is already drained, so the RXNE branch is skipped; the ORE branch is skipped because `cr3.EIE == 0`.
3. ISR exits with ORE still set and RXNEIE enabled → IRQ re-enters immediately → **unbounded IRQ re-entry**, thread mode starved forever: LED stops, MSP dead, config never written, power cycle required.

This is why the lock-up correlates with clicking Save: the flash write window guarantees an RX overrun on any board with live UART RX traffic (receiver/GPS/HD goggles connected).

## Fix

Gate the ORE clear on `RXNEIE || EIE`, matching the hardware interrupt-assert condition (same semantics ST HAL uses). The PE/FE/NE/TC/TXE/IDLE gates were audited and match their hardware enable sources; UART FIFO mode (RXFTIE) is not used in this codebase.

**master is unaffected**: `serial_uart_ll.c` clears ORE unconditionally, so this is a 2025.12-maintenance-only regression — hence this PR targets the maintenance branch directly.

## Scope

All platforms compiling `serial_uart_hal.c`: STM32F7, STM32G4, STM32H7, STM32H5 (F4 uses `serial_uart_stdperiph.c`, unaffected).

## Testing

- Bench-reproduced and verified on KineticoH7 (STM32H743): on 2025.12.4-equivalent firmware, saving with active CRSF (420k)/GPS/MSP-DisplayPort traffic froze the FC (LED dead, no reboot, config sector untouched); with this patch repeated saves complete normally.
- Build verified: STM32H743, STM32F7X2.
- `USART_CR1_RXNEIE` is defined on all four CMSIS families (alias of `RXNEIE_RXFNEIE` on H7/G4/H5).