### PR TITLE
fix(sitl): harden Gazebo gyro yaw sign against silent regression (follow-up to #15354)

### DIFF
--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -79,6 +79,14 @@
 
 #include "dyad.h"
 #include "udplink.h"
+#include "sitl_gyro.h"
+
+// The bridge-specific gyro yaw sign (sitl_gyro.h) is selected by ENABLE_GAZEBO_BRIDGE,
+// so an undefined or non-boolean value would silently fall through to the legacy sign.
+// Require it to be explicitly 0 or 1 (target.h defaults it to 1) so a typo or a dropped
+// config define fails the build instead of silently inverting Gazebo yaw (see #15294).
+STATIC_ASSERT((ENABLE_GAZEBO_BRIDGE) == 0 || (ENABLE_GAZEBO_BRIDGE) == 1,
+              ENABLE_GAZEBO_BRIDGE_must_be_0_or_1);
 
 uint32_t SystemCoreClock;
 
@@ -285,26 +293,22 @@ static void updateState(const fdm_packet* pkt)
         return;
     }
 
-#if ENABLE_GAZEBO_BRIDGE
-    // The BetaflightPlugin reads angular velocity from the IMU *sensor* entity
-    // (components::AngularVelocity on imuEntity), so the data arrives in the
-    // sensor frame. The IMU sensor pose is Rx(π) relative to the FLU link,
-    // which makes the sensor frame effectively FRD (X=fwd, Y=right, Z=down).
-    //
-    // BF gyro conventions:
-    //   Roll  = +wx_FRD (roll right)          → keep X
-    //   Pitch = -wy_FRD (BF positive = nose down, opposite to FRD) → negate Y
-    //   Yaw   = +wz_FRD (CW viewed from above)                    → keep Z
-#endif
     int16_t x,y,z;
     x = constrain(-pkt->imu_linear_acceleration_xyz[0] * ACC_SCALE, -32767, 32767);
     y = constrain(-pkt->imu_linear_acceleration_xyz[1] * ACC_SCALE, -32767, 32767);
     z = constrain(-pkt->imu_linear_acceleration_xyz[2] * ACC_SCALE, -32767, 32767);
     virtualAccSet(virtualAccDev, x, y, z);
 
-    x = constrain(pkt->imu_angular_velocity_rpy[0] * GYRO_SCALE * RAD2DEG, -32767, 32767);
-    y = constrain(-pkt->imu_angular_velocity_rpy[1] * GYRO_SCALE * RAD2DEG, -32767, 32767);
-    z = constrain(-pkt->imu_angular_velocity_rpy[2] * GYRO_SCALE * RAD2DEG, -32767, 32767);
+    // Map simulator IMU angular velocity onto Betaflight gyro axes. The yaw (Z)
+    // polarity is bridge-specific (see sitlGyroBodyFromSim() for the FRD/legacy
+    // rationale); ENABLE_GAZEBO_BRIDGE selects it. Keeping the mapping in one
+    // helper prevents the bridge split from being silently dropped by edits to
+    // this function, which is what caused regression #15294.
+    double gyroRoll, gyroPitch, gyroYaw;
+    sitlGyroBodyFromSim(pkt->imu_angular_velocity_rpy, ENABLE_GAZEBO_BRIDGE, &gyroRoll, &gyroPitch, &gyroYaw);
+    x = constrain(gyroRoll  * GYRO_SCALE * RAD2DEG, -32767, 32767);
+    y = constrain(gyroPitch * GYRO_SCALE * RAD2DEG, -32767, 32767);
+    z = constrain(gyroYaw   * GYRO_SCALE * RAD2DEG, -32767, 32767);
     virtualGyroSet(virtualGyroDev, x, y, z);
 #if ENABLE_GAZEBO_BRIDGE
     // Gazebo plugin doesn't fill pkt->pressure; derive from altitude using the

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -81,10 +81,10 @@
 #include "udplink.h"
 #include "sitl_gyro.h"
 
-// The bridge-specific gyro yaw sign (sitl_gyro.h) is selected by ENABLE_GAZEBO_BRIDGE,
-// so an undefined or non-boolean value would silently fall through to the legacy sign.
-// Require it to be explicitly 0 or 1 (target.h defaults it to 1) so a typo or a dropped
-// config define fails the build instead of silently inverting Gazebo yaw (see #15294).
+// ENABLE_GAZEBO_BRIDGE is a boolean selector for the gyro yaw sign (passed to
+// sitlGyroBodyFromSim below). target.h defaults it to 1; configs set 0 for the
+// legacy bridges. Require it to be explicitly 0 or 1 so an accidental non-boolean
+// value (which would quietly read as "Gazebo") fails the build instead (see #15294).
 STATIC_ASSERT((ENABLE_GAZEBO_BRIDGE) == 0 || (ENABLE_GAZEBO_BRIDGE) == 1,
               ENABLE_GAZEBO_BRIDGE_must_be_0_or_1);
 

