### PR TITLE
feat(h5): enable LED_STRIP and remaining peripherals, drop VIRTUAL_GYRO

### DIFF
--- a/src/platform/STM32/target/STM32H562/target.h
+++ b/src/platform/STM32/target/STM32H562/target.h
@@ -28,57 +28,6 @@
 #define USBD_PRODUCT_STRING     "Betaflight - STM32H562"
 #endif
 
-//#undef USE_PWM
-//#undef USE_PWM_OUTPUT
-//#undef USE_DSHOT
-//#undef USE_ADC
-//#undef USE_TIMER
-//#undef USE_DMA
-//#undef USE_FLASH
-//#undef USE_FLASH_CHIP
-//#undef USE_FLASHFS
-//#undef USE_FLASH_TOOLS
-//#undef USE_FLASH_M25P16
-//#undef USE_FLASH_W25N01G
-//#undef USE_FLASH_W25M
-//#undef USE_FLASH_W25M512
-//#undef USE_FLASH_W25M02G
-//#undef USE_FLASH_W25Q128FV
-//#undef USE_FLASH_PY25Q128HA
-
-//#undef USE_TRANSPONDER
-//#undef USE_SDCARD
-//#undef USE_LED_STRIP
-//#undef USE_SOFTSERIAL
-//#undef USE_VCP
-//#undef USE_ESCSERIAL
-//#undef USE_SPI
-//#undef USE_I2C
-//#undef USE_UART
-//#undef USE_USB_DETECT
-//#undef USE_BEEPER
-//#undef USE_EXTI
-//#undef USE_TIMER_UP_CONFIG
-//#undef USE_RX_SPI
-//#undef USE_RX_CC2500
-//#undef USE_BARO
-//#undef USE_I2C_GYRO
-//#undef USE_SPI_GYRO
-//#undef USE_GYRO
-//#undef USE_ACC
-//#undef USE_MAG
-//#undef USE_MAX7456
-//#undef USE_VTX_RTC6705
-//#undef USE_VTX_RTC6705_SOFTSPI
-//#undef USE_CLI
-//#undef USE_CAMERA_CONTROL
-//#undef USE_RX_PWM
-//#undef USE_SERIAL_4WAY_BLHELI_INTERFACE
-//#undef USE_SERIAL_4WAY_SK_BOOTLOADER
-//#undef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
-//#undef USE_MOTOR
-//#undef USE_SERVO
-
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2
 #define USE_I2C_DEVICE_3

--- a/src/platform/STM32/target/STM32H562/target.h
+++ b/src/platform/STM32/target/STM32H562/target.h
@@ -46,9 +46,9 @@
 //#undef USE_FLASH_W25Q128FV
 //#undef USE_FLASH_PY25Q128HA
 
-#undef USE_TRANSPONDER
+//#undef USE_TRANSPONDER
 //#undef USE_SDCARD
-#undef USE_LED_STRIP
+//#undef USE_LED_STRIP
 //#undef USE_SOFTSERIAL
 //#undef USE_VCP
 //#undef USE_ESCSERIAL
@@ -78,8 +78,6 @@
 //#undef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
 //#undef USE_MOTOR
 //#undef USE_SERVO
-
-#define USE_VIRTUAL_GYRO
 
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2
@@ -119,34 +117,44 @@
 #define USE_I2C
 #define I2C_FULL_RECONFIGURABILITY
 
-//#define USE_BEEPER
-
-#if !defined(ENABLE_SDIO_INIT)
-#define ENABLE_SDIO_INIT 1
-#endif
-#if !defined(ENABLE_SDIO_PIN_CONFIG)
-#define ENABLE_SDIO_PIN_CONFIG 1
-#endif
+#define USE_BEEPER
 
 #ifdef USE_SDCARD
 #define USE_SDCARD_SPI
 #define USE_SDCARD_SDIO
 #endif
 
+// Tie SDIO init/pin config to actually using SDIO. Otherwise the CLI
+// resourceTable[] keeps PG_SDIO_PIN_CONFIG entries, but pg/sdio.c is
+// gated on USE_SDCARD_SDIO so the PG never registers, and `dump`
+// faults inside printResource on a NULL pgFind() result.
+#ifdef USE_SDCARD_SDIO
+#if !defined(ENABLE_SDIO_INIT)
+#define ENABLE_SDIO_INIT 1
+#endif
+#if !defined(ENABLE_SDIO_PIN_CONFIG)
+#define ENABLE_SDIO_PIN_CONFIG 1
+#endif
+#endif
+
 #define USE_SPI
 #define SPI_FULL_RECONFIGURABILITY
 //#define USE_SPI_DMA_ENABLE_LATE
 
