### PR TITLE
telemetry/mavlink: command actuation + mission completeness

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -504,6 +504,11 @@ if (crashFlipModeActive) {
 
 void disarm(flightLogDisarmReason_e reason)
 {
+#if ENABLE_TELEMETRY_MAVLINK_COMMANDS
+    // Drop any MAVLink-commanded mode override so it can never persist into a
+    // disarmed state and re-assert modes on the next arm.
+    rcModeClearExternalOverrides();
+#endif
 
     if (!wasLastDisarmUserRequested()) {
         // Non-user disarm, clear the user-initated flag in rc_controls.c

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -72,6 +72,27 @@ void rcModeUpdate(const boxBitmask_t *newState)
     rcModeActivationMask = *newState;
 }
 
+#if ENABLE_TELEMETRY_MAVLINK_COMMANDS
+// Box modes forced active by an external command source (MAVLink). OR'd into the
+// RC-derived mask each loop in updateActivatedModes() so the request survives the
+// per-loop recompute. Forces modes ON only — RC aux can still add modes on top.
+static boxBitmask_t rcModeExternalOverride;
+
+void rcModeSetExternalOverride(boxId_e boxId, bool enabled)
+{
+    if (enabled) {
+        bitArraySet(&rcModeExternalOverride, boxId);
+    } else {
+        bitArrayClr(&rcModeExternalOverride, boxId);
+    }
+}
+
+void rcModeClearExternalOverrides(void)
+{
+    memset(&rcModeExternalOverride, 0, sizeof(rcModeExternalOverride));
+}
+#endif
+
 bool isAirmodeEnabled(void)
 {
     return airmodeEnabled;
@@ -169,6 +190,13 @@ void updateActivatedModes(void)
     }
 
     bitArrayXor(&newMask, sizeof(newMask), &newMask, &andMask);
+
+#if ENABLE_TELEMETRY_MAVLINK_COMMANDS
+    // Force externally-commanded (MAVLink) modes active on top of the RC mask.
+    for (unsigned i = 0; i < sizeof(newMask.bits) / sizeof(newMask.bits[0]); i++) {
+        newMask.bits[i] |= rcModeExternalOverride.bits[i];
+    }
+#endif
 
     rcModeUpdate(&newMask);
 

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -152,8 +152,13 @@ void rcModeUpdate(const boxBitmask_t *newState);
 // active on top of the RC-derived mask each loop, so a MAVLink DO_SET_MODE / RTL
 // survives the per-loop recompute in updateActivatedModes(). Overrides are
 // cleared on disarm. No effect when ENABLE_TELEMETRY_MAVLINK_COMMANDS is off.
+#if ENABLE_TELEMETRY_MAVLINK_COMMANDS
 void rcModeSetExternalOverride(boxId_e boxId, bool enabled);
 void rcModeClearExternalOverrides(void);
+#else
+static inline void rcModeSetExternalOverride(boxId_e boxId, bool enabled) { (void)boxId; (void)enabled; }
+static inline void rcModeClearExternalOverrides(void) { }
+#endif
 
 bool isAirmodeEnabled(void);
 

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -148,6 +148,13 @@ typedef struct modeActivationProfile_s {
 bool IS_RC_MODE_ACTIVE(boxId_e boxId);
 void rcModeUpdate(const boxBitmask_t *newState);
 
+// External (MAVLink command) flight-mode override. Forces the selected box modes
+// active on top of the RC-derived mask each loop, so a MAVLink DO_SET_MODE / RTL
+// survives the per-loop recompute in updateActivatedModes(). Overrides are
+// cleared on disarm. No effect when ENABLE_TELEMETRY_MAVLINK_COMMANDS is off.
+void rcModeSetExternalOverride(boxId_e boxId, bool enabled);
+void rcModeClearExternalOverrides(void);
+
 bool isAirmodeEnabled(void);
 
 bool isRangeActive(uint8_t auxChannelIndex, const channelRange_t *range);

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -1614,6 +1614,11 @@ bool flightPlanNavSetCurrentIndex(uint8_t index)
         fp.currentIndex = index;
         fp.patternPending = false;
         fp.patternActive = false;
+        fp.abortReason = FP_ABORT_NONE;
+        fp.carrotPrevValid = false;   // a cursor jump re-anchors on the craft
+        fp.carrotSpeedMps = 0.0f;
+        fp.measFiltValid = false;
+        fp.overspeedHold = false;
         clearModifierState();
         fp.state = FP_NAV_TARGETING;
         dispatchWaypoint();

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -1602,12 +1602,12 @@ uint16_t flightPlanNavGetEtaSeconds(void)
     return (etaS >= (float)UINT16_MAX) ? UINT16_MAX : (uint16_t)lrintf(etaS);
 }
 
-void flightPlanNavSetCurrentIndex(uint8_t index)
+bool flightPlanNavSetCurrentIndex(uint8_t index)
 {
     // SET_CURRENT addresses the uploaded PG mission; an injected runtime plan
     // (geofence RTH / failsafe rescue) owns its own sequencing.
     if (fp.injectedCount > 0 || index >= flightPlanConfig()->waypointCount) {
-        return;
+        return false;
     }
 
     if (fp.active) {
@@ -1620,6 +1620,7 @@ void flightPlanNavSetCurrentIndex(uint8_t index)
     } else {
         fp.pendingStartIndex = index;
     }
+    return true;
 }
 
 void flightPlanNavSetReachedListener(flightPlanWaypointReachedFn fn)

--- a/src/main/flight/flight_plan_nav.h
+++ b/src/main/flight/flight_plan_nav.h
@@ -78,9 +78,9 @@ uint16_t flightPlanNavGetEtaSeconds(void);
 
 // Set the active waypoint (MAVLink MISSION_SET_CURRENT). While the executor is
 // running the PG mission it re-dispatches to that leg; while idle it becomes
-// the index the next engage starts from. Ignored for out-of-range indices and
-// while an injected plan is active.
-void flightPlanNavSetCurrentIndex(uint8_t index);
+// the index the next engage starts from. Returns false (and does nothing) for
+// out-of-range indices and while an injected plan is active.
+bool flightPlanNavSetCurrentIndex(uint8_t index);
 
 // Orbit period (deciseconds) at the configured pattern radius for a leg flown
 // at speedCmS (0 = autopilot max velocity). Converts MAVLink LOITER_TURNS turn

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -915,6 +915,24 @@ extern struct linker_symbol __fontdata_end;
 #endif
 #endif
 
+// MAVLink inbound COMMAND_LONG / COMMAND_INT actuation (arm/disarm, mode set,
+// RTL, set-home, reboot). Defaults on wherever MAVLink telemetry is built in.
+#if !defined(ENABLE_TELEMETRY_MAVLINK_COMMANDS)
+#if defined(USE_TELEMETRY_MAVLINK)
+#define ENABLE_TELEMETRY_MAVLINK_COMMANDS 1
+#else
+#define ENABLE_TELEMETRY_MAVLINK_COMMANDS 0
+#endif
+#endif
+
+// Remote arming over MAVLink is opt-in at compile time for safety. The disarm
+// path is always compiled in when commands are enabled; only the arm path is
+// gated. When enabled, arming still routes through tryArm() and honours every
+// arming-disable flag — there is no bypass.
+#if !defined(ENABLE_REMOTE_ARM)
+#define ENABLE_REMOTE_ARM 0
+#endif
+
 #if !defined(ENABLE_RX_UDP)
 #define ENABLE_RX_UDP 0
 #endif

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -44,11 +44,15 @@
 #include "pg/rx.h"
 
 #include "drivers/accgyro/accgyro.h"
+#include "drivers/motor.h"
 #include "drivers/sensor.h"
+#include "drivers/system.h"
 #include "drivers/time.h"
 
 #include "config/config.h"
+#include "fc/core.h"
 #include "fc/rc_controls.h"
+#include "fc/rc_modes.h"
 #include "fc/runtime_config.h"
 
 #include "flight/flight_plan_nav.h"
@@ -74,6 +78,16 @@
 #include "sensors/battery.h"
 
 #include "telemetry/telemetry.h"
+
+// mavlink library uses unnamed unions that causes GCC to complain if -Wpedantic is used
+// until this is resolved in mavlink library - ignore -Wpedantic for mavlink code.
+// Included before telemetry/mavlink.h so its forward-typedef of mavlink_message_t
+// yields to the real (identical) one rather than clashing.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include "common/mavlink.h"
+#pragma GCC diagnostic pop
+
 #include "telemetry/mavlink.h"
 #if ENABLE_TELEMETRY_MAVLINK_MISSION
 #include "telemetry/mavlink_mission.h"
@@ -81,13 +95,6 @@
 
 #include "build/debug.h"
 #include "build/version.h"
-
-// mavlink library uses unnamed unions that causes GCC to complain if -Wpedantic is used
-// until this is resolved in mavlink library - ignore -Wpedantic for mavlink code
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#include "common/mavlink.h"
-#pragma GCC diagnostic pop
 
 #define TELEMETRY_MAVLINK_INITIAL_PORT_MODE MODE_RXTX
 #define TELEMETRY_MAVLINK_MAXRATE 50
@@ -498,6 +505,199 @@ static void handleSetMessageInterval(const mavlink_command_long_t *cmd, uint8_t 
     mavlinkSendCommandAck(cmd->command, success ? MAV_RESULT_ACCEPTED : MAV_RESULT_DENIED, targetSystem, targetComponent);
 }
 
+#if ENABLE_TELEMETRY_MAVLINK_COMMANDS
+// Reboot is deferred until after the COMMAND_ACK has been flushed, so the GCS
+// receives the acknowledgement before the link drops.
+static bool mavlinkRebootPending = false;
+static bool mavlinkRebootToBootloader = false;
+
+// Map a Betaflight custom_mode (bfMavMode_e) onto the box-mode override. ACRO
+// clears the override (manual flight); every other selectable mode forces exactly
+// one box active. Returns false for non-selectable / unknown modes.
+static bool applyMavCustomMode(uint32_t customMode)
+{
+    rcModeClearExternalOverrides();
+
+    switch ((bfMavMode_e)customMode) {
+    case BF_MAV_MODE_ACRO:
+        return true;
+    case BF_MAV_MODE_ANGLE:
+        rcModeSetExternalOverride(BOXANGLE, true);
+        return true;
+    case BF_MAV_MODE_HORIZON:
+        rcModeSetExternalOverride(BOXHORIZON, true);
+        return true;
+    case BF_MAV_MODE_ALT_HOLD:
+        rcModeSetExternalOverride(BOXALTHOLD, true);
+        return true;
+    case BF_MAV_MODE_POS_HOLD:
+        rcModeSetExternalOverride(BOXPOSHOLD, true);
+        return true;
+    case BF_MAV_MODE_AUTOPILOT:
+        rcModeSetExternalOverride(BOXAUTOPILOT, true);
+        return true;
+    case BF_MAV_MODE_RTL:
+        rcModeSetExternalOverride(BOXGPSRESCUE, true);
+        return true;
+    case BF_MAV_MODE_FAILSAFE:
+    default:
+        return false;
+    }
+}
+
+static uint8_t handleArmDisarm(float param1)
+{
+    uint32_t arm;
+    if (!cmdParamToUint32(param1, 1, &arm)) {
+        return MAV_RESULT_DENIED;
+    }
+
+    if (arm == 0) {
+        // Disarm is always honoured.
+        disarm(DISARM_REASON_SERIAL_COMMAND);
+        return MAV_RESULT_ACCEPTED;
+    }
+
+#if ENABLE_REMOTE_ARM
+    if (ARMING_FLAG(ARMED)) {
+        return MAV_RESULT_ACCEPTED;
+    }
+    if (isArmingDisabled()) {
+        return MAV_RESULT_TEMPORARILY_REJECTED;
+    }
+    // Routes through the normal arming path — every arming-disable guard applies.
+    tryArm();
+    return ARMING_FLAG(ARMED) ? MAV_RESULT_ACCEPTED : MAV_RESULT_TEMPORARILY_REJECTED;
+#else
+    // Remote arming is opt-in at compile time (ENABLE_REMOTE_ARM).
+    return MAV_RESULT_UNSUPPORTED;
+#endif
+}
+
+static uint8_t handleSetMode(float baseModeF, float customModeF)
+{
+    uint32_t baseMode, customMode;
+    if (!cmdParamToUint32(baseModeF, 0xFF, &baseMode) ||
+        !cmdParamToUint32(customModeF, BF_MAV_MODE_COUNT - 1, &customMode)) {
+        return MAV_RESULT_DENIED;
+    }
+    // We only support selecting a Betaflight mode via custom_mode.
+    if (!(baseMode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED)) {
+        return MAV_RESULT_DENIED;
+    }
+    return applyMavCustomMode(customMode) ? MAV_RESULT_ACCEPTED : MAV_RESULT_DENIED;
+}
+
+static uint8_t handleReturnToLaunch(void)
+{
+    if (!ARMING_FLAG(ARMED)) {
+        return MAV_RESULT_TEMPORARILY_REJECTED;
+    }
+    rcModeClearExternalOverrides();
+    rcModeSetExternalOverride(BOXGPSRESCUE, true);
+    return MAV_RESULT_ACCEPTED;
+}
+
+static uint8_t handleSetHome(float useCurrentF, bool coordsValid, int32_t lat1e7, int32_t lon1e7, int32_t altCm)
+{
+#ifdef USE_GPS
+    uint32_t useCurrent;
+    if (!cmdParamToUint32(useCurrentF, 1, &useCurrent)) {
+        return MAV_RESULT_DENIED;
+    }
+
+    if (useCurrent) {
+        if (!STATE(GPS_FIX)) {
+            return MAV_RESULT_TEMPORARILY_REJECTED;
+        }
+        GPS_reset_home_position();
+        return MAV_RESULT_ACCEPTED;
+    }
+
+    if (!coordsValid || (lat1e7 == 0 && lon1e7 == 0)) {
+        return MAV_RESULT_DENIED;
+    }
+    GPS_home_llh.lat = constrain(lat1e7, -900000000, 900000000);
+    GPS_home_llh.lon = constrain(lon1e7, -1800000000, 1800000000);
+    GPS_home_llh.altCm = altCm;
+    ENABLE_STATE(GPS_FIX_HOME);
+    return MAV_RESULT_ACCEPTED;
+#else
+    UNUSED(useCurrentF);
+    UNUSED(coordsValid);
+    UNUSED(lat1e7);
+    UNUSED(lon1e7);
+    UNUSED(altCm);
+    return MAV_RESULT_UNSUPPORTED;
+#endif
+}
+
+static uint8_t handleRebootShutdown(float param1)
+{
+    // Refuse to reboot while armed.
+    if (ARMING_FLAG(ARMED)) {
+        return MAV_RESULT_TEMPORARILY_REJECTED;
+    }
+
+    uint32_t action;
+    if (!cmdParamToUint32(param1, 3, &action)) {
+        return MAV_RESULT_DENIED;
+    }
+
+    switch (action) {
+    case 0:  // do nothing
+        return MAV_RESULT_ACCEPTED;
+    case 1:  // reboot autopilot
+        mavlinkRebootToBootloader = false;
+        mavlinkRebootPending = true;
+        return MAV_RESULT_ACCEPTED;
+    case 3:  // reboot autopilot and keep it in the bootloader
+        mavlinkRebootToBootloader = true;
+        mavlinkRebootPending = true;
+        return MAV_RESULT_ACCEPTED;
+    default:
+        return MAV_RESULT_UNSUPPORTED;
+    }
+}
+
+// Shared command executor for COMMAND_LONG and COMMAND_INT. Coordinate-bearing
+// commands receive lat/lon in 1e7 degrees and altitude in cm via coordsValid.
+static uint8_t mavlinkExecCommand(uint16_t command, float param1, float param2,
+    bool coordsValid, int32_t lat1e7, int32_t lon1e7, int32_t altCm)
+{
+    switch (command) {
+    case MAV_CMD_COMPONENT_ARM_DISARM:
+        return handleArmDisarm(param1);
+    case MAV_CMD_DO_SET_MODE:
+        return handleSetMode(param1, param2);
+    case MAV_CMD_NAV_RETURN_TO_LAUNCH:
+        return handleReturnToLaunch();
+    case MAV_CMD_DO_SET_HOME:
+        return handleSetHome(param1, coordsValid, lat1e7, lon1e7, altCm);
+    case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
+        return handleRebootShutdown(param1);
+    default:
+        return MAV_RESULT_UNSUPPORTED;
+    }
+}
+
+static void handleCommandInt(const mavlink_message_t *msg)
+{
+    mavlink_command_int_t cmd;
+    mavlink_msg_command_int_decode(msg, &cmd);
+
+    if ((cmd.target_system != 0 && cmd.target_system != MAVLINK_SYSTEM_ID) ||
+        (cmd.target_component != 0 && cmd.target_component != MAVLINK_COMPONENT_ID)) {
+        return;
+    }
+
+    const int32_t altCm = isfinite(cmd.z) ? (int32_t)lroundf(cmd.z * 100.0f) : 0;
+    const uint8_t result = mavlinkExecCommand(cmd.command, cmd.param1, cmd.param2,
+        true, cmd.x, cmd.y, altCm);
+    mavlinkSendCommandAck(cmd.command, result, msg->sysid, msg->compid);
+}
+#endif // ENABLE_TELEMETRY_MAVLINK_COMMANDS
+
 static void handleCommandLong(const mavlink_message_t *msg)
 {
     mavlink_command_long_t cmd;
@@ -529,9 +729,28 @@ static void handleCommandLong(const mavlink_message_t *msg)
     case MAV_CMD_SET_MESSAGE_INTERVAL:
         handleSetMessageInterval(&cmd, msg->sysid, msg->compid);
         break;
-    default:
-        mavlinkSendCommandAck(cmd.command, MAV_RESULT_UNSUPPORTED, msg->sysid, msg->compid);
+    default: {
+#if ENABLE_TELEMETRY_MAVLINK_COMMANDS
+        // COMMAND_LONG carries lat/lon as float degrees in param5/param6 (lossy);
+        // COMMAND_INT is preferred for precise coordinates. Only convert when the
+        // command actually consumes coordinates, to avoid UB casting NaN floats.
+        bool coordsValid = false;
+        int32_t lat1e7 = 0, lon1e7 = 0, altCm = 0;
+        if (cmd.command == MAV_CMD_DO_SET_HOME &&
+            isfinite(cmd.param5) && isfinite(cmd.param6) && isfinite(cmd.param7)) {
+            coordsValid = true;
+            lat1e7 = (int32_t)lroundf(cmd.param5 * 1.0e7f);
+            lon1e7 = (int32_t)lroundf(cmd.param6 * 1.0e7f);
+            altCm = (int32_t)lroundf(cmd.param7 * 100.0f);
+        }
+        const uint8_t result = mavlinkExecCommand(cmd.command, cmd.param1, cmd.param2,
+            coordsValid, lat1e7, lon1e7, altCm);
+#else
+        const uint8_t result = MAV_RESULT_UNSUPPORTED;
+#endif
+        mavlinkSendCommandAck(cmd.command, result, msg->sysid, msg->compid);
         break;
+    }
     }
 }
 
@@ -550,6 +769,11 @@ static void mavlinkDispatch(const mavlink_message_t *msg)
     case MAVLINK_MSG_ID_COMMAND_LONG:
         handleCommandLong(msg);
         break;
+#if ENABLE_TELEMETRY_MAVLINK_COMMANDS
+    case MAVLINK_MSG_ID_COMMAND_INT:
+        handleCommandInt(msg);
+        break;
+#endif
     default:
 #if ENABLE_TELEMETRY_MAVLINK_MISSION
         mavMissionHandleMessage(msg);
@@ -572,6 +796,20 @@ static void mavlinkProcessIncoming(void)
             mavlinkDispatch(&mavRxMsg);
         }
     }
