### PR TITLE
docs: accgyro_spi_icm20689.c 8Mhz comment correction

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -38,7 +38,7 @@
 #include "drivers/sensor.h"
 #include "drivers/time.h"
 
-// 10 MHz max SPI frequency
+// 9 MHz max SPI frequency
 #define ICM20689_MAX_SPI_CLK_HZ 8000000
 
 // Register 0x37 - INT_PIN_CFG / Pin Bypass Enable Configuration

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -38,7 +38,7 @@
 #include "drivers/sensor.h"
 #include "drivers/time.h"
 
-// 9 MHz max SPI frequency
+// 8 MHz max SPI frequency
 #define ICM20689_MAX_SPI_CLK_HZ 8000000
 
 // Register 0x37 - INT_PIN_CFG / Pin Bypass Enable Configuration


### PR DESCRIPTION
credit to @Andi7891 via https://github.com/betaflight/betaflight/pull/11584#discussion_r3480453461 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the documented maximum SPI frequency for the sensor from **10 MHz** to **8 MHz** to match the existing configured limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->