### PR TITLE
fix(vtx): apply all active VTX activation conditions (#15362)

### DIFF
--- a/src/main/io/vtx_control.c
+++ b/src/main/io/vtx_control.c
@@ -54,7 +54,10 @@ PG_RESET_TEMPLATE(vtxConfig_t, vtxConfig,
     .halfDuplex = true
 );
 
-static uint8_t locked = 0;
+// Latched on first arm and intentionally never cleared for the rest of the session, so band
+// and channel can no longer be changed by switch once the craft has been armed. STATIC_UNIT_TESTED
+// (still 'static' in firmware builds) so unit tests can reset it between cases.
+STATIC_UNIT_TESTED uint8_t locked = 0;
 
 void vtxControlInit(void)
 {
@@ -109,15 +112,15 @@ void vtxUpdateActivatedChannel(void)
     }
 
     if (vtxCommonDevice()) {
-        static uint8_t lastIndex = -1;
-
+        // Apply every active activation condition, like updateActivatedModes() does for mode
+        // ranges. Stopping at the first match (or remembering only the last applied index)
+        // starves higher-indexed conditions when three or more are active at once, so band,
+        // channel and power assigned to separate switches could not all take effect. When two
+        // active conditions set the same field, the highest-indexed one wins (last write).
         for (uint8_t index = 0; index < MAX_CHANNEL_ACTIVATION_CONDITION_COUNT; index++) {
             const vtxChannelActivationCondition_t *vtxChannelActivationCondition = &vtxConfig()->vtxChannelActivationConditions[index];
 
-            if (isRangeActive(vtxChannelActivationCondition->auxChannelIndex, &vtxChannelActivationCondition->range)
-                && index != lastIndex) {
-                lastIndex = index;
-
+            if (isRangeActive(vtxChannelActivationCondition->auxChannelIndex, &vtxChannelActivationCondition->range)) {
                 if (!locked) {
                     if (vtxChannelActivationCondition->band > 0) {
                         vtxSettingsConfigMutable()->band = vtxChannelActivationCondition->band;
@@ -130,7 +133,6 @@ void vtxUpdateActivatedChannel(void)
                 if (vtxChannelActivationCondition->power > 0) {
                     vtxSettingsConfigMutable()->power = vtxChannelActivationCondition->power;
                 }
-                break;
             }
         }
     }

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -42,6 +42,9 @@ extern "C" {
     #include "io/beeper.h"
     #include "io/gps.h"
     #include "io/vtx.h"
+    #include "io/vtx_control.h"
+
+    #include "drivers/vtx_common.h"
 
     #include "pg/gps_rescue.h"
     #include "pg/motor.h"
@@ -123,6 +126,181 @@ TEST(VtxTest, PitMode)
     // expect
     EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXVTXPITMODE));
     EXPECT_EQ(5300, vtxGetSettings().freq);
+}
+
+// vtxUpdateActivatedChannel() only checks that a device is present; it never calls into the
+// vTable, so a stub device with no vTable is sufficient.
+static vtxDevice_t testVtxDevice = { .vTable = NULL };
+
+extern "C" {
+    // STATIC_UNIT_TESTED in vtx_control.c — a session-sticky arm latch with no production reset.
+    // Reset it before each case so the tests are independent of execution order (e.g. shuffle).
+    extern uint8_t locked;
+}
+
+static void clearActivationConditions(void)
+{
+    for (int i = 0; i < MAX_CHANNEL_ACTIVATION_CONDITION_COUNT; i++) {
+        vtxChannelActivationCondition_t *cond = &vtxConfigMutable()->vtxChannelActivationConditions[i];
+        cond->auxChannelIndex = 0;
+        cond->band = 0;
+        cond->channel = 0;
+        cond->power = 0;
+        cond->range.startStep = 0;
+        cond->range.endStep = 0;
+    }
+}
+
+static void setActivationCondition(uint8_t index, uint8_t auxChannelIndex, uint8_t band, uint8_t channel, uint8_t power)
+{
+    vtxChannelActivationCondition_t *cond = &vtxConfigMutable()->vtxChannelActivationConditions[index];
+    cond->auxChannelIndex = auxChannelIndex;
+    cond->band = band;
+    cond->channel = channel;
+    cond->power = power;
+    cond->range.startStep = CHANNEL_VALUE_TO_STEP(1400);
+    cond->range.endStep = CHANNEL_VALUE_TO_STEP(1600);
+    // drive the aux channel into the active range
+    rcData[NON_AUX_CHANNEL_COUNT + auxChannelIndex] = 1500;
+}
+
+// Regression test for #15362: band, channel and power assigned to three separate switches,
+// all active simultaneously. The power condition sits at the highest array index. Before the
+// fix, only one condition was applied per call and the two lowest indices ping-ponged, so the
+// highest-indexed (power) condition was never reached.
+TEST(VtxTest, ActivationConditionsAllAppliedWhenSimultaneouslyActive)
+{
+    // given
+    locked = 0;
+    DISABLE_ARMING_FLAG(ARMED);
+    vtxCommonSetDevice(&testVtxDevice);
+    clearActivationConditions();
+
+    setActivationCondition(0, 0, 1, 0, 0);  // AUX1 -> band 1
+    setActivationCondition(1, 1, 0, 2, 0);  // AUX2 -> channel 2
+    setActivationCondition(2, 2, 0, 0, 3);  // AUX3 -> power 3 (highest index)
+
+    vtxSettingsConfigMutable()->band = 0;
+    vtxSettingsConfigMutable()->channel = 0;
+    vtxSettingsConfigMutable()->power = 0;
+
+    // when
+    vtxUpdateActivatedChannel();
+
+    // expect — all three applied, in particular power (the previously starved condition)
+    EXPECT_EQ(1, vtxSettingsConfig()->band);
+    EXPECT_EQ(2, vtxSettingsConfig()->channel);
+    EXPECT_EQ(3, vtxSettingsConfig()->power);
+}
+
+// A power-only condition (band == 0, channel == 0) must change only power, leaving band and
+// channel untouched — the per-field `> 0` guards must survive removal of the early break.
+TEST(VtxTest, PowerOnlyConditionDoesNotResetBandAndChannel)
+{
+    // given
+    locked = 0;
+    DISABLE_ARMING_FLAG(ARMED);
+    vtxCommonSetDevice(&testVtxDevice);
+    clearActivationConditions();
+
+    setActivationCondition(0, 0, 0, 0, 2);  // AUX1 -> power 2 only
+
+    vtxSettingsConfigMutable()->band = 5;
+    vtxSettingsConfigMutable()->channel = 7;
+    vtxSettingsConfigMutable()->power = 0;
+
+    // when
+    vtxUpdateActivatedChannel();
+
+    // expect — power updated, band/channel preserved
+    EXPECT_EQ(5, vtxSettingsConfig()->band);
+    EXPECT_EQ(7, vtxSettingsConfig()->channel);
+    EXPECT_EQ(2, vtxSettingsConfig()->power);
+}
+
+// Last-write-wins precedence: when two active conditions set the SAME field, the highest-indexed
+// one wins because every active condition is applied in array order. This is the documented
+// behaviour change introduced with the starvation fix.
+TEST(VtxTest, LastActiveConditionWinsForSameField)
+{
+    // given
+    locked = 0;
+    DISABLE_ARMING_FLAG(ARMED);
+    vtxCommonSetDevice(&testVtxDevice);
+    clearActivationConditions();
+
+    // two conditions, both active, both writing band/channel/power
+    setActivationCondition(0, 0, 1, 1, 1);  // AUX1 -> band 1, channel 1, power 1
+    setActivationCondition(1, 1, 5, 6, 7);  // AUX2 -> band 5, channel 6, power 7 (higher index)
+
+    vtxSettingsConfigMutable()->band = 0;
+    vtxSettingsConfigMutable()->channel = 0;
+    vtxSettingsConfigMutable()->power = 0;
+
+    // when
+    vtxUpdateActivatedChannel();
+
+    // expect — highest-indexed active condition wins every field
+    EXPECT_EQ(5, vtxSettingsConfig()->band);
+    EXPECT_EQ(6, vtxSettingsConfig()->channel);
+    EXPECT_EQ(7, vtxSettingsConfig()->power);
+}
+
+// A condition becoming inactive (range no longer matched) is level-triggered with no reset:
+// the last applied values must be left in place, i.e. it must NOT reset settings to 0.
+TEST(VtxTest, InactiveConditionLeavesLastValues)
+{
+    // given
+    locked = 0;
+    DISABLE_ARMING_FLAG(ARMED);
+    vtxCommonSetDevice(&testVtxDevice);
+    clearActivationConditions();
+
+    setActivationCondition(0, 0, 3, 4, 5);  // AUX1 -> band 3, channel 4, power 5, active
+
+    vtxSettingsConfigMutable()->band = 0;
+    vtxSettingsConfigMutable()->channel = 0;
+    vtxSettingsConfigMutable()->power = 0;
+
+    vtxUpdateActivatedChannel();
+    EXPECT_EQ(3, vtxSettingsConfig()->band);
+    EXPECT_EQ(4, vtxSettingsConfig()->channel);
+    EXPECT_EQ(5, vtxSettingsConfig()->power);
+
+    // when the aux channel leaves the active range
+    rcData[NON_AUX_CHANNEL_COUNT + 0] = 1000;
+    vtxUpdateActivatedChannel();
+
+    // expect — values persist, nothing is reset
+    EXPECT_EQ(3, vtxSettingsConfig()->band);
+    EXPECT_EQ(4, vtxSettingsConfig()->channel);
+    EXPECT_EQ(5, vtxSettingsConfig()->power);
+}
+
+// When armed, band/channel are locked but power may still change. `locked` is reset first so
+// this case no longer depends on running last.
+TEST(VtxTest, ArmedLocksBandAndChannelButNotPower)
+{
+    // given
+    locked = 0;
+    DISABLE_ARMING_FLAG(ARMED);
+    vtxCommonSetDevice(&testVtxDevice);
+    clearActivationConditions();
+
+    setActivationCondition(0, 0, 4, 6, 2);  // AUX1 -> band 4, channel 6, power 2
+
+    vtxSettingsConfigMutable()->band = 0;
+    vtxSettingsConfigMutable()->channel = 0;
+    vtxSettingsConfigMutable()->power = 0;
+
+    // when armed
+    ENABLE_ARMING_FLAG(ARMED);
+    vtxUpdateActivatedChannel();
+
+    // expect — band/channel locked out, power still applied
+    EXPECT_EQ(0, vtxSettingsConfig()->band);
+    EXPECT_EQ(0, vtxSettingsConfig()->channel);
+    EXPECT_EQ(2, vtxSettingsConfig()->power);
 }
 
 // STUBS

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -296,6 +296,7 @@ TEST(VtxTest, ArmedLocksBandAndChannelButNotPower)
     // when armed
     ENABLE_ARMING_FLAG(ARMED);
     vtxUpdateActivatedChannel();
+    DISABLE_ARMING_FLAG(ARMED);  // restore global state so later/shuffled tests don't inherit it
 
     // expect — band/channel locked out, power still applied
     EXPECT_EQ(0, vtxSettingsConfig()->band);


### PR DESCRIPTION
## Summary

Fixes #15362 — when VTX band, channel, and power are mapped to three separate AUX switches and all are active simultaneously, the **power** change was silently dropped.

`vtxUpdateActivatedChannel()` applied at most **one** activation condition per call, using a single `static uint8_t lastIndex` as debounce. With three active conditions A&lt;B&lt;C, the two lowest-indexed ones ping-pong forever and C is never reached — and in the reporter's config the power conditions sit at the highest indices, so power starves.

The fix makes the function **level-triggered**, mirroring the canonical `updateActivatedModes()` pattern in `rc_modes.c`: iterate all conditions every call, apply each active one, no `break`, no edge state.

### Changes
- `src/main/io/vtx_control.c` — removed `static uint8_t lastIndex`, the `&& index != lastIndex` guard, and the `break`; now applies every active condition. The per-field `> 0` guards and the `if (!locked)` armed-state gate are retained verbatim.
- `locked` changed `static` → `STATIC_UNIT_TESTED` (expands to `static` in firmware builds — behaviour-neutral) so unit tests can reset the session-sticky arm latch.
- `src/test/unit/vtx_unittest.cc` — 5 new Google Test cases.

### Behaviour change (intended)
Control is now level-triggered: while an AUX switch is held in an active range it continuously re-asserts band/channel/power. A manual OSD/CMS/button change to a field governed by a still-active condition will be overridden within ~1 RX cycle. This is the intended "switch-is-authoritative" semantic and matches `updateActivatedModes()`. The `vtx.c` scheduler is delta-driven, so re-asserting identical values produces no serial traffic or flash writes.

When two active conditions set the same field, the highest-indexed one wins (last write) — deterministic and documented in a code comment.

## Test plan
- `make test_vtx_unittest` → 6/6 PASS.
- The 3 regression tests confirmed **red on the pre-fix source, green on the fix**.
- Order-independent under `--gtest_shuffle` (seeds 2/7/42/99).
- Coverage: all-three-simultaneous (the #15362 regression), power-only does not zero band/channel, last-write-wins precedence, inactive-condition persistence, armed locks band/channel but not power.

Firmware only — no MSP, configurator, docs, or preset impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VTX channel activation behavior when multiple activation conditions are active, with correct priority so the latest applicable setting wins.
  * Prevented unintended resets of band/channel/power when activation conditions change, preserving the last applied values.
  * Enforced locked band/channel behavior while still allowing power updates where permitted.

* **Tests**
  * Added regression coverage for overlapping conditions, priority resolution, persistence after conditions go inactive, and armed-state lock behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->