+
+#if ENABLE_TELEMETRY_MAVLINK_COMMANDS
+    // Execute a pending reboot only after the COMMAND_ACK has been flushed, so the
+    // GCS sees the acknowledgement before the link drops.
+    if (mavlinkRebootPending) {
+        waitForSerialPortToFinishTransmitting(mavlinkPort);
+        motorShutdown();
+        if (mavlinkRebootToBootloader) {
+            systemResetToBootloader(BOOTLOADER_REQUEST_ROM);
+        } else {
+            systemReset();
+        }
+    }
+#endif
 }
 
 #ifdef USE_SERIALRX_MAVLINK

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -516,33 +516,39 @@ static bool mavlinkRebootToBootloader = false;
 // one box active. Returns false for non-selectable / unknown modes.
 static bool applyMavCustomMode(uint32_t customMode)
 {
-    rcModeClearExternalOverrides();
-
+    // Resolve the target box first: a rejected mode must leave any active
+    // override (e.g. an in-progress GPS Rescue) untouched.
+    boxId_e box;
     switch ((bfMavMode_e)customMode) {
     case BF_MAV_MODE_ACRO:
+        rcModeClearExternalOverrides();
         return true;
     case BF_MAV_MODE_ANGLE:
-        rcModeSetExternalOverride(BOXANGLE, true);
-        return true;
+        box = BOXANGLE;
+        break;
     case BF_MAV_MODE_HORIZON:
-        rcModeSetExternalOverride(BOXHORIZON, true);
-        return true;
+        box = BOXHORIZON;
+        break;
     case BF_MAV_MODE_ALT_HOLD:
-        rcModeSetExternalOverride(BOXALTHOLD, true);
-        return true;
+        box = BOXALTHOLD;
+        break;
     case BF_MAV_MODE_POS_HOLD:
-        rcModeSetExternalOverride(BOXPOSHOLD, true);
-        return true;
+        box = BOXPOSHOLD;
+        break;
     case BF_MAV_MODE_AUTOPILOT:
-        rcModeSetExternalOverride(BOXAUTOPILOT, true);
-        return true;
+        box = BOXAUTOPILOT;
+        break;
     case BF_MAV_MODE_RTL:
-        rcModeSetExternalOverride(BOXGPSRESCUE, true);
-        return true;
+        box = BOXGPSRESCUE;
+        break;
     case BF_MAV_MODE_FAILSAFE:
     default:
         return false;
     }
+
+    rcModeClearExternalOverrides();
+    rcModeSetExternalOverride(box, true);
+    return true;
 }
 
 static uint8_t handleArmDisarm(float param1)
