### PR TITLE
serial: +++ escape to exit passthrough on DTR-less links

### DIFF
--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -735,11 +735,19 @@ void serialPassthrough(serialPort_t *left, serialPort_t *right, serialConsumer *
     // Either port might be open in a mode other than MODE_RXTX. We rely on
     // serialRxBytesWaiting() to do the right thing for a TX only port. No
     // special handling is necessary OR performed.
+
+    // On a DTR-less host link (e.g. a BLE/UART bridge) the only way out of
+    // passthrough is a power cycle. Give those links a "+++" escape: a '+++'
+    // that begins after >=1 s of host silence reboots the FC out of passthrough
+    // (GPS keeps power and its fix; the BLE link survives the reset). The idle
+    // guard is what makes it safe: the binary config stream never pauses for
+    // 1 s, so a stray '+' in it can't arm the escape. USB VCP is excluded, so
+    // its DTR-reset behaviour is unchanged.
+    const bool escEnabled = right->identifier != SERIAL_PORT_USB_VCP;
+    uint32_t hostIdleMs = millis();   // time of last host->FC byte
+    int escCount = 0;                 // consecutive '+' since the idle guard
+
     while (1) {
-        // TODO: maintain a timestamp of last data received. Use this to
-        // implement a guard interval and check for `+++` as an escape sequence
-        // to return to CLI command mode.
-        // https://en.wikipedia.org/wiki/Escape_sequence#Modem_control
         if (serialRxBytesWaiting(left)) {
             LED0_ON;
             uint8_t c = serialRead(left);
@@ -756,6 +764,18 @@ void serialPassthrough(serialPort_t *left, serialPort_t *right, serialConsumer *
              while (!serialTxBytesFree(left));
              serialWrite(left, c);
              rightC(c);
+             if (escEnabled) {
+                 const uint32_t nowMs = millis();
+                 // first '+' must follow a >=1 s gap; '+++' then reboots
+                 if (c == '+' && (escCount > 0 || nowMs - hostIdleMs >= 1000)) {
+                     if (++escCount >= 3) {
+                         systemReset();
+                     }
+                 } else {
+                     escCount = 0;
+                 }
+                 hostIdleMs = nowMs;
+             }
              LED0_OFF;
          }
      }

--- a/src/test/unit/io_serial_unittest.cc
+++ b/src/test/unit/io_serial_unittest.cc
@@ -102,8 +102,8 @@ TEST(IoSerialTest, TestPassthroughEscape)
     serialPort_t left = {}, right = {};
     right.identifier = SERIAL_PORT_UART1;   // non-USB host -> "+++" escape enabled
     hostPort = &right;
+    fakeMillis = 0;
     plusToSend = 3;
-
     // when "+++" arrives after an idle gap, then it must reboot out of passthrough
     EXPECT_THROW(serialPassthrough(&left, &right, NULL, NULL), ResetCalled);
 }

--- a/src/test/unit/io_serial_unittest.cc
+++ b/src/test/unit/io_serial_unittest.cc
@@ -55,6 +55,11 @@ TEST(IoSerialTest, TestFindPortConfig)
 }
 
 
+struct ResetCalled {};
+static const serialPort_t *hostPort = NULL;
+static uint32_t fakeMillis = 0;
+static int plusToSend = 0;
+
 // STUBS
 extern "C" {
     void delay(uint32_t) {}
@@ -65,9 +70,12 @@ extern "C" {
 
     bool telemetryCheckRxPortShared(const serialPortConfig_t *) { return false; }
 
-    uint32_t serialRxBytesWaiting(const serialPort_t *) { return 0; }
-    uint8_t serialRead(serialPort_t *) { return 0; }
+    uint32_t serialRxBytesWaiting(const serialPort_t *p) { return p == hostPort ? plusToSend : 0; }
+    uint8_t serialRead(serialPort_t *) { plusToSend--; return '+'; }
     void serialWrite(serialPort_t *, uint8_t) {}
+
+    uint32_t millis(void) { return fakeMillis += 1000; }  // advance so the "+++" idle guard always passes
+    void systemReset(void) { throw ResetCalled(); }
 
     serialPort_t *usbVcpOpen(void) { return NULL; }
 
@@ -86,4 +94,16 @@ extern "C" {
     void serialSetBaudRateCb(serialPort_t *, void (*)(serialPort_t *context, uint32_t baud), serialPort_t *) {}
 
     void pinioSet(int, bool) {}
+}
+
+TEST(IoSerialTest, TestPassthroughEscape)
+{
+    // given
+    serialPort_t left = {}, right = {};
+    right.identifier = SERIAL_PORT_UART1;   // non-USB host -> "+++" escape enabled
+    hostPort = &right;
+    plusToSend = 3;
+
+    // when "+++" arrives after an idle gap, then it must reboot out of passthrough
+    EXPECT_THROW(serialPassthrough(&left, &right, NULL, NULL), ResetCalled);
 }


### PR DESCRIPTION
Implements the TODO in `serialPassthrough()`.

BLE/UART-bridge hosts have no DTR, so passthrough only exited via power cycle. Now `+++` (begun after ≥1s host silence) → `systemReset()`. USB-VCP excluded; DTR path unchanged. +20/−4.

Closes #15356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial passthrough on non-USB host links by adding a guarded escape sequence (“+++”) that exits passthrough automatically after an idle period, preventing accidental entry/exit.
* **Tests**
  * Added/updated unit tests to simulate incoming “+++” with timing control and verify the expected reset/escape behavior deterministically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->