### PR TITLE
fix(position): correct East-West inversion in getLinearAccelENU

### DIFF
--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -25,6 +25,7 @@
 
 #include "platform.h"
 
+#include "build/build_config.h"
 #include "build/debug.h"
 
 #include "common/maths.h"
@@ -279,21 +280,22 @@ void positionEstimatorEnableXY(bool enable)
 }
 
 // Compute earth-frame linear acceleration from IMU (gravity removed), in cm/s^2 ENU
-static void getLinearAccelENU(float *accelEast, float *accelNorth, float *accelUp)
+STATIC_UNIT_TESTED void getLinearAccelENU(float *accelEast, float *accelNorth, float *accelUp)
 {
     const float accScale = acc.dev.acc_1G_rec;
     vector3_t accBF = {{ acc.accADC.x * accScale,
                          acc.accADC.y * accScale,
                          acc.accADC.z * accScale }};
 
-    // rMat^T rotates body -> earth NED (North-East-Down)
-    vectorNED_t accEF_NED;
-    matrixTrnVectorMul(&accEF_NED.u.v, &rMat, &accBF);
+    // rMat rotates body -> earth NWU (North-West-Up); this is the same convention
+    // used throughout imu.c (imuComputeRotationMatrix, attitude extraction, mag fusion).
+    vector3_t accEF_NWU;
+    matrixVectorMul(&accEF_NWU, &rMat, &accBF);
 
-    // NED -> ENU named outputs
-    *accelEast  =  accEF_NED.u.ef.E * GRAVITY_CMSS;
-    *accelNorth =  accEF_NED.u.ef.N * GRAVITY_CMSS;
-    *accelUp    = (accEF_NED.u.ef.D - 1.0f) * GRAVITY_CMSS;
+    // NWU -> ENU named outputs (East = -West, gravity removed from Up).
+    *accelEast  = -accEF_NWU.y * GRAVITY_CMSS;
+    *accelNorth =  accEF_NWU.x * GRAVITY_CMSS;
+    *accelUp    = (accEF_NWU.z - 1.0f) * GRAVITY_CMSS;
 }
 
 #ifdef USE_GPS

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -19,6 +19,10 @@ extern "C" {
 #include "flight/position.h"
 #include "flight/position_estimator.h"
 
+// STATIC_UNIT_TESTED in position_estimator.c — gravity-removed earth-frame
+// linear acceleration in ENU (cm/s^2).
+void getLinearAccelENU(float *accelEast, float *accelNorth, float *accelUp);
+
 #include "io/gps.h"
 
 #include "sensors/acceleration.h"
@@ -154,35 +158,86 @@ TEST_F(PositionEstimatorTest, GPSPositionEastOfArmIsPositive)
     EXPECT_GT(positionEstimatorGetEstimate()->position.x, 0.0f);
 }
 