--- a/src/platform/SIMULATOR/sitl_gyro.h
+++ b/src/platform/SIMULATOR/sitl_gyro.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+// Map a simulator IMU angular-velocity sample (rad/s) from the simulator's IMU
+// sensor frame onto Betaflight's body gyro axes (roll, pitch, yaw), still rad/s.
+//
+// Gazebo (BetaflightPlugin): angular velocity is read from the IMU *sensor*
+// entity, whose pose is Rx(pi) relative to the FLU body link, making the sensor
+// frame effectively FRD (X=fwd, Y=right, Z=down):
+//   Roll  = +wx_FRD (roll right)                               -> keep X
+//   Pitch = -wy_FRD (BF positive = nose down, opposite to FRD) -> negate Y
+//   Yaw   = +wz_FRD (CW viewed from above)                     -> keep Z
+// Legacy bridges (X-Plane, RealFlight) deliver yaw with the opposite polarity
+// and therefore require Z to be negated.
+//
+// The bridge is selected at compile time by ENABLE_GAZEBO_BRIDGE but is passed
+// in as an argument so the convention lives in exactly one place (preventing the
+// silent loss of the bridge split that caused regression #15294) and so the unit
+// test can exercise both bridges.
+static inline void sitlGyroBodyFromSim(const double rpy[3], bool gazeboBridge,
+                                       double *roll, double *pitch, double *yaw)
+{
+    *roll  =  rpy[0];
+    *pitch = -rpy[1];
+    *yaw   =  gazeboBridge ? rpy[2] : -rpy[2];
+}

--- a/src/platform/SIMULATOR/sitl_gyro.h
+++ b/src/platform/SIMULATOR/sitl_gyro.h
@@ -34,10 +34,11 @@
 // Legacy bridges (X-Plane, RealFlight) deliver yaw with the opposite polarity
 // and therefore require Z to be negated.
 //
-// The bridge is selected at compile time by ENABLE_GAZEBO_BRIDGE but is passed
-// in as an argument so the convention lives in exactly one place (preventing the
-// silent loss of the bridge split that caused regression #15294) and so the unit
-// test can exercise both bridges.
+// This helper is bridge-agnostic: the caller selects the yaw polarity via the
+// gazeboBridge argument (sitl.c passes ENABLE_GAZEBO_BRIDGE). Keeping the mapping
+// in one place instead of an inline #if prevents the bridge split from being
+// silently dropped (regression #15294), and the explicit argument lets the unit
+// test exercise both bridges in a single binary.
 static inline void sitlGyroBodyFromSim(const double rpy[3], bool gazeboBridge,
                                        double *roll, double *pitch, double *yaw)
 {

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -372,6 +372,12 @@ sensor_gyro_unittest_SRC := \
 		$(USER_DIR)/pg/pg.c \
 		$(USER_DIR)/pg/gyrodev.c
 
+sitl_gyro_unittest_SRC := \
+		$(TEST_DIR)/sitl_gyro_unittest_c.c
+
+sitl_gyro_unittest_INCLUDE_DIRS := \
+		$(ROOT)/src/platform/SIMULATOR
+
 telemetry_crsf_unittest_SRC := \
 		$(USER_DIR)/rx/crsf.c \
 		$(USER_DIR)/telemetry/crsf.c \

--- a/src/test/unit/sitl_gyro_unittest.cc
+++ b/src/test/unit/sitl_gyro_unittest.cc
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "sitl_gyro.h"
+}
+
+// Regression guard for #15294: PR #15280 dropped the ENABLE_GAZEBO_BRIDGE split
+// around the gyro Z assignment, silently inverting yaw on the (default) Gazebo
+// build. sitlGyroBodyFromSim() now carries the bridge-specific sign, so these
+// tests pin the yaw polarity for *both* bridges in a single binary.
+
+// Gazebo's IMU sensor frame is FRD: roll keeps X, pitch negates Y, yaw keeps Z.
+TEST(SitlGyroUnittest, GazeboBridgeMapping)
+{
+    const double rpy[3] = { 1.0, 2.0, 3.0 };
+    double roll, pitch, yaw;
+
+    sitlGyroBodyFromSim(rpy, true, &roll, &pitch, &yaw);
+
+    EXPECT_DOUBLE_EQ(roll,   1.0);   // +wx -> keep X
+    EXPECT_DOUBLE_EQ(pitch, -2.0);   // -wy -> negate Y
+    EXPECT_DOUBLE_EQ(yaw,    3.0);   // +wz -> keep Z (the bit #15280 broke)
+}
+
+// Legacy bridges (X-Plane, RealFlight) deliver yaw with the opposite polarity.
+TEST(SitlGyroUnittest, LegacyBridgeMapping)
+{
+    const double rpy[3] = { 1.0, 2.0, 3.0 };
+    double roll, pitch, yaw;
+
+    sitlGyroBodyFromSim(rpy, false, &roll, &pitch, &yaw);
+
+    EXPECT_DOUBLE_EQ(roll,   1.0);   // +wx -> keep X
+    EXPECT_DOUBLE_EQ(pitch, -2.0);   // -wy -> negate Y
+    EXPECT_DOUBLE_EQ(yaw,   -3.0);   // -wz -> negate Z
+}
+
+// The defining property of the regression: a positive simulator yaw rate must
+// stay positive under Gazebo, and the two bridges must disagree on yaw sign.
+TEST(SitlGyroUnittest, YawSignDiffersByBridge)
+{
+    const double rpy[3] = { 0.0, 0.0, 1.0 };  // pure positive yaw rate
+    double roll, pitch, gazeboYaw, legacyYaw;
+
+    sitlGyroBodyFromSim(rpy, true,  &roll, &pitch, &gazeboYaw);
+    sitlGyroBodyFromSim(rpy, false, &roll, &pitch, &legacyYaw);
+
+    EXPECT_GT(gazeboYaw, 0.0);                 // Gazebo preserves yaw direction
+    EXPECT_LT(legacyYaw, 0.0);                 // legacy inverts it
+    EXPECT_DOUBLE_EQ(gazeboYaw, -legacyYaw);   // exact opposites
+}

