### PR TITLE
STM32C5: fix I3C legacy-I2C register reads for the SPA06 baro

### DIFF
--- a/src/platform/STM32/bus_i2c_i3c.c
+++ b/src/platform/STM32/bus_i2c_i3c.c
@@ -114,8 +114,13 @@ void i2cInit(i2cDevice_e device)
     // family; the chip ACKs across the full byte sweep so this is in spec.
     LL_I3C_SetBusCharacteristic(I3C1, 0x1D008EU);
 
+    // RX threshold must be 1_8 (byte granularity). The 1_2 setting is one WORD
+    // in a 2-word FIFO, so RXFNEF only asserts once a full 4-byte word is
+    // present -- a trailing partial word (1-3 bytes) of a read never raises the
+    // flag and those bytes can't be drained. Byte granularity makes every
+    // received byte readable.
     LL_I3C_ConfigCtrlFifo(I3C1,
-                          LL_I3C_RXFIFO_THRESHOLD_1_2,
+                          LL_I3C_RXFIFO_THRESHOLD_1_8,
                           LL_I3C_TXFIFO_THRESHOLD_1_2,
                           LL_I3C_CTRL_FIFO_CONTROL_ONLY);
 
@@ -230,11 +235,15 @@ bool i2cReadBuffer(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, u
     }
     LL_I3C_TransmitData8(I3C1, reg);
 
+    // FC marks the closing STOP; this RESTART message issues no STOP (FC fires
+    // after the Phase B read), and FC is unreliable in legacy-I2C controller
+    // mode regardless -- so a guard timeout here is the expected case. Only a
+    // hard ERR is a real failure.
     guard = I3C_AS_I2C_GUARD_LOOPS;
     while (!LL_I3C_IsActiveFlag_FC(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard) { i3cWaitOrError(&guard); }
-    if (!guard || LL_I3C_IsActiveFlag_ERR(I3C1)) {
+    if (LL_I3C_IsActiveFlag_ERR(I3C1)) {
         i2cI3cLastEvr = I3C1->EVR; i2cI3cLastSer = I3C1->SER;
-        i2cI3cLastFail = 0xA2E0 | (guard ? 0 : 1);
+        i2cI3cLastFail = 0xA2E0;
         i2cErrorCount++; i3cClearAllEventFlags(); return false;
     }
     i3cClearAllEventFlags();
@@ -256,11 +265,14 @@ bool i2cReadBuffer(i2cDevice_e device, uint8_t addr, uint8_t reg, uint8_t len, u
         buf[i] = LL_I3C_ReceiveData8(I3C1);
     }
 
+    // All payload bytes are already latched above. The trailing FC/STOP is bus
+    // housekeeping that does not reliably assert in legacy-I2C mode, so a
+    // timeout is benign here -- only a hard ERR is a real failure.
     guard = I3C_AS_I2C_GUARD_LOOPS;
     while (!LL_I3C_IsActiveFlag_FC(I3C1) && !LL_I3C_IsActiveFlag_ERR(I3C1) && guard) { i3cWaitOrError(&guard); }
-    if (!guard || LL_I3C_IsActiveFlag_ERR(I3C1)) {
+    if (LL_I3C_IsActiveFlag_ERR(I3C1)) {
         i2cI3cLastEvr = I3C1->EVR; i2cI3cLastSer = I3C1->SER;
-        i2cI3cLastFail = 0xA4E0 | (guard ? 0 : 1);
+        i2cI3cLastFail = 0xA4E0;
         i2cErrorCount++; i3cClearAllEventFlags(); return false;
     }
     i2cI3cLastFail = 0x0000;


### PR DESCRIPTION
On STM32C5 the I3C-as-I2C read path could not complete a multi-byte register read (e.g. the SPA06 barometer's calibration coefficients), so the baro failed to detect.

Two causes:
- The RX FIFO threshold was one word (`RXFIFO_THRESHOLD_1_2`): `RXFNEF` only asserts once a full 4-byte word is buffered, so a read's trailing partial word (1-3 bytes) never raised the flag and couldn't be drained — reads came back short. Switch to byte granularity (`RXFIFO_THRESHOLD_1_8`).
- The register-pointer phase ends with a RESTART, which never raises Frame-Complete (FC fires only at the closing STOP). The read's FC waits now fail only on a hard ERR, not on the expected timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved I2C/I3C bus communication reliability by adjusting RX FIFO buffer threshold configuration for byte-level data processing.
  * Enhanced communication robustness by refining timeout handling during data transfer phases, ensuring expected communication states are treated appropriately and only critical hardware errors are flagged as failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->