-// Regression test: forward thrust when heading East must produce a positive East velocity
-// estimate even when the craft is rolled.  A level-only rMat does not distinguish
-// matrixVectorMul from matrixTrnVectorMul because the off-diagonal z terms vanish.
-// With roll the gravity components in body Y and Z create cross-coupling that
-// matrixVectorMul handles incorrectly (yielding zero East acceleration here) while
-// matrixTrnVectorMul correctly cancels them and recovers the full forward thrust.
+// Build rMat from roll/pitch/yaw using the exact quaternion + rotation-matrix
+// formulas from imu.c (imuComputeQuaternionFromRPY + imuComputeRotationMatrix),
+// so the matrix carries the firmware's body->earth NWU (North-West-Up) convention.
+// Yaw follows the attitude/compass convention: 0 = North, +90 = East increases the
+// reported heading, so a craft heading East is built with yawDeg = -90.
+static void setRMatFromEuler(float rollDeg, float pitchDeg, float yawDeg)
+{
+    const float hr = DEGREES_TO_RADIANS(rollDeg) * 0.5f;
+    const float hp = DEGREES_TO_RADIANS(pitchDeg) * 0.5f;
+    const float hy = DEGREES_TO_RADIANS(yawDeg) * 0.5f;
+
+    const float cr = cosf(hr), sr = sinf(hr);
+    const float cp = cosf(hp), sp = sinf(hp);
+    const float cy = cosf(hy), sy = sinf(hy);
+
+    const float q0 = cr * cp * cy + sr * sp * sy;
+    const float q1 = sr * cp * cy - cr * sp * sy;
+    const float q2 = cr * sp * cy + sr * cp * sy;
+    const float q3 = cr * cp * sy - sr * sp * cy;
+
+    const float xx = q1 * q1, yy = q2 * q2, zz = q3 * q3;
+    const float xy = q1 * q2, xz = q1 * q3, yz = q2 * q3;
+    const float wx = q0 * q1, wy = q0 * q2, wz = q0 * q3;
+
+    rMat.m[0][0] = 1.0f - 2.0f * yy - 2.0f * zz;
+    rMat.m[0][1] = 2.0f * (xy - wz);
+    rMat.m[0][2] = 2.0f * (xz + wy);
+    rMat.m[1][0] = 2.0f * (xy + wz);
+    rMat.m[1][1] = 1.0f - 2.0f * xx - 2.0f * zz;
+    rMat.m[1][2] = 2.0f * (yz - wx);
+    rMat.m[2][0] = 2.0f * (xz - wy);
+    rMat.m[2][1] = 2.0f * (yz + wx);
+    rMat.m[2][2] = 1.0f - 2.0f * xx - 2.0f * yy;
+}
+
+// Regression test for the East-West / magnitude bug discussed in #15321 and #15339.
+// getLinearAccelENU must use matrixVectorMul (body->earth NWU) with East = -West;
+// the previously-used matrixTrnVectorMul applied the inverse rotation, giving the
+// wrong magnitude and a spurious North term.
+//
+// Scenario: heading East, 30 deg right roll, 0.5 g of forward (East) thrust.
+// Gravity projects onto body Y and Z because of the roll, so accBF = (0.5, 0.5, 0.866).
+// In the correct NWU formulation the gravity cross-terms cancel exactly, leaving
+// the full 0.5 g of thrust on East and nothing on North or Up.
+TEST_F(PositionEstimatorTest, EastThrustProducesEastAccelENU)
+{
+    constexpr float GRAVITY_CMSS = 980.665f;
+
+    // rMat produced via imuComputeRotationMatrix's convention for heading East + 30 deg roll.
+    setRMatFromEuler(30.0f, 0.0f, -90.0f);
+
+    // Forward (East) thrust of 0.5 g; gravity projects onto body Y and Z due to the roll.
+    acc.dev.acc_1G_rec = 1.0f;
+    acc.accADC.x = 0.5f;
+    acc.accADC.y = 0.5f;    // sin(30) * 1g
+    acc.accADC.z = 0.866f;  // cos(30) * 1g
+
+    float accelEast, accelNorth, accelUp;
+    getLinearAccelENU(&accelEast, &accelNorth, &accelUp);
+
+    EXPECT_NEAR(accelEast,  0.5f * GRAVITY_CMSS, 0.01f * GRAVITY_CMSS);
+    EXPECT_NEAR(accelNorth, 0.0f,                0.01f * GRAVITY_CMSS);
+    EXPECT_NEAR(accelUp,    0.0f,                0.01f * GRAVITY_CMSS);
+}
+
+// Integration counterpart: with the same attitude/thrust, the IMU prediction alone
+// (GPS held at the origin) must drive a positive East velocity estimate.
 TEST_F(PositionEstimatorTest, EastThrustProducesPositiveEastVelocity)
 {
     // Run a couple of steps so XY fusion is established with the arm at origin.
     stepEstimator(2);
 
-    // rMat = Cbn for heading East (yaw 90 deg) + 30 deg right roll.
-    // Cbn = Cbn_roll(30) * Cbn_yaw(90):
-    //   row0 = (0,       1,        0      )
-    //   row1 = (-cos30,  0,        sin30  )
-    //   row2 = ( sin30,  0,        cos30  )
-    memset(&rMat, 0, sizeof(rMat));
-    rMat.m[0][1] =  1.0f;
-    rMat.m[1][0] = -0.866f;  rMat.m[1][2] = 0.5f;
-    rMat.m[2][0] =  0.5f;    rMat.m[2][2] = 0.866f;
+    setRMatFromEuler(30.0f, 0.0f, -90.0f);
 
-    // Forward (East) thrust of 0.5 g; gravity projects onto body Y and Z due to the roll.
     acc.accADC.x = 0.5f;
     acc.accADC.y = 0.5f;    // sin(30) * 1g
     acc.accADC.z = 0.866f;  // cos(30) * 1g
 
     // GPS position and velocity remain zero so any non-zero velocity estimate is
-    // driven purely by the IMU prediction.  The gravity cross-terms cancel exactly
-    // and only the 0.5 g forward thrust contributes to East, giving velocity.x > 0.
+    // driven purely by the IMU prediction.
     stepEstimator(100);
 
     EXPECT_GT(positionEstimatorGetEstimate()->velocity.x, 0.0f);


### PR DESCRIPTION
## Summary

Corrects an East-West inversion (and magnitude error) in `getLinearAccelENU` in `position_estimator.c`. This is the productive follow-up to the investigation in #15339 — the inversion that PR surfaced is real, but it lives here, not in `imu.c`.

## Background

`rMat` is **body→earth NWU** (North-West-Up) throughout the codebase, and three independent, well-exercised call sites agree on this:

1. **`imuComputeRotationMatrix`** builds exactly the standard `R(q)` body→earth matrix.
2. **Attitude extraction** decodes roll/pitch/yaw assuming `rMat = Rz(yaw)·Ry(pitch)·Rx(roll)` body→earth (drives OSD horizon / angle mode).
3. **Mahony gravity error** reads gravity-in-body from the third row `rMat[2][*]` = `Rᵀ·ẑ`, which only holds if `rMat` is body→earth.

Given that, `matrixVectorMul(rMat, v_body)` **is** the correct body→earth transform. `getLinearAccelENU` instead used `matrixTrnVectorMul` (= `rMatᵀ·v`, i.e. the inverse, earth→body) while labeling the result "body → earth NED". The result had the wrong magnitude and a spurious cross-axis term.

`imu.c` is **not** changed — that code is already a self-consistent NWU formulation (`matrixVectorMul` + `(cos D, −sin D)` magnetic-north reference + un-negated `magErr`).

## Changes

- **`getLinearAccelENU`**: use `matrixVectorMul` (body→earth NWU) and map NWU → ENU with `East = -West`, gravity removed from Up. Marked `STATIC_UNIT_TESTED` so the transform can be asserted directly.
- **Test**: the #15321 regression test only checked velocity *sign* using a hand-built `rMat` that didn't match `imuComputeRotationMatrix`'s convention, so it masked the magnitude error. Added `setRMatFromEuler()` (exact quaternion + rotation-matrix formulas from `imu.c`) and a new `EastThrustProducesEastAccelENU` test asserting ENU **magnitudes**.

## Verification

Scenario: heading East, 30° right roll, 0.5 g forward thrust → `accBF = (0.5, 0.5, 0.866)`.

| | East | North | Up |
|---|---:|---:|---:|
| **Fixed** (`matrixVectorMul`, East = −West) | **+0.500 g** | 0.000 | 0.000 |
| Previous (`matrixTrnVectorMul`) | +0.866 g | −0.500 g | −0.500 g |

The gravity cross-terms now cancel exactly, leaving the full forward thrust on East and nothing on North/Up. The new test fails against the previous implementation, so it is a genuine regression guard.

```
[==========] 4 tests from PositionEstimatorTest
[  PASSED  ] 4 tests.
```

Closes the real issue raised in #15339.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved linear acceleration estimation calculations from IMU sensor readings, enhancing accuracy of flight position and velocity tracking.

* **Tests**
  * Added comprehensive unit test validation for acceleration estimation under various thrust and attitude scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->