### PR TITLE
Fix potential East-West magnetic inversion in imu.c

### DIFF
--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -177,7 +177,6 @@ void imuConfigure(uint16_t throttle_correction_angle, uint8_t throttle_correctio
     // magnetic declination has negative sign (positive clockwise when seen from top)
     const float imuMagneticDeclinationRad = DEGREES_TO_RADIANS(imuConfig()->mag_declination / 10.0f);
     sincosf_approx(imuMagneticDeclinationRad, &north_ef.y, &north_ef.x);
-    north_ef.y = -north_ef.y;
 
     smallAngleCosZ = cos_approx(degreesToRadians(imuConfig()->small_angle));
 
@@ -504,7 +503,7 @@ static void imuDebug_GPS_RESCUE_HEADING(void)
 
         vector3_t mag_bf = mag.magADC;
         vector3_t mag_ef;
-        matrixVectorMul(&mag_ef, &rMat, &mag_bf); // BF->EF true north
+        matrixTrnVectorMul(&mag_ef, &rMat, &mag_bf); // BF->EF true north (rMat^T = correct body->earth)
 
         matrix33_t rMatZTrans;
         yawToRotationMatrixZ(&rMatZTrans, -atan2_approx(rMat.m[1][0], rMat.m[0][0]));
@@ -537,7 +536,7 @@ STATIC_UNIT_TESTED float imuCalcMagErr(void)
     if (magNormSquared > 0.01f) {
         // project magnetometer reading into Earth frame
         vector3_t mag_ef;
-        matrixVectorMul(&mag_ef, &rMat, &mag_bf); // BF->EF true north
+        matrixTrnVectorMul(&mag_ef, &rMat, &mag_bf); // BF->EF true north (rMat^T = correct body->earth)
         // Normalise magnetometer measurement
         vector3Scale(&mag_ef, &mag_ef, 1.0f / sqrtf(magNormSquared));
 

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -674,7 +674,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
 #endif
         ) {
         useMag = true;
-        magErr = imuCalcMagErr();
+        magErr = -imuCalcMagErr();
     }
 #endif
 


### PR DESCRIPTION
Hello,

While looking into some heading behavior, I noticed what appears to be an East-West inversion when calculating mag_ef in imu.c. It looks like matrixVectorMul is being used instead of the transpose matrixTrnVectorMul for the body-to-earth transformation, similar to the math corrected in PR #15321.

To compensate for this, it seems the Y-axis (East) was manually negated in the declination logic (PR #13073).

I've drafted a fix here, but I'm not entirely sure of the full downstream impact (especially on GPS Rescue or OSD) if this is changed, so I wanted to open this as a draft to get your thoughts. Let me know if I'm off base or if this is worth pursuing!