--- a/src/test/unit/sitl_gyro_unittest_c.c
+++ b/src/test/unit/sitl_gyro_unittest_c.c
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// sitl_gyro.h is a header-only (static inline) helper. This translation unit
+// exists so the gyro-mapping logic is also compiled as C (matching its use in
+// sitl.c) alongside the C++ unit test, and to satisfy the unit-test framework's
+// requirement that every test declare a non-empty _SRC.
+
+#include "sitl_gyro.h"


### PR DESCRIPTION
## Summary

Follow-up to #15354 (thank you @nerdCopter). That PR correctly traces the Gazebo yaw inversion to #15280 and reverts it by restoring #15158's `ENABLE_GAZEBO_BRIDGE` split. This PR builds on the same fix and closes the gap that let the regression slip in unnoticed in the first place.

## Why a follow-up

The regression (#15294) was possible because the bridge-specific gyro Z sign lived as an inline `#if ENABLE_GAZEBO_BRIDGE` plus a prose comment inside `updateState()`, with **no test and no compile-time guard**. #15280 — an unrelated POS_HOLD build-gating change — dropped one arm of that conditional, and because the *default* SITL build has `ENABLE_GAZEBO_BRIDGE=1`, yaw silently inverted rather than failing the build. This is the same earth/sensor-frame sign-confusion class as #15342 / #15346, so it deserves the same structural hardening.

## What

- **Extract the mapping** into a single helper, `sitlGyroBodyFromSim()` (`sitl_gyro.h`), that takes the bridge as an **argument**. The `#if` leaves `updateState()` entirely; the FRD-vs-legacy convention now lives in exactly one documented place and can no longer be silently dropped by edits to `updateState()`.
- **Compile-time guard**: `STATIC_ASSERT((ENABLE_GAZEBO_BRIDGE) == 0 || (ENABLE_GAZEBO_BRIDGE) == 1, ...)` so a typo'd or undefined selector fails the build instead of falling through to the legacy sign.
- **Unit test** (`sitl_gyro_unittest`) pinning the yaw polarity for **both** bridges in one binary — Gazebo keeps `+wz`, legacy negates — the regression guard #15280 lacked. Roll/pitch mapping is asserted too.

## Relationship to #15354

This PR contains the behavioural fix as well (via the helper's `+wz` Gazebo path), so it is functionally a superset of #15354. Maintainers' choice on merge order:

- Merge this **instead of** #15354 (it both fixes and hardens), or
- Merge #15354 **first**; I'll rebase this to drop the behavioural overlap, leaving it as pure hardening (helper + assert + test).

Either way #15354 stands on its own and the diagnosis credit is @nerdCopter's.

## Verification

- `make test_sitl_gyro_unittest` → **3/3 PASS**.
- `make TARGET=SITL` → clean build, no warnings on `sitl.c`, `.elf` produced (confirms the `STATIC_ASSERT` holds with the default `ENABLE_GAZEBO_BRIDGE=1`).
- Assertion confirmed to fail the build on a non-`{0,1}` value (genuine guard, not tautological).

Fixes #15294.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected simulator gyro axis mapping, including proper yaw-rate polarity handling between Gazebo and legacy modes.
  * Added a compile-time guard to ensure the Gazebo bridge setting is valid (0/1) to prevent misconfiguration.

* **Tests**
  * Added unit tests and test build wiring to verify gyro roll/pitch/yaw mapping and yaw-polarity behavior across simulator configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->