@@ -801,6 +807,7 @@ static void mavlinkProcessIncoming(void)
     // Execute a pending reboot only after the COMMAND_ACK has been flushed, so the
     // GCS sees the acknowledgement before the link drops.
     if (mavlinkRebootPending) {
+        mavlinkRebootPending = false;
         waitForSerialPortToFinishTransmitting(mavlinkPort);
         motorShutdown();
         if (mavlinkRebootToBootloader) {

--- a/src/main/telemetry/mavlink.h
+++ b/src/main/telemetry/mavlink.h
@@ -32,8 +32,13 @@ void freeMAVLinkTelemetryPort(void);
 void configureMAVLinkTelemetryPort(void);
 
 // Forward-typedef so consumers can hold pointers without dragging in
-// common/mavlink.h (which carries -Wpedantic-noisy unnamed unions).
+// common/mavlink.h (which carries -Wpedantic-noisy unnamed unions). When the
+// full MAVLink headers are already in the translation unit they provide the real
+// (identical) typedef, so skip ours to avoid a -Wtypedef-redefinition clash
+// under stricter compilers. MAVLINK_MAX_PAYLOAD_LEN is defined by mavlink_types.h.
+#ifndef MAVLINK_MAX_PAYLOAD_LEN
 typedef struct __mavlink_message mavlink_message_t;
+#endif
 
 // Pack a fully-formed mavlink_message_t into the shared TX buffer and write it
 // to the open MAVLink serial port. Implemented in telemetry/mavlink.c; shared

--- a/src/main/telemetry/mavlink_mission.c
+++ b/src/main/telemetry/mavlink_mission.c
@@ -43,6 +43,10 @@
 #include "pg/autopilot.h"
 #include "pg/flight_plan.h"
 
+// Pull in the full MAVLink headers before telemetry/mavlink.h so the latter's
+// forward-typedef of mavlink_message_t yields to the real (identical) one.
+#include "common/mavlink.h"
+
 #include "telemetry/mavlink.h"
 #include "telemetry/mavlink_mission.h"
 
@@ -62,6 +66,7 @@ typedef enum {
 
 static struct {
     missionState_e state;
+    uint8_t  missionType;       // MAV_MISSION_TYPE of the active transfer
     uint16_t nextSeq;
     uint16_t totalCount;
     uint8_t  partnerSys;
@@ -72,6 +77,22 @@ static struct {
     int16_t  pendingReachedIndex;
     bool     rtlTerminator;     // current upload ends with NAV_RETURN_TO_LAUNCH (last slot discarded)
 } m;
+
+// Geofence storage. Accepted and round-tripped to the GCS for display, but NOT
+// yet enforced or persisted across reboot — enforcement + a backing PG land in a
+// later step. Held in RAM only.
+#define MAX_FENCE_POINTS 16
+typedef struct {
+    uint16_t command;   // MAV_CMD_NAV_FENCE_*
+    int32_t  lat;       // 1e7 degrees
+    int32_t  lon;       // 1e7 degrees
+    float    param1;    // vertex count (polygon) or radius in metres (circle)
+} fencePoint_t;
+
+static struct {
+    uint8_t count;
+    fencePoint_t points[MAX_FENCE_POINTS];
+} fenceStore;
 
 static mavlink_message_t txMsg;
 
@@ -94,35 +115,46 @@ static bool senderIsActivePartner(const mavlink_message_t *msg)
     return msg->sysid == m.partnerSys && msg->compid == m.partnerComp;
 }
 
-static void sendAck(uint8_t partnerSys, uint8_t partnerComp, uint8_t type)
+static void sendAck(uint8_t partnerSys, uint8_t partnerComp, uint8_t missionType, uint8_t result)
 {
     mavlink_msg_mission_ack_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
-        partnerSys, partnerComp, type, MAV_MISSION_TYPE_MISSION, 0);
+        partnerSys, partnerComp, result, missionType, 0);
     mavlinkSendMessage(&txMsg);
 }
 
-static void sendRequestInt(uint8_t partnerSys, uint8_t partnerComp, uint16_t seq)
+static void sendRequestInt(uint8_t partnerSys, uint8_t partnerComp, uint8_t missionType, uint16_t seq)
 {
     mavlink_msg_mission_request_int_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
-        partnerSys, partnerComp, seq, MAV_MISSION_TYPE_MISSION);
+        partnerSys, partnerComp, seq, missionType);
     mavlinkSendMessage(&txMsg);
 }
 
