### PR TITLE
refactor(axis): sign-bearing earth-frame axis enums (ENU/NWU/EF) across IMU & navigation

### DIFF
--- a/src/main/common/axis.h
+++ b/src/main/common/axis.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "common/utils.h"
+
 typedef enum {
     X = 0,
     Y,
@@ -77,5 +79,12 @@ typedef enum {
     EF_EAST = 0,   // +East
     EF_NORTH = 1   // +North
 } efAxis_e;
+
+// The autopilot stores into EF_AXIS_COUNT arrays by EF_EAST/EF_NORTH while
+// reading the estimate by ENU_E/ENU_N; that is only correct because the two
+// horizontal frames share index values. Lock the invariant so a future
+// reordering of either enum fails to compile rather than silently swapping axes.
+STATIC_ASSERT((int)EF_EAST == (int)ENU_E, ef_east_must_match_enu_east);
+STATIC_ASSERT((int)EF_NORTH == (int)ENU_N, ef_north_must_match_enu_north);
 
 #define GET_DIRECTION(isReversed) ((isReversed) ? -1 : 1)

--- a/src/main/common/axis.h
+++ b/src/main/common/axis.h
@@ -45,11 +45,37 @@ typedef enum {
 #define RP_AXIS_COUNT 2
 #define EF_AXIS_COUNT 2
 
-// NED (North-East-Down) coordinate frame - aviation standard
+// Earth-frame axis indices.
+//
+// These names encode three things at every call site: the frame, the axis,
+// and the positive direction. Indexing a vector with e.g. NWU_W makes it
+// obvious that the value is West-positive, so the sign of any North/East/Up
+// conversion is visible in the code rather than carried in a reader's head.
+// Do NOT reintroduce bare .x/.y for earth-frame quantities - the inability to
+// tell which axis (and which sign) .x meant was the root cause of the
+// getLinearAccelENU East-West inversion.
+
+// NWU (North-West-Up): the body->earth frame produced by rMat in imu.c.
+// matrixVectorMul(&v, &rMat, &bodyVec) yields a vector indexed by these.
 typedef enum {
-    NED_NORTH = 0,  // X-axis in NED frame
-    NED_EAST = 1,   // Y-axis in NED frame
-    NED_DOWN = 2    // Z-axis in NED frame
-} axisNED_e;
+    NWU_N = 0,  // +North
+    NWU_W = 1,  // +West
+    NWU_U = 2   // +Up
+} axisNWU_e;
+
+// ENU (East-North-Up): the navigation frame used by the position estimator
+// and autopilot. The position/velocity vector3_t fields are indexed by these.
+typedef enum {
+    ENU_E = 0,  // +East
+    ENU_N = 1,  // +North
+    ENU_U = 2   // +Up
+} axisENU_e;
+
+// Horizontal earth-frame (East-North) index for the 2-axis position/velocity
+// PID arrays. Matches the first two ENU indices (see EF_AXIS_COUNT).
+typedef enum {
+    EF_EAST = 0,   // +East
+    EF_NORTH = 1   // +North
+} efAxis_e;
 
 #define GET_DIRECTION(isReversed) ((isReversed) ? -1 : 1)

--- a/src/main/common/vector.h
+++ b/src/main/common/vector.h
@@ -43,19 +43,10 @@ typedef union vector3_u {
     };
 } vector3_t;
 
-// NED (North-East-Down) framed vector.  The union member u allows the same
-// storage to be addressed either as a plain vector3_t (for passing to math
-// routines) or with named geographic axes (for readability at call sites).
-typedef struct {
-    union {
-        vector3_t v;
-        struct {
-            float N;  // North
-            float E;  // East
-            float D;  // Down
-        } ef;
-    } u;
-} vectorNED_t;
+// Earth-frame vectors use a plain vector3_t indexed by the axisNWU_e / axisENU_e
+// enums in common/axis.h, which name the frame, axis, and sign at each call site.
+// (The former vectorNED_t struct was removed: its .ef.N/.E/.D members claimed an
+// NED frame while rMat actually produces NWU, which caused a sign inversion.)
 
 typedef struct matrix33_s {
     float m[3][3];

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -159,17 +159,15 @@ static inline float sanityCheckDistance(const float speedCmS)
 static void capturePositionHoldTarget(const positionEstimate3d_t *est)
 {
     isPositionHeld = true;
-    targetPosition.x = est->position.x;
-    targetPosition.y = est->position.y;
-    targetPosition.z = est->position.z;
+    targetPosition = est->position;  // ENU
     ap.sanityCheckDistance = sanityCheckDistance(1000.0f);
 }
 
 static void resetPositionStopState(const positionEstimate3d_t *est)
 {
     // Prevent a sharp spike on D
-    previousVelocity[EF_EAST] = est->velocity.x;
-    previousVelocity[EF_NORTH] = est->velocity.y;
+    previousVelocity[EF_EAST] = est->velocity.v[ENU_E];
+    previousVelocity[EF_NORTH] = est->velocity.v[ENU_N];
 
     // Reset the D filter
     initPositionAccelLpf();
@@ -184,7 +182,7 @@ void resetPositionControl(unsigned taskRateHz)
 
     // Set sanity distance from current speed
     const positionEstimate3d_t *est = positionEstimatorGetEstimate();
-    const float speedXY = sqrtf(est->velocity.x * est->velocity.x + est->velocity.y * est->velocity.y);
+    const float speedXY = sqrtf(sq(est->velocity.v[ENU_E]) + sq(est->velocity.v[ENU_N]));
     ap.sanityCheckDistance = sanityCheckDistance(speedXY);
 
     // Reset PID state (velocity-only until capture)
@@ -201,9 +199,7 @@ void resetPositionControl(unsigned taskRateHz)
 
     // Enable XY estimation and set target to current position
     positionEstimatorEnableXY(true);
-    targetPosition.x = est->position.x;
-    targetPosition.y = est->position.y;
-    targetPosition.z = est->position.z;
+    targetPosition = est->position;  // ENU
     isPositionHeld = true;
 
     positionNavReset();
@@ -344,9 +340,7 @@ bool positionControl(void)
 
     // Smooth transition: nav just completed/cleared -> seed position hold target
     if (!navActive && wasNavActive) {
-        targetPosition.x = est->position.x;
-        targetPosition.y = est->position.y;
-        targetPosition.z = est->position.z;
+        targetPosition = est->position;  // ENU
         for (unsigned i = 0; i < EF_AXIS_COUNT; i++) {
             posSlowIntegral[i] = 0.0f;
         }
@@ -355,8 +349,8 @@ bool positionControl(void)
     }
     wasNavActive = navActive;
 
-    const float velEast  = est->velocity.x;
-    const float velNorth = est->velocity.y;
+    const float velEast  = est->velocity.v[ENU_E];
+    const float velNorth = est->velocity.v[ENU_N];
     const float speedXY  = sqrtf(velEast * velEast + velNorth * velNorth);
     const float velocities[EF_AXIS_COUNT] = { velEast, velNorth };
 
@@ -375,8 +369,8 @@ bool positionControl(void)
         // Nav mode: inner velocity-tracking PID
         const vector3_t tgtVel = positionNavGetTargetVelocityCmS();
         const float velErrors[EF_AXIS_COUNT] = {
-            velEast - tgtVel.x,
-            velNorth - tgtVel.y
+            velEast - tgtVel.v[ENU_E],
+            velNorth - tgtVel.v[ENU_N]
         };
 
         for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
@@ -400,8 +394,8 @@ bool positionControl(void)
             }
         }
     } else {
-        errorEast = est->position.x - targetPosition.x;
-        const float errorNorth = est->position.y - targetPosition.y;
+        errorEast = est->position.v[ENU_E] - targetPosition.v[ENU_E];
+        const float errorNorth = est->position.v[ENU_N] - targetPosition.v[ENU_N];
         distanceCm = sqrtf(errorEast * errorEast + errorNorth * errorNorth);
 
         if (distanceCm > ap.sanityCheckDistance) {
@@ -453,9 +447,7 @@ bool positionControl(void)
             for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
                 posSlowIntegral[axis] = 0.0f;
             }
-            targetPosition.x = est->position.x;
-            targetPosition.y = est->position.y;
-            targetPosition.z = est->position.z;
+            targetPosition = est->position;  // ENU
             ap.sanityCheckDistance = sanityCheckDistance(speedXY);
         }
     } else {
@@ -472,8 +464,8 @@ bool positionControl(void)
         }
     }
 