-//#define USE_USB_DETECT
+#define USE_USB_DETECT
 
-//#define USE_ESCSERIAL
+#define USE_ESCSERIAL
 
 #define USE_ADC
 #define USE_EXTI
-//#define USE_TIMER_UP_CONFIG
+#define USE_TIMER_UP_CONFIG
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x2000) // 8K sectors
 
-#if defined(USE_LED_STRIP) && !defined(USE_LED_STRIP_CACHE_MGMT)
-#define USE_LED_STRIP_CACHE_MGMT
+// CONFIG_IN_RAM bring-up needs more than the default 4 KiB to hold every PG that
+// gets compiled in for a 2 MiB flash target (VTX table alone is ~290 B). Bump to
+// 8 KiB so writeSettingsToEEPROM doesn't overrun eepromData[] and tear the
+// next-PG size field, which makes isEEPROMStructureValid() walk off the end.
+#ifndef EEPROM_SIZE
+#define EEPROM_SIZE 8192
 #endif

--- a/src/platform/STM32/target/STM32H563/target.h
+++ b/src/platform/STM32/target/STM32H563/target.h
@@ -28,57 +28,6 @@
 #define USBD_PRODUCT_STRING     "Betaflight - STM32H563"
 #endif
 
-//#undef USE_PWM
-//#undef USE_PWM_OUTPUT
-//#undef USE_DSHOT
-//#undef USE_ADC
-//#undef USE_TIMER
-//#undef USE_DMA
-//#undef USE_FLASH
-//#undef USE_FLASH_CHIP
-//#undef USE_FLASHFS
-//#undef USE_FLASH_TOOLS
-//#undef USE_FLASH_M25P16
-//#undef USE_FLASH_W25N01G
-//#undef USE_FLASH_W25M
-//#undef USE_FLASH_W25M512
-//#undef USE_FLASH_W25M02G
-//#undef USE_FLASH_W25Q128FV
-//#undef USE_FLASH_PY25Q128HA
-
-//#undef USE_TRANSPONDER
-//#undef USE_SDCARD
-//#undef USE_LED_STRIP
-//#undef USE_SOFTSERIAL
-//#undef USE_VCP
-//#undef USE_ESCSERIAL
-//#undef USE_SPI
-//#undef USE_I2C
-//#undef USE_UART
-//#undef USE_USB_DETECT
-//#undef USE_BEEPER
-//#undef USE_EXTI
-//#undef USE_TIMER_UP_CONFIG
-//#undef USE_RX_SPI
-//#undef USE_RX_CC2500
-//#undef USE_BARO
-//#undef USE_I2C_GYRO
-//#undef USE_SPI_GYRO
-//#undef USE_GYRO
-//#undef USE_ACC
-//#undef USE_MAG
-//#undef USE_MAX7456
-//#undef USE_VTX_RTC6705
-//#undef USE_VTX_RTC6705_SOFTSPI
-//#undef USE_CLI
-//#undef USE_CAMERA_CONTROL
-//#undef USE_RX_PWM
-//#undef USE_SERIAL_4WAY_BLHELI_INTERFACE
-//#undef USE_SERIAL_4WAY_SK_BOOTLOADER
-//#undef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
-//#undef USE_MOTOR
-//#undef USE_SERVO
-
 #define USE_I2C_DEVICE_1
 #define USE_I2C_DEVICE_2
 #define USE_I2C_DEVICE_3

--- a/src/platform/STM32/target/STM32H563/target.h
+++ b/src/platform/STM32/target/STM32H563/target.h
@@ -46,9 +46,9 @@
 //#undef USE_FLASH_W25Q128FV
 //#undef USE_FLASH_PY25Q128HA
 
-#undef USE_TRANSPONDER
+//#undef USE_TRANSPONDER
 //#undef USE_SDCARD
-#undef USE_LED_STRIP
+//#undef USE_LED_STRIP
 //#undef USE_SOFTSERIAL
 //#undef USE_VCP
 //#undef USE_ESCSERIAL
@@ -73,8 +73,6 @@
 //#undef USE_CLI
 //#undef USE_CAMERA_CONTROL
 //#undef USE_RX_PWM
-//#undef USE_LED_STRIP
-//#undef USE_TRANSPONDER
 //#undef USE_SERIAL_4WAY_BLHELI_INTERFACE
 //#undef USE_SERIAL_4WAY_SK_BOOTLOADER
 //#undef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
