### PR TITLE
fix(h5): use correct system bootloader address for software DFU entry

### DIFF
--- a/src/platform/STM32/system_stm32h5xx.c
+++ b/src/platform/STM32/system_stm32h5xx.c
@@ -82,8 +82,18 @@ void systemResetToBootloader(bootloaderRequestType_e requestType)
     NVIC_SystemReset();
 }
 
-// STM32H5 system flash (ROM bootloader) base address
-#define SYSMEMBOOT_VECTOR_TABLE ((uint32_t *)FLASH_SYSTEM_BASE_NS)
+// STM32H5 system bootloader vector-table address (AN2606).
+// This is the bootloader entry point, NOT the FLASH_SYSTEM_BASE_NS region base
+// (0x0BF80000): reading the initial SP / reset vector from the region base lands
+// on garbage, so the software `bl`/MSP DFU request never enters the bootloader
+// while the hardware BOOT pin still works (the ROM handles that path itself).
+#if defined(STM32H562xx) || defined(STM32H563xx) || defined(STM32H573xx)
+#define SYSMEMBOOT_VECTOR_TABLE ((uint32_t *)0x0BF97000)
+#elif defined(STM32H503xx)
+#define SYSMEMBOOT_VECTOR_TABLE ((uint32_t *)0x0BF87000)
+#else
+#error "STM32H5: system bootloader address unknown for this part (see AN2606)"
+#endif
 
 typedef void *(*bootJumpPtr)(void);
 


### PR DESCRIPTION
## Summary

On STM32H5 (H562/H563), the CLI `bl` command and the MSP reboot-to-bootloader request do **not** put the board into DFU mode — the user has to use the physical BOOT pin instead. On F4/F7/H7/G4 the software request works.

## Root cause

`systemJumpToBootloader()` read the initial stack pointer and reset vector from `FLASH_SYSTEM_BASE_NS` (`0x0BF80000`), which is the **system-flash region base**, not the bootloader entry point.

Per ST **AN2606** ("STM32 microcontroller system memory boot mode"), the system bootloader vector table is located at:
- **`0x0BF97000`** on STM32H562/H563/H573 (device ID 0x484)
- **`0x0BF87000`** on STM32H503

Reading `[0]`/`[1]` from `0x0BF80000` yields a bogus SP/PC, so `__set_MSP()` + the jump land on garbage and the bootloader never starts. The hardware BOOT pin still works because that path is handled entirely by the ROM/RSS (AN2606 boot pattern with `PRODUCT_STATE=Open`, `BOOT0=1`), bypassing the application jump code — which is exactly why only the software request was affected.

## Fix

Point `SYSMEMBOOT_VECTOR_TABLE` at the correct per-part bootloader address from AN2606 instead of the region base. The rest of `systemJumpToBootloader()` (set `SCB->VTOR`, load SP/reset-handler, `__set_MSP`, jump) is already correct for the remap-less Cortex-M33.

## Testing

- Builds clean: `STM32H563` (27.07% flash) and `STM32H562` (27.02% flash).
- **Hardware validation needed**: with this change, `bl` in the CLI (or MSP reboot-to-bootloader) should re-enumerate the board as `STM32 BOOTLOADER` / DFU (verify with `dfu-util -l` or STM32CubeProgrammer, device ID 0x484). The existing `RESET_BOOTLOADER_POST` recovery path still returns to firmware if no DFU host activity follows.

## References

- AN2606, §STM32H562xx/H563xx/H573xx — system memory at `0x0BF97000`
- ST KB: [How to jump to system bootloader from application code on STM32](https://community.st.com/t5/stm32-mcus/how-to-jump-to-system-bootloader-from-application-code-on-stm32/ta-p/49424)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootloader entry handling on supported STM32H5 variants.
  * Fixed an issue where the system could read incorrect startup values, which could prevent entering the bootloader using the DFU request path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