-static void sendCount(uint8_t partnerSys, uint8_t partnerComp, uint16_t count)
+static void sendCount(uint8_t partnerSys, uint8_t partnerComp, uint8_t missionType, uint16_t count)
 {
     mavlink_msg_mission_count_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
-        partnerSys, partnerComp, count, MAV_MISSION_TYPE_MISSION, 0);
+        partnerSys, partnerComp, count, missionType, 0);
     mavlinkSendMessage(&txMsg);
 }
 
 static void abortUpload(uint8_t result)
 {
-    sendAck(m.partnerSys, m.partnerComp, result);
+    sendAck(m.partnerSys, m.partnerComp, m.missionType, result);
     m.state = MISSION_IDLE;
 }
 
 static void sendMissionItem(uint8_t partnerSys, uint8_t partnerComp, uint16_t seq)
 {
+    if (m.missionType == MAV_MISSION_TYPE_FENCE) {
+        const fencePoint_t *fpt = &fenceStore.points[seq];
+        mavlink_msg_mission_item_int_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
+            partnerSys, partnerComp, seq, MAV_FRAME_GLOBAL_INT, fpt->command, 0, 1,
+            fpt->param1, 0.0f, 0.0f, 0.0f,
+            fpt->lat, fpt->lon, 0.0f,
+            MAV_MISSION_TYPE_FENCE);
+        mavlinkSendMessage(&txMsg);
+        return;
+    }
+
     const flightPlanConfig_t *plan = flightPlanConfig();
     const waypoint_t *wp = &plan->waypoints[seq];
 
@@ -186,6 +218,21 @@ static void sendMissionItem(uint8_t partnerSys, uint8_t partnerComp, uint16_t se
         lat, lon, zM,
         MAV_MISSION_TYPE_MISSION);
     mavlinkSendMessage(&txMsg);
+}
+
+// True for the fence item commands we accept and round-trip.
+static bool isSupportedFenceCommand(uint16_t command)
+{
+    switch (command) {
+    case MAV_CMD_NAV_FENCE_RETURN_POINT:
+    case MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION:
+    case MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION:
+    case MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION:
+    case MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION:
+        return true;
+    default:
+        return false;
+    }
 }
 
 static bool decodeFrameAltCm(uint8_t frame, float z, int32_t *altCmOut, uint8_t *resultOut)
@@ -390,14 +437,17 @@ static bool mapMavCmdToWaypoint(const mavlink_mission_item_int_t *it, waypoint_t
     return true;
 }
 
-static void handleRequestList(const mavlink_message_t *msg)
+static void handleRequestList(const mavlink_message_t *msg, uint8_t missionType)
 {
-    const uint16_t count = flightPlanConfig()->waypointCount;
+    const uint16_t count = (missionType == MAV_MISSION_TYPE_FENCE)
+        ? fenceStore.count
+        : flightPlanConfig()->waypointCount;
     m.partnerSys = msg->sysid;
     m.partnerComp = msg->compid;
+    m.missionType = missionType;
 
     if (count == 0) {
-        sendCount(msg->sysid, msg->compid, 0);
+        sendCount(msg->sysid, msg->compid, missionType, 0);
         m.state = MISSION_IDLE;
         return;
     }
@@ -406,7 +456,7 @@ static void handleRequestList(const mavlink_message_t *msg)
     m.nextSeq = 0;
     m.totalCount = count;
     m.lastActivityMs = millis();
-    sendCount(msg->sysid, msg->compid, count);
+    sendCount(msg->sysid, msg->compid, missionType, count);
 }
 
 static void handleRequestInt(const mavlink_message_t *msg)
@@ -417,21 +467,22 @@ static void handleRequestInt(const mavlink_message_t *msg)
     if (!targetIsUs(req.target_system, req.target_component)) {
         return;
     }
