### PR TITLE
fix(crsf): rate-limit crsfTelemetryUpdateCheck to prevent scheduler starvation

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -1116,12 +1116,13 @@ FAST_CODE void crsfScheduleTelemetryResponse(void)
 }
 
 // Scheduler check function for event-driven telemetry.
-// Periodic sensor telemetry is already capped to CRSF_TELEMETRY_FRAME_INTERVAL_MAX_US (50Hz)
-// inside processCrsf() (CRSF_CYCLETIME_US / crsfScheduleCount). Mirror that cap on the task
-// wake-up rate so high RC link rates (e.g. 250Hz ELRS) cannot wake TASK_TELEMETRY faster than
-// it can produce a frame, which otherwise starves time-critical tasks (PID/motor write).
-// Latency-sensitive ad-hoc responses (MSP-over-telemetry, device info) bypass the cap so they
-// still drain at the inbound frame rate.
+// Cap TASK_TELEMETRY wake-ups at 50Hz so high RC link rates (e.g. 250Hz ELRS)
+// cannot wake the scheduler faster than it produces frames, which otherwise
+// starves time-critical tasks (PID/motor write). Each sensor frame type is
+// sent at most once per CRSF_CYCLETIME_US (100ms), so 50Hz task wakes are
+// sufficient to transmit all types on schedule.
+// Latency-sensitive ad-hoc responses (MSP-over-telemetry, device info) bypass
+// the cap so they still drain at the inbound frame rate.
 bool crsfTelemetryUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
 {
     UNUSED(currentDeltaTimeUs);

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -1118,7 +1118,7 @@ FAST_CODE void crsfScheduleTelemetryResponse(void)
 // Scheduler check function for event-driven telemetry.
 // Rate-limited to CRSF_TELEMETRY_FRAME_INTERVAL_MAX_US to prevent scheduler starvation
 // at high RC link rates (e.g. 250Hz ELRS) where crsfScheduleTelemetryResponse() fires on every frame.
-FAST_CODE bool crsfTelemetryUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
+bool crsfTelemetryUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
 {
     UNUSED(currentDeltaTimeUs);
 

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -1116,14 +1116,28 @@ FAST_CODE void crsfScheduleTelemetryResponse(void)
 }
 
 // Scheduler check function for event-driven telemetry.
-// Rate-limited to CRSF_TELEMETRY_FRAME_INTERVAL_MAX_US to prevent scheduler starvation
-// at high RC link rates (e.g. 250Hz ELRS) where crsfScheduleTelemetryResponse() fires on every frame.
+// Periodic sensor telemetry is already capped to CRSF_TELEMETRY_FRAME_INTERVAL_MAX_US (50Hz)
+// inside processCrsf() (CRSF_CYCLETIME_US / crsfScheduleCount). Mirror that cap on the task
+// wake-up rate so high RC link rates (e.g. 250Hz ELRS) cannot wake TASK_TELEMETRY faster than
+// it can produce a frame, which otherwise starves time-critical tasks (PID/motor write).
+// Latency-sensitive ad-hoc responses (MSP-over-telemetry, device info) bypass the cap so they
+// still drain at the inbound frame rate.
 bool crsfTelemetryUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
 {
     UNUSED(currentDeltaTimeUs);
 
     if (!telemetryResponsePending) {
         return false;
+    }
+
+    // Ad-hoc responses must be serviced as soon as possible, not rate-limited.
+#if defined(USE_MSP_OVER_TELEMETRY)
+    if (mspReplyPending) {
+        return true;
+    }
+#endif
+    if (deviceInfoReplyPending) {
+        return true;
     }
 
     static timeUs_t lastTelemetryCheckTimeUs = 0;

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -1116,13 +1116,23 @@ FAST_CODE void crsfScheduleTelemetryResponse(void)
 }
 
 // Scheduler check function for event-driven telemetry.
-// Parameters reserved for potential future rate-limiting or timing logic.
-bool crsfTelemetryUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
+// Rate-limited to CRSF_TELEMETRY_FRAME_INTERVAL_MAX_US to prevent scheduler starvation
+// at high RC link rates (e.g. 250Hz ELRS) where crsfScheduleTelemetryResponse() fires on every frame.
+FAST_CODE bool crsfTelemetryUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
 {
-    UNUSED(currentTimeUs);
     UNUSED(currentDeltaTimeUs);
 
-    return telemetryResponsePending;
+    if (!telemetryResponsePending) {
+        return false;
+    }
+
+    static timeUs_t lastTelemetryCheckTimeUs = 0;
+    if (cmpTimeUs(currentTimeUs, lastTelemetryCheckTimeUs) < CRSF_TELEMETRY_FRAME_INTERVAL_MAX_US) {
+        return false;
+    }
+
+    lastTelemetryCheckTimeUs = currentTimeUs;
+    return true;
 }
 
 #endif

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -1127,7 +1127,7 @@ bool crsfTelemetryUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTi
     }
 
     static timeUs_t lastTelemetryCheckTimeUs = 0;
-    if (cmpTimeUs(currentTimeUs, lastTelemetryCheckTimeUs) < CRSF_TELEMETRY_FRAME_INTERVAL_MAX_US) {
+    if (cmpTimeUs(currentTimeUs, lastTelemetryCheckTimeUs) < (timeDelta_t)CRSF_TELEMETRY_FRAME_INTERVAL_MAX_US) {
         return false;
     }
 


### PR DESCRIPTION
AI Generated pull-request

## Summary

`crsfScheduleTelemetryResponse()` fires on every valid incoming CRSF frame, setting
`telemetryResponsePending = true` each time. `crsfTelemetryUpdateCheck()` is the scheduler
`checkFunc` for `TASK_TELEMETRY`, so at 250 Hz ELRS it was waking the telemetry task 250×/sec.
This starved time-critical tasks (PID/motor write), manifesting as motors not responding to
throttle above idle.

The `currentTimeUs` parameter was explicitly reserved in the original function with the comment
_"Parameters reserved for potential future rate-limiting or timing logic."_
`CRSF_TELEMETRY_FRAME_INTERVAL_MAX_US` (20 ms / 50 Hz) was already defined for this cap.

The fix gates the checkFunc on an elapsed-time check using those reserved values, capping
`TASK_TELEMETRY` wake-ups at 50 Hz for periodic sensor telemetry. Latency-sensitive ad-hoc
paths (`mspReplyPending`, `deviceInfoReplyPending`) bypass the gate so MSP-over-telemetry and
device-info transfers drain at the inbound frame rate rather than being artificially slowed.
`telemetryResponsePending` must still be set to trigger the task (preserves event-driven
behaviour); the rate limit purely bounds how often periodic sensor frames wake the scheduler.

Fixes: #15066

## Test plan
- [x] Build passes: OMNIBUSF4SD / STM32F7 / H7 targets
- [ ] Hardware verified: ELRS 250 Hz link — confirm PID loop no longer starved and telemetry still received at correct rate
- [ ] Hardware verified: ELRS 50 Hz link — confirm no regression in telemetry delivery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry message handling to prevent excessive event-driven transmissions.
  * Kept latency-sensitive/urgent responses flowing immediately when pending.
  * Added stricter timing limits between repeated telemetry checks to make behavior more consistent and stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->