### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ repositories.
 **Please report security vulnerabilities privately — never through public
 GitHub issues, pull requests, or Discord.**
 
-- **GitHub (preferred):** use the **Security** tab → **Report a vulnerability**
-  on this repository.
-- **Email:** security@betaflight.com
+- **GitHub (preferred, where enabled):** on this repository's **Security** tab,
+  use **Report a vulnerability** if that button is shown.
+- **Email (always works):** security@betaflight.com
 
 For the full policy — scope, what to include, our disclosure timeline, and safe
 harbour — see the canonical Betaflight security policy:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+Betaflight uses a single, organisation-wide security policy for all of its
+repositories.
+
+**Please report security vulnerabilities privately — never through public
+GitHub issues, pull requests, or Discord.**
+
+- **GitHub (preferred):** use the **Security** tab → **Report a vulnerability**
+  on this repository.
+- **Email:** security@betaflight.com
+
+For the full policy — scope, what to include, our disclosure timeline, and safe
+harbour — see the canonical Betaflight security policy:
+
+https://github.com/betaflight/.github/blob/main/SECURITY.md


### PR DESCRIPTION
Adds a `SECURITY.md` that points to the canonical organisation-wide policy in `betaflight/.github`, with the quick private-reporting paths (GitHub "Report a vulnerability" and `security@betaflight.com`).

Companion to the org policy PR in `betaflight/.github`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security policy (`SECURITY.md`) for privately reporting vulnerabilities.
  * Directs reporters to preferred private submission channels (including the repository’s security tab when available) with an email fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->