-    if (req.mission_type != MAV_MISSION_TYPE_MISSION) {
-        sendAck(msg->sysid, msg->compid, MAV_MISSION_UNSUPPORTED);
+    if (m.state != MISSION_SENDING || !senderIsActivePartner(msg)) {
         return;
     }
-    if (m.state != MISSION_SENDING || !senderIsActivePartner(msg)) {
+    if (req.mission_type != m.missionType) {
+        sendAck(msg->sysid, msg->compid, req.mission_type, MAV_MISSION_UNSUPPORTED);
+        m.state = MISSION_IDLE;
         return;
     }
     // Allow current seq or one-back retransmit; everything else is out of sequence.
     if (req.seq != m.nextSeq && !(m.nextSeq > 0 && req.seq == m.nextSeq - 1)) {
-        sendAck(msg->sysid, msg->compid, MAV_MISSION_INVALID_SEQUENCE);
+        sendAck(msg->sysid, msg->compid, m.missionType, MAV_MISSION_INVALID_SEQUENCE);
         m.state = MISSION_IDLE;
         return;
     }
     if (req.seq >= m.totalCount) {
-        sendAck(msg->sysid, msg->compid, MAV_MISSION_INVALID_SEQUENCE);
+        sendAck(msg->sysid, msg->compid, m.missionType, MAV_MISSION_INVALID_SEQUENCE);
         m.state = MISSION_IDLE;
         return;
     }
@@ -455,22 +506,47 @@ static void handleCount(const mavlink_message_t *msg)
     if (!targetIsUs(mc.target_system, mc.target_component)) {
         return;
     }
+
+    if (mc.mission_type == MAV_MISSION_TYPE_FENCE) {
+        if (mc.count > MAX_FENCE_POINTS) {
+            sendAck(msg->sysid, msg->compid, MAV_MISSION_TYPE_FENCE, MAV_MISSION_NO_SPACE);
+            return;
+        }
+        fenceStore.count = 0;   // a new upload replaces the existing fence
+        if (mc.count == 0) {
+            sendAck(msg->sysid, msg->compid, MAV_MISSION_TYPE_FENCE, MAV_MISSION_ACCEPTED);
+            m.state = MISSION_IDLE;
+            return;
+        }
+        m.state = MISSION_RECEIVING;
+        m.missionType = MAV_MISSION_TYPE_FENCE;
+        m.nextSeq = 0;
+        m.totalCount = mc.count;
+        m.partnerSys = msg->sysid;
+        m.partnerComp = msg->compid;
+        m.lastActivityMs = millis();
+        m.retries = 0;
+        m.rtlTerminator = false;
+        sendRequestInt(msg->sysid, msg->compid, MAV_MISSION_TYPE_FENCE, 0);
+        return;
+    }
+
     if (mc.mission_type != MAV_MISSION_TYPE_MISSION) {
-        sendAck(msg->sysid, msg->compid, MAV_MISSION_UNSUPPORTED);
+        sendAck(msg->sysid, msg->compid, mc.mission_type, MAV_MISSION_UNSUPPORTED);
         return;
     }
     if (FLIGHT_MODE(AUTOPILOT_MODE)) {
-        sendAck(msg->sysid, msg->compid, MAV_MISSION_DENIED);
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_TYPE_MISSION, MAV_MISSION_DENIED);
         return;
     }
     if (mc.count > MAX_WAYPOINTS) {
-        sendAck(msg->sysid, msg->compid, MAV_MISSION_NO_SPACE);
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_TYPE_MISSION, MAV_MISSION_NO_SPACE);
         return;
     }
     if (mc.count == 0) {
         flightPlanConfigMutable()->waypointCount = 0;
         saveConfigAndNotify();
-        sendAck(msg->sysid, msg->compid, MAV_MISSION_ACCEPTED);
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED);
         m.state = MISSION_IDLE;
         return;
     }
@@ -481,6 +557,7 @@ static void handleCount(const mavlink_message_t *msg)
     flightPlanConfigMutable()->waypointCount = 0;
 
     m.state = MISSION_RECEIVING;
+    m.missionType = MAV_MISSION_TYPE_MISSION;
     m.nextSeq = 0;
     m.totalCount = mc.count;
     m.partnerSys = msg->sysid;
@@ -488,7 +565,7 @@ static void handleCount(const mavlink_message_t *msg)
     m.lastActivityMs = millis();
     m.retries = 0;
     m.rtlTerminator = false;
-    sendRequestInt(msg->sysid, msg->compid, 0);
+    sendRequestInt(msg->sysid, msg->compid, MAV_MISSION_TYPE_MISSION, 0);
 }
 
 static void handleItemInt(const mavlink_message_t *msg)
@@ -502,12 +579,36 @@ static void handleItemInt(const mavlink_message_t *msg)
     if (m.state != MISSION_RECEIVING || !senderIsActivePartner(msg)) {
         return;
     }
-    if (it.mission_type != MAV_MISSION_TYPE_MISSION) {
+    if (it.mission_type != m.missionType) {
         abortUpload(MAV_MISSION_UNSUPPORTED);
         return;
     }
     if (it.seq != m.nextSeq) {
         abortUpload(MAV_MISSION_INVALID_SEQUENCE);
+        return;
+    }
+
+    if (m.missionType == MAV_MISSION_TYPE_FENCE) {
+        if (!isSupportedFenceCommand(it.command)) {
+            abortUpload(MAV_MISSION_UNSUPPORTED);
+            return;
+        }
+        fenceStore.points[it.seq].command = it.command;
+        fenceStore.points[it.seq].lat = it.x;
+        fenceStore.points[it.seq].lon = it.y;
+        fenceStore.points[it.seq].param1 = it.param1;
+
+        m.nextSeq++;
+        m.lastActivityMs = millis();
+        m.retries = 0;
+
+        if (m.nextSeq < m.totalCount) {
+            sendRequestInt(msg->sysid, msg->compid, MAV_MISSION_TYPE_FENCE, m.nextSeq);
+            return;
+        }
+        fenceStore.count = (uint8_t)m.totalCount;
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_TYPE_FENCE, MAV_MISSION_ACCEPTED);
+        m.state = MISSION_IDLE;
         return;
     }
 
@@ -532,7 +633,7 @@ static void handleItemInt(const mavlink_message_t *msg)
     m.retries = 0;
 
     if (m.nextSeq < m.totalCount) {
-        sendRequestInt(msg->sysid, msg->compid, m.nextSeq);
+        sendRequestInt(msg->sysid, msg->compid, MAV_MISSION_TYPE_MISSION, m.nextSeq);
         return;
     }
 
@@ -540,7 +641,7 @@ static void handleItemInt(const mavlink_message_t *msg)
     const uint16_t finalCount = m.rtlTerminator ? m.totalCount - 1 : m.totalCount;
     flightPlanConfigMutable()->waypointCount = finalCount;
     saveConfigAndNotify();
-    sendAck(msg->sysid, msg->compid, MAV_MISSION_ACCEPTED);
+    sendAck(msg->sysid, msg->compid, MAV_MISSION_TYPE_MISSION, MAV_MISSION_ACCEPTED);
     m.state = MISSION_IDLE;
 }
 
@@ -551,17 +652,28 @@ static void handleClearAll(const mavlink_message_t *msg)
     if (!targetIsUs(mc.target_system, mc.target_component)) {
         return;
     }
-    if (mc.mission_type != MAV_MISSION_TYPE_MISSION) {
-        sendAck(msg->sysid, msg->compid, MAV_MISSION_UNSUPPORTED);
+
+    // mission_type 255 (MAV_MISSION_TYPE_ALL) clears every store.
+    const bool clearMission = (mc.mission_type == MAV_MISSION_TYPE_MISSION || mc.mission_type == MAV_MISSION_TYPE_ALL);
+    const bool clearFence = (mc.mission_type == MAV_MISSION_TYPE_FENCE || mc.mission_type == MAV_MISSION_TYPE_ALL);
+
+    if (!clearMission && !clearFence) {
+        sendAck(msg->sysid, msg->compid, mc.mission_type, MAV_MISSION_UNSUPPORTED);
         return;
     }
-    if (FLIGHT_MODE(AUTOPILOT_MODE)) {
-        sendAck(msg->sysid, msg->compid, MAV_MISSION_DENIED);
+    if (clearMission && FLIGHT_MODE(AUTOPILOT_MODE)) {
+        sendAck(msg->sysid, msg->compid, mc.mission_type, MAV_MISSION_DENIED);
         return;
     }
-    flightPlanConfigMutable()->waypointCount = 0;
-    saveConfigAndNotify();
-    sendAck(msg->sysid, msg->compid, MAV_MISSION_ACCEPTED);
+
+    if (clearFence) {
+        fenceStore.count = 0;
+    }
+    if (clearMission) {
+        flightPlanConfigMutable()->waypointCount = 0;
+        saveConfigAndNotify();
+    }
+    sendAck(msg->sysid, msg->compid, mc.mission_type, MAV_MISSION_ACCEPTED);
     m.state = MISSION_IDLE;
 }
 
@@ -580,14 +692,6 @@ static void handleMissionAck(const mavlink_message_t *msg)
 static void onWaypointReached(uint8_t index)
 {
     m.pendingReachedIndex = index;
-}
-
-void mavMissionInit(void)
-{
-    memset(&m, 0, sizeof(m));
-    m.state = MISSION_IDLE;
-    m.pendingReachedIndex = -1;
-    flightPlanNavSetReachedListener(onWaypointReached);
 }
 
 // Pack and send MISSION_CURRENT from live executor state. Driven at 1 Hz by
@@ -614,6 +718,30 @@ static void sendMissionCurrent(void)
     mavlinkSendMessage(&txMsg);
 }
 
