### PR TITLE
STM32C5: config partition at end of flash; C591 UART pins

### DIFF
--- a/src/platform/STM32/link/stm32_flash_c5xx_1m.ld
+++ b/src/platform/STM32/link/stm32_flash_c5xx_1m.ld
@@ -17,17 +17,15 @@ ENTRY(Reset_Handler)
 0x20000000 to 0x2003FFFF  256K SRAM (SRAM1 128K + SRAM2 128K)
 
 0x08000000 to 0x080FFFFF 1024K full flash,
-0x08000000 to 0x0801FFFF  128K isr vector, startup code,
-0x08020000 to 0x0803FFFF  128K config, // FLASH_Sector_1
-0x08040000 to 0x080FFFFF  768K firmware,
+0x08000000 to 0x080FBFFF 1008K isr vector, startup code, firmware,
+0x080FC000 to 0x080FFFFF   16K config (last two 8K pages),
 */
 
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)        : ORIGIN = 0x08000000, LENGTH = 128K
-    FLASH_CONFIG (r)  : ORIGIN = 0x08020000, LENGTH = 128K
-    FLASH1 (rx)       : ORIGIN = 0x08040000, LENGTH = 768K
+    FLASH (rx)        : ORIGIN = 0x08000000, LENGTH = 1008K
+    FLASH_CONFIG (r)  : ORIGIN = 0x080FC000, LENGTH = 16K
 
     RAM (rwx)         : ORIGIN = 0x20000000, LENGTH = 256K
     MEMORY_B1 (rx)    : ORIGIN = 0x60000000, LENGTH = 0K
@@ -76,18 +74,18 @@ SECTIONS
 
     . = ALIGN(4);
     _etext = .;        /* define a global symbols at end of code */
-  } >FLASH1
+  } >FLASH
 
   .ARM.extab   :
   {
     *(.ARM.extab* .gnu.linkonce.armextab.*)
-  } >FLASH1
+  } >FLASH
 
   .ARM :
   {
     __exidx_start = .;
     *(.ARM.exidx*) __exidx_end = .;
-  } >FLASH1
+  } >FLASH
 
   .pg_registry :
   {
@@ -95,14 +93,14 @@ SECTIONS
     KEEP (*(.pg_registry))
     KEEP (*(SORT(.pg_registry.*)))
     PROVIDE_HIDDEN (__pg_registry_end = .);
-  } >FLASH1
+  } >FLASH
 
   .pg_resetdata :
   {
     PROVIDE_HIDDEN (__pg_resetdata_start = .);
     KEEP (*(.pg_resetdata))
     PROVIDE_HIDDEN (__pg_resetdata_end = .);
-  } >FLASH1
+  } >FLASH
 
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
@@ -117,7 +115,7 @@ SECTIONS
 
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-  } >RAM AT >FLASH1
+  } >RAM AT >FLASH
 
   /* Uninitialized data section */
   . = ALIGN(4);
@@ -162,7 +160,7 @@ SECTIONS
 
     . = ALIGN(4);
     _efastram_data = .;
-  } >FASTRAM AT >FLASH1
+  } >FASTRAM AT >FLASH
 
   . = ALIGN(4);
   .fastram_bss (NOLOAD) :
@@ -191,7 +189,7 @@ SECTIONS
     *(.dmaram_data*)
     . = ALIGN(32);
     _edmaram_data = .;
-  } >RAM AT >FLASH1
+  } >RAM AT >FLASH
 
   . = ALIGN(32);
   .dmaram_bss (NOLOAD) :

--- a/src/platform/STM32/serial_uart_stm32c5xx.c
+++ b/src/platform/STM32/serial_uart_stm32c5xx.c
@@ -97,6 +97,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .txPins = {
             { DEFIO_TAG_E(PA9),  HAL_GPIO_AF7_USART1 },
             { DEFIO_TAG_E(PB6),  HAL_GPIO_AF7_USART1 },
+            { DEFIO_TAG_E(PA15), HAL_GPIO_AF11_USART1 },
         },
         .rcc = RCC_APB2(USART1),
         .irqn = USART1_IRQn,
@@ -153,6 +154,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PC4),  HAL_GPIO_AF7_USART3 },
             { DEFIO_TAG_E(PC11), HAL_GPIO_AF7_USART3 },
             { DEFIO_TAG_E(PD9),  HAL_GPIO_AF7_USART3 },
+            { DEFIO_TAG_E(PB1),  HAL_GPIO_AF7_USART3 },
         },
         .txPins = {
             { DEFIO_TAG_E(PB10), HAL_GPIO_AF7_USART3 },
@@ -274,6 +276,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PA15), HAL_GPIO_AF7_UART7 },
             { DEFIO_TAG_E(PB4),  HAL_GPIO_AF7_UART7 },
             { DEFIO_TAG_E(PF7),  HAL_GPIO_AF7_UART7 },
+            { DEFIO_TAG_E(PA10), HAL_GPIO_AF10_UART7 },
         },
         .rcc = RCC_APB1L(UART7),
         .irqn = UART7_IRQn,

--- a/src/platform/STM32/target/STM32C591/target.h
+++ b/src/platform/STM32/target/STM32C591/target.h
@@ -39,6 +39,7 @@
 #define USE_UART3
 #define USE_UART4
 #define USE_UART5
+#define USE_UART7
 
 #define USE_SPI_DEVICE_1
 #define USE_SPI_DEVICE_2

--- a/src/platform/STM32/target/STM32C5A3/target.h
+++ b/src/platform/STM32/target/STM32C5A3/target.h
@@ -66,7 +66,7 @@
 
 // 8 KiB matches STM32H5 — handles the default PG set plus virtual
 // sensors during bring-up. Must fit within the FLASH_CONFIG partition
-// defined in stm32_flash_c5xx_1m.ld (128 KiB at 0x08020000).
+// defined in stm32_flash_c5xx_1m.ld (16 KiB at the end of flash, 0x080FC000).
 #define EEPROM_SIZE     8192
 
 #ifndef DEFAULT_PID_PROCESS_DENOM


### PR DESCRIPTION
Two C5 platform changes from GEETAC591_V1 bring-up:

- **Config at end of flash** — `stm32_flash_c5xx_1m.ld` previously kept only the vector table in a 128 KB region at `0x08000000` and pinned config mid-flash at `0x08020000`. Firmware is now one contiguous region from `0x08000000` and config moves to the last two 8 KB pages (`0x080FC000`, 16 KB), recovering ~127.5 KB and keeping user config at the end. Shared by the C591 and C5A3 1 MB parts; the address-driven `getFLASHSectorForEEPROM` needs no change.
- **C591 UARTs** — add PA15/PB1/PA10 (USART1_TX/USART3_RX/UART7_TX) to the C5 serial pin tables and enable UART7.

Verified on a C591 board: boots to USB CLI, all sensors detected, and a CLI `save` persists across reboot at the relocated config location.

Companion config: betaflight/config#1129.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added UART7 support for STM32C591 targets
  * Extended GPIO pin mapping options for UART1, UART3, and UART7 peripherals

* **Refactor**
  * Reorganized STM32C5xx flash memory layout consolidation
  * Updated target configuration documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->