### PR TITLE
dshot_bitbang: replace telemetry busy-wait with non-blocking DMA abort

### DIFF
--- a/src/platform/APM32/dshot_bitbang.c
+++ b/src/platform/APM32/dshot_bitbang.c
@@ -57,9 +57,6 @@
 // 2 - Count of reception not complete in time
 // 3 - Number of high bits before telemetry start
 
-// Maximum time to wait for telemetry reception to complete
-#define DSHOT_TELEMETRY_TIMEOUT 2000
-
 // For MCUs that use MPU to control DMA coherency, there might be a performance hit
 // on manipulating input buffer content especially if it is read multiple times,
 // as the buffer region is attributed as not cachable.
@@ -472,23 +469,21 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
 
 static bool bbTelemetryWait(void)
 {
-    // Wait for telemetry reception to complete
-    bool telemetryPending;
+    // If telemetry input DMA is still running, abort it rather than busy-waiting.
+    // Skipping one telemetry frame is harmless; busy-waiting can block TASK_RX for
+    // tens of milliseconds on high-loop-rate targets (e.g. F7 at 8K with bidirDSHOT).
+    // bbUpdateComplete() handles the port still being in INPUT direction.
     bool telemetryWait = false;
-    const timeUs_t startTimeUs = micros();
 
-    do {
-        telemetryPending = false;
-        for (int i = 0; i < usedMotorPorts; i++) {
-            telemetryPending |= bbPorts[i].telemetryPending;
+    for (int i = 0; i < usedMotorPorts; i++) {
+        if (bbPorts[i].telemetryPending) {
+            bbTIM_DMACmd(bbPorts[i].timhw->tim, bbPorts[i].dmaSource, DISABLE);
+            bbDMA_Cmd(&bbPorts[i], DISABLE);
+            bbPorts[i].telemetryPending = false;
+            bbPorts[i].telemetryAborted = true;
+            telemetryWait = true;
         }
-
-        telemetryWait |= telemetryPending;
-
-        if (cmpTimeUs(micros(), startTimeUs) > DSHOT_TELEMETRY_TIMEOUT) {
-            break;
-        }
-    } while (telemetryPending);
+    }
 
     if (telemetryWait) {
         DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);
@@ -519,6 +514,11 @@ static bool bbDecodeTelemetry(void)
         }
 #endif
         for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < dshotMotorCount; motorIndex++) {
+            if (bbMotors[motorIndex].bbPort->telemetryAborted) {
+                // Aborted reception; already counted in debug[2] by bbTelemetryWait().
+                // Don't bump debug[1] (missing-edge) - an abort is not a missing edge.
+                continue;
+            }
 #ifdef APM32F4
             uint32_t rawValue = decode_bb_bitband(
                 bbMotors[motorIndex].bbPort->portInputBuffer,
@@ -548,6 +548,10 @@ static bool bbDecodeTelemetry(void)
         }
 
         dshotTelemetryState.rawValueState = DSHOT_RAW_VALUE_STATE_NOT_PROCESSED;
+
+        for (int i = 0; i < usedMotorPorts; i++) {
+            bbPorts[i].telemetryAborted = false;
+        }
     }
 #endif
 

