### PR TITLE
DroneCAN ESC: RawCommand output, Status telemetry, dynamic node-ID allocation

### DIFF
--- a/mk/dronecan.mk
+++ b/mk/dronecan.mk
@@ -18,6 +18,7 @@ MCU_COMMON_SRC += \
             io/dronecan/dronecan_gnss.c \
             io/dronecan/dronecan_node.c \
             io/dronecan/dronecan_esc.c \
+            io/dronecan/dronecan_dna.c \
             dronecan/libcanard/canard.c
 
 SIZE_OPTIMISED_SRC += \

--- a/mk/dronecan.mk
+++ b/mk/dronecan.mk
@@ -17,6 +17,7 @@ MCU_COMMON_SRC += \
             io/dronecan/dronecan.c \
             io/dronecan/dronecan_gnss.c \
             io/dronecan/dronecan_node.c \
+            io/dronecan/dronecan_esc.c \
             dronecan/libcanard/canard.c
 
 SIZE_OPTIMISED_SRC += \

--- a/mk/source.mk
+++ b/mk/source.mk
@@ -12,6 +12,7 @@ PG_SRC = \
             pg/can.c \
             pg/dashboard.c \
             pg/dronecan.c \
+            pg/dronecan_dna.c \
             pg/displayport_profiles.c \
             pg/dyn_notch.c \
             pg/flash.c \

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1928,6 +1928,7 @@ const clivalue_t valueTable[] = {
     { "dronecan_node_id", VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, 127 }, PG_DRONECAN_CONFIG, offsetof(dronecanConfig_t, node_id) },
     { "dronecan_device", VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 1, CANDEV_COUNT }, PG_DRONECAN_CONFIG, offsetof(dronecanConfig_t, device) },
     { "dronecan_esc_rate_hz", VAR_UINT16 | HARDWARE_VALUE, .config.minmaxUnsigned = { 50, 500 }, PG_DRONECAN_CONFIG, offsetof(dronecanConfig_t, esc_rate_hz) },