+static void handleSetCurrent(const mavlink_message_t *msg)
+{
+    mavlink_mission_set_current_t sc;
+    mavlink_msg_mission_set_current_decode(msg, &sc);
+    if (!targetIsUs(sc.target_system, sc.target_component)) {
+        return;
+    }
+    if (sc.seq > UINT8_MAX || !flightPlanNavSetCurrentIndex((uint8_t)sc.seq)) {
+        // Per spec, a failed SET_CURRENT is reported via MISSION_ACK(MAV_MISSION_ERROR).
+        sendAck(msg->sysid, msg->compid, MAV_MISSION_TYPE_MISSION, MAV_MISSION_ERROR);
+        return;
+    }
+    // Acknowledge by broadcasting the new cursor.
+    sendMissionCurrent();
+}
+
+void mavMissionInit(void)
+{
+    memset(&m, 0, sizeof(m));
+    m.state = MISSION_IDLE;
+    m.pendingReachedIndex = -1;
+    flightPlanNavSetReachedListener(onWaypointReached);
+}
+
 bool mavMissionHandleMessage(const mavlink_message_t *msg)
 {
     // Each handler decodes the typed payload and applies its own target filter
@@ -626,11 +754,11 @@ bool mavMissionHandleMessage(const mavlink_message_t *msg)
         if (!targetIsUs(r.target_system, r.target_component)) {
             return true;
         }
-        if (r.mission_type != MAV_MISSION_TYPE_MISSION) {
-            sendAck(msg->sysid, msg->compid, MAV_MISSION_UNSUPPORTED);
+        if (r.mission_type != MAV_MISSION_TYPE_MISSION && r.mission_type != MAV_MISSION_TYPE_FENCE) {
+            sendAck(msg->sysid, msg->compid, r.mission_type, MAV_MISSION_UNSUPPORTED);
             return true;
         }
-        handleRequestList(msg);
+        handleRequestList(msg, r.mission_type);
         return true;
     }
     case MAVLINK_MSG_ID_MISSION_REQUEST_INT:
@@ -642,24 +770,12 @@ bool mavMissionHandleMessage(const mavlink_message_t *msg)
     case MAVLINK_MSG_ID_MISSION_ITEM_INT:
         handleItemInt(msg);
         return true;
+    case MAVLINK_MSG_ID_MISSION_SET_CURRENT:
+        handleSetCurrent(msg);
+        return true;
     case MAVLINK_MSG_ID_MISSION_CLEAR_ALL:
         handleClearAll(msg);
         return true;
-    case MAVLINK_MSG_ID_MISSION_SET_CURRENT: {
-        mavlink_mission_set_current_t sc;
-        mavlink_msg_mission_set_current_decode(msg, &sc);
-        if (!targetIsUs(sc.target_system, sc.target_component)) {
-            return true;
-        }
-        // Out-of-range seq is a no-op on the cursor; the executor guards the
-        // range too. Guard the narrowing cast so a seq > 255 can't wrap into a
-        // valid index. Either way the partner gets the current cursor back.
-        if (sc.seq <= UINT8_MAX) {
-            flightPlanNavSetCurrentIndex((uint8_t)sc.seq);
-        }
-        sendMissionCurrent();
-        return true;
-    }
     case MAVLINK_MSG_ID_MISSION_ACK:
         handleMissionAck(msg);
         return true;
@@ -677,7 +793,7 @@ void mavMissionUpdate(timeMs_t nowMs)
         } else {
             m.retries++;
             m.lastActivityMs = nowMs;
-            sendRequestInt(m.partnerSys, m.partnerComp, m.nextSeq);
+            sendRequestInt(m.partnerSys, m.partnerComp, m.missionType, m.nextSeq);
         }
     }
 

--- a/src/main/telemetry/mavlink_mission.c
+++ b/src/main/telemetry/mavlink_mission.c
@@ -43,9 +43,14 @@
 #include "pg/autopilot.h"
 #include "pg/flight_plan.h"
 
-// Pull in the full MAVLink headers before telemetry/mavlink.h so the latter's
-// forward-typedef of mavlink_message_t yields to the real (identical) one.
+// mavlink library uses unnamed unions that causes GCC to complain if -Wpedantic
+// is used - ignore -Wpedantic for mavlink code. Pull in the full MAVLink headers
+// before telemetry/mavlink.h so the latter's forward-typedef of
+// mavlink_message_t yields to the real (identical) one.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include "common/mavlink.h"
+#pragma GCC diagnostic pop
 
 #include "telemetry/mavlink.h"
 #include "telemetry/mavlink_mission.h"
@@ -512,7 +517,12 @@ static void handleCount(const mavlink_message_t *msg)
             sendAck(msg->sysid, msg->compid, MAV_MISSION_TYPE_FENCE, MAV_MISSION_NO_SPACE);
             return;
         }
-        fenceStore.count = 0;   // a new upload replaces the existing fence
+        // MAVLink semantics: MISSION_COUNT begins a full replacement, so drop
+        // the old fence up front (as the waypoint path does) rather than leave a
+        // half-overwritten store visible mid-transfer. A partner that aborts must
+        // re-upload; the fence is RAM-only and not yet enforced, so no armed
+        // behaviour depends on it surviving a failed transfer.
+        fenceStore.count = 0;
         if (mc.count == 0) {
             sendAck(msg->sysid, msg->compid, MAV_MISSION_TYPE_FENCE, MAV_MISSION_ACCEPTED);
             m.state = MISSION_IDLE;

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -638,6 +638,18 @@ osd_nav_map_unittest_DEFINES := \
 		USE_OSD= \
 		USE_OSD_NAV_MAP=
 
+mavlink_mission_unittest_SRC := \
+		$(USER_DIR)/telemetry/mavlink_mission.c \
+		$(USER_DIR)/pg/autopilot.c \
+		$(USER_DIR)/pg/flight_plan.c
+
+mavlink_mission_unittest_DEFINES := \
+		USE_GPS= \
+		USE_FLIGHT_PLAN= \
+		ENABLE_FLIGHT_PLAN=1 \
+		USE_TELEMETRY_MAVLINK= \
+		ENABLE_TELEMETRY_MAVLINK_MISSION=1
+
 rcdevice_unittest_DEFINES := \
 		USE_RCDEVICE=
 

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -1776,3 +1776,35 @@ TEST_F(FlightPlanNavCarrotTest, ChaseLagCompensationCrossesGateNearCornerSpeed)
     ASSERT_GE(crossingSpeedMps, 0.0f);
     EXPECT_LT(crossingSpeedMps, 4.3f);
 }
+
+// MAVLink MISSION_SET_CURRENT — flightPlanNavSetCurrentIndex().
+TEST_F(FlightPlanNavTest, SetCurrentIndexRejectsOutOfRange)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
+
+    EXPECT_FALSE(flightPlanNavSetCurrentIndex(2));   // count is 2 -> valid 0..1
+    EXPECT_FALSE(flightPlanNavSetCurrentIndex(99));
+}
+
+TEST_F(FlightPlanNavTest, SetCurrentIndexRejectsWhenNoMission)
+{
+    EXPECT_FALSE(flightPlanNavSetCurrentIndex(0));   // empty plan: nothing to select
+}
+
+TEST_F(FlightPlanNavTest, SetCurrentIndexJumpsActiveMission)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
+    addWaypoint(50, 60, 15000, WAYPOINT_TYPE_FLYOVER);
+
+    flightPlanNavEngage();
+    ASSERT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    const int dispatchesBefore = g_setTargetCalls;
+
+    EXPECT_TRUE(flightPlanNavSetCurrentIndex(2));
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 2);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    // Jumping re-dispatches the new leg immediately.
+    EXPECT_GT(g_setTargetCalls, dispatchesBefore);
+}