--- a/src/platform/AT32/dshot_bitbang.c
+++ b/src/platform/AT32/dshot_bitbang.c
@@ -282,6 +282,7 @@ FAST_IRQ_HANDLER void bbDMAIrqHandler(dmaChannelDescriptor_t *descriptor)
 #ifdef USE_DSHOT_TELEMETRY
     if (useDshotTelemetry) {
         if (bbPort->direction == DSHOT_BITBANG_DIRECTION_INPUT) {
+            bbPort->telemetryPending = false;
 #ifdef DEBUG_COUNT_INTERRUPT
             bbPort->inputIrq++;
 #endif
@@ -295,6 +296,7 @@ FAST_IRQ_HANDLER void bbDMAIrqHandler(dmaChannelDescriptor_t *descriptor)
             // Switch to input
 
             bbSwitchToInput(bbPort);
+            bbPort->telemetryPending = true;
 
             bbTIM_DMACmd(bbPort->timhw->tim, bbPort->dmaSource, TRUE);
         }

--- a/src/platform/AT32/dshot_bitbang.c
+++ b/src/platform/AT32/dshot_bitbang.c
@@ -50,9 +50,6 @@
 
 #include "pg/motor.h"
 
-// Maximum time to wait for telemetry reception to complete
-#define DSHOT_TELEMETRY_TIMEOUT 2000
-
 // For MCUs that use MPU to control DMA coherency, there might be a performance hit
 // on manipulating input buffer content especially if it is read multiple times,
 // as the buffer region is attributed as not cachable.
@@ -453,23 +450,21 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
 
 static bool bbTelemetryWait(void)
 {
-    // Wait for telemetry reception to complete
-    bool telemetryPending;
+    // If telemetry input DMA is still running, abort it rather than busy-waiting.
+    // Skipping one telemetry frame is harmless; busy-waiting can block TASK_RX for
+    // tens of milliseconds on high-loop-rate targets (e.g. F7 at 8K with bidirDSHOT).
+    // bbUpdateComplete() handles the port still being in INPUT direction.
     bool telemetryWait = false;
-    const timeUs_t startTimeUs = micros();
 
-    do {
-        telemetryPending = false;
-        for (int i = 0; i < usedMotorPorts; i++) {
-            telemetryPending |= bbPorts[i].telemetryPending;
+    for (int i = 0; i < usedMotorPorts; i++) {
+        if (bbPorts[i].telemetryPending) {
+            bbTIM_DMACmd(bbPorts[i].timhw->tim, bbPorts[i].dmaSource, FALSE);
+            bbDMA_Cmd(&bbPorts[i], FALSE);
+            bbPorts[i].telemetryPending = false;
+            bbPorts[i].telemetryAborted = true;
+            telemetryWait = true;
         }
-
-        telemetryWait |= telemetryPending;
-
-        if (cmpTimeUs(micros(), startTimeUs) > DSHOT_TELEMETRY_TIMEOUT) {
-            break;
-        }
-    } while (telemetryPending);
+    }
 
     if (telemetryWait) {
         DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);
@@ -500,6 +495,11 @@ static bool bbDecodeTelemetry(void)
         }
 #endif
         for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < dshotMotorCount; motorIndex++) {
+            if (bbMotors[motorIndex].bbPort->telemetryAborted) {
+                // Aborted reception; already counted in debug[2] by bbTelemetryWait().
+                // Don't bump debug[1] (missing-edge) - an abort is not a missing edge.
+                continue;
+            }
 
             uint32_t rawValue = decode_bb_bitband(
                 bbMotors[motorIndex].bbPort->portInputBuffer,
@@ -529,6 +529,10 @@ static bool bbDecodeTelemetry(void)
         }
 
         dshotTelemetryState.rawValueState = DSHOT_RAW_VALUE_STATE_NOT_PROCESSED;
+
+        for (int i = 0; i < usedMotorPorts; i++) {
+            bbPorts[i].telemetryAborted = false;
+        }
     }
 #endif
 

--- a/src/platform/STM32/dshot_bitbang.c
+++ b/src/platform/STM32/dshot_bitbang.c
@@ -56,9 +56,6 @@
 // 2 - Count of reception not complete in time
 // 3 - Number of high bits before telemetry start
 
-// Maximum time to wait for telemetry reception to complete
-#define DSHOT_TELEMETRY_TIMEOUT 2000
-
 // For MCUs that use MPU to control DMA coherency, there might be a performance hit
 // on manipulating input buffer content especially if it is read multiple times,
 // as the buffer region is attributed as not cachable.
@@ -508,23 +505,25 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
 
 static bool bbTelemetryWait(void)
 {
-    // Wait for telemetry reception to complete
-    bool telemetryPending;
+    // If telemetry input DMA is still running, abort it rather than busy-waiting.
+    // Skipping one telemetry frame is harmless; busy-waiting can block TASK_RX for
+    // tens of milliseconds on high-loop-rate targets (e.g. F7 at 8K with bidirDSHOT).
+    // bbUpdateComplete() handles the port still being in INPUT direction.
     bool telemetryWait = false;
-    const timeUs_t startTimeUs = micros();
 
-    do {
-        telemetryPending = false;
-        for (int i = 0; i < usedMotorPorts; i++) {
-            telemetryPending |= bbPorts[i].telemetryPending;
+    for (int i = 0; i < usedMotorPorts; i++) {
+        if (bbPorts[i].telemetryPending) {
+            bbTIM_DMACmd(bbPorts[i].timhw->tim, bbPorts[i].dmaSource, DISABLE);
+            bbDMA_Cmd(&bbPorts[i], DISABLE);
+            bbPorts[i].telemetryPending = false;
+            // The input capture was aborted mid-transfer, so the buffer holds a
+            // partial frame. Mark the port so decodeTelemetry() skips it rather
+            // than decoding a torn buffer (which could yield a bad-but-valid GCR
+            // frame). Skipping one telemetry frame is harmless.
+            bbPorts[i].telemetryAborted = true;
+            telemetryWait = true;
         }
-
-        telemetryWait |= telemetryPending;
-
-        if (cmpTimeUs(micros(), startTimeUs) > DSHOT_TELEMETRY_TIMEOUT) {
-            break;
-        }
-    } while (telemetryPending);
+    }
 
     if (telemetryWait) {
         DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);
@@ -555,6 +554,11 @@ static bool bbDecodeTelemetry(void)
         }
 #endif
         for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < dshotMotorCount; motorIndex++) {
+            if (bbMotors[motorIndex].bbPort->telemetryAborted) {
+                // Aborted reception; already counted in debug[2] by bbTelemetryWait().
+                // Don't bump debug[1] (missing-edge) - an abort is not a missing edge.
+                continue;
+            }
 #ifdef STM32F4
             uint32_t rawValue = decode_bb_bitband(
                 bbMotors[motorIndex].bbPort->portInputBuffer,
@@ -589,6 +593,10 @@ static bool bbDecodeTelemetry(void)
         }
 
         dshotTelemetryState.rawValueState = DSHOT_RAW_VALUE_STATE_NOT_PROCESSED;
+
+        for (int i = 0; i < usedMotorPorts; i++) {
+            bbPorts[i].telemetryAborted = false;
+        }
     }
 #endif
 

--- a/src/platform/common/stm32/dshot_bitbang_impl.h
+++ b/src/platform/common/stm32/dshot_bitbang_impl.h
@@ -208,6 +208,7 @@ typedef struct bbPort_s {
     uint32_t portInputCount;
     bool inputActive;
     volatile bool telemetryPending;
+    bool telemetryAborted;
 
     // Misc
 #ifdef DEBUG_COUNT_INTERRUPT


### PR DESCRIPTION
@SteveCEvans @blckmn

Chris the human here: This is a reasonably important bug fix I think. I noticed horrible RC packet lag (20-30ms) running 250Hz ELRS on 2026.06 with an F722 (8k/8k bidshot). Testing showed that once you get a CPU overload that pushes the motor output later than normal bbTelemetryWait() busy spins waiting for the bidshot data to arrive. This makes the overload much worse and quickly compounds, starving the TASK_RX and leading to **big** chunks of time without new RC packets getting processed (!). This PR fixes that problem by aborting the capture of bidshot rpm data if it would delay the PID loop. This allows the overload to recover the very next cycle and avoids starving TASK_RX.

Chris the AI here:
## Problem

On targets running an 8 kHz PID loop with bidirectional DSHOT (e.g. STM32F722), `TASK_RX` can be starved for 10–20 ms at a time, causing 10 - 20ms of consecutive RC packet drops. The cause is `bbTelemetryWait()`, which busy-spins for up to 2000 µs waiting for the ESC telemetry input DMA to complete.

Under load the REALTIME chain (GYRO → FILTER → PID) slightly overruns the 125 µs budget. That delays `bbUpdateComplete()`, which delays the next DSHOT output frame, which pushes the ESC reply later, which makes the next `bbTelemetryWait()` spin longer — a compounding cascade that produces starvation bursts of tens of milliseconds. Hardware DSHOT has no such problem: its vtable has no `.telemetryWait` entry and decode is non-blocking.

## Solution

Replace the busy-spin with a single non-blocking check. If a port's input DMA hasn't completed by the time the next PID cycle calls `motorWriteAll()`, abort it and proceed:

```c
for (int i = 0; i < usedMotorPorts; i++) {
    if (bbPorts[i].telemetryPending) {
        bbTIM_DMACmd(bbPorts[i].timhw->tim, bbPorts[i].dmaSource, DISABLE);
        bbDMA_Cmd(&bbPorts[i], DISABLE);
        bbPorts[i].telemetryPending = false;
        bbPorts[i].telemetryAborted = true;   // skip decode of the torn buffer
        telemetryWait = true;
    }
}
```

`bbUpdateComplete()` already handles a port still in `INPUT` direction (`bbSwitchToOutput()` fully reinitialises the DMA from its cached register set), so the surrounding call sequence is unchanged.

An aborted capture leaves a partial frame in the buffer, so the port is flagged `telemetryAborted` and `bbDecodeTelemetry()` skips it rather than decoding a torn buffer (which could occasionally produce a bad-but-valid GCR frame). The flag is cleared after each decode pass. Skipping one telemetry frame is harmless — the RPM filter smooths over it. The abort rate is visible in `debug[2]` (`DEBUG_DSHOT_TELEMETRY_COUNTS`).

## Scope

Applied to the STM32, APM32 and AT32 platform copies. This PR also fixes a pre-existing AT32 bug (separate commit) where the bitbang DMA IRQ handler never set `telemetryPending`, leaving telemetry timing ungated on AT32. The PICO implementation already has a no-op telemetry wait and is unaffected.

## Testing

Tested on STM32F722, 8 kHz / DSHOT600 / bidirDSHOT, ELRS 150 Hz:

- ✅ **RC packet drops eliminated** — the starvation bursts that motivated this PR are gone.
- The non-blocking abort fires only on overrun cycles; in steady hover it never fires (`debug[2]` stays flat).

### eRPM telemetry sanity check

A set of single-frame eRPM "spikes" (~3× for one sample, ~2/s) was investigated and traced to **pre-existing baseline bidirDSHOT decode noise**, not this PR. Matched back-to-back hover logs (same flight, 8 kHz, `DSHOT_TELEMETRY_COUNTS`):

| Build | Spikes | Rate |
| --- | --- | --- |
| master | 24 / 13.3 s | 1.81 / s |
| this PR | 26 / 12.8 s | 2.03 / s |

Rates are statistically indistinguishable and both are lopsided toward the same motor (per-wire signal integrity). The abort path does not fire in hover, so it cannot be the source. Out of scope for this PR.

Review and testing from APM32 / AT32 owners welcome.

## Could this starve telemetry entirely?

In normal operation, no: the DSHOT round-trip completes (~90 µs) before `bbTelemetryWait()` runs (~100–120 µs into the cycle), so `telemetryPending` is already `false` and the abort is never taken.

The degenerate case is a target so overloaded that *every* cycle overruns — you would abort every frame and the RPM filter would run on stale data. But there the old code was actively worse: it compounded each overrun into RC starvation. No RPM update is far safer in flight than no RC packets, and the condition is diagnosable via `debug[2]`.

## Notes for reviewers

- The long-term fix would be to drive `bbUpdateComplete()` from the input-DMA-completion ISR, making bitbang fully asynchronous like hardware DSHOT. This PR is a minimal, low-risk step toward that.
- F4/G4 targets already force DSHOT300 + 4 kHz under bidirDSHOT via `USE_PID_DENOM_CHECK`. F7/H7 have no such guard and are the primary beneficiaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes  
* **Bug Fixes**
  * Updated DSHOT telemetry handling across supported platforms to use abort-based processing rather than timeout polling.
  * Telemetry reception is now tracked per port; any pending reception is safely aborted and affected motors are skipped during decoding.
  * Per-cycle telemetry abort state is cleared after decoding to keep future telemetry runs consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->