-    const float stopDistanceEast = est->position.x - targetPosition.x;
-    const float stopDistanceNorth = est->position.y - targetPosition.y;
+    const float stopDistanceEast = est->position.v[ENU_E] - targetPosition.v[ENU_E];
+    const float stopDistanceNorth = est->position.v[ENU_N] - targetPosition.v[ENU_N];
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 0, lrintf(sqrtf(stopDistanceEast * stopDistanceEast + stopDistanceNorth * stopDistanceNorth)));
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 1, lrintf(speedXY));
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 2, ap.sticksActive ? 1 : 0);

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -102,12 +102,8 @@ static uint16_t altHoldCapturedHoverPwm;
 static float altitudeI = 0.0f;
 static float throttleOut = 0.0f;
 
-// Per-axis position PID state (earth frame)
-typedef enum {
-    EF_EAST = 0,
-    EF_NORTH
-} efAxis_e;
-
+// Per-axis position PID state (earth frame). efAxis_e (EF_EAST/EF_NORTH) is
+// defined in common/axis.h alongside the other earth-frame axis enums.
 static float posIntegral[EF_AXIS_COUNT];       // I term: integral of position error
 static float posSlowIntegral[EF_AXIS_COUNT];   // II term: slow drift correction
 static float previousVelocity[EF_AXIS_COUNT];

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -97,8 +97,9 @@ static bool computeTargetEnuM(const waypoint_t *wp, vector3_t *out)
     vector2_t enuCm;
     GPS_distance2d(&origin, &wpLoc, &enuCm);
 
-    out->v[ENU_E] = enuCm.v[ENU_E] * 0.01f;  // East
-    out->v[ENU_N] = enuCm.v[ENU_N] * 0.01f;  // North
+    // enuCm is a 2-axis horizontal earth-frame vector (efAxis_e); out is 3-axis ENU.
+    out->v[ENU_E] = enuCm.v[EF_EAST] * 0.01f;
+    out->v[ENU_N] = enuCm.v[EF_NORTH] * 0.01f;
     // Waypoint altitude is AMSL (GPS frame); the estimator's Z is zeroed to
     // whichever source armed it first (baro or GPS). zBiasM is the estimator
     // reading at engage time, which aligns the target Up with the feedback Up.

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -97,12 +97,12 @@ static bool computeTargetEnuM(const waypoint_t *wp, vector3_t *out)
     vector2_t enuCm;
     GPS_distance2d(&origin, &wpLoc, &enuCm);
 
-    out->x = enuCm.x * 0.01f;
-    out->y = enuCm.y * 0.01f;
+    out->v[ENU_E] = enuCm.v[ENU_E] * 0.01f;  // East
+    out->v[ENU_N] = enuCm.v[ENU_N] * 0.01f;  // North
     // Waypoint altitude is AMSL (GPS frame); the estimator's Z is zeroed to
     // whichever source armed it first (baro or GPS). zBiasM is the estimator
-    // reading at engage time, which aligns the target Z with the feedback Z.
-    out->z = (wp->altitude - origin.altCm) * 0.01f + fp.zBiasM;
+    // reading at engage time, which aligns the target Up with the feedback Up.
+    out->v[ENU_U] = (wp->altitude - origin.altCm) * 0.01f + fp.zBiasM;
     return true;
 }
 