--- a/src/test/unit/mavlink_mission_unittest.cc
+++ b/src/test/unit/mavlink_mission_unittest.cc
@@ -1,0 +1,278 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Coverage for the MAVLink MISSION microservice extensions: geofence
+// upload/download (MAV_MISSION_TYPE_FENCE), MISSION_SET_CURRENT, and a
+// regression that the MISSION_TYPE_MISSION waypoint path still round-trips after
+// the transfer state machine was made mission-type-aware.
+
+#include <stdint.h>
+#include <string.h>
+
+#include <vector>
+
+extern "C" {
+    #include "platform.h"
+
+    #include "common/mavlink.h"
+
+    #include "config/config.h"
+    #include "fc/runtime_config.h"
+    #include "flight/flight_plan_nav.h"
+    #include "io/gps.h"
+    #include "pg/flight_plan.h"
+    #include "telemetry/mavlink.h"
+    #include "telemetry/mavlink_mission.h"
+
+    // --- runtime_config backing globals (STATE / FLIGHT_MODE) ---
+    uint8_t stateFlags;
+    uint16_t flightModeFlags;
+    gpsLocation_t GPS_home_llh;
+
+    // --- controllable time ---
+    static uint32_t fakeMillis = 1000;
+    uint32_t millis(void) { return fakeMillis; }
+
+    // --- config save observed but inert ---
+    static int saveCount;
+    void saveConfigAndNotify(void) { saveCount++; }
+
+    // --- flight-plan nav stubs ---
+    static bool     navActive;
+    static uint8_t  navCurrentIndex;
+    static bool     navSetResult;          // value returned by SetCurrentIndex
+    static int      navSetIndexArg;        // arg captured (-1 if not called)
+    bool flightPlanNavIsActive(void) { return navActive; }
+    uint8_t flightPlanNavGetCurrentIndex(void) { return navCurrentIndex; }
+    flightPlanNavState_e flightPlanNavGetState(void) { return FP_NAV_TARGETING; }
+    void flightPlanNavSetReachedListener(flightPlanWaypointReachedFn) {}
+    bool flightPlanNavSetCurrentIndex(uint8_t index) {
+        navSetIndexArg = index;
+        return navSetResult;
+    }
+    bool flightPlanNavIsInjectedPlanActive(void) { return false; }
+    uint16_t flightPlanNavOrbitPeriodDs(uint16_t) { return 0; }
+
+    // --- TX capture ---
+    static std::vector<mavlink_message_t> *g_sent;
+    void mavlinkSendMessage(mavlink_message_t *msg) { g_sent->push_back(*msg); }
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+#define GCS_SYS 255
+#define GCS_COMP MAV_COMP_ID_MISSIONPLANNER
+#define FC_SYS 1
+#define FC_COMP MAV_COMP_ID_AUTOPILOT1
+
+class MavMissionTest : public ::testing::Test {
+protected:
+    std::vector<mavlink_message_t> sent;
+
+    void SetUp() override {
+        g_sent = &sent;
+        sent.clear();
+        saveCount = 0;
+        fakeMillis = 1000;
+        stateFlags = 0;
+        flightModeFlags = 0;
+        memset(&GPS_home_llh, 0, sizeof(GPS_home_llh));
+
+        navActive = false;
+        navCurrentIndex = 0;
+        navSetResult = true;
+        navSetIndexArg = -1;
+
+        memset(flightPlanConfigMutable(), 0, sizeof(flightPlanConfig_t));
+
+        mavMissionInit();
+    }
+
+    void feed(const mavlink_message_t *msg) { mavMissionHandleMessage(msg); }
+
+    // Returns the last sent message of a given id, or nullptr.
+    const mavlink_message_t *lastOf(uint32_t msgid) {
+        for (auto it = sent.rbegin(); it != sent.rend(); ++it) {
+            if (it->msgid == msgid) {
+                return &(*it);
+            }
+        }
+        return nullptr;
+    }
+
+    void sendCount(uint16_t count, uint8_t type) {
+        mavlink_message_t m;
+        mavlink_msg_mission_count_pack(GCS_SYS, GCS_COMP, &m, FC_SYS, FC_COMP, count, type, 0);
+        feed(&m);
+    }
+
+    void sendItem(uint16_t seq, uint16_t command, uint8_t type, int32_t x, int32_t y, float param1 = 0.0f) {
+        mavlink_message_t m;
+        mavlink_msg_mission_item_int_pack(GCS_SYS, GCS_COMP, &m, FC_SYS, FC_COMP,
+            seq, MAV_FRAME_GLOBAL_INT, command, 0, 1,
+            param1, 0.0f, 0.0f, 0.0f, x, y, 0.0f, type);
+        feed(&m);
+    }
+
+    void sendRequestList(uint8_t type) {
+        mavlink_message_t m;
+        mavlink_msg_mission_request_list_pack(GCS_SYS, GCS_COMP, &m, FC_SYS, FC_COMP, type);
+        feed(&m);
+    }
+
+    void sendRequestInt(uint16_t seq, uint8_t type) {
+        mavlink_message_t m;
+        mavlink_msg_mission_request_int_pack(GCS_SYS, GCS_COMP, &m, FC_SYS, FC_COMP, seq, type);
+        feed(&m);
+    }
+
+    uint8_t lastAckResult() {
+        const mavlink_message_t *m = lastOf(MAVLINK_MSG_ID_MISSION_ACK);
+        EXPECT_NE(m, nullptr);
+        mavlink_mission_ack_t a;
+        mavlink_msg_mission_ack_decode(m, &a);
+        return a.type;
+    }
+};
+
+// --- Geofence upload + download round-trip ---
+TEST_F(MavMissionTest, FenceUploadThenDownloadRoundTrips)
+{
+    sendCount(2, MAV_MISSION_TYPE_FENCE);
+    // FC should request item 0 of the fence.
+    const mavlink_message_t *req = lastOf(MAVLINK_MSG_ID_MISSION_REQUEST_INT);
+    ASSERT_NE(req, nullptr);
+    mavlink_mission_request_int_t r;
+    mavlink_msg_mission_request_int_decode(req, &r);
+    EXPECT_EQ(r.seq, 0);
+    EXPECT_EQ(r.mission_type, MAV_MISSION_TYPE_FENCE);
+
+    sendItem(0, MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION, MAV_MISSION_TYPE_FENCE, 100, 200, 4.0f);
+    sendItem(1, MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION, MAV_MISSION_TYPE_FENCE, 300, 400, 25.0f);
+
+    EXPECT_EQ(lastAckResult(), MAV_MISSION_ACCEPTED);
+    EXPECT_EQ(saveCount, 0); // fence is RAM-only; must not thrash flash
+
+    // Download: request the fence back.
+    sent.clear();
+    sendRequestList(MAV_MISSION_TYPE_FENCE);
+    const mavlink_message_t *cm = lastOf(MAVLINK_MSG_ID_MISSION_COUNT);
+    ASSERT_NE(cm, nullptr);
+    mavlink_mission_count_t mc;
+    mavlink_msg_mission_count_decode(cm, &mc);
+    EXPECT_EQ(mc.count, 2);
+    EXPECT_EQ(mc.mission_type, MAV_MISSION_TYPE_FENCE);
+
+    // Download requests are sequential: ask for seq 0 first, then seq 1.
+    sendRequestInt(0, MAV_MISSION_TYPE_FENCE);
+    sendRequestInt(1, MAV_MISSION_TYPE_FENCE);
+    const mavlink_message_t *im = lastOf(MAVLINK_MSG_ID_MISSION_ITEM_INT);
+    ASSERT_NE(im, nullptr);
+    mavlink_mission_item_int_t it;
+    mavlink_msg_mission_item_int_decode(im, &it);
+    EXPECT_EQ(it.mission_type, MAV_MISSION_TYPE_FENCE);
+    EXPECT_EQ(it.command, MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION);
+    EXPECT_EQ(it.x, 300);
+    EXPECT_EQ(it.y, 400);
+    EXPECT_FLOAT_EQ(it.param1, 25.0f);
+}
+
+TEST_F(MavMissionTest, FenceUploadRejectsNonFenceCommand)
+{
+    sendCount(1, MAV_MISSION_TYPE_FENCE);
+    sendItem(0, MAV_CMD_NAV_WAYPOINT, MAV_MISSION_TYPE_FENCE, 1, 2);
+    EXPECT_EQ(lastAckResult(), MAV_MISSION_UNSUPPORTED);
+}
+
+TEST_F(MavMissionTest, FenceUploadRejectsOverCapacity)
+{
+    sendCount(100, MAV_MISSION_TYPE_FENCE); // exceeds MAX_FENCE_POINTS
+    EXPECT_EQ(lastAckResult(), MAV_MISSION_NO_SPACE);
+}
+
+// --- MISSION_SET_CURRENT ---
+TEST_F(MavMissionTest, SetCurrentValidEmitsMissionCurrent)
+{
+    navActive = true;
+    navCurrentIndex = 3;
+    navSetResult = true;
+
+    mavlink_message_t m;
+    mavlink_msg_mission_set_current_pack(GCS_SYS, GCS_COMP, &m, FC_SYS, FC_COMP, 3);
+    feed(&m);
+
+    EXPECT_EQ(navSetIndexArg, 3);
+    EXPECT_NE(lastOf(MAVLINK_MSG_ID_MISSION_CURRENT), nullptr);
+    EXPECT_EQ(lastOf(MAVLINK_MSG_ID_MISSION_ACK), nullptr); // success is not an ACK
+}
+
+TEST_F(MavMissionTest, SetCurrentInvalidReportsError)
+{
+    navSetResult = false;
+
+    mavlink_message_t m;
+    mavlink_msg_mission_set_current_pack(GCS_SYS, GCS_COMP, &m, FC_SYS, FC_COMP, 9);
+    feed(&m);
+
+    EXPECT_EQ(navSetIndexArg, 9);
+    EXPECT_EQ(lastAckResult(), MAV_MISSION_ERROR);
+}
+
+// --- Regression: waypoint mission path still works ---
+TEST_F(MavMissionTest, MissionWaypointUploadStillWorks)
+{
+    sendCount(1, MAV_MISSION_TYPE_MISSION);
+    sendItem(0, MAV_CMD_NAV_WAYPOINT, MAV_MISSION_TYPE_MISSION, 123, 456);
+
+    EXPECT_EQ(lastAckResult(), MAV_MISSION_ACCEPTED);
+    EXPECT_EQ(flightPlanConfig()->waypointCount, 1);
+    EXPECT_EQ(flightPlanConfig()->waypoints[0].latitude, 123);
+    EXPECT_EQ(flightPlanConfig()->waypoints[0].longitude, 456);
+    EXPECT_GT(saveCount, 0); // mission IS persisted
+}
+
+TEST_F(MavMissionTest, ClearAllTypeAllClearsBoth)
+{
+    // Seed a waypoint mission + a fence.
+    sendCount(1, MAV_MISSION_TYPE_MISSION);
+    sendItem(0, MAV_CMD_NAV_WAYPOINT, MAV_MISSION_TYPE_MISSION, 1, 2);
+    ASSERT_EQ(flightPlanConfig()->waypointCount, 1);
+
+    sendCount(1, MAV_MISSION_TYPE_FENCE);
+    sendItem(0, MAV_CMD_NAV_FENCE_RETURN_POINT, MAV_MISSION_TYPE_FENCE, 3, 4);
+
+    mavlink_message_t m;
+    mavlink_msg_mission_clear_all_pack(GCS_SYS, GCS_COMP, &m, FC_SYS, FC_COMP, MAV_MISSION_TYPE_ALL);
+    feed(&m);
+
+    EXPECT_EQ(lastAckResult(), MAV_MISSION_ACCEPTED);
+    EXPECT_EQ(flightPlanConfig()->waypointCount, 0);
+
+    // Fence should now download as empty.
+    sent.clear();
+    sendRequestList(MAV_MISSION_TYPE_FENCE);
+    const mavlink_message_t *cm = lastOf(MAVLINK_MSG_ID_MISSION_COUNT);
+    ASSERT_NE(cm, nullptr);
+    mavlink_mission_count_t mc;
+    mavlink_msg_mission_count_decode(cm, &mc);
+    EXPECT_EQ(mc.count, 0);
+}

--- a/src/test/unit/telemetry_mavlink_mission_unittest.cc
+++ b/src/test/unit/telemetry_mavlink_mission_unittest.cc
@@ -52,7 +52,7 @@ extern "C" {
     bool flightPlanNavIsInjectedPlanActive(void) { return s_navInjected; }
     flightPlanNavState_e flightPlanNavGetState(void) { return s_navState; }
     uint8_t flightPlanNavGetCurrentIndex(void) { return s_navIndex; }
-    void flightPlanNavSetCurrentIndex(uint8_t index) { s_setCurrentArg = index; }
+    bool flightPlanNavSetCurrentIndex(uint8_t index) { s_setCurrentArg = index; return true; }
     void flightPlanNavSetReachedListener(flightPlanWaypointReachedFn fn) { s_reachedListener = fn; }
 
     // Fixed orbit period so LOITER_TURNS <-> ORBIT conversion is deterministic.


### PR DESCRIPTION
Adds inbound MAVLink command actuation and rounds out the MISSION microservice (P1 + P2 of the command/mission work).

Commands (`ENABLE_TELEMETRY_MAVLINK_COMMANDS`, default on wherever MAVLink telemetry is built in) over COMMAND_LONG and COMMAND_INT, all replying with COMMAND_ACK: `DO_SET_MODE` (custom_mode maps to a Betaflight mode through a new `rc_modes` external override that survives the per-loop aux recompute in `updateActivatedModes()`, cleared on disarm), `NAV_RETURN_TO_LAUNCH` (forces GPS rescue), `DO_SET_HOME` (current position or explicit COMMAND_INT coordinates), `PREFLIGHT_REBOOT_SHUTDOWN` (deferred until the ACK has flushed, refused while armed), and `COMPONENT_ARM_DISARM`.

> ⚠️ **Remote arming is opt-in at compile time.** Disarm is always compiled in, but arming over MAVLink only builds with `ENABLE_REMOTE_ARM` (default `0`). Even when enabled it routes through `tryArm()`, so every arming-disable guard still applies — there is no bypass. Out of the box a GCS can disarm, change mode, RTL and reboot, but **cannot arm** until a target opts in.

Mission: `MISSION_SET_CURRENT` jumps the active waypoint; geofence upload/download/clear (`MAV_MISSION_TYPE_FENCE`) is accepted and round-tripped to the GCS but held in RAM only — not yet persisted across reboot or enforced (persistence + enforcement to follow). The transfer state machine is now mission-type-aware.

Also fixes a latent `mavlink_message_t` double-typedef that only surfaced once the mission translation unit was first compiled under the stricter unit-test toolchain.

Verified: STM32F405 builds clean (with and without `ENABLE_REMOTE_ARM`). New `mavlink_mission_unittest` (fence round-trip, set-current, waypoint regression) and `flight_plan_nav_unittest` extended for set-current both pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote flight-mode control via MAVLink telemetry commands when enabled
  * Mission waypoint selection, jumping, clearing, and status reporting
  * Geofence mission upload and download via MAVLink
  * Remote reboot, shutdown, home-position setting, and return-to-launch commands
  * Optional remote arming through standard safety checks

* **Bug Fixes**
  * Improved MAVLink command validation and acknowledgements
  * Invalid mission selections and coordinate parameters are rejected safely
  * External flight-mode overrides are cleared when disarming
<!-- end of auto-generated comment: release notes by coderabbit.ai -->