### PR TITLE
The MAVLink serial RX provider is connected to telemetry incomming message handler

### DIFF
--- a/src/main/rx/mavlink.c
+++ b/src/main/rx/mavlink.c
@@ -165,8 +165,8 @@ STATIC_UNIT_TESTED void mavlinkDataReceive(uint16_t c, void *data)
             handleIncoming_RADIO_STATUS();
             break;
         default:
-            // Add another message into the queye, to handle it in the mavlink telemetry task later
-            mavlinkAddMessageToQueye();
+            // Add another message into the queue, to handle it in the mavlink telemetry task later
+            mavlinkAddMessageToQueue();
         }
     }
 }

--- a/src/main/rx/mavlink.c
+++ b/src/main/rx/mavlink.c
@@ -59,22 +59,22 @@ static mavlink_message_t mavRecvMsg;
 static mavlink_status_t mavRecvStatus;
 static volatile uint8_t txbuff_free = 100;  // tx buffer space in %, start with empty buffer
 static volatile bool txbuff_valid = false;
-static mavlinkRxQueye_t mavlinkRxQueye;
+static mavlinkRxQueue_t mavlinkRxQueue;
 
-static void mavlinkAddMessageToQueye(void)
+static void mavlinkAddMessageToQueue(void)
 {
-    uint8_t next = (mavlinkRxQueye.head + 1) % MAVLINK_RX_QUEUE_SIZE;
-    if (next != mavlinkRxQueye.tail) {
-        mavlinkRxQueye.msgs[mavlinkRxQueye.head] = mavRecvMsg;
-        mavlinkRxQueye.head = next;
+    uint8_t next = (mavlinkRxQueue.head + 1) % MAVLINK_RX_QUEUE_SIZE;
+    if (next != mavlinkRxQueue.tail) {
+        mavlinkRxQueue.msgs[mavlinkRxQueue.head] = mavRecvMsg;
+        mavlinkRxQueue.head = next;
     }
 }
 
-bool mavlinkGetNextQueyeMessage(mavlink_message_t *msg)
+bool mavlinkGetNextQueueMessage(mavlink_message_t *msg)
 {
-    if (mavlinkRxQueye.tail != mavlinkRxQueye.head) {
-        *msg = mavlinkRxQueye.msgs[mavlinkRxQueye.tail];
-        mavlinkRxQueye.tail = (mavlinkRxQueye.tail + 1) % MAVLINK_RX_QUEUE_SIZE;
+    if (mavlinkRxQueue.tail != mavlinkRxQueue.head) {
+        *msg = mavlinkRxQueue.msgs[mavlinkRxQueue.tail];
+        mavlinkRxQueue.tail = (mavlinkRxQueue.tail + 1) % MAVLINK_RX_QUEUE_SIZE;
         return true;
     } else {
         return false;

--- a/src/main/rx/mavlink.c
+++ b/src/main/rx/mavlink.c
@@ -59,6 +59,27 @@ static mavlink_message_t mavRecvMsg;
 static mavlink_status_t mavRecvStatus;
 static volatile uint8_t txbuff_free = 100;  // tx buffer space in %, start with empty buffer
 static volatile bool txbuff_valid = false;
+static mavlinkRxQueye_t mavlinkRxQueye;
+
+static void mavlinkAddMessageToQueye(void)
+{
+    uint8_t next = (mavlinkRxQueye.head + 1) % MAVLINK_RX_QUEUE_SIZE;
+    if (next != mavlinkRxQueye.tail) {
+        mavlinkRxQueye.msgs[mavlinkRxQueye.head] = mavRecvMsg;
+        mavlinkRxQueye.head = next;
+    }
+}
+
+bool mavlinkGetNextQueyeMessage(mavlink_message_t *msg)
+{
+    if (mavlinkRxQueye.tail != mavlinkRxQueye.head) {
+        *msg = mavlinkRxQueye.msgs[mavlinkRxQueye.tail];
+        mavlinkRxQueye.tail = (mavlinkRxQueye.tail + 1) % MAVLINK_RX_QUEUE_SIZE;
+        return true;
+    } else {
+        return false;
+    }
+}
 
 void mavlinkRxHandleMessage(const mavlink_rc_channels_override_t *msg) {
     const uint16_t *channelsPtr = (uint16_t*)&msg->chan1_raw;
@@ -136,12 +157,16 @@ STATIC_UNIT_TESTED void mavlinkDataReceive(uint16_t c, void *data)
     if (result == MAVLINK_FRAMING_OK) {
         switch (mavRecvMsg.msgid) {
         case MAVLINK_MSG_ID_RC_CHANNELS_OVERRIDE:
+            // Handle RC CHANNELS data immediately to get maximum RC rate
             handleIncoming_RC_CHANNELS_OVERRIDE();
             rxRuntimeState->lastRcFrameTimeUs = micros();
             break;
         case MAVLINK_MSG_ID_RADIO_STATUS:
             handleIncoming_RADIO_STATUS();
             break;
+        default:
+            // Add another message into the queye, to handle it in the mavlink telemetry task later
+            mavlinkAddMessageToQueye();
         }
     }
 }

--- a/src/main/rx/mavlink.h
+++ b/src/main/rx/mavlink.h
@@ -26,11 +26,17 @@
 #include "common/mavlink.h"
 #pragma GCC diagnostic pop
 
-void mavlinkRxHandleMessage(const mavlink_rc_channels_override_t *msg);
 bool mavlinkRxInit(const rxConfig_t *initialRxConfig, rxRuntimeState_t *rxRuntimeState);
 #if defined(USE_SERIALRX_MAVLINK)
 bool isValidMavlinkTxBuffer (void);
 bool shouldSendMavlinkTelemetry(void);
+#define MAVLINK_RX_QUEUE_SIZE 16
+typedef struct mavlinkRxQueye_s {
+    mavlink_message_t msgs[MAVLINK_RX_QUEUE_SIZE];
+    volatile uint8_t head;
+    volatile uint8_t tail;
+} mavlinkRxQueye_t;
+bool mavlinkGetNextQueyeMessage(mavlink_message_t *msg);
 #else
 static inline bool isValidMavlinkTxBuffer(void) { return false; }
 static inline bool shouldSendMavlinkTelemetry(void) { return false; }

--- a/src/main/rx/mavlink.h
+++ b/src/main/rx/mavlink.h
@@ -31,12 +31,12 @@ bool mavlinkRxInit(const rxConfig_t *initialRxConfig, rxRuntimeState_t *rxRuntim
 bool isValidMavlinkTxBuffer (void);
 bool shouldSendMavlinkTelemetry(void);
 #define MAVLINK_RX_QUEUE_SIZE 16
-typedef struct mavlinkRxQueye_s {
+typedef struct mavlinkRxQueue_s {
     mavlink_message_t msgs[MAVLINK_RX_QUEUE_SIZE];
     volatile uint8_t head;
     volatile uint8_t tail;
-} mavlinkRxQueye_t;
-bool mavlinkGetNextQueyeMessage(mavlink_message_t *msg);
+} mavlinkRxQueue_t;
+bool mavlinkGetNextQueueMessage(mavlink_message_t *msg);
 #else
 static inline bool isValidMavlinkTxBuffer(void) { return false; }
 static inline bool shouldSendMavlinkTelemetry(void) { return false; }

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -576,11 +576,9 @@ static void mavlinkProcessIncoming(void)
 #ifdef USE_SERIALRX_MAVLINK
 static void mavlinkProcessQueyeMessages(void)
 {
-    while (mavlinkGetNextQueyeMessage(&mavRxMsg)) {
+    uint8_t rxBudget = MAVLINK_RX_QUEUE_SIZE;
+    while (rxBudget-- && mavlinkGetNextQueyeMessage(&mavRxMsg)) {
         mavlinkDispatch(&mavRxMsg);
-    }
-    if (!mavlinkPortOwned || !mavlinkPort) {
-        return;
     }
 }
 #endif

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -574,10 +574,10 @@ static void mavlinkProcessIncoming(void)
 }
 
 #ifdef USE_SERIALRX_MAVLINK
-static void mavlinkProcessQueyeMessages(void)
+static void mavlinkProcessQueueMessages(void)
 {
     uint8_t rxBudget = MAVLINK_RX_QUEUE_SIZE;
-    while (rxBudget-- && mavlinkGetNextQueyeMessage(&mavRxMsg)) {
+    while (rxBudget-- && mavlinkGetNextQueueMessage(&mavRxMsg)) {
         mavlinkDispatch(&mavRxMsg);
     }
 }

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -1315,7 +1315,7 @@ void handleMAVLinkTelemetry(void)
     mavlinkProcessIncoming();
 #else
     if (telemetrySharedPort != NULL && rxRuntimeState.serialrxProvider == SERIALRX_MAVLINK) {
-        mavlinkProcessQueyeMessages();
+        mavlinkProcessQueueMessages();
     } else {
         mavlinkProcessIncoming();
     }

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -1314,7 +1314,7 @@ void handleMAVLinkTelemetry(void)
 #ifndef USE_SERIALRX_MAVLINK
     mavlinkProcessIncoming();
 #else
-    if (telemetrySharedPort != NULL) {
+    if (telemetrySharedPort != NULL && rxRuntimeState.serialrxProvider == SERIALRX_MAVLINK) {
         mavlinkProcessQueyeMessages();
     } else {
         mavlinkProcessIncoming();

--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -573,6 +573,18 @@ static void mavlinkProcessIncoming(void)
     }
 }
 
+#ifdef USE_SERIALRX_MAVLINK
+static void mavlinkProcessQueyeMessages(void)
+{
+    while (mavlinkGetNextQueyeMessage(&mavRxMsg)) {
+        mavlinkDispatch(&mavRxMsg);
+    }
+    if (!mavlinkPortOwned || !mavlinkPort) {
+        return;
+    }
+}
+#endif
+
 void freeMAVLinkTelemetryPort(void)
 {
     closeSerialPort(mavlinkPort);
@@ -1301,7 +1313,15 @@ void handleMAVLinkTelemetry(void)
         return;
     }
 
+#ifndef USE_SERIALRX_MAVLINK
     mavlinkProcessIncoming();
+#else
+    if (telemetrySharedPort != NULL) {
+        mavlinkProcessQueyeMessages();
+    } else {
+        mavlinkProcessIncoming();
+    }
+#endif
 #if ENABLE_TELEMETRY_MAVLINK_MISSION
     mavMissionUpdate(millis());
 #endif


### PR DESCRIPTION
The MAVLink serial RX provider is connected to incomming message handler in telemetry module. 
The MAVLInk Serial RX provider handles RC OVERRIDE and RADIO STATUS messages and transmit another message in the ring buffer queue. The telemetry module handles these messages in the telemetry task. 
It allows to use the all new MAVLink features in the [ELRS-MAVLink](https://www.expresslrs.org/software/mavlink/) mode by using MAVLink serial RX provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved telemetry handling for incoming MAVLink data, reducing missed or delayed updates under busy traffic.
  * Preserves immediate responsiveness for RC channel override and radio status messages while other MAVLink messages are processed shortly after.

* **New Features**
  * Added an internal MAVLink receive queue (with a fixed buffer size) for serial RX builds, draining and dispatching queued messages during telemetry processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->