### PR TITLE
[4.5] fix(msp): cancel pendingRequest on '$' only, restoring per-byte lastActivityMs

### DIFF
--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -526,17 +526,15 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
             continue;
         }
 
-        // Abort pending request once per activity burst, not per byte.
-        // Prevents multi-byte sequences (e.g. '#\r') from cancelling CLI entry.
-        if (mspPort->portState == PORT_IDLE && serialRxBytesWaiting(mspPort->port)) {
-            mspPort->lastActivityMs = millis();
-            mspPort->pendingRequest = MSP_PENDING_NONE;
-        }
-
         // whilst port is idle, poll incoming until portState changes or no more bytes
         while (mspPort->portState == PORT_IDLE && serialRxBytesWaiting(mspPort->port)) {
+            mspPort->lastActivityMs = millis();
             const uint8_t c = serialRead(mspPort->port);
             if (c == '$') {
+                // MSP frame incoming — cancel any pending non-MSP request.
+                // Resetting here (not per-byte) allows '#\r' sequences to set
+                // MSP_PENDING_CLI without the trailing '\r' wiping it.
+                mspPort->pendingRequest = MSP_PENDING_NONE;
                 mspPort->portState = PORT_MSP_PACKET;
                 mspPort->packetState = MSP_HEADER_START;
             } else if (evaluateNonMspData == MSP_EVALUATE_NON_MSP_DATA) {

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -531,10 +531,14 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
             mspPort->lastActivityMs = millis();
             const uint8_t c = serialRead(mspPort->port);
             if (c == '$') {
+                // MSP frame incoming — cancel any pending non-MSP request.
+                // Resetting only on '$' (not every byte) allows '#\r' sequences to set
+                // MSP_PENDING_CLI without the trailing '\r' wiping it.
                 mspPort->pendingRequest = MSP_PENDING_NONE;
                 mspPort->portState = PORT_MSP_PACKET;
                 mspPort->packetState = MSP_HEADER_START;
             } else if (evaluateNonMspData == MSP_EVALUATE_NON_MSP_DATA) {
+                // evaluate the non-MSP data
                 if (c == serialConfig()->reboot_character) {
                     mspPort->pendingRequest = MSP_PENDING_BOOTLOADER_ROM;
 #ifdef USE_CLI

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -531,14 +531,10 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
             mspPort->lastActivityMs = millis();
             const uint8_t c = serialRead(mspPort->port);
             if (c == '$') {
-                // MSP frame incoming — cancel any pending non-MSP request.
-                // Resetting here (not per-byte) allows '#\r' sequences to set
-                // MSP_PENDING_CLI without the trailing '\r' wiping it.
                 mspPort->pendingRequest = MSP_PENDING_NONE;
                 mspPort->portState = PORT_MSP_PACKET;
                 mspPort->packetState = MSP_HEADER_START;
             } else if (evaluateNonMspData == MSP_EVALUATE_NON_MSP_DATA) {
-                // evaluate the non-MSP data
                 if (c == serialConfig()->reboot_character) {
                     mspPort->pendingRequest = MSP_PENDING_BOOTLOADER_ROM;
 #ifdef USE_CLI
@@ -548,6 +544,9 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
                     mspPort->portState = PORT_CLI_CMD;
                     cliEnter(mspPort->port, false);
 #endif
+                } else if (mspPort->pendingRequest == MSP_PENDING_BOOTLOADER_ROM) {
+                    // unrecognized byte cancels bootloader-ROM pending; CLI pending is preserved
+                    mspPort->pendingRequest = MSP_PENDING_NONE;
                 }
             }
         }


### PR DESCRIPTION
AI Generated pull-request

---

***Need authentic testing, unsure if this was true bug-cause or if this is authentic bug-fix.***

---


Backport of #15323 to `4.5-maintenance`.

## Summary

Fixes the regression introduced by #15200 (backport of #15193) that caused GUI save with GPS enabled to wipe config to defaults — reported in #15315, confirmed on FLYWOOF722PROV2 and BETAFPVG473.

**Root cause and fix:** see #15323 for full analysis. In short: `pendingRequest = MSP_PENDING_NONE` is now only reset when `$` is received (MSP frame start), not in a one-shot pre-loop guard. Per-byte `lastActivityMs` updates are restored. The `#\r` CLI entry fix from #15200 is preserved.

## Test plan
- [x] Cherry-picks cleanly onto `4.5-maintenance`
- [ ] Hardware verify: GUI save with GPS physically connected on FLYWOOF722PROV2 (#15315)
- [ ] Hardware verify: GUI save with GPS physically connected on BETAFPVG473 (#15315)
- [ ] CLI entry via `#` / `#\r` still works

Closes #15315
Related: #15200, #15193, #14169, #15071