### PR TITLE
fix(sitl): restore Gazebo gyro Z sign lost in #15280

### DIFF
--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -304,7 +304,11 @@ static void updateState(const fdm_packet* pkt)
 
     x = constrain(pkt->imu_angular_velocity_rpy[0] * GYRO_SCALE * RAD2DEG, -32767, 32767);
     y = constrain(-pkt->imu_angular_velocity_rpy[1] * GYRO_SCALE * RAD2DEG, -32767, 32767);
+#if ENABLE_GAZEBO_BRIDGE
+    z = constrain(pkt->imu_angular_velocity_rpy[2] * GYRO_SCALE * RAD2DEG, -32767, 32767);
+#else
     z = constrain(-pkt->imu_angular_velocity_rpy[2] * GYRO_SCALE * RAD2DEG, -32767, 32767);
+#endif
     virtualGyroSet(virtualGyroDev, x, y, z);
 #if ENABLE_GAZEBO_BRIDGE
     // Gazebo plugin doesn't fill pkt->pressure; derive from altitude using the


### PR DESCRIPTION
AI Generated pull-request

## Summary
PR #15280 removed the `ENABLE_GAZEBO_BRIDGE` conditional around the gyro Z
assignment, unifying both bridge paths to the negated form (`-wz`). This
regressed the deliberate sign split introduced by PR #15158, which established
that Gazebo data arrives in the FRD sensor frame and requires `+wz` (no
negation), while legacy bridges (X-Plane, RealFlight) require `-wz`.

Restores the conditional exactly as it existed before #15280.

Fixes #15294.

## Test plan
- [ ] Build passes: `TARGET=SITL`
- [ ] Gazebo yaw direction verified (awaiting @blckmn confirmation — see PR comment)