@@ -119,7 +117,7 @@
 #define USE_I2C
 #define I2C_FULL_RECONFIGURABILITY
 
-//#define USE_BEEPER
+#define USE_BEEPER
 
 #ifdef USE_SDCARD
 #define USE_SDCARD_SPI
@@ -143,13 +141,13 @@
 #define SPI_FULL_RECONFIGURABILITY
 #define USE_SPI_DMA_ENABLE_LATE
 
-//#define USE_USB_DETECT
+#define USE_USB_DETECT
 
-//#define USE_ESCSERIAL
+#define USE_ESCSERIAL
 
 #define USE_ADC
 #define USE_EXTI
-//#define USE_TIMER_UP_CONFIG
+#define USE_TIMER_UP_CONFIG
 
 #define FLASH_PAGE_SIZE ((uint32_t)0x2000) // 8K sectors
 
@@ -159,8 +157,4 @@
 // next-PG size field, which makes isEEPROMStructureValid() walk off the end.
 #ifndef EEPROM_SIZE
 #define EEPROM_SIZE 8192
-#endif
-
-#if defined(USE_LED_STRIP) && !defined(USE_LED_STRIP_CACHE_MGMT)
-#define USE_LED_STRIP_CACHE_MGMT
 #endif


### PR DESCRIPTION
## Summary

Completes the STM32H5 bring-up started by the UART fixes in #15367. Enables the remaining missing peripheral features on the `STM32H562` and `STM32H563` generic targets and removes the bring-up `VIRTUAL_GYRO` placeholder.

## Changes

### LED strip
- Remove `#undef USE_LED_STRIP` on both targets.
- Remove the `USE_LED_STRIP_CACHE_MGMT` auto-define block. It was copied from the H7/N6 targets, but **STM32H5 (Cortex-M33) has no CPU L1 D-cache** — `SCB_CleanDCache_by_Addr()` does not exist for CM33 (`core_cm33.h` does not pull in `cachel1_armv7.h`), and the only no-op shim is `CORE_CM4`-gated, so the cache path would fail to compile. H5's `DCACHE` only covers external OCTOSPI/FMC memory, not the SRAM DMA buffer, so cache maintenance is unnecessary. This matches G4 behaviour.
- The WS2811 timer/GPDMA driver layer was already ported in #15092, so no driver changes are required.

### Virtual gyro
- Remove `#define USE_VIRTUAL_GYRO` from H562. The classic-build defaults (`common_pre.h`) already enable the full real SPI gyro driver suite, so this brings H562 to parity with H563. H562 now requires a real gyro, as intended.

### Remaining peripheral features (parity with H743)
- Enable `USE_TRANSPONDER`, `USE_BEEPER`, `USE_USB_DETECT`, `USE_ESCSERIAL`, `USE_TIMER_UP_CONFIG`. All corresponding driver sources are already in `STM32H5.mk`.

### H562 / H563 reconciliation
- Gate the SDIO init/pin-config on `USE_SDCARD_SDIO` in H562 (prevents the `dump`/`printResource` NULL fault that the H563 comment describes).
- Add `EEPROM_SIZE 8192` to H562 (CONFIG_IN_RAM headroom), matching H563.
- Drop duplicate `//#undef` scaffolding lines in H563.

Out of scope (left for follow-up / hardware validation): the `TARGET_IO_PORTG` and `USE_SPI_DMA_ENABLE_LATE` divergence between the two targets, MSC, and CAN.

## Testing
Both targets build and link cleanly:

| Target | Flash (FLASH1) | RAM |
|--------|----------------|-----|
| STM32H563 | 27.07% (~496 KB) | 16.75% |
| STM32H562 | 27.02% (~496 KB) | 16.73% |

H562 links without `USE_VIRTUAL_GYRO`, confirming the real gyro suite is present and there is no undefined symbol; LED strip compiles with the cache-mgmt block removed, confirming the `SCB_CleanDCache_by_Addr` blocker is resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled additional hardware capabilities on STM32H562/STM32H563, including beeper support, USB detection, ESC serial, and timer up configuration.
  * Refined SD card/SDIO setup so SPI/SDIO options and SDIO initialization are applied only when SDIO is selected.
  * Added a conditional default EEPROM size (8192) for STM32H562.

* **Bug Fixes**
  * Stopped force-disabling optional features, allowing configuration to take effect consistently across both targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