+    { "dronecan_dna_enabled", VAR_UINT8 | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_DRONECAN_CONFIG, offsetof(dronecanConfig_t, dna_enabled) },
 #endif
 #ifdef USE_MCO
 #if defined(USE_MCO_DEVICE1)

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -314,7 +314,8 @@ static const char * const lookupTableCameraControlMode[] = {
 static const char * const lookupTablePwmProtocol[] = {
     "PWM", "ONESHOT125", "ONESHOT42", "MULTISHOT", "BRUSHED",
     "DSHOT150", "DSHOT300", "DSHOT600", "PROSHOT1000",
-    "DISABLED"
+    "DISABLED",
+    "DRONECAN"
 };
 
 static const char * const lookupTableLowpassType[] = {
@@ -1926,6 +1927,7 @@ const clivalue_t valueTable[] = {
     { "dronecan_enabled", VAR_UINT8 | HARDWARE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_DRONECAN_CONFIG, offsetof(dronecanConfig_t, enabled) },
     { "dronecan_node_id", VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, 127 }, PG_DRONECAN_CONFIG, offsetof(dronecanConfig_t, node_id) },
     { "dronecan_device", VAR_UINT8 | HARDWARE_VALUE, .config.minmaxUnsigned = { 1, CANDEV_COUNT }, PG_DRONECAN_CONFIG, offsetof(dronecanConfig_t, device) },
+    { "dronecan_esc_rate_hz", VAR_UINT16 | HARDWARE_VALUE, .config.minmaxUnsigned = { 50, 500 }, PG_DRONECAN_CONFIG, offsetof(dronecanConfig_t, esc_rate_hz) },
 #endif
 #ifdef USE_MCO
 #if defined(USE_MCO_DEVICE1)

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -390,7 +390,9 @@ static void validateAndFixConfig(void)
     }
 
 #if defined(USE_ESC_SENSOR)
-    if (!findSerialPortConfig(FUNCTION_ESC_SENSOR)) {
+    // DroneCAN ESC telemetry feeds escSensorData[] without a serial port, so
+    // only a serial-sourced sensor requires one.
+    if (!findSerialPortConfig(FUNCTION_ESC_SENSOR) && !isMotorProtocolDronecan()) {
         featureDisableImmediate(FEATURE_ESC_SENSOR);
     }
 #endif

--- a/src/main/drivers/can/can_impl.h
+++ b/src/main/drivers/can/can_impl.h
@@ -34,6 +34,20 @@
 // Maximum number of alternate pin options per TX/RX line.
 #define CAN_MAX_PIN_SEL 3
 
+// Software TX ring depth (power of two so the index can be masked). Sized to
+// hold a burst of small frames — a worst-case octo esc.RawCommand is 2 frames
+// and NodeStatus/telemetry add a few more — beyond the 3-slot hardware FIFO.
+#define CAN_TX_RING_SIZE 16U
+#define CAN_TX_RING_MASK (CAN_TX_RING_SIZE - 1U)
+
+// One queued outgoing classic-CAN frame held in the software TX ring.
+typedef struct canTxFrame_s {
+    uint32_t id;                        // raw identifier (no XTD flag)
+    uint8_t  data[CAN_CLASSIC_MAX_DLC];
+    uint8_t  length;
+    bool     isExtended;
+} canTxFrame_t;
+
 typedef struct canPinDef_s {
     ioTag_t pin;
     uint8_t af;
@@ -66,6 +80,16 @@ typedef struct canDevice_s {
     uint8_t irq1;
     canRxCallbackPtr rxCallback;
     volatile uint32_t rxOverruns;   // FIFO 0 message-lost events (diagnostics)
+
+    // Software TX ring drained into the hardware Tx FIFO by canTxKick(). The
+    // producer (canTransmit, task context) advances txHead; the consumer
+    // (canTxKick, run from task with irq0 masked or from the TC ISR) advances
+    // txTail. See can_hw.c for the concurrency contract.
+    canTxFrame_t txRing[CAN_TX_RING_SIZE];
+    volatile uint8_t txHead;        // producer index (next write slot)
+    volatile uint8_t txTail;        // consumer index (next slot to transmit)
+    volatile uint32_t txRingOverflows;  // frames dropped, ring full (diagnostics)
+
     bool initialized;
 } canDevice_t;
 

--- a/src/main/drivers/can/can_impl.h
+++ b/src/main/drivers/can/can_impl.h
@@ -23,6 +23,8 @@
 
 #include "platform.h"
 
+#include "common/time.h"
+
 #include "drivers/can/can.h"
 #include "drivers/can/can_types.h"
 #include "drivers/io_types.h"
@@ -89,6 +91,15 @@ typedef struct canDevice_s {
     volatile uint8_t txHead;        // producer index (next write slot)
     volatile uint8_t txTail;        // consumer index (next slot to transmit)
     volatile uint32_t txRingOverflows;  // frames dropped, ring full (diagnostics)
+
+    // No-ACK wedge detection. With nothing to ACK (peers unpowered, bus
+    // fault) the pending hardware slots retransmit forever and TC never
+    // fires; canTransmit() watches completions while the ring is saturated
+    // and cancels the pending slots after a timeout of zero progress.
+    volatile uint32_t txCompletions;    // TC events, incremented in the ISR
+    uint32_t txCompletionsSeen;         // task-side progress snapshot
+    timeUs_t txStallSinceUs;            // when the snapshot was last refreshed
+    volatile uint32_t txStallRecoveries;    // cancel-and-drop events (diagnostics)
 
     bool initialized;
 } canDevice_t;

--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -42,6 +42,10 @@
 
 #include "sensors/battery.h"
 
+#if ENABLE_DRONECAN_ESC
+#include "io/dronecan/dronecan_esc.h"
+#endif
+
 #include "motor.h"
 
 static FAST_DATA_ZERO_INIT motorDevice_t motorDevice;
@@ -172,6 +176,11 @@ bool checkMotorProtocolEnabled(const motorDevConfig_t *motorDevConfig, bool *isP
         isDshot = true;
         break;
 #endif
+#if ENABLE_DRONECAN_ESC
+    case MOTOR_PROTOCOL_DRONECAN:
+        enabled = true;
+        break;
+#endif
     default:
         break;
     }
@@ -201,9 +210,22 @@ motorProtocolFamily_e motorGetProtocolFamily(void)
     case MOTOR_PROTOCOL_PROSHOT1000:
         return MOTOR_PROTOCOL_FAMILY_DSHOT;
 #endif
+#if ENABLE_DRONECAN_ESC
+    case MOTOR_PROTOCOL_DRONECAN:
+        return MOTOR_PROTOCOL_FAMILY_CAN;
+#endif
     default:
         return MOTOR_PROTOCOL_FAMILY_UNKNOWN;
     }
+}
+
+bool isMotorProtocolDronecan(void)
+{
+#if ENABLE_DRONECAN_ESC
+    return motorConfig()->dev.motorProtocol == MOTOR_PROTOCOL_DRONECAN;
+#else
+    return false;
+#endif
 }
 
 static void checkMotorProtocol(const motorDevConfig_t *motorDevConfig)
@@ -226,6 +248,11 @@ void motorInitEndpoints(const motorConfig_t *motorConfig, float outputLimit, flo
 #ifdef USE_DSHOT
         case MOTOR_PROTOCOL_FAMILY_DSHOT:
             dshotInitEndpoints(motorConfig, outputLimit, outputLow, outputHigh, disarm, deadbandMotor3dHigh, deadbandMotor3dLow);
+            break;
+#endif
+#if ENABLE_DRONECAN_ESC
+        case MOTOR_PROTOCOL_FAMILY_CAN:
+            dronecanMotorInitEndpoints(motorConfig, outputLimit, outputLow, outputHigh, disarm, deadbandMotor3dHigh, deadbandMotor3dLow);
             break;
 #endif
         default:
@@ -289,6 +316,12 @@ void motorDevInit(unsigned motorCount)
     motorDevice.count = motorCount;
     if (isMotorProtocolEnabled()) {
         do {
+#if ENABLE_DRONECAN_ESC
+            if (isMotorProtocolDronecan()) {
+                success = dronecanMotorDevInit(&motorDevice, motorCount);
+                break;
+            }
+#endif
             if (!isMotorProtocolDshot()) {
 #ifdef USE_PWM_OUTPUT
                 success = motorPwmDevInit(&motorDevice, motorDevConfig, idlePulse);

--- a/src/main/drivers/motor.h
+++ b/src/main/drivers/motor.h
@@ -46,6 +46,7 @@ motorProtocolFamily_e motorGetProtocolFamily(void);
 
 bool isMotorProtocolDshot(void);
 bool isMotorProtocolBidirDshot(void);
+bool isMotorProtocolDronecan(void);
 bool isMotorProtocolEnabled(void);
 
 void motorDisable(void);

--- a/src/main/drivers/motor_types.h
+++ b/src/main/drivers/motor_types.h
@@ -32,6 +32,7 @@ typedef enum {
     MOTOR_PROTOCOL_FAMILY_UNKNOWN = 0,
     MOTOR_PROTOCOL_FAMILY_PWM,
     MOTOR_PROTOCOL_FAMILY_DSHOT,
+    MOTOR_PROTOCOL_FAMILY_CAN,
 } motorProtocolFamily_e;
 
 typedef enum {
@@ -46,6 +47,9 @@ typedef enum {
 /*  MOTOR_PROTOCOL_DSHOT1200, removed */
     MOTOR_PROTOCOL_PROSHOT1000,
     MOTOR_PROTOCOL_DISABLED,
+    // Appended after DISABLED so existing stored motor_pwm_protocol values keep
+    // their meaning across a config upgrade.
+    MOTOR_PROTOCOL_DRONECAN,
     MOTOR_PROTOCOL_MAX
 } motorProtocolTypes_e;
 

--- a/src/main/io/dronecan/dronecan.c
+++ b/src/main/io/dronecan/dronecan.c
@@ -317,15 +317,18 @@ void dronecanUpdate(timeUs_t currentTimeUs)
     dronecanEscUpdate(currentTimeUs);
 #endif
 
+#if ENABLE_DRONECAN_DNA
+    // Drop dynamic-allocation sessions that have stalled mid-handshake. Runs
+    // every tick so expiry tracks the 500 ms follow-up timeout, not the 1 Hz
+    // boundary below.
+    dronecanDnaExpireSessions(currentTimeUs);
+#endif
+
     // 1 Hz boundary — publish NodeStatus and sweep stale RX transfers.
     if (cmpTimeUs(currentTimeUs, dronecanLastSecondUs) >= 1000000) {
         dronecanLastSecondUs = currentTimeUs;
         dronecanNodeUpdate(currentTimeUs);
         canardCleanupStaleTransfers(&dronecanInstance, (uint64_t)currentTimeUs);
-#if ENABLE_DRONECAN_DNA
-        // Drop dynamic-allocation sessions that have stalled mid-handshake.
-        dronecanDnaExpireSessions(currentTimeUs);
-#endif
     }
 
     dronecanDrainTxQueue();

--- a/src/main/io/dronecan/dronecan.c
+++ b/src/main/io/dronecan/dronecan.c
@@ -46,6 +46,9 @@
 #if ENABLE_DRONECAN_ESC
 #include "io/dronecan/dronecan_esc.h"
 #endif
+#if ENABLE_DRONECAN_DNA
+#include "io/dronecan/dronecan_dna.h"
+#endif
 
 // Forward declarations; implemented in dronecan_node.c / dronecan_gnss.c.
 void dronecanNodeInit(void);
@@ -272,6 +275,10 @@ void dronecanInit(void)
     // Install the esc.Status subscriber and reset the RawCommand buffer.
     dronecanEscInit();
 #endif
+#if ENABLE_DRONECAN_DNA
+    // Bring up the dynamic node-ID allocator (no-op if dna_enabled is clear).
+    dronecanDnaInit();
+#endif
 
     canRegisterRxCallback(dronecanDevice, dronecanCanRxAdapter);
 
@@ -314,6 +321,10 @@ void dronecanUpdate(timeUs_t currentTimeUs)
         dronecanLastSecondUs = currentTimeUs;
         dronecanNodeUpdate(currentTimeUs);
         canardCleanupStaleTransfers(&dronecanInstance, (uint64_t)currentTimeUs);
+#if ENABLE_DRONECAN_DNA
+        // Drop dynamic-allocation sessions that have stalled mid-handshake.
+        dronecanDnaExpireSessions(currentTimeUs);
+#endif
     }
 
     dronecanDrainTxQueue();

--- a/src/main/io/dronecan/dronecan.c
+++ b/src/main/io/dronecan/dronecan.c
@@ -283,9 +283,10 @@ void dronecanInit(void)
     canRegisterRxCallback(dronecanDevice, dronecanCanRxAdapter);
 
 #if ENABLE_DRONECAN_ESC
-    // Commanding ESCs needs a faster cadence than the 1 Hz node housekeeping.
-    // Raise the task tick to the configured RawCommand rate when DRONECAN is
-    // the active motor protocol; otherwise the default 50 Hz is ample.
+    // RawCommand is emitted from the PID loop (see dronecan_esc.c), so the task
+    // no longer drives command timing. We still raise the tick to the ESC rate
+    // when commanding so RX telemetry servicing and the fallback TX flush keep
+    // pace with the bus; otherwise the default 50 Hz node housekeeping is ample.
     if (isMotorProtocolDronecan()) {
         const uint16_t rateHz = constrain(dronecanConfig()->esc_rate_hz, 50, 500);
         rescheduleTask(TASK_DRONECAN, TASK_PERIOD_HZ(rateHz));
@@ -342,6 +343,14 @@ bool dronecanRegisterSubscriber(const dronecanSubscriber_t *subscriber)
 CanardInstance *dronecanGetInstance(void)
 {
     return &dronecanInstance;
+}
+
+void dronecanFlushTx(void)
+{
+    if (!dronecanInitialised) {
+        return;
+    }
+    dronecanDrainTxQueue();
 }
 
 #endif // ENABLE_DRONECAN

--- a/src/main/io/dronecan/dronecan.c
+++ b/src/main/io/dronecan/dronecan.c
@@ -34,11 +34,18 @@
 #include "common/utils.h"
 
 #include "drivers/can/can.h"
+#include "drivers/motor.h"
 #include "drivers/time.h"
+
+#include "scheduler/scheduler.h"
 
 #include "io/dronecan/dronecan.h"
 
 #include "pg/dronecan.h"
+
+#if ENABLE_DRONECAN_ESC
+#include "io/dronecan/dronecan_esc.h"
+#endif
 
 // Forward declarations; implemented in dronecan_node.c / dronecan_gnss.c.
 void dronecanNodeInit(void);
@@ -261,7 +268,22 @@ void dronecanInit(void)
     // land in our cache as soon as the transport is live.
     dronecanGnssInit();
 
+#if ENABLE_DRONECAN_ESC
+    // Install the esc.Status subscriber and reset the RawCommand buffer.
+    dronecanEscInit();
+#endif
+
     canRegisterRxCallback(dronecanDevice, dronecanCanRxAdapter);
+
+#if ENABLE_DRONECAN_ESC
+    // Commanding ESCs needs a faster cadence than the 1 Hz node housekeeping.
+    // Raise the task tick to the configured RawCommand rate when DRONECAN is
+    // the active motor protocol; otherwise the default 50 Hz is ample.
+    if (isMotorProtocolDronecan()) {
+        const uint16_t rateHz = constrain(dronecanConfig()->esc_rate_hz, 50, 500);
+        rescheduleTask(TASK_DRONECAN, TASK_PERIOD_HZ(rateHz));
+    }
+#endif
 
     dronecanStartUs = micros();
     dronecanLastSecondUs = dronecanStartUs;
@@ -280,6 +302,12 @@ void dronecanUpdate(timeUs_t currentTimeUs)
     }
 
     dronecanDrainRxRing(currentTimeUs);
+
+#if ENABLE_DRONECAN_ESC
+    // Broadcast esc.RawCommand (when commanding ESCs) and age stale telemetry.
+    // Runs every tick — this is the high-rate path the task is rescheduled for.
+    dronecanEscUpdate(currentTimeUs);
+#endif
 
     // 1 Hz boundary — publish NodeStatus and sweep stale RX transfers.
     if (cmpTimeUs(currentTimeUs, dronecanLastSecondUs) >= 1000000) {

--- a/src/main/io/dronecan/dronecan.c
+++ b/src/main/io/dronecan/dronecan.c
@@ -283,13 +283,13 @@ void dronecanInit(void)
     canRegisterRxCallback(dronecanDevice, dronecanCanRxAdapter);
 
 #if ENABLE_DRONECAN_ESC
-    // RawCommand is emitted from the PID loop (see dronecan_esc.c), so the task
-    // no longer drives command timing. We still raise the tick to the ESC rate
-    // when commanding so RX telemetry servicing and the fallback TX flush keep
-    // pace with the bus; otherwise the default 50 Hz node housekeeping is ample.
+    // RawCommand is emitted from the PID loop (see dronecan_esc.c) and every
+    // emission drains the TX queue, so the task only services RX telemetry and
+    // housekeeping. 100 Hz keeps the 32-slot RX ring ahead of worst-case
+    // esc.Status/GNSS bursts; tracking esc_rate_hz here would just duplicate
+    // the PID-loop flush at up to 500 Hz.
     if (isMotorProtocolDronecan()) {
-        const uint16_t rateHz = constrain(dronecanConfig()->esc_rate_hz, 50, 500);
-        rescheduleTask(TASK_DRONECAN, TASK_PERIOD_HZ(rateHz));
+        rescheduleTask(TASK_DRONECAN, TASK_PERIOD_HZ(100));
     }
 #endif
 

--- a/src/main/io/dronecan/dronecan.h
+++ b/src/main/io/dronecan/dronecan.h
@@ -73,4 +73,11 @@ bool dronecanRegisterSubscriber(const dronecanSubscriber_t *subscriber);
 // each one having to re-discover the pool.
 CanardInstance *dronecanGetInstance(void);
 
+// Drain libcanard's TX queue into the CAN driver. Safe to call from any task
+// context (the cooperative scheduler serialises libcanard access). Used by the
+// PID-loop ESC emission to push a freshly-queued RawCommand straight out, and
+// by the dronecan task as a fallback for anything left when the driver ring
+// was momentarily full. No-op until the stack is initialised.
+void dronecanFlushTx(void);
+
 #endif // ENABLE_DRONECAN

--- a/src/main/io/dronecan/dronecan_dna.c
+++ b/src/main/io/dronecan/dronecan_dna.c
@@ -229,6 +229,10 @@ static void handleAllocation(CanardInstance *ins, CanardRxTransfer *t)
 
     if (firstPart) {
         dnaAccumLen = 0;            // stage 1 — restart accumulation
+    } else if (!dnaSessionActive) {
+        // Continuation with no session in flight: a late or out-of-order frame
+        // from an abandoned handshake. Ignore it rather than resurrect state.
+        return;
     }
 
     for (uint16_t i = 0; i < idBytes && dnaAccumLen < UAVCAN_DNA_UNIQUE_ID_LEN; i++) {
@@ -252,13 +256,19 @@ static void handleAllocation(CanardInstance *ins, CanardRxTransfer *t)
         nodeId = dnaFindFreeNodeId(preferredId);
         if (nodeId == 0) {
             dnaSessionActive = false;   // nothing free to hand out
+            dnaAccumLen = 0;
             return;
         }
         dnaTableStore(dnaAccum, nodeId);
+        // Mark the grant in the live-ID mask immediately, so the ID can't be
+        // handed out twice even when the store was skipped (armed, table full)
+        // and the peer hasn't broadcast its first NodeStatus yet.
+        dnaSeenNodeIds[nodeId / 32] |= 1U << (nodeId % 32);
     }
 
     dnaRespond(nodeId, dnaAccum, UAVCAN_DNA_UNIQUE_ID_LEN);
     dnaSessionActive = false;
+    dnaAccumLen = 0;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/main/io/dronecan/dronecan_dna.c
+++ b/src/main/io/dronecan/dronecan_dna.c
@@ -1,0 +1,266 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if ENABLE_DRONECAN_DNA
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "canard.h"
+
+#include "common/time.h"
+#include "common/utils.h"
+
+#include "config/config.h"
+
+#include "drivers/time.h"
+
+#include "fc/runtime_config.h"
+
+#include "scheduler/scheduler.h"
+
+#include "pg/dronecan.h"
+#include "pg/dronecan_dna.h"
+
+#include "io/dronecan/dronecan.h"
+#include "io/dronecan/dronecan_dna.h"
+#include "io/dronecan/dronecan_msg.h"
+
+//-----------------------------------------------------------------------------
+// Centralised allocator. The FC hands node IDs to anonymous peers (e.g. ESCs)
+// via the three-stage uavcan.protocol.dynamic_node_id.Allocation handshake.
+//
+// A single in-flight session is tracked: the unique_id is accumulated 6 bytes
+// per request; each intermediate request is echoed back (node_id 0); once all
+// 16 bytes are in, a free node ID is assigned, persisted, and returned with the
+// full unique_id. first_part_of_unique_id always resets the accumulator, so a
+// fresh stage-1 from any peer cleanly restarts the sequence.
+//-----------------------------------------------------------------------------
+
+static uint8_t  dnaAccum[UAVCAN_DNA_UNIQUE_ID_LEN];
+static uint8_t  dnaAccumLen;
+static bool     dnaSessionActive;
+static timeUs_t dnaLastActivityUs;
+static uint8_t  dnaTransferId;
+
+//-----------------------------------------------------------------------------
+// Persistent table helpers
+//-----------------------------------------------------------------------------
+
+// Return the node ID previously bound to this unique_id, or 0 if none.
+static uint8_t dnaTableLookup(const uint8_t uniqueId[UAVCAN_DNA_UNIQUE_ID_LEN])
+{
+    for (int i = 0; i < DRONECAN_DNA_MAX_ENTRIES; i++) {
+        const dronecanDnaEntry_t *e = &dronecanDnaConfig()->entry[i];
+        if (e->nodeId != 0
+                && memcmp(e->uniqueId, uniqueId, UAVCAN_DNA_UNIQUE_ID_LEN) == 0) {
+            return e->nodeId;
+        }
+    }
+    return 0;
+}
+
+// Persist a new binding. Writes EEPROM only while disarmed — allocations happen
+// at peer power-up, so this is a rare, ground-only event.
+static void dnaTableStore(const uint8_t uniqueId[UAVCAN_DNA_UNIQUE_ID_LEN], uint8_t nodeId)
+{
+    for (int i = 0; i < DRONECAN_DNA_MAX_ENTRIES; i++) {
+        dronecanDnaEntry_t *e = &dronecanDnaConfigMutable()->entry[i];
+        if (e->nodeId == 0) {
+            memcpy(e->uniqueId, uniqueId, UAVCAN_DNA_UNIQUE_ID_LEN);
+            e->nodeId = nodeId;
+            if (!ARMING_FLAG(ARMED)) {
+                // The flash write stalls this task for milliseconds; tell the
+                // scheduler to ignore it rather than flag a timing overrun.
+                schedulerIgnoreTaskExecTime();
+                writeEEPROM();
+            }
+            return;
+        }
+    }
+    // Table full: the binding still works for this power cycle (the response is
+    // sent regardless), it just won't survive a reboot.
+}
+
+// Pick a free node ID, honouring the peer's preference where possible. Searches
+// up from the preferred (or 125) towards 125, then down towards 1, skipping our
+// own node ID and any already in the table. Returns 0 if none is available.
+static uint8_t dnaFindFreeNodeId(uint8_t preferred)
+{
+    bool occupied[CANARD_MAX_NODE_ID + 1];
+    memset(occupied, 0, sizeof(occupied));
+
+    const uint8_t ownId = dronecanConfig()->node_id;
+    if (ownId >= CANARD_MIN_NODE_ID && ownId <= CANARD_MAX_NODE_ID) {
+        occupied[ownId] = true;
+    }
+    for (int i = 0; i < DRONECAN_DNA_MAX_ENTRIES; i++) {
+        const uint8_t id = dronecanDnaConfig()->entry[i].nodeId;
+        if (id >= CANARD_MIN_NODE_ID && id <= CANARD_MAX_NODE_ID) {
+            occupied[id] = true;
+        }
+    }
+
+    // Dynamic IDs live in [1, 125]; 126/127 are reserved for static use.
+    const uint8_t topId = 125;
+    uint8_t start = (preferred >= CANARD_MIN_NODE_ID && preferred <= topId) ? preferred : topId;
+
+    for (uint8_t id = start; id <= topId; id++) {
+        if (!occupied[id]) {
+            return id;
+        }
+    }
+    for (uint8_t id = start; id >= CANARD_MIN_NODE_ID; id--) {
+        if (!occupied[id]) {
+            return id;
+        }
+    }
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+// Allocation message: build + send the (broadcast) response
+//-----------------------------------------------------------------------------
+
+static void dnaRespond(uint8_t nodeId, const uint8_t *uniqueId, uint8_t len)
+{
+    // node_id (7) + first_part (1) = 1 byte, then len unique_id bytes.
+    uint8_t payload[1U + UAVCAN_DNA_UNIQUE_ID_LEN];
+    memset(payload, 0, sizeof(payload));
+
+    const uint8_t firstPart = 0;    // responses never set first_part
+    canardEncodeScalar(payload, UAVCAN_DNA_OFFSET_NODE_ID,    7, &nodeId);
+    canardEncodeScalar(payload, UAVCAN_DNA_OFFSET_FIRST_PART, 1, &firstPart);
+    for (uint8_t i = 0; i < len; i++) {
+        canardEncodeScalar(payload, UAVCAN_DNA_OFFSET_UNIQUE_ID + i * 8U, 8, &uniqueId[i]);
+    }
+
+    CanardTxTransfer tx;
+    canardInitTxTransfer(&tx);
+    tx.transfer_type       = CanardTransferTypeBroadcast;
+    tx.data_type_signature = UAVCAN_DNA_ALLOCATION_SIGNATURE;
+    tx.data_type_id        = UAVCAN_DNA_ALLOCATION_ID;
+    tx.inout_transfer_id   = &dnaTransferId;
+    tx.priority            = CANARD_TRANSFER_PRIORITY_LOW;
+    tx.payload             = payload;
+    tx.payload_len         = (uint16_t)(1U + len);
+
+    canardBroadcastObj(dronecanGetInstance(), &tx);
+}
+
+//-----------------------------------------------------------------------------
+// Allocation request handler
+//-----------------------------------------------------------------------------
+
+static void handleAllocation(CanardInstance *ins, CanardRxTransfer *t)
+{
+    UNUSED(ins);
+
+    // Only anonymous transfers are allocation requests; non-anonymous Allocation
+    // messages are our own echoes or another allocator's traffic — ignore them.
+    if (t->source_node_id != CANARD_BROADCAST_NODE_ID) {
+        return;
+    }
+
+    uint8_t preferredId = 0;
+    uint8_t firstPart = 0;
+    canardDecodeScalar(t, UAVCAN_DNA_OFFSET_NODE_ID,    7, false, &preferredId);
+    canardDecodeScalar(t, UAVCAN_DNA_OFFSET_FIRST_PART, 1, false, &firstPart);
+
+    // unique_id is the tail array: everything after the 1-byte header.
+    uint16_t idBytes = (t->payload_len > 1U) ? (uint16_t)(t->payload_len - 1U) : 0U;
+    if (idBytes > UAVCAN_DNA_MAX_BYTES_PER_REQUEST) {
+        idBytes = UAVCAN_DNA_MAX_BYTES_PER_REQUEST;
+    }
+
+    if (firstPart) {
+        dnaAccumLen = 0;            // stage 1 — restart accumulation
+    }
+
+    for (uint16_t i = 0; i < idBytes && dnaAccumLen < UAVCAN_DNA_UNIQUE_ID_LEN; i++) {
+        uint8_t b = 0;
+        canardDecodeScalar(t, UAVCAN_DNA_OFFSET_UNIQUE_ID + i * 8U, 8, false, &b);
+        dnaAccum[dnaAccumLen++] = b;
+    }
+
+    dnaSessionActive = true;
+    dnaLastActivityUs = micros();
+
+    if (dnaAccumLen < UAVCAN_DNA_UNIQUE_ID_LEN) {
+        // Intermediate stage — echo what we have so far with node_id 0.
+        dnaRespond(0, dnaAccum, (uint8_t)dnaAccumLen);
+        return;
+    }
+
+    // Full unique_id received — assign (or reuse) a node ID and finalise.
+    uint8_t nodeId = dnaTableLookup(dnaAccum);
+    if (nodeId == 0) {
+        nodeId = dnaFindFreeNodeId(preferredId);
+        if (nodeId == 0) {
+            dnaSessionActive = false;   // nothing free to hand out
+            return;
+        }
+        dnaTableStore(dnaAccum, nodeId);
+    }
+
+    dnaRespond(nodeId, dnaAccum, UAVCAN_DNA_UNIQUE_ID_LEN);
+    dnaSessionActive = false;
+}
+
+//-----------------------------------------------------------------------------
+// Public surface
+//-----------------------------------------------------------------------------
+
+void dronecanDnaInit(void)
+{
+    dnaAccumLen = 0;
+    dnaSessionActive = false;
+    dnaLastActivityUs = 0;
+    dnaTransferId = 0;
+
+    if (!dronecanConfig()->dna_enabled) {
+        return;
+    }
+
+    const dronecanSubscriber_t sub = {
+        .signature    = UAVCAN_DNA_ALLOCATION_SIGNATURE,
+        .dataTypeId   = UAVCAN_DNA_ALLOCATION_ID,
+        .transferType = CanardTransferTypeBroadcast,
+        .handler      = handleAllocation,
+    };
+    (void)dronecanRegisterSubscriber(&sub);
+}
+
+void dronecanDnaExpireSessions(timeUs_t currentTimeUs)
+{
+    if (dnaSessionActive
+            && cmpTimeUs(currentTimeUs, dnaLastActivityUs) >= (timeDelta_t)(UAVCAN_DNA_FOLLOWUP_TIMEOUT_MS * 1000U)) {
+        // Allocatee went quiet mid-handshake; drop the partial state so its next
+        // stage-1 request starts cleanly.
+        dnaSessionActive = false;
+        dnaAccumLen = 0;
+    }
+}
+
+#endif // ENABLE_DRONECAN_DNA

--- a/src/main/io/dronecan/dronecan_dna.c
+++ b/src/main/io/dronecan/dronecan_dna.c
@@ -64,6 +64,27 @@ static bool     dnaSessionActive;
 static timeUs_t dnaLastActivityUs;
 static uint8_t  dnaTransferId;
 
+// Node IDs observed live on the bus (one bit per ID). Statically-configured
+// peers and nodes bound by another allocator never appear in the persisted
+// table, so the allocator must also exclude anyone it has heard NodeStatus
+// from. Never cleared: a node that goes quiet may only be rebooting.
+static uint32_t dnaSeenNodeIds[(CANARD_MAX_NODE_ID + 32) / 32];
+
+static void handleNodeStatus(CanardInstance *ins, CanardRxTransfer *t)
+{
+    UNUSED(ins);
+
+    const uint8_t id = t->source_node_id;
+    if (id >= CANARD_MIN_NODE_ID && id <= CANARD_MAX_NODE_ID) {
+        dnaSeenNodeIds[id / 32] |= 1U << (id % 32);
+    }
+}
+
+static bool dnaNodeIdSeen(uint8_t id)
+{
+    return (dnaSeenNodeIds[id / 32] & (1U << (id % 32))) != 0;
+}
+
 //-----------------------------------------------------------------------------
 // Persistent table helpers
 //-----------------------------------------------------------------------------
@@ -105,7 +126,8 @@ static void dnaTableStore(const uint8_t uniqueId[UAVCAN_DNA_UNIQUE_ID_LEN], uint
 
 // Pick a free node ID, honouring the peer's preference where possible. Searches
 // up from the preferred (or 125) towards 125, then down towards 1, skipping our
-// own node ID and any already in the table. Returns 0 if none is available.
+// own node ID, any already in the table, and any heard live on the bus.
+// Returns 0 if none is available.
 static uint8_t dnaFindFreeNodeId(uint8_t preferred)
 {
     bool occupied[CANARD_MAX_NODE_ID + 1];
@@ -118,6 +140,11 @@ static uint8_t dnaFindFreeNodeId(uint8_t preferred)
     for (int i = 0; i < DRONECAN_DNA_MAX_ENTRIES; i++) {
         const uint8_t id = dronecanDnaConfig()->entry[i].nodeId;
         if (id >= CANARD_MIN_NODE_ID && id <= CANARD_MAX_NODE_ID) {
+            occupied[id] = true;
+        }
+    }
+    for (uint8_t id = CANARD_MIN_NODE_ID; id <= CANARD_MAX_NODE_ID; id++) {
+        if (dnaNodeIdSeen(id)) {
             occupied[id] = true;
         }
     }
@@ -238,18 +265,29 @@ void dronecanDnaInit(void)
     dnaSessionActive = false;
     dnaLastActivityUs = 0;
     dnaTransferId = 0;
+    memset(dnaSeenNodeIds, 0, sizeof(dnaSeenNodeIds));
 
     if (!dronecanConfig()->dna_enabled) {
         return;
     }
 
-    const dronecanSubscriber_t sub = {
+    const dronecanSubscriber_t allocationSub = {
         .signature    = UAVCAN_DNA_ALLOCATION_SIGNATURE,
         .dataTypeId   = UAVCAN_DNA_ALLOCATION_ID,
         .transferType = CanardTransferTypeBroadcast,
         .handler      = handleAllocation,
     };
-    (void)dronecanRegisterSubscriber(&sub);
+    (void)dronecanRegisterSubscriber(&allocationSub);
+
+    // Every node broadcasts NodeStatus at >=1 Hz, so listening to it is enough
+    // to learn which IDs are already taken on the bus.
+    const dronecanSubscriber_t nodeStatusSub = {
+        .signature    = UAVCAN_NODE_STATUS_SIGNATURE,
+        .dataTypeId   = UAVCAN_NODE_STATUS_ID,
+        .transferType = CanardTransferTypeBroadcast,
+        .handler      = handleNodeStatus,
+    };
+    (void)dronecanRegisterSubscriber(&nodeStatusSub);
 }
 
 void dronecanDnaExpireSessions(timeUs_t currentTimeUs)

--- a/src/main/io/dronecan/dronecan_dna.c
+++ b/src/main/io/dronecan/dronecan_dna.c
@@ -106,17 +106,23 @@ static uint8_t dnaTableLookup(const uint8_t uniqueId[UAVCAN_DNA_UNIQUE_ID_LEN])
 // at peer power-up, so this is a rare, ground-only event.
 static void dnaTableStore(const uint8_t uniqueId[UAVCAN_DNA_UNIQUE_ID_LEN], uint8_t nodeId)
 {
+    if (ARMING_FLAG(ARMED)) {
+        // Config stays untouched in flight. The binding still works for this
+        // power cycle (the response is sent regardless) and the granted ID
+        // stays excluded via the live-ID mask; the peer simply renegotiates
+        // after its next power cycle.
+        return;
+    }
+
     for (int i = 0; i < DRONECAN_DNA_MAX_ENTRIES; i++) {
         dronecanDnaEntry_t *e = &dronecanDnaConfigMutable()->entry[i];
         if (e->nodeId == 0) {
             memcpy(e->uniqueId, uniqueId, UAVCAN_DNA_UNIQUE_ID_LEN);
             e->nodeId = nodeId;
-            if (!ARMING_FLAG(ARMED)) {
-                // The flash write stalls this task for milliseconds; tell the
-                // scheduler to ignore it rather than flag a timing overrun.
-                schedulerIgnoreTaskExecTime();
-                writeEEPROM();
-            }
+            // The flash write stalls this task for milliseconds; tell the
+            // scheduler to ignore it rather than flag a timing overrun.
+            schedulerIgnoreTaskExecTime();
+            writeEEPROM();
             return;
         }
     }

--- a/src/main/io/dronecan/dronecan_dna.h
+++ b/src/main/io/dronecan/dronecan_dna.h
@@ -21,16 +21,18 @@
 
 #pragma once
 
-#include <stdint.h>
+#include "platform.h"
 
-#include "pg/pg.h"
+#if ENABLE_DRONECAN_DNA
 
-typedef struct dronecanConfig_s {
-    uint8_t enabled;    // 0 = off, 1 = on
-    uint8_t node_id;    // DroneCAN node ID (1..127). 0 == unset (node stays inactive).
-    uint8_t device;     // CAN device number (1..CANDEV_COUNT), 1-based to match CLI
-    uint16_t esc_rate_hz; // esc.RawCommand broadcast rate; also the dronecan task tick rate when commanding ESCs (50..500)
-    uint8_t dna_enabled;  // 0 = off, 1 = on: act as the dynamic node-ID allocator
-} dronecanConfig_t;
+#include "common/time.h"
 
-PG_DECLARE(dronecanConfig_t, dronecanConfig);
+// Install the dynamic node-ID allocation handler. No-op if dronecan_dna_enabled
+// is clear. Called once from dronecanInit().
+void dronecanDnaInit(void);
+
+// Drop an in-progress allocation session that has stalled past the follow-up
+// timeout. Called on the dronecan task's 1 Hz boundary.
+void dronecanDnaExpireSessions(timeUs_t currentTimeUs);
+
+#endif // ENABLE_DRONECAN_DNA

--- a/src/main/io/dronecan/dronecan_esc.c
+++ b/src/main/io/dronecan/dronecan_esc.c
@@ -42,6 +42,7 @@
 
 #include "flight/mixer.h"
 
+#include "pg/dronecan.h"
 #include "pg/motor.h"
 #include "pg/pg.h"
 
@@ -56,21 +57,24 @@
 //-----------------------------------------------------------------------------
 // Command out: esc.RawCommand
 //
-// motorWriteAll() runs in the PID-loop task (kHz). libcanard is not re-entrant
-// and is owned by the dronecan task, so the motor vtable can't broadcast
-// directly. Instead write()/updateComplete() stage throttles into a shared
-// buffer (seqlock-published, same pattern as dronecan_gnss.c) and the dronecan
-// task broadcasts RawCommand at its own rate.
+// motorWriteAll() runs in the PID-loop task (kHz). Betaflight's scheduler is
+// cooperative — the PID task and the dronecan task never interleave — so the
+// PID-context updateComplete() can call libcanard directly without racing the
+// dronecan task's own libcanard use (the only true concurrency is the CAN ISR,
+// which touches driver-level rings only). We therefore emit RawCommand straight
+// from updateComplete(), rate-gated to esc_rate_hz, for low and jitter-free
+// command latency that does not depend on the LOW-priority task being serviced.
 //-----------------------------------------------------------------------------
 
-// Staging array touched only by the PID task between write() calls.
+// Throttle staging, written per-motor by write() and read by the broadcast in
+// the same PID iteration — no cross-context sharing, so no seqlock needed.
 static int16_t escStaging[MAX_SUPPORTED_MOTORS];
 
-// Shared snapshot published by updateComplete(), consumed by the task.
-static int16_t escShared[MAX_SUPPORTED_MOTORS];
-static volatile uint32_t escSeq;            // odd = write in progress
-
 static uint8_t escRawCommandTransferId;
+
+// Rate gate for PID-loop emission. Period is derived from esc_rate_hz at init.
+static uint32_t escBroadcastPeriodUs;
+static timeUs_t escLastBroadcastUs;
 
 void dronecanEscWrite(uint8_t motorIndex, float value)
 {
@@ -82,42 +86,12 @@ void dronecanEscWrite(uint8_t motorIndex, float value)
     escStaging[motorIndex] = (int16_t)constrainf(value, 0, UAVCAN_ESC_RAWCOMMAND_MAX);
 }
 
-void dronecanEscUpdateComplete(void)
-{
-    // Publish the staged throttles: bump the sequence odd, copy, bump even.
-    // The compiler fences stop the stores being reordered around the counter.
-    escSeq++;
-    __asm volatile ("" ::: "memory");
-    memcpy(escShared, escStaging, sizeof(escShared));
-    __asm volatile ("" ::: "memory");
-    escSeq++;
-}
-
-// Copy the shared throttle snapshot atomically into the caller's buffer.
-static void escReadShared(int16_t out[MAX_SUPPORTED_MOTORS])
-{
-    uint32_t s1;
-    uint32_t s2;
-    do {
-        do {
-            s1 = escSeq;
-        } while (s1 & 1U);
-        __asm volatile ("" ::: "memory");
-        memcpy(out, escShared, sizeof(escShared));
-        __asm volatile ("" ::: "memory");
-        s2 = escSeq;
-    } while (s1 != s2);
-}
-
 static void broadcastRawCommand(void)
 {
     const uint8_t motorCount = getMotorCount();
     if (motorCount == 0) {
         return;
     }
-
-    int16_t cmd[MAX_SUPPORTED_MOTORS];
-    escReadShared(cmd);
 
     // Pack motorCount int14 values, MSB-first per field. TAO: no length prefix.
     // 8 motors * 14 bits = 112 bits = 14 bytes worst case.
@@ -126,7 +100,7 @@ static void broadcastRawCommand(void)
 
     uint32_t bitOffset = 0;
     for (uint8_t i = 0; i < motorCount; i++) {
-        const int16_t v = constrain(cmd[i], 0, UAVCAN_ESC_RAWCOMMAND_MAX);
+        const int16_t v = constrain(escStaging[i], 0, UAVCAN_ESC_RAWCOMMAND_MAX);
         canardEncodeScalar(payload, bitOffset, UAVCAN_ESC_RAWCOMMAND_BITS, &v);
         bitOffset += UAVCAN_ESC_RAWCOMMAND_BITS;
     }
@@ -143,6 +117,39 @@ static void broadcastRawCommand(void)
     tx.payload_len         = payloadLen;
 
     canardBroadcastObj(dronecanGetInstance(), &tx);
+}
+
+// Encode the current throttles into a RawCommand transfer and push it to the
+// driver immediately. Ungated — callers handle rate limiting / forcing.
+static void emitRawCommand(void)
+{
+    if (!dronecanIsInitialised()) {
+        return;
+    }
+    broadcastRawCommand();
+    // Flush straight to the driver so the frame rides out on this PID iteration
+    // if the bus is free; the driver's SW ring + TC interrupt absorb the rest.
+    dronecanFlushTx();
+}
+
+void dronecanEscUpdateComplete(void)
+{
+    // Only command ESCs when DRONECAN is the active motor protocol; otherwise
+    // another protocol owns the motors and we must stay off the bus.
+    if (!isMotorProtocolDronecan()) {
+        return;
+    }
+
+    // Rate-gate to esc_rate_hz. We run every PID loop (kHz) but the bus can
+    // only carry frames at the configured rate; emit the instant a period is
+    // due rather than waiting on the dronecan task tick.
+    const timeUs_t now = micros();
+    if (cmpTimeUs(now, escLastBroadcastUs) < (timeDelta_t)escBroadcastPeriodUs) {
+        return;
+    }
+    escLastBroadcastUs = now;
+
+    emitRawCommand();
 }
 
 //-----------------------------------------------------------------------------
@@ -206,9 +213,13 @@ static void handleEscStatus(CanardInstance *ins, CanardRxTransfer *t)
 void dronecanEscInit(void)
 {
     memset(escStaging, 0, sizeof(escStaging));
-    memset(escShared, 0, sizeof(escShared));
-    escSeq = 0;
     escRawCommandTransferId = 0;
+
+    // Derive the PID-loop emission period from the configured rate. The PG
+    // value is already range-checked elsewhere; constrain again defensively.
+    const uint16_t rateHz = constrain(dronecanConfig()->esc_rate_hz, 50, 500);
+    escBroadcastPeriodUs = 1000000U / rateHz;
+    escLastBroadcastUs = micros();
 
     for (int i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
         escStatusLastUs[i] = 0;
@@ -227,11 +238,8 @@ void dronecanEscInit(void)
 
 void dronecanEscUpdate(timeUs_t currentTimeUs)
 {
-    // Only command ESCs when the DRONECAN motor protocol is the active output;
-    // otherwise we'd contend with another protocol driving the same motors.
-    if (isMotorProtocolDronecan()) {
-        broadcastRawCommand();
-    }
+    // RawCommand is emitted from the PID loop (dronecanEscUpdateComplete) for
+    // low, jitter-free latency, so the task only handles telemetry here.
 
     // Age telemetry slots that have gone quiet so consumers see stale data
     // rather than a frozen last reading.
@@ -247,9 +255,10 @@ void dronecanEscUpdate(timeUs_t currentTimeUs)
 //-----------------------------------------------------------------------------
 // Motor driver (vtable) — bridges drivers/motor.c to the throttle buffer above.
 //
-// write()/updateComplete() run in the PID-loop task and only touch the staging
-// buffer + seqlock; the actual CAN broadcast happens in dronecanEscUpdate()
-// from the dronecan task, satisfying libcanard's single-context requirement.
+// write() stages throttles and updateComplete() encodes + broadcasts RawCommand,
+// both in the PID-loop task. The cooperative scheduler guarantees this never
+// interleaves with the dronecan task's libcanard use, so libcanard's
+// single-context requirement is still met.
 //-----------------------------------------------------------------------------
 
 static bool dronecanMotorEnable(void)
@@ -259,9 +268,12 @@ static bool dronecanMotorEnable(void)
 
 static void dronecanMotorDisable(void)
 {
-    // Park every motor at stop; the next task tick broadcasts zeros.
+    // Park every motor at stop and force a zero RawCommand out now (bypassing
+    // the rate gate) so the ESCs see the stop immediately rather than on the
+    // next due period.
     memset(escStaging, 0, sizeof(escStaging));
-    dronecanEscUpdateComplete();
+    escLastBroadcastUs = micros();
+    emitRawCommand();
 }
 
 static bool dronecanMotorIsEnabled(unsigned index)

--- a/src/main/io/dronecan/dronecan_esc.c
+++ b/src/main/io/dronecan/dronecan_esc.c
@@ -1,0 +1,328 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if ENABLE_DRONECAN_ESC
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "canard.h"
+
+#include "common/maths.h"
+#include "common/time.h"
+#include "common/utils.h"
+
+#include "config/feature.h"
+
+#include "drivers/motor.h"
+#include "drivers/motor_types.h"
+#include "drivers/time.h"
+
+#include "flight/mixer.h"
+
+#include "pg/motor.h"
+#include "pg/pg.h"
+
+#include "rx/rx.h"      // PWM_RANGE_MIN / PWM_RANGE_MAX
+
+#include "sensors/esc_sensor.h"
+
+#include "io/dronecan/dronecan.h"
+#include "io/dronecan/dronecan_esc.h"
+#include "io/dronecan/dronecan_msg.h"
+
+//-----------------------------------------------------------------------------
+// Command out: esc.RawCommand
+//
+// motorWriteAll() runs in the PID-loop task (kHz). libcanard is not re-entrant
+// and is owned by the dronecan task, so the motor vtable can't broadcast
+// directly. Instead write()/updateComplete() stage throttles into a shared
+// buffer (seqlock-published, same pattern as dronecan_gnss.c) and the dronecan
+// task broadcasts RawCommand at its own rate.
+//-----------------------------------------------------------------------------
+
+// Staging array touched only by the PID task between write() calls.
+static int16_t escStaging[MAX_SUPPORTED_MOTORS];
+
+// Shared snapshot published by updateComplete(), consumed by the task.
+static int16_t escShared[MAX_SUPPORTED_MOTORS];
+static volatile uint32_t escSeq;            // odd = write in progress
+
+static uint8_t escRawCommandTransferId;
+
+void dronecanEscWrite(uint8_t motorIndex, float value)
+{
+    if (motorIndex >= MAX_SUPPORTED_MOTORS) {
+        return;
+    }
+    // Endpoints hand us a value already in RawCommand units (0..8191, disarm 0);
+    // clamp to the int14 positive range to be safe against transient overshoot.
+    escStaging[motorIndex] = (int16_t)constrainf(value, 0, UAVCAN_ESC_RAWCOMMAND_MAX);
+}
+
+void dronecanEscUpdateComplete(void)
+{
+    // Publish the staged throttles: bump the sequence odd, copy, bump even.
+    // The compiler fences stop the stores being reordered around the counter.
+    escSeq++;
+    __asm volatile ("" ::: "memory");
+    memcpy(escShared, escStaging, sizeof(escShared));
+    __asm volatile ("" ::: "memory");
+    escSeq++;
+}
+
+// Copy the shared throttle snapshot atomically into the caller's buffer.
+static void escReadShared(int16_t out[MAX_SUPPORTED_MOTORS])
+{
+    uint32_t s1;
+    uint32_t s2;
+    do {
+        do {
+            s1 = escSeq;
+        } while (s1 & 1U);
+        __asm volatile ("" ::: "memory");
+        memcpy(out, escShared, sizeof(escShared));
+        __asm volatile ("" ::: "memory");
+        s2 = escSeq;
+    } while (s1 != s2);
+}
+
+static void broadcastRawCommand(void)
+{
+    const uint8_t motorCount = getMotorCount();
+    if (motorCount == 0) {
+        return;
+    }
+
+    int16_t cmd[MAX_SUPPORTED_MOTORS];
+    escReadShared(cmd);
+
+    // Pack motorCount int14 values, MSB-first per field. TAO: no length prefix.
+    // 8 motors * 14 bits = 112 bits = 14 bytes worst case.
+    uint8_t payload[(MAX_SUPPORTED_MOTORS * UAVCAN_ESC_RAWCOMMAND_BITS + 7U) / 8U];
+    memset(payload, 0, sizeof(payload));
+
+    uint32_t bitOffset = 0;
+    for (uint8_t i = 0; i < motorCount; i++) {
+        const int16_t v = constrain(cmd[i], 0, UAVCAN_ESC_RAWCOMMAND_MAX);
+        canardEncodeScalar(payload, bitOffset, UAVCAN_ESC_RAWCOMMAND_BITS, &v);
+        bitOffset += UAVCAN_ESC_RAWCOMMAND_BITS;
+    }
+    const uint16_t payloadLen = (uint16_t)((bitOffset + 7U) / 8U);
+
+    CanardTxTransfer tx;
+    canardInitTxTransfer(&tx);
+    tx.transfer_type       = CanardTransferTypeBroadcast;
+    tx.data_type_signature = UAVCAN_ESC_RAWCOMMAND_SIGNATURE;
+    tx.data_type_id        = UAVCAN_ESC_RAWCOMMAND_ID;
+    tx.inout_transfer_id   = &escRawCommandTransferId;
+    tx.priority            = CANARD_TRANSFER_PRIORITY_HIGH;
+    tx.payload             = payload;
+    tx.payload_len         = payloadLen;
+
+    canardBroadcastObj(dronecanGetInstance(), &tx);
+}
+
+//-----------------------------------------------------------------------------
+// Telemetry in: esc.Status -> escSensorData[]
+//-----------------------------------------------------------------------------
+
+// Last-heard timestamp per ESC index, for aging stale telemetry slots.
+static timeUs_t escStatusLastUs[MAX_SUPPORTED_MOTORS];
+
+#define ESC_STATUS_STALE_US     1000000     // 1s without a Status -> age the slot
+#define KELVIN_TO_CELSIUS       273.15f
+
+static void handleEscStatus(CanardInstance *ins, CanardRxTransfer *t)
+{
+    UNUSED(ins);
+
+    uint32_t errorCount = 0;
+    uint16_t voltageF16 = 0;
+    uint16_t currentF16 = 0;
+    uint16_t tempF16 = 0;
+    int32_t rpm = 0;
+    uint8_t powerPct = 0;
+    uint8_t escIndex = 0;
+
+    canardDecodeScalar(t, ESC_STATUS_OFFSET_ERROR_COUNT, 32, false, &errorCount);
+    canardDecodeScalar(t, ESC_STATUS_OFFSET_VOLTAGE,     16, false, &voltageF16);
+    canardDecodeScalar(t, ESC_STATUS_OFFSET_CURRENT,     16, false, &currentF16);
+    canardDecodeScalar(t, ESC_STATUS_OFFSET_TEMPERATURE, 16, false, &tempF16);
+    canardDecodeScalar(t, ESC_STATUS_OFFSET_RPM,         18, true,  &rpm);
+    canardDecodeScalar(t, ESC_STATUS_OFFSET_POWER_PCT,    7, false, &powerPct);
+    canardDecodeScalar(t, ESC_STATUS_OFFSET_ESC_INDEX,    5, false, &escIndex);
+
+    if (escIndex >= MAX_SUPPORTED_MOTORS) {
+        return;
+    }
+
+    const float voltage = canardConvertFloat16ToNativeFloat(voltageF16);
+    const float current = canardConvertFloat16ToNativeFloat(currentF16);
+    const float tempK   = canardConvertFloat16ToNativeFloat(tempF16);
+    const float tempC   = tempK - KELVIN_TO_CELSIUS;
+
+    escSensorData_t data;
+    memset(&data, 0, sizeof(data));
+    data.voltage     = (uint16_t)constrainf(voltage * 100.0f, 0, UINT16_MAX);   // 0.01V
+    data.current     = (int32_t)constrainf(current * 100.0f, INT32_MIN, INT32_MAX); // 0.01A
+    data.temperature = (uint8_t)constrainf(tempC, 0, UINT8_MAX);                // °C
+    // Status.rpm is electrical RPM; escSensorData.rpm is eRPM/100 (LSB = 100),
+    // matching the DShot telemetry convention so erpmToRpm() agrees downstream.
+    data.rpm         = (int16_t)constrainf(rpm / 100.0f, INT16_MIN, INT16_MAX);
+    // consumption (mAh) isn't carried by esc.Status; leave 0 (battery falls
+    // back to its own coulomb counter).
+
+    escSensorSetExternal(escIndex, &data);
+    escStatusLastUs[escIndex] = micros();
+}
+
+//-----------------------------------------------------------------------------
+// Public surface
+//-----------------------------------------------------------------------------
+
+void dronecanEscInit(void)
+{
+    memset(escStaging, 0, sizeof(escStaging));
+    memset(escShared, 0, sizeof(escShared));
+    escSeq = 0;
+    escRawCommandTransferId = 0;
+
+    for (int i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
+        escStatusLastUs[i] = 0;
+    }
+
+    escSensorExternalInit();
+
+    const dronecanSubscriber_t sub = {
+        .signature    = UAVCAN_ESC_STATUS_SIGNATURE,
+        .dataTypeId   = UAVCAN_ESC_STATUS_ID,
+        .transferType = CanardTransferTypeBroadcast,
+        .handler      = handleEscStatus,
+    };
+    (void)dronecanRegisterSubscriber(&sub);
+}
+
+void dronecanEscUpdate(timeUs_t currentTimeUs)
+{
+    // Only command ESCs when the DRONECAN motor protocol is the active output;
+    // otherwise we'd contend with another protocol driving the same motors.
+    if (isMotorProtocolDronecan()) {
+        broadcastRawCommand();
+    }
+
+    // Age telemetry slots that have gone quiet so consumers see stale data
+    // rather than a frozen last reading.
+    for (uint8_t i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
+        if (escStatusLastUs[i] != 0
+                && cmpTimeUs(currentTimeUs, escStatusLastUs[i]) >= ESC_STATUS_STALE_US) {
+            escSensorExternalAge(i);
+            escStatusLastUs[i] = currentTimeUs;
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Motor driver (vtable) — bridges drivers/motor.c to the throttle buffer above.
+//
+// write()/updateComplete() run in the PID-loop task and only touch the staging
+// buffer + seqlock; the actual CAN broadcast happens in dronecanEscUpdate()
+// from the dronecan task, satisfying libcanard's single-context requirement.
+//-----------------------------------------------------------------------------
+
+static bool dronecanMotorEnable(void)
+{
+    return true;
+}
+
+static void dronecanMotorDisable(void)
+{
+    // Park every motor at stop; the next task tick broadcasts zeros.
+    memset(escStaging, 0, sizeof(escStaging));
+    dronecanEscUpdateComplete();
+}
+
+static bool dronecanMotorIsEnabled(unsigned index)
+{
+    UNUSED(index);
+    return true;
+}
+
+static void dronecanMotorShutdown(void)
+{
+    dronecanMotorDisable();
+}
+
+// MSP motor passthrough works in the external [1000,2000] µs convention.
+static float dronecanMotorConvertFromExternal(uint16_t externalValue)
+{
+    externalValue = constrain(externalValue, PWM_RANGE_MIN, PWM_RANGE_MAX);
+    return scaleRangef(externalValue, PWM_RANGE_MIN, PWM_RANGE_MAX, 0, UAVCAN_ESC_RAWCOMMAND_MAX);
+}
+
+static uint16_t dronecanMotorConvertToExternal(float motorValue)
+{
+    return (uint16_t)lrintf(scaleRangef(motorValue, 0, UAVCAN_ESC_RAWCOMMAND_MAX, PWM_RANGE_MIN, PWM_RANGE_MAX));
+}
+
+static const motorVTable_t dronecanMotorVTable = {
+    .enable                 = dronecanMotorEnable,
+    .disable                = dronecanMotorDisable,
+    .isMotorEnabled         = dronecanMotorIsEnabled,
+    .write                  = dronecanEscWrite,
+    .updateComplete         = dronecanEscUpdateComplete,
+    .convertExternalToMotor = dronecanMotorConvertFromExternal,
+    .convertMotorToExternal = dronecanMotorConvertToExternal,
+    .shutdown               = dronecanMotorShutdown,
+    .requestTelemetry       = NULL,
+    .isMotorIdle            = NULL,
+    .getMotorIO             = NULL,
+};
+
+bool dronecanMotorDevInit(motorDevice_t *device, uint8_t motorCount)
+{
+    device->vTable = &dronecanMotorVTable;
+    device->count = motorCount;
+    return true;
+}
+
+void dronecanMotorInitEndpoints(const motorConfig_t *motorConfig, float outputLimit,
+                                float *outputLow, float *outputHigh, float *disarm,
+                                float *deadbandMotor3dHigh, float *deadbandMotor3dLow)
+{
+    UNUSED(deadbandMotor3dHigh);
+    UNUSED(deadbandMotor3dLow);
+
+    // Map the mixer's normalised output onto the int14 throttle range, mirroring
+    // the DShot endpoint model. 3D/reverse is not yet wired, so forward-only.
+    const float range = UAVCAN_ESC_RAWCOMMAND_MAX;
+    const float motorIdlePercent = CONVERT_PARAMETER_TO_PERCENT(motorConfig->motorIdle * 0.01f);
+
+    *disarm = 0;                                            // RawCommand 0 = stop
+    *outputLow = motorIdlePercent * range;
+    *outputHigh = range * outputLimit;
+}
+
+#endif // ENABLE_DRONECAN_ESC

--- a/src/main/io/dronecan/dronecan_esc.c
+++ b/src/main/io/dronecan/dronecan_esc.c
@@ -156,6 +156,10 @@ void dronecanEscUpdateComplete(void)
 // Telemetry in: esc.Status -> escSensorData[]
 //-----------------------------------------------------------------------------
 
+// esc.Status ingestion lands in esc_sensor.c's store, which only exists on
+// USE_ESC_SENSOR targets; RawCommand output above has no such dependency.
+#if defined(USE_ESC_SENSOR)
+
 // Last-heard timestamp per ESC index, for aging stale telemetry slots.
 static timeUs_t escStatusLastUs[MAX_SUPPORTED_MOTORS];
 
@@ -206,6 +210,8 @@ static void handleEscStatus(CanardInstance *ins, CanardRxTransfer *t)
     escStatusLastUs[escIndex] = micros();
 }
 
+#endif // USE_ESC_SENSOR
+
 //-----------------------------------------------------------------------------
 // Public surface
 //-----------------------------------------------------------------------------
@@ -221,6 +227,7 @@ void dronecanEscInit(void)
     escBroadcastPeriodUs = 1000000U / rateHz;
     escLastBroadcastUs = micros();
 
+#if defined(USE_ESC_SENSOR)
     for (int i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
         escStatusLastUs[i] = 0;
     }
@@ -234,6 +241,7 @@ void dronecanEscInit(void)
         .handler      = handleEscStatus,
     };
     (void)dronecanRegisterSubscriber(&sub);
+#endif
 }
 
 void dronecanEscUpdate(timeUs_t currentTimeUs)
@@ -243,6 +251,7 @@ void dronecanEscUpdate(timeUs_t currentTimeUs)
 
     // Age telemetry slots that have gone quiet so consumers see stale data
     // rather than a frozen last reading.
+#if defined(USE_ESC_SENSOR)
     for (uint8_t i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
         if (escStatusLastUs[i] != 0
                 && cmpTimeUs(currentTimeUs, escStatusLastUs[i]) >= ESC_STATUS_STALE_US) {
@@ -250,6 +259,9 @@ void dronecanEscUpdate(timeUs_t currentTimeUs)
             escStatusLastUs[i] = currentTimeUs;
         }
     }
+#else
+    UNUSED(currentTimeUs);
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/src/main/io/dronecan/dronecan_esc.c
+++ b/src/main/io/dronecan/dronecan_esc.c
@@ -163,7 +163,10 @@ void dronecanEscUpdateComplete(void)
 // Last-heard timestamp per ESC index, for aging stale telemetry slots.
 static timeUs_t escStatusLastUs[MAX_SUPPORTED_MOTORS];
 
-#define ESC_STATUS_STALE_US     1000000     // 1s without a Status -> age the slot
+// Age quiet slots every 100 ms so a silent ESC crosses ESC_BATTERY_AGE_MAX
+// (10) in about a second — the same suppression timescale as the serial
+// ESC-sensor path. A healthy Status stream resets the age on every frame.
+#define ESC_STATUS_AGE_INTERVAL_US  100000
 #define KELVIN_TO_CELSIUS       273.15f
 
 static void handleEscStatus(CanardInstance *ins, CanardRxTransfer *t)
@@ -254,7 +257,7 @@ void dronecanEscUpdate(timeUs_t currentTimeUs)
 #if defined(USE_ESC_SENSOR)
     for (uint8_t i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
         if (escStatusLastUs[i] != 0
-                && cmpTimeUs(currentTimeUs, escStatusLastUs[i]) >= ESC_STATUS_STALE_US) {
+                && cmpTimeUs(currentTimeUs, escStatusLastUs[i]) >= ESC_STATUS_AGE_INTERVAL_US) {
             escSensorExternalAge(i);
             escStatusLastUs[i] = currentTimeUs;
         }

--- a/src/main/io/dronecan/dronecan_esc.h
+++ b/src/main/io/dronecan/dronecan_esc.h
@@ -37,13 +37,14 @@
 // throttle buffer (command out). Called once from dronecanInit().
 void dronecanEscInit(void);
 
-// Per-tick service from the dronecan task: broadcasts esc.RawCommand from the
-// latest motor throttles and ages telemetry slots that have gone quiet.
+// Per-tick service from the dronecan task: ages telemetry slots that have gone
+// quiet. RawCommand emission lives in updateComplete() (PID-loop context).
 void dronecanEscUpdate(timeUs_t currentTimeUs);
 
-// Called from the motor driver vtable (PID-loop context). Stores one motor's
-// normalised command [0,1] into the shared throttle buffer; the dronecan task
-// reads it and broadcasts RawCommand at its own rate. updateComplete() commits.
+// Called from the motor driver vtable (PID-loop context). write() stages one
+// motor's RawCommand-unit throttle; updateComplete() encodes the staged values
+// and, rate-gated to esc_rate_hz, broadcasts RawCommand and flushes it to the
+// CAN driver immediately — no cross-task buffer needed (cooperative scheduler).
 void dronecanEscWrite(uint8_t motorIndex, float value);
 void dronecanEscUpdateComplete(void);
 

--- a/src/main/io/dronecan/dronecan_esc.h
+++ b/src/main/io/dronecan/dronecan_esc.h
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "platform.h"
+
+#if ENABLE_DRONECAN_ESC
+
+#include <stdint.h>
+
+#include "common/time.h"
+
+#include "pg/motor.h"
+
+#include "drivers/motor_types.h"
+
+// Install the esc.Status subscriber (telemetry in) and reset the RawCommand
+// throttle buffer (command out). Called once from dronecanInit().
+void dronecanEscInit(void);
+
+// Per-tick service from the dronecan task: broadcasts esc.RawCommand from the
+// latest motor throttles and ages telemetry slots that have gone quiet.
+void dronecanEscUpdate(timeUs_t currentTimeUs);
+
+// Called from the motor driver vtable (PID-loop context). Stores one motor's
+// normalised command [0,1] into the shared throttle buffer; the dronecan task
+// reads it and broadcasts RawCommand at its own rate. updateComplete() commits.
+void dronecanEscWrite(uint8_t motorIndex, float value);
+void dronecanEscUpdateComplete(void);
+
+// Motor-driver entry points (called from drivers/motor.c). Populate the motor
+// vtable and define the output endpoints for the DRONECAN protocol family.
+bool dronecanMotorDevInit(motorDevice_t *device, uint8_t motorCount);
+void dronecanMotorInitEndpoints(const motorConfig_t *motorConfig, float outputLimit,
+                                float *outputLow, float *outputHigh, float *disarm,
+                                float *deadbandMotor3dHigh, float *deadbandMotor3dLow);
+
+#endif // ENABLE_DRONECAN_ESC

--- a/src/main/io/dronecan/dronecan_msg.h
+++ b/src/main/io/dronecan/dronecan_msg.h
@@ -62,3 +62,33 @@
 #define UAVCAN_NODE_MODE_MAINTENANCE        2U
 #define UAVCAN_NODE_MODE_SOFTWARE_UPDATE    3U
 #define UAVCAN_NODE_MODE_OFFLINE            7U
+
+// uavcan.equipment.esc.RawCommand — broadcast throttle command.
+//   saturated int14[<=20] cmd   (tail-array optimised: no length prefix on the
+//   wire; element count is inferred from the transfer payload length). Each
+//   element is a signed 14-bit value; for throttle the useful range is
+//   0..8191 (negative would request reverse on bidirectional ESCs).
+#define UAVCAN_ESC_RAWCOMMAND_ID            1030U
+#define UAVCAN_ESC_RAWCOMMAND_SIGNATURE     0x217f5c87d7ec951dULL
+#define UAVCAN_ESC_RAWCOMMAND_BITS          14U
+#define UAVCAN_ESC_RAWCOMMAND_MAX           8191    // 2^13 - 1 (positive throttle ceiling)
+#define UAVCAN_ESC_RAWCOMMAND_MAX_MOTORS    20U     // DSDL array bound
+
+// uavcan.equipment.esc.Status — broadcast ESC telemetry. Fixed layout, no TAO.
+//   uint32  error_count       @  0
+//   float16 voltage           @ 32  (volt)
+//   float16 current           @ 48  (ampere, may be negative under regen)
+//   float16 temperature       @ 64  (kelvin)
+//   int18   rpm               @ 80  (signed; negative = reverse)
+//   uint7   power_rating_pct  @ 98
+//   uint5   esc_index         @ 105 (zero-based; matches RawCommand cmd[] index)
+// Total 110 bits = 14 bytes.
+#define UAVCAN_ESC_STATUS_ID                1034U
+#define UAVCAN_ESC_STATUS_SIGNATURE         0xa9af28aea2fbb254ULL
+#define ESC_STATUS_OFFSET_ERROR_COUNT       0U
+#define ESC_STATUS_OFFSET_VOLTAGE           32U
+#define ESC_STATUS_OFFSET_CURRENT           48U
+#define ESC_STATUS_OFFSET_TEMPERATURE       64U
+#define ESC_STATUS_OFFSET_RPM               80U
+#define ESC_STATUS_OFFSET_POWER_PCT         98U
+#define ESC_STATUS_OFFSET_ESC_INDEX         105U

--- a/src/main/io/dronecan/dronecan_msg.h
+++ b/src/main/io/dronecan/dronecan_msg.h
@@ -92,3 +92,17 @@
 #define ESC_STATUS_OFFSET_RPM               80U
 #define ESC_STATUS_OFFSET_POWER_PCT         98U
 #define ESC_STATUS_OFFSET_ESC_INDEX         105U
+
+// uavcan.protocol.dynamic_node_id.Allocation — broadcast (both request from the
+// allocatee and response from the allocator use this same message type).
+//   uint7        node_id                 @ 0  (preferred/allocated; 0 = ANY)
+//   bool         first_part_of_unique_id @ 7
+//   uint8[<=16]  unique_id               @ 8  (tail-array optimised)
+#define UAVCAN_DNA_ALLOCATION_ID            1U
+#define UAVCAN_DNA_ALLOCATION_SIGNATURE     0x0b2a812620a11d40ULL
+#define UAVCAN_DNA_OFFSET_NODE_ID           0U
+#define UAVCAN_DNA_OFFSET_FIRST_PART        7U
+#define UAVCAN_DNA_OFFSET_UNIQUE_ID         8U
+#define UAVCAN_DNA_UNIQUE_ID_LEN            16U
+#define UAVCAN_DNA_MAX_BYTES_PER_REQUEST    6U      // single-frame anonymous limit
+#define UAVCAN_DNA_FOLLOWUP_TIMEOUT_MS      500U

--- a/src/main/pg/dronecan.c
+++ b/src/main/pg/dronecan.c
@@ -33,6 +33,7 @@ PG_RESET_TEMPLATE(dronecanConfig_t, dronecanConfig,
     .enabled = 0,
     .node_id = 0,
     .device = 1,
+    .esc_rate_hz = 200,
 );
 
 #endif // ENABLE_DRONECAN

--- a/src/main/pg/dronecan.c
+++ b/src/main/pg/dronecan.c
@@ -34,6 +34,7 @@ PG_RESET_TEMPLATE(dronecanConfig_t, dronecanConfig,
     .node_id = 0,
     .device = 1,
     .esc_rate_hz = 200,
+    .dna_enabled = 1,
 );
 
 #endif // ENABLE_DRONECAN

--- a/src/main/pg/dronecan.h
+++ b/src/main/pg/dronecan.h
@@ -29,6 +29,7 @@ typedef struct dronecanConfig_s {
     uint8_t enabled;    // 0 = off, 1 = on
     uint8_t node_id;    // DroneCAN node ID (1..127). 0 == unset (node stays inactive).
     uint8_t device;     // CAN device number (1..CANDEV_COUNT), 1-based to match CLI
+    uint16_t esc_rate_hz; // esc.RawCommand broadcast rate; also the dronecan task tick rate when commanding ESCs (50..500)
 } dronecanConfig_t;
 
 PG_DECLARE(dronecanConfig_t, dronecanConfig);

--- a/src/main/pg/dronecan_dna.c
+++ b/src/main/pg/dronecan_dna.c
@@ -19,18 +19,17 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
+#include "platform.h"
 
-#include <stdint.h>
+#if ENABLE_DRONECAN_DNA
 
+#include "pg/dronecan_dna.h"
 #include "pg/pg.h"
+#include "pg/pg_ids.h"
 
-typedef struct dronecanConfig_s {
-    uint8_t enabled;    // 0 = off, 1 = on
-    uint8_t node_id;    // DroneCAN node ID (1..127). 0 == unset (node stays inactive).
-    uint8_t device;     // CAN device number (1..CANDEV_COUNT), 1-based to match CLI
-    uint16_t esc_rate_hz; // esc.RawCommand broadcast rate; also the dronecan task tick rate when commanding ESCs (50..500)
-    uint8_t dna_enabled;  // 0 = off, 1 = on: act as the dynamic node-ID allocator
-} dronecanConfig_t;
+// Reset to all-empty (every nodeId 0). Zero-init via the default template.
+PG_REGISTER_WITH_RESET_TEMPLATE(dronecanDnaConfig_t, dronecanDnaConfig, PG_DRONECAN_DNA_CONFIG, 0);
 
-PG_DECLARE(dronecanConfig_t, dronecanConfig);
+PG_RESET_TEMPLATE(dronecanDnaConfig_t, dronecanDnaConfig, );
+
+#endif // ENABLE_DRONECAN_DNA

--- a/src/main/pg/dronecan_dna.h
+++ b/src/main/pg/dronecan_dna.h
@@ -21,16 +21,30 @@
 
 #pragma once
 
+#include "platform.h"
+
+#if ENABLE_DRONECAN_DNA
+
 #include <stdint.h>
 
 #include "pg/pg.h"
 
-typedef struct dronecanConfig_s {
-    uint8_t enabled;    // 0 = off, 1 = on
-    uint8_t node_id;    // DroneCAN node ID (1..127). 0 == unset (node stays inactive).
-    uint8_t device;     // CAN device number (1..CANDEV_COUNT), 1-based to match CLI
-    uint16_t esc_rate_hz; // esc.RawCommand broadcast rate; also the dronecan task tick rate when commanding ESCs (50..500)
-    uint8_t dna_enabled;  // 0 = off, 1 = on: act as the dynamic node-ID allocator
-} dronecanConfig_t;
+#include "io/dronecan/dronecan_msg.h"
 
-PG_DECLARE(dronecanConfig_t, dronecanConfig);
+// Persisted dynamic node-ID allocation table. Each occupied slot binds a peer's
+// 16-byte unique ID to the node ID this FC handed it, so the same device keeps
+// its ID across reboots. nodeId == 0 marks an empty slot.
+#define DRONECAN_DNA_MAX_ENTRIES    16
+
+typedef struct dronecanDnaEntry_s {
+    uint8_t uniqueId[UAVCAN_DNA_UNIQUE_ID_LEN];
+    uint8_t nodeId;
+} dronecanDnaEntry_t;
+
+typedef struct dronecanDnaConfig_s {
+    dronecanDnaEntry_t entry[DRONECAN_DNA_MAX_ENTRIES];
+} dronecanDnaConfig_t;
+
+PG_DECLARE(dronecanDnaConfig_t, dronecanDnaConfig);
+
+#endif // ENABLE_DRONECAN_DNA

--- a/src/main/pg/pg_ids.h
+++ b/src/main/pg/pg_ids.h
@@ -164,6 +164,7 @@
 #define PG_CAN_PIN_CONFIG           563
 #define PG_CAN_CONFIG               564
 #define PG_DRONECAN_CONFIG          565
+#define PG_DRONECAN_DNA_CONFIG      567
 
 // TODO TBC
 #define PG_DISPLAY_PORT_FBOSD_CONFIG 566

--- a/src/main/sensors/esc_sensor.c
+++ b/src/main/sensors/esc_sensor.c
@@ -192,6 +192,45 @@ escSensorData_t *getEscSensorData(uint8_t motorNumber)
     }
 }
 
+#if ENABLE_DRONECAN_ESC
+// External telemetry feed (e.g. DroneCAN esc.Status). Lets an out-of-band
+// source publish into the same escSensorData[] store the serial KISS decoder
+// uses, so every consumer (battery, OSD, telemetry, MSP, blackbox) reads it
+// through getEscSensorData() unchanged. Values use the escSensorData_t units:
+// temperature °C, voltage 0.01V, current 0.01A, consumption mAh, rpm eRPM/100.
+void escSensorSetExternal(uint8_t motorIndex, const escSensorData_t *data)
+{
+    if (motorIndex >= MAX_SUPPORTED_MOTORS || data == NULL) {
+        return;
+    }
+    escSensorData[motorIndex] = *data;
+    escSensorData[motorIndex].dataAge = 0;
+    combinedDataNeedsUpdate = true;
+}
+
+// Mark every slot invalid. Called by the external source at init so a consumer
+// that polls before the first frame arrives sees ESC_DATA_INVALID rather than
+// a zero-filled "valid" reading.
+void escSensorExternalInit(void)
+{
+    for (int i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
+        escSensorData[i].dataAge = ESC_DATA_INVALID;
+    }
+}
+
+// Age a single slot towards ESC_DATA_INVALID. The external source calls this on
+// its own cadence for motors it hasn't heard from, mirroring increaseDataAge()
+// for the serial path.
+void escSensorExternalAge(uint8_t motorIndex)
+{
+    if (motorIndex < MAX_SUPPORTED_MOTORS
+            && escSensorData[motorIndex].dataAge < ESC_DATA_INVALID) {
+        escSensorData[motorIndex].dataAge++;
+        combinedDataNeedsUpdate = true;
+    }
+}
+#endif // ENABLE_DRONECAN_ESC
+
 // Receive ISR callback
 static void escSensorDataReceive(uint16_t c, void *data)
 {

--- a/src/main/sensors/esc_sensor.h
+++ b/src/main/sensors/esc_sensor.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "platform.h"
+
 #include "common/time.h"
 
 typedef struct escSensorConfig_s {
@@ -49,6 +51,14 @@ void escSensorProcess(timeUs_t currentTime);
 #define ESC_SENSOR_COMBINED 255
 
 escSensorData_t *getEscSensorData(uint8_t motorNumber);
+
+#if ENABLE_DRONECAN_ESC
+// Publish telemetry from an out-of-band source (DroneCAN esc.Status) into the
+// shared escSensorData[] store. Fields use escSensorData_t units.
+void escSensorSetExternal(uint8_t motorIndex, const escSensorData_t *data);
+void escSensorExternalInit(void);
+void escSensorExternalAge(uint8_t motorIndex);
+#endif
 
 void startEscDataRead(uint8_t *frameBuffer, uint8_t frameLength);
 uint8_t getNumberEscBytesRead(void);

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -910,6 +910,13 @@ extern struct linker_symbol __fontdata_end;
 #define ENABLE_DRONECAN_ESC ENABLE_DRONECAN
 #endif
 
+// DroneCAN dynamic node-ID allocation: the FC acts as the centralised allocator,
+// handing node IDs to unconfigured peers (e.g. ESCs). Runtime PG flag
+// (dronecan_dna_enabled) decides whether the allocator actually runs.
+#if !defined(ENABLE_DRONECAN_DNA)
+#define ENABLE_DRONECAN_DNA ENABLE_DRONECAN
+#endif
+
 // First-cut probe for SPA06-003 (Goertek) over STM32C5 I3C1 in legacy-I2C
 // mode. When set, the probe runs once after baroInit() to confirm I3C bring-up
 // on PC10/PC11 by reading the SPA06 CHIP_ID (reg 0x0D) at address 0x77/0x76.

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -903,6 +903,13 @@ extern struct linker_symbol __fontdata_end;
 #define ENABLE_DRONECAN ENABLE_CAN
 #endif
 
+// DroneCAN ESC: command ESCs over CAN (uavcan.equipment.esc.RawCommand) and
+// ingest their telemetry (uavcan.equipment.esc.Status). Built in wherever the
+// DroneCAN stack is, gated at runtime by selecting the DRONECAN motor protocol.
+#if !defined(ENABLE_DRONECAN_ESC)
+#define ENABLE_DRONECAN_ESC ENABLE_DRONECAN
+#endif
+
 // First-cut probe for SPA06-003 (Goertek) over STM32C5 I3C1 in legacy-I2C
 // mode. When set, the probe runs once after baroInit() to confirm I3C bring-up
 // on PC10/PC11 by reading the SPA06 CHIP_ID (reg 0x0D) at address 0x77/0x76.

--- a/src/platform/common/stm32/can_hw.c
+++ b/src/platform/common/stm32/can_hw.c
@@ -37,6 +37,7 @@
 #error "ENABLE_CAN is set but the target MCU family has no FDCAN support in this driver"
 #endif
 
+#include "common/time.h"
 #include "common/utils.h"
 
 #include "drivers/can/can.h"
@@ -44,7 +45,12 @@
 #include "drivers/io.h"
 #include "drivers/nvic.h"
 #include "drivers/resource.h"
+#include "drivers/time.h"
 #include "platform/rcc.h"
+
+// Zero TX completions for this long while the software ring is saturated is
+// treated as a wedged (unacknowledged) bus — see canTransmit().
+#define CAN_TX_STALL_TIMEOUT_US 100000
 
 //-----------------------------------------------------------------------------
 // Message RAM layout
@@ -501,6 +507,10 @@ void canInitDevice(canDevice_e device, uint32_t bitrate)
     pDev->txHead = 0;
     pDev->txTail = 0;
     pDev->txRingOverflows = 0;
+    pDev->txCompletions = 0;
+    pDev->txCompletionsSeen = 0;
+    pDev->txStallSinceUs = micros();
+    pDev->txStallRecoveries = 0;
 
     // Enable Rx FIFO 0 new-message and message-lost interrupts, the
     // transmission-complete interrupt, and arm the peripheral side of IRQ
@@ -645,6 +655,28 @@ bool canTransmit(canDevice_e device, uint32_t identifier, bool isExtended,
     if (next == pDev->txTail) {
         // Ring full — genuine backpressure. Drop and report so the caller can
         // retry; libcanard leaves the frame at its queue head on a false.
+        //
+        // A saturated ring with zero completions means nothing is ACKing
+        // (peers unpowered, bus fault): auto-retransmission keeps the pending
+        // hardware slots busy forever and TC never fires. The FDCAN has no
+        // per-frame one-shot mode and disabling retransmission globally would
+        // drop frames on ordinary arbitration loss, so recover by cancelling
+        // the pending slots and discarding the stale backlog. A live bus
+        // completes a classic frame in well under a millisecond, so this
+        // never fires from congestion alone.
+        const timeUs_t now = micros();
+        if (pDev->txCompletions != pDev->txCompletionsSeen) {
+            pDev->txCompletionsSeen = pDev->txCompletions;
+            pDev->txStallSinceUs = now;
+        } else if (cmpTimeUs(now, pDev->txStallSinceUs) >= CAN_TX_STALL_TIMEOUT_US) {
+            FDCAN_GlobalTypeDef *regs = canRegs(device);
+            NVIC_DisableIRQ((IRQn_Type)pDev->irq0);
+            regs->TXBCR = (1UL << CAN_TX_FIFO_DEPTH) - 1UL;
+            pDev->txTail = head;
+            pDev->txStallRecoveries++;
+            pDev->txStallSinceUs = now;
+            NVIC_EnableIRQ((IRQn_Type)pDev->irq0);
+        }
         pDev->txRingOverflows++;
         return false;
     }
@@ -749,6 +781,7 @@ void canIrqHandler(canDevice_e device)
     // resume draining the software TX ring into the hardware FIFO.
     if (ir & FDCAN_IR_TC) {
         regs->IR = FDCAN_IR_TC;
+        canDevice[device].txCompletions++;
         canTxKick(device);
     }
 }

--- a/src/platform/common/stm32/can_hw.c
+++ b/src/platform/common/stm32/can_hw.c
@@ -110,6 +110,8 @@
 #define CAN_RX_ELEMENT_BYTES    CAN_SRAM_RF_SIZE
 #define CAN_TX_ELEMENT_BYTES    CAN_SRAM_TFQ_SIZE
 
+#define CAN_TX_FIFO_DEPTH       CAN_SRAM_TFQ_NBR
+
 #elif defined(STM32H7)
 
 // H7 layout (software-defined). Values are in *elements* or *bytes* as noted.
@@ -132,6 +134,8 @@
 
 #define CAN_RX_ELEMENT_BYTES        (CAN_H7_ELEMENT_WORDS * 4U)
 #define CAN_TX_ELEMENT_BYTES        (CAN_H7_ELEMENT_WORDS * 4U)
+
+#define CAN_TX_FIFO_DEPTH           CAN_H7_TFQ_NBR
 
 #endif
 
@@ -493,13 +497,24 @@ void canInitDevice(canDevice_e device, uint32_t bitrate)
     canConfigureMessageRamH7(device, regs);
 #endif
 
-    // Enable Rx FIFO 0 new-message and message-lost interrupts, and arm
-    // the peripheral side of IRQ line 0. The line-select register (ILS)
-    // resets to 0 which routes all sources to line 0, so no write needed.
-    // Enabling RF0LE lets the IRQ path observe and clear overrun flags so
-    // the peripheral does not stay stuck in the "lost" state after a burst.
-    regs->IE  |= FDCAN_IE_RF0NE | FDCAN_IE_RF0LE;
+    // Reset the software TX ring so a re-init starts from a clean queue.
+    pDev->txHead = 0;
+    pDev->txTail = 0;
+    pDev->txRingOverflows = 0;
+
+    // Enable Rx FIFO 0 new-message and message-lost interrupts, the
+    // transmission-complete interrupt, and arm the peripheral side of IRQ
+    // line 0. The line-select register (ILS) resets to 0 which routes all
+    // sources to line 0, so no write needed. Enabling RF0LE lets the IRQ
+    // path observe and clear overrun flags so the peripheral does not stay
+    // stuck in the "lost" state after a burst. TCE lets a freed Tx FIFO slot
+    // re-trigger the ring drain (see canTxKick).
+    regs->IE  |= FDCAN_IE_RF0NE | FDCAN_IE_RF0LE | FDCAN_IE_TCE;
     regs->ILE |= FDCAN_ILE_EINT0;
+
+    // TXBTIE selects which Tx buffers raise the TC interrupt; set the low
+    // CAN_TX_FIFO_DEPTH bits so every FIFO slot signals completion.
+    regs->TXBTIE = (1UL << CAN_TX_FIFO_DEPTH) - 1UL;
 
     canEnableInterrupt(device, pDev->irq0);
 
@@ -531,10 +546,82 @@ void canRegisterRxCallback(canDevice_e device, canRxCallbackPtr callback)
     canDevice[device].rxCallback = callback;
 }
 
-// NOTE: canTransmit() is NOT internally synchronised. The read-modify-write
-// sequence on the Tx FIFO (read TXFQS put-index, write slot, set TXBAR) is
-// not re-entrant; calling concurrently from thread context and an ISR can
-// corrupt messages. Callers must serialise externally if they need that.
+// Move queued frames from the software TX ring into the hardware Tx FIFO
+// until the ring is empty or the FIFO is full. When the FIFO fills we stop;
+// the transmission-complete (TC) interrupt re-invokes this to resume the
+// drain as slots free up.
+//
+// Concurrency: this is the sole consumer of txTail and the sole writer of the
+// Tx FIFO. It runs either from task context (canTransmit, which masks irq0
+// around the call) or from the TC ISR. Because the task path masks irq0 and
+// the ISR path runs at the CAN NVIC priority, the two can never overlap, so
+// the TXFQS read / slot write / TXBAR sequence stays atomic with respect to
+// itself.
+static void canTxKick(canDevice_e device)
+{
+    canDevice_t *pDev = &canDevice[device];
+    FDCAN_GlobalTypeDef *regs = canRegs(device);
+
+    while (pDev->txTail != pDev->txHead) {
+        // Pair the producer-side fence on txHead so the compiler cannot hoist
+        // the slot reads above the head snapshot above.
+        __asm volatile ("" ::: "memory");
+
+        uint32_t txfqs = regs->TXFQS;
+        if (txfqs & FDCAN_TXFQS_TFQF) {
+            // Hardware FIFO full; the TC interrupt will call us again once a
+            // slot frees. Leave the frame queued at txTail. NOTE: resuming the
+            // backlog relies on this function draining every free slot greedily
+            // on each entry — a single latched TC per batch of completions is
+            // then enough to flush the whole ring, so no wakeup is ever lost.
+            break;
+        }
+
+        const canTxFrame_t *frame = &pDev->txRing[pDev->txTail];
+
+        // Put index tells us which slot in the Tx FIFO the next message
+        // belongs in. The peripheral manages the ring; software just fills
+        // the slot and sets the corresponding TXBAR bit.
+        uint32_t putIndex = (txfqs & FDCAN_TXFQS_TFQPI) >> 16;
+        volatile uint32_t *slot = (volatile uint32_t *)canTxElementAddress(device, putIndex);
+
+        // Word 0: identifier with XTD flag if extended.
+        if (frame->isExtended) {
+            slot[0] = CAN_TX_WORD0_XTD | (frame->id & 0x1FFFFFFFUL);
+        } else {
+            slot[0] = (frame->id & 0x7FFUL) << 18;
+        }
+
+        // Word 1: length only (no BRS/FDF -> classic CAN frame).
+        slot[1] = (uint32_t)frame->length << CAN_TX_WORD1_DLC_POS;
+
+        // Words 2..3: copy the payload in 32-bit chunks. The Tx RAM requires
+        // 32-bit writes and classic CAN tops out at 8 bytes of payload, so
+        // two words is always enough.
+        uint32_t words[2] = { 0, 0 };
+        for (uint8_t i = 0; i < frame->length; i++) {
+            words[i >> 2] |= ((uint32_t)frame->data[i]) << ((i & 3U) * 8U);
+        }
+        slot[2] = words[0];
+        slot[3] = words[1];
+
+        // Trigger transmission of this slot, then release the ring entry.
+        regs->TXBAR = 1UL << putIndex;
+        pDev->txTail = (pDev->txTail + 1U) & CAN_TX_RING_MASK;
+    }
+}
+
+// Queue a classic CAN frame for transmission. The frame is appended to the
+// software TX ring and pushed into the hardware FIFO immediately if room is
+// available; anything that doesn't fit is drained by the TC interrupt.
+//
+// Returns false only on invalid parameters, an uninitialised device, or a
+// genuinely full software ring (true backpressure) — not on a transient
+// hardware-FIFO-full, which the ring now absorbs.
+//
+// Must be called from task context only. The producer index (txHead) assumes
+// a single producer; Betaflight's cooperative scheduler serialises task-level
+// callers, and this function is never called from an ISR.
 bool canTransmit(canDevice_e device, uint32_t identifier, bool isExtended,
                  const uint8_t *data, uint8_t length)
 {
@@ -553,43 +640,39 @@ bool canTransmit(canDevice_e device, uint32_t identifier, bool isExtended,
         return false;
     }
 
-    FDCAN_GlobalTypeDef *regs = canRegs(device);
-
-    // Bail early if the hardware FIFO is full. The caller decides whether to
-    // retry or drop; we don't block so the ISR-side callers stay non-blocking.
-    uint32_t txfqs = regs->TXFQS;
-    if (txfqs & FDCAN_TXFQS_TFQF) {
+    const uint8_t head = pDev->txHead;
+    const uint8_t next = (head + 1U) & CAN_TX_RING_MASK;
+    if (next == pDev->txTail) {
+        // Ring full — genuine backpressure. Drop and report so the caller can
+        // retry; libcanard leaves the frame at its queue head on a false.
+        pDev->txRingOverflows++;
         return false;
     }
 
-    // Put index tells us which slot in the Tx FIFO the next message belongs
-    // in. The peripheral manages the ring; software just fills the slot and
-    // sets the corresponding TXBAR bit.
-    uint32_t putIndex = (txfqs & FDCAN_TXFQS_TFQPI) >> 16;
-    volatile uint32_t *slot = (volatile uint32_t *)canTxElementAddress(device, putIndex);
-
-    // Word 0: identifier with XTD flag if extended.
-    if (isExtended) {
-        slot[0] = CAN_TX_WORD0_XTD | (identifier & 0x1FFFFFFFUL);
-    } else {
-        slot[0] = (identifier & 0x7FFUL) << 18;
-    }
-
-    // Word 1: length only (no BRS/FDF -> classic CAN frame).
-    slot[1] = (uint32_t)length << CAN_TX_WORD1_DLC_POS;
-
-    // Words 2..3: copy the payload in 32-bit chunks. The Tx RAM requires
-    // 32-bit writes and classic CAN tops out at 8 bytes of payload, so two
-    // words is always enough.
-    uint32_t words[2] = { 0, 0 };
+    canTxFrame_t *frame = &pDev->txRing[head];
+    frame->id = identifier;
+    frame->isExtended = isExtended;
+    frame->length = length;
     for (uint8_t i = 0; i < length; i++) {
-        words[i >> 2] |= ((uint32_t)data[i]) << ((i & 3U) * 8U);
+        frame->data[i] = data[i];
     }
-    slot[2] = words[0];
-    slot[3] = words[1];
 
-    // Trigger transmission of this slot.
-    regs->TXBAR = 1UL << putIndex;
+    // Publish the filled slot before advancing head so the TC ISR (which
+    // consumes via txTail) never observes an advanced head over a partially
+    // written slot. Cortex-M is strongly ordered in hardware but the compiler
+    // may reorder these non-volatile stores around the volatile head write.
+    __asm volatile ("" ::: "memory");
+    pDev->txHead = next;
+
+    // Push as much as the hardware FIFO will take now. Mask this device's IRQ
+    // so the TC handler (the other canTxKick caller) cannot run concurrently
+    // and corrupt the FIFO put sequence. This also briefly masks RX on the same
+    // line, but the critical section is only a few SRAM writes long. Safe to
+    // unconditionally re-enable: irq0 is always enabled once initialized is set,
+    // and canTransmit is task-context only (never called from an ISR).
+    NVIC_DisableIRQ((IRQn_Type)pDev->irq0);
+    canTxKick(device);
+    NVIC_EnableIRQ((IRQn_Type)pDev->irq0);
 
     return true;
 }
@@ -660,6 +743,13 @@ void canIrqHandler(canDevice_e device)
     if (ir & FDCAN_IR_RF0L) {
         regs->IR = FDCAN_IR_RF0L;
         canDevice[device].rxOverruns++;
+    }
+
+    // TC = transmission complete on a Tx FIFO slot. A slot has freed, so
+    // resume draining the software TX ring into the hardware FIFO.
+    if (ir & FDCAN_IR_TC) {
+        regs->IR = FDCAN_IR_TC;
+        canTxKick(device);
     }
 }
 


### PR DESCRIPTION
Adds DroneCAN ESC support on top of the existing libcanard stack: the FC can now command ESCs over CAN, ingest their telemetry, and hand out node IDs.

- **Command** — new `DRONECAN` motor protocol broadcasts `esc.RawCommand` (id 1030). The command is encoded and emitted directly from the PID-loop `updateComplete()`, rate-gated to `dronecan_esc_rate_hz` (default 200), so timing no longer inherits the LOW-priority task's scheduling jitter. This is safe because Betaflight's scheduler is cooperative — the PID task and the dronecan task never interleave, and the CAN ISR only touches driver-level rings — so libcanard stays single-context without the previous seqlock buffer. Disarm/shutdown force a zero RawCommand so ESCs idle immediately.
- **Driver TX buffering** — the FDCAN driver gains a per-device software TX ring drained into the hardware Tx FIFO, plus a transmission-complete (TC) interrupt that refills the FIFO as slots free. `canTransmit()` is now non-blocking and FIFO-ordered, returning false only on true ring-full rather than on every transient FIFO-full; bursts beyond the 3 hardware slots are absorbed and drained autonomously. (FDCAN message RAM is memory-mapped, so the TC interrupt — not DMA — is the restart mechanism.) Works on both the G4/C5 fixed and H7 software-defined message-RAM layouts.
- **Telemetry** — `esc.Status` (id 1034) is decoded into the shared `escSensorData` store via a new `escSensorSetExternal()`, so battery, OSD, MSP, telemetry and blackbox read it through `getEscSensorData()` unchanged.
- **Dynamic node-ID allocation** — centralised allocator implements the three-stage `dynamic_node_id.Allocation` handshake (id 1); the unique_id→node_id table is persisted to a new parameter group so devices keep their ID across reboots.

New CLI settings `dronecan_esc_rate_hz` and `dronecan_dna_enabled`. Built wherever the DroneCAN stack is present (STM32 G4/H7/C5); selected at runtime via `motor_pwm_protocol = DRONECAN`.

Builds clean on G4/H7/SITL and the full unit-test suite is green. **Draft pending hardware benchtest.** First cut is forward-only throttle (no 3D/reverse), and the DNA free-ID search is seeded from the FC's own node ID plus the persisted table.

Four commits: ESC command + telemetry, dynamic node-ID allocation, the driver TX ring + TC interrupt, then PID-loop RawCommand emission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DroneCAN ESC motor control via broadcast `RawCommand` with configurable rate (50–500 Hz; default 200 Hz) and improved command/telemetry timing.
  * Added DroneCAN ESC telemetry ingestion from `esc.Status` and aged “last heard” handling for sensor validity.
  * Added dynamic node-ID allocation (DNA) with persistent bindings; DNA enablement is now configurable (default enabled) and exposed as a dedicated parameter page.
  * Added **DRONECAN** as a selectable motor protocol.
  * Improved classic CAN transmission reliability using queued TX with overflow and stall recovery.
* **Bug Fixes**
  * Prevented ESC sensor from being disabled when using DroneCAN ESC, even if no serial port is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->