### PR TITLE
fix(x32m7b): fix spi and sdmmc

### DIFF
--- a/src/platform/X32/bus_spi_x32.c
+++ b/src/platform/X32/bus_spi_x32.c
@@ -217,6 +217,8 @@ void spiInitDevice(spiDevice_e device)
     IOConfigGPIOAF(IOGetByTag(spi->sck), SPI_IO_AF_SCK_CFG, spi->sckAF);
     IOConfigGPIOAF(IOGetByTag(spi->miso), SPI_IO_AF_SDI_CFG, spi->misoAF);
     IOConfigGPIOAF(IOGetByTag(spi->mosi), SPI_IO_AF_CFG, spi->mosiAF);
+    /*Enable all SPI mode , not I2S mode*/
+    AFIO_ConfigSPII2SMode(0x1E000000,SPI_MODE);
 
     SPI_I2S_DeInit(instance);
     spiApplyConfig(instance, 8, false);

--- a/src/platform/X32/sdio_x32.c
+++ b/src/platform/X32/sdio_x32.c
@@ -265,9 +265,15 @@ bool SD_IsDetected(void)
 
 bool SD_GetState(void)
 {
-    Status_card cardState = SD_PollingCardStatusBusy(&card,1000);
 
-    // return (cardState == Status_CardStatusBusy);
+
+    // Phase 1: Hardware DAT0 check (microseconds)
+    if (SDMMC_GetPresentFlagStatus(card.SDHOSTx, SDHOST_Data0LineLevelFlag) != SET) {
+        return false;  // DAT0 low = card definitely busy, no need to send CMD13
+    }
+
+    Status_card cardState = SD_PollingCardStatusBusy(&card, 1);
+
     return (cardState == Status_CardStatusIdle);
 }
 
@@ -884,6 +890,9 @@ SD_Error_t SD_Init(void)
     static SD_Error_t result = SD_ERROR;
 
     if (sdInitAttempted) {
+        if (result == SD_OK) {
+            return SD_GetState() ? SD_OK : SD_ERROR;
+        }
         return result;
     }
 

--- a/src/platform/common/stm32/bus_spi_pinconfig.c
+++ b/src/platform/common/stm32/bus_spi_pinconfig.c
@@ -814,6 +814,7 @@ const spiHardware_t spiHardware[] = {
         .mosiPins = {
             { DEFIO_TAG_E(PA7), GPIO_AF5 },
             { DEFIO_TAG_E(PD7), GPIO_AF3 },
+            { DEFIO_TAG_E(PB5), GPIO_AF5 },
         },
         .rcc = RCC_APB2_2(SPI1),
     },
@@ -862,6 +863,7 @@ const spiHardware_t spiHardware[] = {
                 { DEFIO_TAG_E(PB2), GPIO_AF6 },
                 { DEFIO_TAG_E(PC12), GPIO_AF5 },
                 { DEFIO_TAG_E(PD6), GPIO_AF5 },
+                { DEFIO_TAG_E(PB5), GPIO_AF6 },
             },
             .rcc = RCC_APB1_2(SPI3),
         },
@@ -883,6 +885,7 @@ const spiHardware_t spiHardware[] = {
             },
             .mosiPins = {
                 { DEFIO_TAG_E(PA7), GPIO_AF6 },
+                { DEFIO_TAG_E(PB5), GPIO_AF7 },
                 { DEFIO_TAG_E(PG14), GPIO_AF6 },
             },
             .rcc = RCC_APB5_1(SPI4),


### PR DESCRIPTION
1.fix PB5 can't be used as spi mosi issue;
2.fix sdcard crash issue;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SD card state detection for more reliable startup and resume behavior.
  * Reduced false “card busy” results by rechecking the card before reporting it ready.
  * SPI devices now initialize more consistently, helping certain hardware setups work as expected.

* **New Features**
  * Added support for additional SPI pin routing options on supported STM32/X32M7 hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->