@@ -187,11 +187,11 @@ static bool dispatchWaypoint(void)
     if (fp.delayActive) {
         const float delaySec = fp.delayDurationDs * 0.1f;
         const positionEstimate3d_t *est = positionEstimatorGetEstimate();
-        const vector3_t legVec = {
-            .x = targetEnuM.x - est->position.x * 0.01f,
-            .y = targetEnuM.y - est->position.y * 0.01f,
-            .z = targetEnuM.z - est->position.z * 0.01f,
-        };
+        const vector3_t legVec = {.v = {
+            [ENU_E] = targetEnuM.v[ENU_E] - est->position.v[ENU_E] * 0.01f,
+            [ENU_N] = targetEnuM.v[ENU_N] - est->position.v[ENU_N] * 0.01f,
+            [ENU_U] = targetEnuM.v[ENU_U] - est->position.v[ENU_U] * 0.01f,
+        }};
         const float legLenM = vector3Norm(&legVec);
         if (delaySec > 0.0f && legLenM > 0.1f) {
             const float scaledMps = MAX(FP_DELAY_MIN_CRUISE_MPS, legLenM / delaySec);

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -517,16 +517,17 @@ static void sensorUpdate(bool newGpsData)
 
     if (useEstXY) {
         const positionEstimate3d_t *est = positionEstimatorGetEstimate();
-        rescueState.sensor.distanceToHomeCm = hypotf(est->position.x, est->position.y);
+        rescueState.sensor.distanceToHomeCm = hypotf(est->position.v[ENU_E], est->position.v[ENU_N]);
         rescueState.sensor.distanceToHomeM = rescueState.sensor.distanceToHomeCm * 0.01f;
-        rescueState.sensor.directionToHome = rescueBearingToHomeDecideg(est->position.x, est->position.y);
-        rescueState.sensor.groundSpeedCmS = hypotf(est->velocity.x, est->velocity.y);
+        rescueState.sensor.directionToHome = rescueBearingToHomeDecideg(est->position.v[ENU_E], est->position.v[ENU_N]);
+        rescueState.sensor.groundSpeedCmS = hypotf(est->velocity.v[ENU_E], est->velocity.v[ENU_N]);
         const float distCm = rescueState.sensor.distanceToHomeCm;
         if (distCm > 10.0f) {
             const float invDist = 1.0f / distCm;
-            const float ux = -est->position.x * invDist;
-            const float uy = -est->position.y * invDist;
-            rescueState.sensor.velocityToHomeCmS = est->velocity.x * ux + est->velocity.y * uy;
+            // Unit vector from craft toward home (negated position), ENU horizontal.
+            const float uEast  = -est->position.v[ENU_E] * invDist;
+            const float uNorth = -est->position.v[ENU_N] * invDist;
+            rescueState.sensor.velocityToHomeCmS = est->velocity.v[ENU_E] * uEast + est->velocity.v[ENU_N] * uNorth;
         } else {
             rescueState.sensor.velocityToHomeCmS = 0.0f;
         }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -95,6 +95,9 @@ static float smallAngleCosZ = 0;
 static imuRuntimeConfig_t imuRuntimeConfig;
 
 matrix33_t rMat;
+// Horizontal earth-frame heading vectors in imu.c (north_ef, cog_ef, heading_ef,
+// mag2d_ef) are vector2_t in the NWU ground plane: index NWU_N and NWU_W only.
+// NWU_U (==2) would read past a 2-element vector - do not use it on these.
 static vector2_t north_ef;
 
 #if defined(USE_ACC)

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -176,8 +176,10 @@ void imuConfigure(uint16_t throttle_correction_angle, uint8_t throttle_correctio
     imuRuntimeConfig.imuDcmKi = imuConfig()->imu_dcm_ki / 10000.0f;
     // magnetic declination has negative sign (positive clockwise when seen from top)
     const float imuMagneticDeclinationRad = DEGREES_TO_RADIANS(imuConfig()->mag_declination / 10.0f);
-    sincosf_approx(imuMagneticDeclinationRad, &north_ef.y, &north_ef.x);
-    north_ef.y = -north_ef.y;
+    // north_ef: magnetic-north reference in the horizontal earth frame (NWU).
+    // v[NWU_N] = cos(declination), v[NWU_W] = -sin(declination).
+    sincosf_approx(imuMagneticDeclinationRad, &north_ef.v[NWU_W], &north_ef.v[NWU_N]);
+    north_ef.v[NWU_W] = -north_ef.v[NWU_W];
 
     smallAngleCosZ = cos_approx(degreesToRadians(imuConfig()->small_angle));
 
@@ -461,14 +463,16 @@ static float imuCalcGroundspeedGain(float dt)
 // return value rotation around earth Z axis, pointing in directipon of smaller error, [rad/s]
 STATIC_UNIT_TESTED float imuCalcCourseErr(float courseOverGround)
 {
-    // Compute COG heading unit vector in earth frame (ef) from scalar GPS CourseOverGround
-    // Earth frame X is pointing north and sin/cos argument is anticlockwise. (|cog_ef| == 1.0)
+    // Compute COG heading unit vector in the horizontal earth frame (NWU) from
+    // scalar GPS CourseOverGround. North is v[NWU_N]; the sin/cos argument is
+    // anticlockwise so the orthogonal component lands on West (v[NWU_W]). (|cog_ef| == 1.0)
     float sin, cos;
     sincosf_approx(-courseOverGround, &sin, &cos);
-    const vector2_t cog_ef = {.x = cos, .y = sin};
+    const vector2_t cog_ef = {.v = {[NWU_N] = cos, [NWU_W] = sin}};
 
-    // Compute and normalise craft Earth frame heading vector from body X axis
-    vector2_t heading_ef = {.x = rMat.m[X][X], .y = rMat.m[Y][X]};
+    // Compute and normalise craft earth-frame heading vector from the body X axis
+    // (first column of rMat): row NWU_N is North, row NWU_W is West.
+    vector2_t heading_ef = {.v = {[NWU_N] = rMat.m[X][X], [NWU_W] = rMat.m[Y][X]}};
     vector2Normalize(&heading_ef, &heading_ef); // XY only, normalised to magnitude 1.0
 
     // cross (vector product) = |heading| * |cog| * sin(angle) = 1 * 1 * sin(angle)
@@ -513,7 +517,7 @@ static void imuDebug_GPS_RESCUE_HEADING(void)
         matrixVectorMul(&mag_ef_yawed, &rMatZTrans, &mag_ef); // EF->EF yawed
 
         // Magnetic yaw is the angle between true north and the X axis of the body frame
-        int16_t magYaw = lrintf((atan2_approx(mag_ef_yawed.y, mag_ef_yawed.x) * (1800.0f / M_PIf)));
+        int16_t magYaw = lrintf((atan2_approx(mag_ef_yawed.v[NWU_W], mag_ef_yawed.v[NWU_N]) * (1800.0f / M_PIf)));
         if (magYaw < 0) {
             magYaw += 3600;
         }
@@ -543,7 +547,7 @@ STATIC_UNIT_TESTED float imuCalcMagErr(void)
 
         // For magnetometer correction we make an assumption that magnetic field is perpendicular to gravity (ignore Z-component in EF).
         // This way magnetic field will only affect heading and wont mess roll/pitch angles
-        vector2_t mag2d_ef = {.x = mag_ef.x, .y = mag_ef.y};
+        vector2_t mag2d_ef = {.v = {[NWU_N] = mag_ef.v[NWU_N], [NWU_W] = mag_ef.v[NWU_W]}};
         // mag2d_ef - measured mag field vector in EF (2D ground plane projection)
         // north_ef - reference mag field vector heading due North in EF (2D ground plane projection).
         //              Adjusted for magnetic declination (in imuConfigure)

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -146,21 +146,25 @@ STATIC_UNIT_TESTED void imuComputeRotationMatrix(void)
 {
     imuQuaternionComputeProducts(&q, &qP);
 
-    rMat.m[0][0] = 1.0f - 2.0f * qP.yy - 2.0f * qP.zz;
-    rMat.m[0][1] = 2.0f * (qP.xy + -qP.wz);
-    rMat.m[0][2] = 2.0f * (qP.xz - -qP.wy);
+    // rMat is the body->earth rotation: earthVec = rMat * bodyVec, with earth in
+    // NWU. The row selects the earth axis (NWU_N/NWU_W/NWU_U), the column selects
+    // the body axis (X/Y/Z). NWU_N/W/U and X/Y/Z share index values 0/1/2, so the
+    // named form denotes the same storage as the old m[0..2][0..2] literals.
+    rMat.m[NWU_N][X] = 1.0f - 2.0f * qP.yy - 2.0f * qP.zz;
+    rMat.m[NWU_N][Y] = 2.0f * (qP.xy + -qP.wz);
+    rMat.m[NWU_N][Z] = 2.0f * (qP.xz - -qP.wy);
 
-    rMat.m[1][0] = 2.0f * (qP.xy - -qP.wz);
-    rMat.m[1][1] = 1.0f - 2.0f * qP.xx - 2.0f * qP.zz;
-    rMat.m[1][2] = 2.0f * (qP.yz + -qP.wx);
+    rMat.m[NWU_W][X] = 2.0f * (qP.xy - -qP.wz);
+    rMat.m[NWU_W][Y] = 1.0f - 2.0f * qP.xx - 2.0f * qP.zz;
+    rMat.m[NWU_W][Z] = 2.0f * (qP.yz + -qP.wx);
 
-    rMat.m[2][0] = 2.0f * (qP.xz + -qP.wy);
-    rMat.m[2][1] = 2.0f * (qP.yz - -qP.wx);
-    rMat.m[2][2] = 1.0f - 2.0f * qP.xx - 2.0f * qP.yy;
+    rMat.m[NWU_U][X] = 2.0f * (qP.xz + -qP.wy);
+    rMat.m[NWU_U][Y] = 2.0f * (qP.yz - -qP.wx);
+    rMat.m[NWU_U][Z] = 1.0f - 2.0f * qP.xx - 2.0f * qP.yy;
 
 #if ENABLE_SIMULATOR && !defined(USE_IMU_CALC) && !defined(SET_IMU_FROM_EULER)
-    rMat.m[1][0] = -2.0f * (qP.xy - -qP.wz);
-    rMat.m[2][0] = -2.0f * (qP.xz + -qP.wy);
+    rMat.m[NWU_W][X] = -2.0f * (qP.xy - -qP.wz);
+    rMat.m[NWU_U][X] = -2.0f * (qP.xz + -qP.wy);
 #endif
 }
 
@@ -240,10 +244,11 @@ STATIC_UNIT_TESTED void imuMahonyAHRSupdate(float dt,
     float ex = 0, ey = 0, ez = 0;
 
     // Add error from magnetometer and Cog
-    // just rotate input value to body frame
-    ex += rMat.m[Z][X] * (headingErrCog + headingErrMag);
-    ey += rMat.m[Z][Y] * (headingErrCog + headingErrMag);
-    ez += rMat.m[Z][Z] * (headingErrCog + headingErrMag);
+    // The earth-Up row (NWU_U) of rMat is earth-up expressed in the body frame,
+    // so it rotates the earth-Z heading error onto the body axes.
+    ex += rMat.m[NWU_U][X] * (headingErrCog + headingErrMag);
+    ey += rMat.m[NWU_U][Y] * (headingErrCog + headingErrMag);
+    ez += rMat.m[NWU_U][Z] * (headingErrCog + headingErrMag);
 
     DEBUG_SET(DEBUG_ATTITUDE, 3, (headingErrCog * 100));
     DEBUG_SET(DEBUG_ATTITUDE, 7, lrintf(dcmKpGain * 100.0f));
@@ -258,10 +263,11 @@ STATIC_UNIT_TESTED void imuMahonyAHRSupdate(float dt,
         ay *= recipAccNorm;
         az *= recipAccNorm;
 
-        // Error is sum of cross product between estimated direction and measured direction of gravity
-        ex += (ay * rMat.m[2][2] - az * rMat.m[2][1]);
-        ey += (az * rMat.m[2][0] - ax * rMat.m[2][2]);
-        ez += (ax * rMat.m[2][1] - ay * rMat.m[2][0]);
+        // Error is sum of cross product between estimated direction and measured direction of gravity.
+        // The earth-Up row (NWU_U) is the estimated gravity/up direction in the body frame.
+        ex += (ay * rMat.m[NWU_U][Z] - az * rMat.m[NWU_U][Y]);
+        ey += (az * rMat.m[NWU_U][X] - ax * rMat.m[NWU_U][Z]);
+        ez += (ax * rMat.m[NWU_U][Y] - ay * rMat.m[NWU_U][X]);
     }
 
     // Compute and apply integral feedback if enabled
@@ -325,9 +331,9 @@ STATIC_UNIT_TESTED void imuUpdateEulerAngles(void)
        attitude.values.yaw = lrintf((-atan2_approx((+2.0f * (buffer.wz + buffer.xy)), (+1.0f - 2.0f * (buffer.yy + buffer.zz))) * (1800.0f / M_PIf)));
        imuAttitudeQuaternion = headfree;
     } else {
-       attitude.values.roll = lrintf(atan2_approx(rMat.m[2][1], rMat.m[2][2]) * (1800.0f / M_PIf));
-       attitude.values.pitch = lrintf(((0.5f * M_PIf) - acos_approx(-rMat.m[2][0])) * (1800.0f / M_PIf));
-       attitude.values.yaw = lrintf((-atan2_approx(rMat.m[1][0], rMat.m[0][0]) * (1800.0f / M_PIf)));
+       attitude.values.roll = lrintf(atan2_approx(rMat.m[NWU_U][Y], rMat.m[NWU_U][Z]) * (1800.0f / M_PIf));
+       attitude.values.pitch = lrintf(((0.5f * M_PIf) - acos_approx(-rMat.m[NWU_U][X])) * (1800.0f / M_PIf));
+       attitude.values.yaw = lrintf((-atan2_approx(rMat.m[NWU_W][X], rMat.m[NWU_N][X]) * (1800.0f / M_PIf)));
        imuAttitudeQuaternion = q; //using current q quaternion  for blackbox log
     }
 
@@ -472,7 +478,7 @@ STATIC_UNIT_TESTED float imuCalcCourseErr(float courseOverGround)
 
     // Compute and normalise craft earth-frame heading vector from the body X axis
     // (first column of rMat): row NWU_N is North, row NWU_W is West.
-    vector2_t heading_ef = {.v = {[NWU_N] = rMat.m[X][X], [NWU_W] = rMat.m[Y][X]}};
+    vector2_t heading_ef = {.v = {[NWU_N] = rMat.m[NWU_N][X], [NWU_W] = rMat.m[NWU_W][X]}};
     vector2Normalize(&heading_ef, &heading_ef); // XY only, normalised to magnitude 1.0
 
     // cross (vector product) = |heading| * |cog| * sin(angle) = 1 * 1 * sin(angle)
@@ -511,7 +517,7 @@ static void imuDebug_GPS_RESCUE_HEADING(void)
         matrixVectorMul(&mag_ef, &rMat, &mag_bf); // BF->EF true north
 
         matrix33_t rMatZTrans;
-        yawToRotationMatrixZ(&rMatZTrans, -atan2_approx(rMat.m[1][0], rMat.m[0][0]));
+        yawToRotationMatrixZ(&rMatZTrans, -atan2_approx(rMat.m[NWU_W][X], rMat.m[NWU_N][X]));
 
         vector3_t mag_ef_yawed;
         matrixVectorMul(&mag_ef_yawed, &rMatZTrans, &mag_ef); // EF->EF yawed
@@ -807,12 +813,12 @@ void imuUpdateAttitude(timeUs_t currentTimeUs)
 // Positive angle - nose down, negative angle - nose up.
 float getSinPitchAngle(void)
 {
-    return -rMat.m[2][0];
+    return -rMat.m[NWU_U][X];
 }
 
 float getCosTiltAngle(void)
 {
-    return rMat.m[2][2];
+    return rMat.m[NWU_U][Z];
 }
 
 void getQuaternion(quaternion_t *quat)

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -258,10 +258,10 @@ void positionEstimatorEnableXY(bool enable)
     if (enable && !xyEnabled) {
         kalmanInit(&kfX, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
         kalmanInit(&kfY, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
-        estimate.position.x = 0.0f;
-        estimate.position.y = 0.0f;
-        estimate.velocity.x = 0.0f;
-        estimate.velocity.y = 0.0f;
+        estimate.position.v[ENU_E] = 0.0f;
+        estimate.position.v[ENU_N] = 0.0f;
+        estimate.velocity.v[ENU_E] = 0.0f;
+        estimate.velocity.v[ENU_N] = 0.0f;
         lastXYMeasurementUs = 0;
         estimate.isValidXY = false;
 #ifdef USE_GPS
@@ -370,12 +370,13 @@ static void feedGPSMeasurements(timeUs_t nowUs)
     if (xyEnabled && gpsXYAllowed && gpsArmLocationSet) {
         vector2_t gpsDistCm;
         GPS_distance2d(&armLocationGps, &gpsSol.llh, &gpsDistCm);
-        // gpsDistCm: X = East-West (lon), Y = North-South (lat) of craft relative to arm position
+        // gpsDistCm is ENU horizontal: v[ENU_E] = East (lon), v[ENU_N] = North (lat)
+        // of the craft relative to the arm position.
 
         const uint16_t xyDop = gpsDopOrFallback(gpsSol.dop.hdop, gpsSol.dop.pdop);
         const float rPos = gpsR(R_GPS_POS_BASE, xyDop);
-        kalmanUpdatePosition(&kfX, gpsDistCm.x, rPos);
-        kalmanUpdatePosition(&kfY, gpsDistCm.y, rPos);
+        kalmanUpdatePosition(&kfX, gpsDistCm.v[ENU_E], rPos);
+        kalmanUpdatePosition(&kfY, gpsDistCm.v[ENU_N], rPos);
 
         // GPS velocity (NED from UBX) -> ENU
         const float rVel = gpsR(R_GPS_VEL_BASE, xyDop);
@@ -611,14 +612,14 @@ void positionEstimatorUpdate(void)
     // Calibrate drifting sensor offsets against KF estimate anchored by non-drifting sources
     crossCalibrateOffsets(zCal, CAL_Z_COUNT, kalmanGetPosition(&kfZ));
 
-    // Extract state into the unified estimate
-    estimate.position.x = kalmanGetPosition(&kfX);
-    estimate.position.y = kalmanGetPosition(&kfY);
-    estimate.position.z = kalmanGetPosition(&kfZ);
+    // Extract state into the unified estimate (kfX/kfY/kfZ are the East/North/Up filters)
+    estimate.position.v[ENU_E] = kalmanGetPosition(&kfX);
+    estimate.position.v[ENU_N] = kalmanGetPosition(&kfY);
+    estimate.position.v[ENU_U] = kalmanGetPosition(&kfZ);
 
-    estimate.velocity.x = kalmanGetVelocity(&kfX);
-    estimate.velocity.y = kalmanGetVelocity(&kfY);
-    estimate.velocity.z = kalmanGetVelocity(&kfZ);
+    estimate.velocity.v[ENU_E] = kalmanGetVelocity(&kfX);
+    estimate.velocity.v[ENU_N] = kalmanGetVelocity(&kfY);
+    estimate.velocity.v[ENU_U] = kalmanGetVelocity(&kfZ);
 
     // Validity: based on recent measurement updates
     if (xyEnabled) {
@@ -644,12 +645,12 @@ const positionEstimate3d_t *positionEstimatorGetEstimate(void)
 
 float positionEstimatorGetAltitudeCm(void)
 {
-    return estimate.position.z;
+    return estimate.position.v[ENU_U];
 }
 
 float positionEstimatorGetAltitudeDerivative(void)
 {
-    return estimate.velocity.z;
+    return estimate.velocity.v[ENU_U];
 }
 
 bool positionEstimatorIsValidXY(void)
@@ -687,8 +688,8 @@ bool positionEstimatorIsGPSContributing(void)
 void positionEstimatorResetZ(void)
 {
     kalmanInit(&kfZ, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_Z);
-    estimate.position.z = 0.0f;
-    estimate.velocity.z = 0.0f;
+    estimate.position.v[ENU_U] = 0.0f;
+    estimate.velocity.v[ENU_U] = 0.0f;
     estimate.isValidZ = false;
     lastZMeasurementUs = 0;
 #ifdef USE_GPS
@@ -712,10 +713,10 @@ void positionEstimatorResetXY(void)
 {
     kalmanInit(&kfX, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
     kalmanInit(&kfY, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
-    estimate.position.x = 0.0f;
-    estimate.position.y = 0.0f;
-    estimate.velocity.x = 0.0f;
-    estimate.velocity.y = 0.0f;
+    estimate.position.v[ENU_E] = 0.0f;
+    estimate.position.v[ENU_N] = 0.0f;
+    estimate.velocity.v[ENU_E] = 0.0f;
+    estimate.velocity.v[ENU_N] = 0.0f;
     estimate.isValidXY = false;
     lastXYMeasurementUs = 0;
 #ifdef USE_GPS

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -171,9 +171,10 @@ typedef struct {
 
 enum { CAL_Z_BARO = 0, CAL_Z_GPS, CAL_Z_RF, CAL_Z_COUNT };
 
-static positionKalman_t kfX;
-static positionKalman_t kfY;
-static positionKalman_t kfZ;
+// Independent 1-D Kalman filters, one per ENU axis (East, North, Up).
+static positionKalman_t kfEast;
+static positionKalman_t kfNorth;
+static positionKalman_t kfUp;
 
 static positionEstimate3d_t estimate;
 
@@ -219,9 +220,9 @@ static void initZCalEntries(void)
 
 void positionEstimatorInit(void)
 {
-    kalmanInit(&kfX, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
-    kalmanInit(&kfY, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
-    kalmanInit(&kfZ, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_Z);
+    kalmanInit(&kfEast, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
+    kalmanInit(&kfNorth, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
+    kalmanInit(&kfUp, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_Z);
 
     estimate.position = (vector3_t){{0, 0, 0}};
     estimate.velocity = (vector3_t){{0, 0, 0}};
@@ -256,8 +257,8 @@ void positionEstimatorInit(void)
 void positionEstimatorEnableXY(bool enable)
 {
     if (enable && !xyEnabled) {
-        kalmanInit(&kfX, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
-        kalmanInit(&kfY, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
+        kalmanInit(&kfEast, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
+        kalmanInit(&kfNorth, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
         estimate.position.v[ENU_E] = 0.0f;
         estimate.position.v[ENU_N] = 0.0f;
         estimate.velocity.v[ENU_E] = 0.0f;
@@ -375,13 +376,13 @@ static void feedGPSMeasurements(timeUs_t nowUs)
 
         const uint16_t xyDop = gpsDopOrFallback(gpsSol.dop.hdop, gpsSol.dop.pdop);
         const float rPos = gpsR(R_GPS_POS_BASE, xyDop);
-        kalmanUpdatePosition(&kfX, gpsDistCm.v[ENU_E], rPos);
-        kalmanUpdatePosition(&kfY, gpsDistCm.v[ENU_N], rPos);
+        kalmanUpdatePosition(&kfEast, gpsDistCm.v[ENU_E], rPos);
+        kalmanUpdatePosition(&kfNorth, gpsDistCm.v[ENU_N], rPos);
 
         // GPS velocity (NED from UBX) -> ENU
         const float rVel = gpsR(R_GPS_VEL_BASE, xyDop);
-        kalmanUpdateVelocity(&kfX, (float)gpsSol.velned.velE, rVel);
-        kalmanUpdateVelocity(&kfY, (float)gpsSol.velned.velN, rVel);
+        kalmanUpdateVelocity(&kfEast, (float)gpsSol.velned.velE, rVel);
+        kalmanUpdateVelocity(&kfNorth, (float)gpsSol.velned.velN, rVel);
 
         lastXYMeasurementUs = nowUs;
     }
@@ -400,7 +401,7 @@ static void feedGPSMeasurements(timeUs_t nowUs)
         const float gpsAltR = gpsR(R_GPS_ALT_BASE, altDop) * (1.0f + baroPreference * 2.0f);
 
         const float gpsRelativeAltCm = gpsSol.llh.altCm - gpsAltOffsetCm;
-        kalmanUpdatePosition(&kfZ, gpsRelativeAltCm, gpsAltR);
+        kalmanUpdatePosition(&kfUp, gpsRelativeAltCm, gpsAltR);
         lastZMeasurementUs = nowUs;
 
         zCal[CAL_Z_GPS].rawReading = gpsSol.llh.altCm;
@@ -437,7 +438,7 @@ static void feedBaroMeasurements(timeUs_t nowUs)
     const float baroPreference = constrainf(positionConfig()->altitude_prefer_baro * 0.01f, 0.01f, 1.0f);
     const float baroR = R_BARO_ALT / baroPreference;
 
-    kalmanUpdatePosition(&kfZ, baroAltCm - baroAltOffsetCm, baroR);
+    kalmanUpdatePosition(&kfUp, baroAltCm - baroAltOffsetCm, baroR);
     lastZMeasurementUs = nowUs;
 
     zCal[CAL_Z_BARO].rawReading = baroAltCm;
@@ -473,7 +474,7 @@ static void feedRangefinderMeasurements(timeUs_t nowUs)
         rfR *= 0.25f;  // even lower noise -> stronger pull
     }
 
-    kalmanUpdatePosition(&kfZ, altCm - rangefinderAltOffsetCm, rfR);
+    kalmanUpdatePosition(&kfUp, altCm - rangefinderAltOffsetCm, rfR);
     lastZMeasurementUs = nowUs;
 
     zCal[CAL_Z_RF].rawReading = altCm;
@@ -549,8 +550,8 @@ static void feedOpticalFlowMeasurements(timeUs_t nowUs)
     const float velEast  =  velForward * sinYaw - velRight * cosYaw;
     const float velNorth =  velForward * cosYaw + velRight * sinYaw;
 
-    kalmanUpdateVelocity(&kfX, velEast, flowR);
-    kalmanUpdateVelocity(&kfY, velNorth, flowR);
+    kalmanUpdateVelocity(&kfEast, velEast, flowR);
+    kalmanUpdateVelocity(&kfNorth, velNorth, flowR);
 
     lastXYMeasurementUs = nowUs;
 #else
@@ -595,12 +596,12 @@ void positionEstimatorUpdate(void)
     // Z-axis: always runs (for altitude hold, OSD, vario).
     // While disarmed, predict with zero acceleration so covariance continues to evolve
     // and incoming baro/rangefinder updates remain responsive.
-    kalmanPredict(&kfZ, dt, ARMING_FLAG(ARMED) ? accelUp : 0.0f);
+    kalmanPredict(&kfUp, dt, ARMING_FLAG(ARMED) ? accelUp : 0.0f);
 
     // XY axes: only when a consumer is active
     if (xyEnabled && ARMING_FLAG(ARMED)) {
-        kalmanPredict(&kfX, dt, accelEast);
-        kalmanPredict(&kfY, dt, accelNorth);
+        kalmanPredict(&kfEast, dt, accelEast);
+        kalmanPredict(&kfNorth, dt, accelNorth);
     }
 
     // Feed sensor measurements (order does not matter)
@@ -610,16 +611,16 @@ void positionEstimatorUpdate(void)
     feedOpticalFlowMeasurements(nowUs);
 
     // Calibrate drifting sensor offsets against KF estimate anchored by non-drifting sources
-    crossCalibrateOffsets(zCal, CAL_Z_COUNT, kalmanGetPosition(&kfZ));
+    crossCalibrateOffsets(zCal, CAL_Z_COUNT, kalmanGetPosition(&kfUp));
 
-    // Extract state into the unified estimate (kfX/kfY/kfZ are the East/North/Up filters)
-    estimate.position.v[ENU_E] = kalmanGetPosition(&kfX);
-    estimate.position.v[ENU_N] = kalmanGetPosition(&kfY);
-    estimate.position.v[ENU_U] = kalmanGetPosition(&kfZ);
+    // Extract state into the unified estimate (kfEast/kfNorth/kfUp are the East/North/Up filters)
+    estimate.position.v[ENU_E] = kalmanGetPosition(&kfEast);
+    estimate.position.v[ENU_N] = kalmanGetPosition(&kfNorth);
+    estimate.position.v[ENU_U] = kalmanGetPosition(&kfUp);
 
-    estimate.velocity.v[ENU_E] = kalmanGetVelocity(&kfX);
-    estimate.velocity.v[ENU_N] = kalmanGetVelocity(&kfY);
-    estimate.velocity.v[ENU_U] = kalmanGetVelocity(&kfZ);
+    estimate.velocity.v[ENU_E] = kalmanGetVelocity(&kfEast);
+    estimate.velocity.v[ENU_N] = kalmanGetVelocity(&kfNorth);
+    estimate.velocity.v[ENU_U] = kalmanGetVelocity(&kfUp);
 
     // Validity: based on recent measurement updates
     if (xyEnabled) {
@@ -633,9 +634,9 @@ void positionEstimatorUpdate(void)
 
     // Trust: derived from position covariance (lower variance = higher trust)
     // Map variance to 0-1: trust = 1 / (1 + variance/scale)
-    const float xyVar = (kalmanGetPositionVariance(&kfX) + kalmanGetPositionVariance(&kfY)) * 0.5f;
+    const float xyVar = (kalmanGetPositionVariance(&kfEast) + kalmanGetPositionVariance(&kfNorth)) * 0.5f;
     estimate.trustXY = 1.0f / (1.0f + xyVar / 10000.0f);
-    estimate.trustZ = 1.0f / (1.0f + kalmanGetPositionVariance(&kfZ) / 10000.0f);
+    estimate.trustZ = 1.0f / (1.0f + kalmanGetPositionVariance(&kfUp) / 10000.0f);
 }
 
 const positionEstimate3d_t *positionEstimatorGetEstimate(void)
@@ -687,7 +688,7 @@ bool positionEstimatorIsGPSContributing(void)
 
 void positionEstimatorResetZ(void)
 {
-    kalmanInit(&kfZ, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_Z);
+    kalmanInit(&kfUp, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_Z);
     estimate.position.v[ENU_U] = 0.0f;
     estimate.velocity.v[ENU_U] = 0.0f;
     estimate.isValidZ = false;
@@ -711,8 +712,8 @@ void positionEstimatorResetZ(void)
 
 void positionEstimatorResetXY(void)
 {
-    kalmanInit(&kfX, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
-    kalmanInit(&kfY, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
+    kalmanInit(&kfEast, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
+    kalmanInit(&kfNorth, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
     estimate.position.v[ENU_E] = 0.0f;
     estimate.position.v[ENU_N] = 0.0f;
     estimate.velocity.v[ENU_E] = 0.0f;

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -292,10 +292,11 @@ STATIC_UNIT_TESTED void getLinearAccelENU(float *accelEast, float *accelNorth, f
     vector3_t accEF_NWU;
     matrixVectorMul(&accEF_NWU, &rMat, &accBF);
 
-    // NWU -> ENU named outputs (East = -West, gravity removed from Up).
-    *accelEast  = -accEF_NWU.y * GRAVITY_CMSS;
-    *accelNorth =  accEF_NWU.x * GRAVITY_CMSS;
-    *accelUp    = (accEF_NWU.z - 1.0f) * GRAVITY_CMSS;
+    // NWU -> ENU named outputs. Indexing by NWU_W makes the East = -West sign
+    // explicit; gravity (a steady +1 g on NWU_U) is removed from Up.
+    *accelEast  = -accEF_NWU.v[NWU_W] * GRAVITY_CMSS;
+    *accelNorth =  accEF_NWU.v[NWU_N] * GRAVITY_CMSS;
+    *accelUp    = (accEF_NWU.v[NWU_U] - 1.0f) * GRAVITY_CMSS;
 }
 
 #ifdef USE_GPS

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -371,13 +371,13 @@ static void feedGPSMeasurements(timeUs_t nowUs)
     if (xyEnabled && gpsXYAllowed && gpsArmLocationSet) {
         vector2_t gpsDistCm;
         GPS_distance2d(&armLocationGps, &gpsSol.llh, &gpsDistCm);
-        // gpsDistCm is ENU horizontal: v[ENU_E] = East (lon), v[ENU_N] = North (lat)
-        // of the craft relative to the arm position.
+        // gpsDistCm is a 2-axis horizontal earth-frame vector (efAxis_e):
+        // v[EF_EAST] = East (lon), v[EF_NORTH] = North (lat) relative to the arm point.
 
         const uint16_t xyDop = gpsDopOrFallback(gpsSol.dop.hdop, gpsSol.dop.pdop);
         const float rPos = gpsR(R_GPS_POS_BASE, xyDop);
-        kalmanUpdatePosition(&kfEast, gpsDistCm.v[ENU_E], rPos);
-        kalmanUpdatePosition(&kfNorth, gpsDistCm.v[ENU_N], rPos);
+        kalmanUpdatePosition(&kfEast, gpsDistCm.v[EF_EAST], rPos);
+        kalmanUpdatePosition(&kfNorth, gpsDistCm.v[EF_NORTH], rPos);
 
         // GPS velocity (NED from UBX) -> ENU
         const float rVel = gpsR(R_GPS_VEL_BASE, xyDop);

--- a/src/main/flight/position_estimator.h
+++ b/src/main/flight/position_estimator.h
@@ -42,7 +42,7 @@ void positionEstimatorInit(void);
 void positionEstimatorUpdate(void);
 
 // Request XY fusion (normally automatic from armed state / sensors / modes).
-// May re-initialize kfX/kfY when transitioning to enabled; disabling stops prediction only.
+// May re-initialize kfEast/kfNorth when transitioning to enabled; disabling stops prediction only.
 void positionEstimatorEnableXY(bool enable);
 
 // Read the unified estimate

--- a/src/main/flight/position_nav.c
+++ b/src/main/flight/position_nav.c
@@ -130,17 +130,17 @@ void positionNavUpdate(float dt, const positionEstimate3d_t *est)
         return;
     }
 
-    const float posEastM  = est->position.x * 0.01f;
-    const float posNorthM = est->position.y * 0.01f;
-    const float posUpM    = est->position.z * 0.01f;
+    const float posEastM  = est->position.v[ENU_E] * 0.01f;
+    const float posNorthM = est->position.v[ENU_N] * 0.01f;
+    const float posUpM    = est->position.v[ENU_U] * 0.01f;
 
-    vector3_t errorEfM = {{
-        cmd.targetPosEfM.x - posEastM,
-        cmd.targetPosEfM.y - posNorthM,
-        cmd.includeAltitude ? (cmd.targetPosEfM.z - posUpM) : 0.0f
+    vector3_t errorEfM = {.v = {
+        [ENU_E] = cmd.targetPosEfM.v[ENU_E] - posEastM,
+        [ENU_N] = cmd.targetPosEfM.v[ENU_N] - posNorthM,
+        [ENU_U] = cmd.includeAltitude ? (cmd.targetPosEfM.v[ENU_U] - posUpM) : 0.0f
     }};
 
-    const float horizDistM = sqrtf(sq(errorEfM.x) + sq(errorEfM.y));
+    const float horizDistM = sqrtf(sq(errorEfM.v[ENU_E]) + sq(errorEfM.v[ENU_N]));
     const float distanceM = cmd.includeAltitude ? vector3Norm(&errorEfM) : horizDistM;
 
     vector3_t dirEf;
@@ -173,15 +173,11 @@ void positionNavUpdate(float dt, const positionEstimate3d_t *est)
 
     previousTargetVelMps = targetVelMps;
 
-    currentTargetVelCmS = (vector3_t){{
-        targetVelMps.x * 100.0f,
-        targetVelMps.y * 100.0f,
-        targetVelMps.z * 100.0f
-    }};
+    vector3Scale(&currentTargetVelCmS, &targetVelMps, 100.0f);  // m/s -> cm/s, ENU
 
-    const float horizSpeedMps = sqrtf(sq(est->velocity.x) + sq(est->velocity.y)) * 0.01f;
-    const float absVzMps = fabsf(est->velocity.z * 0.01f);
-    const float absErrZM = fabsf(cmd.targetPosEfM.z - posUpM);
+    const float horizSpeedMps = sqrtf(sq(est->velocity.v[ENU_E]) + sq(est->velocity.v[ENU_N])) * 0.01f;
+    const float absVzMps = fabsf(est->velocity.v[ENU_U] * 0.01f);
+    const float absErrZM = fabsf(cmd.targetPosEfM.v[ENU_U] - posUpM);
 
     if (!withinAcceptanceRadius) {
         if (horizDistM <= cmd.acceptanceRadiusM) {

--- a/src/main/flight/position_nav.h
+++ b/src/main/flight/position_nav.h
@@ -32,8 +32,8 @@ typedef struct positionNavCommand_s {
     bool completed;
     bool completionSignalled;
 
-    vector3_t targetPosEfM;         // target position, metres, ENU (x=east, y=north, z=up)
-    bool includeAltitude;           // when false, z is ignored for nav, arrival, and alt coupling
+    vector3_t targetPosEfM;         // target position, metres, ENU (index by ENU_E/ENU_N/ENU_U)
+    bool includeAltitude;           // when false, ENU_U is ignored for nav, arrival, and alt coupling
 
     float cruiseSpeedMps;           // maximum cruise speed (m/s)
     float acceptanceRadiusM;        // arrival zone radius (metres)

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -837,7 +837,8 @@ static void osdElementArtificialHorizon(osdElementParms_t *element)
 static void osdElementUpDownReference(osdElementParms_t *element)
 {
 // Up/Down reference feature displays reference points on the OSD at Zenith and Nadir
-    const float earthUpinBodyFrame[3] = {-rMat.m[2][0], -rMat.m[2][1], -rMat.m[2][2]}; //transforum the up vector to the body frame
+    // The earth-Up row (NWU_U) of rMat is earth-up expressed per body axis; negate to point down.
+    const float earthUpinBodyFrame[3] = {-rMat.m[NWU_U][X], -rMat.m[NWU_U][Y], -rMat.m[NWU_U][Z]};
 
     if (fabsf(earthUpinBodyFrame[2]) < SINE_25_DEG && fabsf(earthUpinBodyFrame[1]) < SINE_25_DEG) {
         float thetaB; // pitch from body frame to zenith/nadir

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -109,15 +109,15 @@ TEST(FlightImuTest, TestCalculateRotationMatrix)
 
     imuComputeRotationMatrix();
 
-    EXPECT_FLOAT_EQ(1.0f, rMat.m[0][0]);
-    EXPECT_FLOAT_EQ(0.0f, rMat.m[0][1]);
-    EXPECT_FLOAT_EQ(0.0f, rMat.m[0][2]);
-    EXPECT_FLOAT_EQ(0.0f, rMat.m[1][0]);
-    EXPECT_FLOAT_EQ(1.0f, rMat.m[1][1]);
-    EXPECT_FLOAT_EQ(0.0f, rMat.m[1][2]);
-    EXPECT_FLOAT_EQ(0.0f, rMat.m[2][0]);
-    EXPECT_FLOAT_EQ(0.0f, rMat.m[2][1]);
-    EXPECT_FLOAT_EQ(1.0f, rMat.m[2][2]);
+    EXPECT_FLOAT_EQ(1.0f, rMat.m[NWU_N][X]);
+    EXPECT_FLOAT_EQ(0.0f, rMat.m[NWU_N][Y]);
+    EXPECT_FLOAT_EQ(0.0f, rMat.m[NWU_N][Z]);
+    EXPECT_FLOAT_EQ(0.0f, rMat.m[NWU_W][X]);
+    EXPECT_FLOAT_EQ(1.0f, rMat.m[NWU_W][Y]);
+    EXPECT_FLOAT_EQ(0.0f, rMat.m[NWU_W][Z]);
+    EXPECT_FLOAT_EQ(0.0f, rMat.m[NWU_U][X]);
+    EXPECT_FLOAT_EQ(0.0f, rMat.m[NWU_U][Y]);
+    EXPECT_FLOAT_EQ(1.0f, rMat.m[NWU_U][Z]);
 
     // 90 degrees around Z axis
     q.w = sqrt2over2;
@@ -127,15 +127,15 @@ TEST(FlightImuTest, TestCalculateRotationMatrix)
 
     imuComputeRotationMatrix();
 
-    EXPECT_NEAR(0.0f, rMat.m[0][0], TOL);
-    EXPECT_NEAR(-1.0f, rMat.m[0][1], TOL);
-    EXPECT_NEAR(0.0f, rMat.m[0][2], TOL);
-    EXPECT_NEAR(1.0f, rMat.m[1][0], TOL);
-    EXPECT_NEAR(0.0f, rMat.m[1][1], TOL);
-    EXPECT_NEAR(0.0f, rMat.m[1][2], TOL);
-    EXPECT_NEAR(0.0f, rMat.m[2][0], TOL);
-    EXPECT_NEAR(0.0f, rMat.m[2][1], TOL);
-    EXPECT_NEAR(1.0f, rMat.m[2][2], TOL);
+    EXPECT_NEAR(0.0f, rMat.m[NWU_N][X], TOL);
+    EXPECT_NEAR(-1.0f, rMat.m[NWU_N][Y], TOL);
+    EXPECT_NEAR(0.0f, rMat.m[NWU_N][Z], TOL);
+    EXPECT_NEAR(1.0f, rMat.m[NWU_W][X], TOL);
+    EXPECT_NEAR(0.0f, rMat.m[NWU_W][Y], TOL);
+    EXPECT_NEAR(0.0f, rMat.m[NWU_W][Z], TOL);
+    EXPECT_NEAR(0.0f, rMat.m[NWU_U][X], TOL);
+    EXPECT_NEAR(0.0f, rMat.m[NWU_U][Y], TOL);
+    EXPECT_NEAR(1.0f, rMat.m[NWU_U][Z], TOL);
 
     // 60 degrees around X axis
     q.w = 0.866f;
@@ -145,15 +145,15 @@ TEST(FlightImuTest, TestCalculateRotationMatrix)
 
     imuComputeRotationMatrix();
 
-    EXPECT_NEAR(1.0f, rMat.m[0][0], TOL);
-    EXPECT_NEAR(0.0f, rMat.m[0][1], TOL);
-    EXPECT_NEAR(0.0f, rMat.m[0][2], TOL);
-    EXPECT_NEAR(0.0f, rMat.m[1][0], TOL);
-    EXPECT_NEAR(0.5f, rMat.m[1][1], TOL);
-    EXPECT_NEAR(-0.866f, rMat.m[1][2], TOL);
-    EXPECT_NEAR(0.0f, rMat.m[2][0], TOL);
-    EXPECT_NEAR(0.866f, rMat.m[2][1], TOL);
-    EXPECT_NEAR(0.5f, rMat.m[2][2], TOL);
+    EXPECT_NEAR(1.0f, rMat.m[NWU_N][X], TOL);
+    EXPECT_NEAR(0.0f, rMat.m[NWU_N][Y], TOL);
+    EXPECT_NEAR(0.0f, rMat.m[NWU_N][Z], TOL);
+    EXPECT_NEAR(0.0f, rMat.m[NWU_W][X], TOL);
+    EXPECT_NEAR(0.5f, rMat.m[NWU_W][Y], TOL);
+    EXPECT_NEAR(-0.866f, rMat.m[NWU_W][Z], TOL);
+    EXPECT_NEAR(0.0f, rMat.m[NWU_U][X], TOL);
+    EXPECT_NEAR(0.866f, rMat.m[NWU_U][Y], TOL);
+    EXPECT_NEAR(0.5f, rMat.m[NWU_U][Z], TOL);
 }
 
 TEST(FlightImuTest, TestUpdateEulerAngles)
@@ -169,10 +169,10 @@ TEST(FlightImuTest, TestUpdateEulerAngles)
 
     // 45 degree yaw
     memset(&rMat, 0.0, sizeof(float) * 9);
-    rMat.m[0][0] = sqrt2over2;
-    rMat.m[0][1] = sqrt2over2;
-    rMat.m[1][0] = -sqrt2over2;
-    rMat.m[1][1] = sqrt2over2;
+    rMat.m[NWU_N][X] = sqrt2over2;
+    rMat.m[NWU_N][Y] = sqrt2over2;
+    rMat.m[NWU_W][X] = -sqrt2over2;
+    rMat.m[NWU_W][Y] = sqrt2over2;
 
     imuUpdateEulerAngles();
 
@@ -201,10 +201,10 @@ TEST(FlightImuTest, TestSmallAngle)
     EXPECT_FALSE(isUpright());
 
     // given
-    rMat.m[0][0] = r1;
-    rMat.m[0][2] = r2;
-    rMat.m[2][0] = -r2;
-    rMat.m[2][2] = r1;
+    rMat.m[NWU_N][X] = r1;
+    rMat.m[NWU_N][Z] = r2;
+    rMat.m[NWU_U][X] = -r2;
+    rMat.m[NWU_U][Z] = r1;
 
     // when
     imuComputeRotationMatrix();

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -91,9 +91,9 @@ protected:
         memset(debug, 0, sizeof(debug));
 
         // Identity rotation and 1G reciprocal scale so zero accel stays zero.
-        rMat.m[0][0] = 1.0f;
-        rMat.m[1][1] = 1.0f;
-        rMat.m[2][2] = 1.0f;
+        rMat.m[NWU_N][X] = 1.0f;
+        rMat.m[NWU_W][Y] = 1.0f;
+        rMat.m[NWU_U][Z] = 1.0f;
         acc.dev.acc_1G_rec = 1.0f;
         acc.accADC.z = 1.0f;
 
@@ -142,7 +142,7 @@ TEST_F(PositionEstimatorTest, RangefinderPreferFallsBackAndRecovers)
 }
 
 // Regression test: GPS_distance2d must be called as (arm, current) so that a craft
-// East of the arm position produces a positive kfX (East) position estimate.
+// East of the arm position produces a positive kfEast (East) position estimate.
 // The bug had the arguments reversed — (current, arm) — giving a negative East estimate.
 TEST_F(PositionEstimatorTest, GPSPositionEastOfArmIsPositive)
 {
@@ -183,15 +183,15 @@ static void setRMatFromEuler(float rollDeg, float pitchDeg, float yawDeg)
     const float xy = q1 * q2, xz = q1 * q3, yz = q2 * q3;
     const float wx = q0 * q1, wy = q0 * q2, wz = q0 * q3;
 
-    rMat.m[0][0] = 1.0f - 2.0f * yy - 2.0f * zz;
-    rMat.m[0][1] = 2.0f * (xy - wz);
-    rMat.m[0][2] = 2.0f * (xz + wy);
-    rMat.m[1][0] = 2.0f * (xy + wz);
-    rMat.m[1][1] = 1.0f - 2.0f * xx - 2.0f * zz;
-    rMat.m[1][2] = 2.0f * (yz - wx);
-    rMat.m[2][0] = 2.0f * (xz - wy);
-    rMat.m[2][1] = 2.0f * (yz + wx);
-    rMat.m[2][2] = 1.0f - 2.0f * xx - 2.0f * yy;
+    rMat.m[NWU_N][X] = 1.0f - 2.0f * yy - 2.0f * zz;
+    rMat.m[NWU_N][Y] = 2.0f * (xy - wz);
+    rMat.m[NWU_N][Z] = 2.0f * (xz + wy);
+    rMat.m[NWU_W][X] = 2.0f * (xy + wz);
+    rMat.m[NWU_W][Y] = 1.0f - 2.0f * xx - 2.0f * zz;
+    rMat.m[NWU_W][Z] = 2.0f * (yz - wx);
+    rMat.m[NWU_U][X] = 2.0f * (xz - wy);
+    rMat.m[NWU_U][Y] = 2.0f * (yz + wx);
+    rMat.m[NWU_U][Z] = 1.0f - 2.0f * xx - 2.0f * yy;
 }
 
 // Regression test for the East-West / magnitude bug discussed in #15321 and #15339.

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -155,7 +155,8 @@ TEST_F(PositionEstimatorTest, GPSPositionEastOfArmIsPositive)
     // Let the Kalman filter converge toward the GPS position measurement.
     stepEstimator(30);
 
-    EXPECT_GT(positionEstimatorGetEstimate()->position.x, 0.0f);
+    // position is ENU; index by ENU_E so "East" is explicit rather than ".x".
+    EXPECT_GT(positionEstimatorGetEstimate()->position.v[ENU_E], 0.0f);
 }
 
 // Build rMat from roll/pitch/yaw using the exact quaternion + rotation-matrix
@@ -240,6 +241,7 @@ TEST_F(PositionEstimatorTest, EastThrustProducesPositiveEastVelocity)
     // driven purely by the IMU prediction.
     stepEstimator(100);
 
-    EXPECT_GT(positionEstimatorGetEstimate()->velocity.x, 0.0f);
+    // velocity is ENU; index by ENU_E so "East" is explicit rather than ".x".
+    EXPECT_GT(positionEstimatorGetEstimate()->velocity.v[ENU_E], 0.0f);
 }
 


### PR DESCRIPTION
Implements #15344 and #15345.

> [!NOTE]
> **#15342 is now merged** (`fix(position): correct East-West inversion in getLinearAccelENU`, master `64f0b2901`). This branch has been **rebased onto master and the fix commit dropped** — the diff against `master` is now **refactor-only, with no behavioural change**. The earlier merge-order caveat no longer applies.

## Why

`.x` / `.y` on a `vector3_t` cannot tell you which axis you have or what its sign convention is — the reader has to *remember* that a given vector is ENU, or NWU, or NED. That ambiguity is exactly what produced the East–West inversion fixed in #15342: an NWU quantity was labelled NED (`vectorNED_t.ef.E/.N/.D`) and rotated the wrong way. This PR removes the ambiguity at its source by making the frame, axis, and positive direction explicit at every earth-frame access site.

## What

New sign-bearing axis enums in `common/axis.h`:

| Enum | Members | Frame |
|------|---------|-------|
| `axisNWU_e` | `NWU_N` / `NWU_W` / `NWU_U` | body→earth frame produced by `rMat` (imu.c) |
| `axisENU_e` | `ENU_E` / `ENU_N` / `ENU_U` | navigation frame (position estimator, autopilot) |
| `efAxis_e`  | `EF_EAST` / `EF_NORTH` | 2-axis horizontal earth frame |

The misleading, now-unused `axisNED_e` and `vectorNED_t` are removed (they claimed NED while `rMat` produces NWU).

Every earth-frame `.x/.y/.z` access in the position/IMU/navigation code is converted to index by these enums. Where per-axis code was really a whole-vector operation, it is collapsed (`targetPosition = est->position`, `vector3Scale` for m/s→cm/s). The `rMat` rotation matrix is indexed by **earth axis on the row** (`NWU_*`) and **body axis on the column** (`X/Y/Z`), and the `kfX/kfY/kfZ` Kalman filters are renamed `kfEast/kfNorth/kfUp`.

## Relationship to the #15342 fix (now in master)

The one behaviourally-significant change — `getLinearAccelENU` switching `matrixTrnVectorMul` (`rMatᵀ`, earth→body) → `matrixVectorMul` (`rMat`, body→earth) with `East = -v[NWU_W]`, plus the `EastThrustProducesEastAccelENU` regression test — **landed in master as #15342** and is no longer part of this branch. What remains here for that function is purely the rename of its access pattern (`accEF_NWU.y` → `accEF_NWU.v[NWU_W]`, etc.), which is behaviourally inert.

## Behavioural neutrality — verified

`NWU_N/W/U`, `ENU_E/N/U` and `X/Y/Z` all share index values `0/1/2` (and `EF_EAST/EF_NORTH` = `0/1`), so the rename conversions are pure storage renames over the same union — **no logic change**. The SITL `.text` size is byte-identical across the rename and hardening commits.

## Commits

| Commit | Scope |
|--------|-------|
| `refactor(axis): sign-bearing earth-frame axis enums` | new enums; remove `axisNED_e` / `vectorNED_t` |
| `refactor(nav): index ENU consumers by named axis enums` | estimator, autopilot, position_nav, flight_plan_nav, gps_rescue |
| `refactor(imu): name horizontal earth-frame heading vectors (NWU)` | `north_ef`, `cog_ef`, `heading_ef`, `mag2d_ef`, `mag_ef_yawed` |
| `refactor(imu): name rMat rows (earth NWU) and columns (body) + ENU kf names` | rotation matrix + Kalman filter handles |
| `refactor(axis): lock EF/ENU invariant and harden 2-axis indexing` | review follow-up (below) |

## Review hardening (last commit)

- `STATIC_ASSERT((int)EF_EAST == (int)ENU_E)` + the `EF_NORTH`/`ENU_N` counterpart lock the cross-enum coupling the autopilot relies on (stores by `EF_*`, reads by `ENU_*`): reordering either enum now fails to compile instead of silently swapping axes.
- The genuinely 2-axis ENU vectors (`gpsDistCm`, `enuCm`) are indexed by `efAxis_e` so there is no `_U` member to read past the end of a `vector2_t`.
- imu.c's horizontal NWU heading vectors are documented as `vector2_t` (index `NWU_N`/`NWU_W` only).

## Verification

- Unit tests pass: `flight_imu` (17), `position_estimator` (4), `althold`/autopilot (6), `position_nav` (23), `flight_plan_nav` (13).
- `make TARGET=SITL` links clean (covers `gps_rescue_multirotor.c` and `osd_elements.c`, which have no unit tests).
- Grep confirms no bare earth-frame `.x/.y/.z`, no numeric `rMat.m[..][..]`, and no `kfX/Y/Z` remain.

## Deliberately out of scope

Giving `rMat`'s body-axis **columns** (and other body-frame vectors: `gyroADC`, `accADC`, PID axes) sign-bearing names beyond the existing `X/Y/Z` enum is **not** done here, by design:

- **Consistency:** body `X/Y/Z` (`axis_e`) is used in ~254 sites across ~47 files. The body X that is column 0 of `rMat` is the same body X as `accADC.x` everywhere else. Renaming it only in `rMat`'s columns would read against the convention every other site follows; doing it properly means a codebase-wide body-frame sweep (gyro/acc/PID/filters) — large and behaviourally sensitive.
- **Different risk class:** the bug this PR targets was earth-frame *frame-confusion* (ENU vs NWU vs NED, where `.y` silently meant West in one place and North in another, with a sign flip). Body `X/Y/Z` has no such trap — it is consistently forward/left/up (right-handed) and never reinterpreted with a hidden sign. It is generically named, not *ambiguously* named.

Tracked as a separate follow-up: #15347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated coordinate-frame axis handling to use consistent Earth-frame ENU indexing.
  * Simplified Earth-frame vector usage and updated related navigation/position computations.
* **Bug Fixes**
  * Corrected gravity-removed linear acceleration and associated Earth-frame velocity/position component mapping.
  * Improved consistency of heading/orientation-derived calculations (including OSD earth-up reference behavior).
* **Tests**
  * Expanded unit tests for ENU gravity-removed acceleration and updated expectations for heading/rotation matrix indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
