### PR TITLE
fix(dshot): remove stale requestTelemetry bridge in AT32/APM32 bitbang bbWriteInt

### DIFF
--- a/src/platform/APM32/dshot_bitbang.c
+++ b/src/platform/APM32/dshot_bitbang.c
@@ -562,11 +562,6 @@ static void bbWriteInt(uint8_t motorIndex, uint16_t value)
         return;
     }
 
-    // fetch requestTelemetry from motors. Needs to be refactored.
-    motorDmaOutput_t * const motor = getMotorDmaOutput(motorIndex);
-    bbmotor->protocolControl.requestTelemetry = motor->protocolControl.requestTelemetry;
-    motor->protocolControl.requestTelemetry = false;
-
     // If there is a command ready to go overwrite the value and send that instead
     if (dshotCommandIsProcessing()) {
         value = dshotCommandGetCurrent(motorIndex);

--- a/src/platform/AT32/dshot_bitbang.c
+++ b/src/platform/AT32/dshot_bitbang.c
@@ -541,11 +541,6 @@ static void bbWriteInt(uint8_t motorIndex, uint16_t value)
         return;
     }
 
-    // fetch requestTelemetry from motors. Needs to be refactored.
-    motorDmaOutput_t * const motor = getMotorDmaOutput(motorIndex);
-    bbmotor->protocolControl.requestTelemetry = motor->protocolControl.requestTelemetry;
-    motor->protocolControl.requestTelemetry = false;
-
     // If there is a command ready to go overwrite the value and send that instead
     if (dshotCommandIsProcessing()) {
         value = dshotCommandGetCurrent(motorIndex);


### PR DESCRIPTION
## Summary

On AT32 and APM32 with bitbang DShot, configurator-initiated DShot setting commands (1-47) — most visibly **motor SPIN_DIRECTION** — are silently ignored by ESCs. This PR removes the stale `dmaMotors`→`bbMotors` `requestTelemetry` bridge in `bbWriteInt()`, aligning both platforms with the STM32 implementation where this bridge was already removed.

## Root cause

The blocking command path (`MSP2_SEND_DSHOT_COMMAND` → `dshotCommandWrite()`) drives the motor vtable directly:

```c
vTable->requestTelemetry(i);
vTable->writeInt(i, command);
```

`bbDshotRequestTelemetry()` (`src/platform/common/stm32/dshot_bitbang_shared.c`) sets `bbMotors[i].protocolControl.requestTelemetry = true`.

But AT32/APM32 `bbWriteInt()` then executes the stale bridge (the comment itself says *"Needs to be refactored"*):

```c
// fetch requestTelemetry from motors. Needs to be refactored.
motorDmaOutput_t * const motor = getMotorDmaOutput(motorIndex);
bbmotor->protocolControl.requestTelemetry = motor->protocolControl.requestTelemetry;
motor->protocolControl.requestTelemetry = false;
```

In bitbang mode the active control object is `bbMotors[]`, not `dmaMotors[]` — nothing ever writes `getMotorDmaOutput(i)->protocolControl.requestTelemetry` — so the bridge always reads **false** and clears the flag that was just set.

The `dshotCommandIsProcessing()` fallback below does not rescue the blocking path: blocking commands only place a *fake entry* in the command queue without advancing its state machine (see `dshot_command.c`: *"Blocking commands are launched from cli, and no inline commands are running"*), so `dshotCommandIsProcessing()` returns false during the writes.

`prepareDshotPacket()` encodes `(value << 1) | telemetryBit`; DShot commands 1-47 require the telemetry bit set. With it cleared, the ESC interprets the command value as below-minimum throttle and ignores it — all repeats fail, SPIN_DIRECTION never applies.

## Why removal is safe

- **STM32 parity**: `STM32/dshot_bitbang.c` `bbWriteInt()` has no such bridge — this PR makes AT32/APM32 structurally identical.
- **Normal throttle output**: unaffected (`bbmotor->protocolControl.value` handling unchanged).
- **ESC telemetry** (`motorRequestTelemetry()`): unaffected — uses the vtable `bbDshotRequestTelemetry` which writes `bbMotors[]` directly (and now no longer gets overwritten).
- **Inline command path**: unaffected — the `dshotCommandIsProcessing()` fallback remains intact.
- **PWM-DShot (non-bitbang)**: unaffected — `pwm_output_dshot_shared.c` keeps using `dmaMotors[]` as before.

## Affected hardware

AT32F435/437 and APM32F405/F407 boards using bitbang DShot (the default for DSHOT on these platforms with `dshot_bitbang = AUTO`).

## Testing

- Bench-verified on AT32F435 (bitbang DSHOT600): motor direction changes from configurator had no effect before; with this patch they apply correctly. Normal flight outputs and bidirectional DShot telemetry unaffected.
- Build verified: `AT32F435G`, `APM32F405`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified telemetry request handling in platform-specific motor driver implementations. Consolidated synchronization logic to eliminate redundant operations and reduce code duplication across ARM-based processor variants while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->