### PR TITLE
msp: bound stream reads against payload length to prevent OOB reads

### DIFF
--- a/src/main/common/streambuf.c
+++ b/src/main/common/streambuf.c
@@ -95,7 +95,10 @@ void sbufWriteStringWithZeroTerminator(sbuf_t *dst, const char *string)
     sbufWriteData(dst, string, strlen(string) + 1);
 }
 
-uint8_t sbufReadU8(sbuf_t *src)
+// The readers are kept out-of-line: under LTO the end-bounds check would
+// otherwise be inlined at every one of the ~hundreds of call sites, bloating
+// flash on constrained targets. A single shared copy costs a call instead.
+NOINLINE uint8_t sbufReadU8(sbuf_t *src)
 {
     if (src->ptr < src->end) {
         return *src->ptr++;
@@ -103,7 +106,7 @@ uint8_t sbufReadU8(sbuf_t *src)
     return 0;
 }
 
-uint16_t sbufReadU16(sbuf_t *src)
+NOINLINE uint16_t sbufReadU16(sbuf_t *src)
 {
     uint16_t ret;
     ret = sbufReadU8(src);
@@ -111,7 +114,7 @@ uint16_t sbufReadU16(sbuf_t *src)
     return ret;
 }
 
-uint32_t sbufReadU32(sbuf_t *src)
+NOINLINE uint32_t sbufReadU32(sbuf_t *src)
 {
     uint32_t ret;
     ret = sbufReadU8(src);
@@ -121,7 +124,7 @@ uint32_t sbufReadU32(sbuf_t *src)
     return ret;
 }
 
-void sbufReadData(sbuf_t *src, void *data, int len)
+NOINLINE void sbufReadData(sbuf_t *src, void *data, int len)
 {
     const int available = MAX((int)(src->end - src->ptr), 0);
     const int toCopy = MIN(len, available);

--- a/src/main/common/streambuf.c
+++ b/src/main/common/streambuf.c
@@ -97,7 +97,10 @@ void sbufWriteStringWithZeroTerminator(sbuf_t *dst, const char *string)
 
 uint8_t sbufReadU8(sbuf_t *src)
 {
-    return *src->ptr++;
+    if (src->ptr < src->end) {
+        return *src->ptr++;
+    }
+    return 0;
 }
 
 uint16_t sbufReadU16(sbuf_t *src)
@@ -120,8 +123,13 @@ uint32_t sbufReadU32(sbuf_t *src)
 
 void sbufReadData(sbuf_t *src, void *data, int len)
 {
-    memcpy(data, src->ptr, len);
-    src->ptr += len;
+    const int available = MAX((int)(src->end - src->ptr), 0);
+    const int toCopy = MIN(len, available);
+    memcpy(data, src->ptr, toCopy);
+    if (toCopy < len) {
+        memset((uint8_t *)data + toCopy, 0, len - toCopy);
+    }
+    src->ptr += toCopy;
 }
 
 // reader - return bytes remaining in buffer
@@ -146,7 +154,11 @@ const uint8_t* sbufConstPtr(const sbuf_t *buf)
 // writer - commit written data
 void sbufAdvance(sbuf_t *buf, int size)
 {
-    buf->ptr += size;
+    if (size > 0 && size > (int)(buf->end - buf->ptr)) {
+        buf->ptr = buf->end;
+    } else {
+        buf->ptr += size;
+    }
 }
 
 // modifies streambuf so that written data are prepared for reading

--- a/src/main/common/streambuf.h
+++ b/src/main/common/streambuf.h
@@ -22,7 +22,9 @@
 
 #include <stdint.h>
 
-// simple buffer-based serializer/deserializer without implicit size check
+// simple buffer-based serializer/deserializer.
+// writers do not check available space; readers are bounded by end - reads past
+// the end return 0 (sbufReadData zero-fills) and never dereference past the buffer.
 
 typedef struct sbuf_s {
     uint8_t *ptr;          // data pointer must be first (sbuf_t* is equivalent to uint8_t **)

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3130,6 +3130,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #endif
 
     case MSP_SET_MOTOR:
+        if (dataSize < getMotorCount() * sizeof(uint16_t)) {
+            return MSP_RESULT_ERROR;
+        }
         for (int i = 0; i < getMotorCount(); i++) {
             motor_disarmed[i] = motorConvertFromExternal(sbufReadU16(src));
         }
@@ -3730,6 +3733,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             uint16_t frequencies[VTX_TABLE_MAX_CHANNELS];
             const uint8_t band = sbufReadU8(src);
             const uint8_t bandNameLength = sbufReadU8(src);
+            if (sbufBytesRemaining(src) < bandNameLength) {
+                return MSP_RESULT_ERROR;
+            }
             for (int i = 0; i < bandNameLength; i++) {
                 const char nameChar = sbufReadU8(src);
                 if (i < VTX_TABLE_BAND_NAME_LENGTH) {
@@ -3739,6 +3745,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             const char bandLetter = toupper(sbufReadU8(src));
             const bool isFactoryBand = (bool)sbufReadU8(src);
             const uint8_t channelCount = sbufReadU8(src);
+            if (sbufBytesRemaining(src) < channelCount * (int)sizeof(uint16_t)) {
+                return MSP_RESULT_ERROR;
+            }
             for (int i = 0; i < channelCount; i++) {
                 const uint16_t frequency = sbufReadU16(src);
                 if (i < vtxTableConfig()->channels) {
@@ -3778,6 +3787,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             const uint8_t powerLevel = sbufReadU8(src);
             const uint16_t powerValue = sbufReadU16(src);
             const uint8_t powerLevelLabelLength = sbufReadU8(src);
+            if (sbufBytesRemaining(src) < powerLevelLabelLength) {
+                return MSP_RESULT_ERROR;
+            }
             for (int i = 0; i < powerLevelLabelLength; i++) {
                 const char labelChar = sbufReadU8(src);
                 if (i < VTX_TABLE_POWER_LABEL_LENGTH) {
@@ -3802,6 +3814,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
     case MSP2_SET_MOTOR_OUTPUT_REORDERING:
         {
             const uint8_t arraySize = sbufReadU8(src);
+            if (sbufBytesRemaining(src) < MIN(arraySize, MAX_SUPPORTED_MOTORS)) {
+                return MSP_RESULT_ERROR;
+            }
 
             for (unsigned i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
                 uint8_t value = i;
@@ -3821,9 +3836,15 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             const bool armed = ARMING_FLAG(ARMED);
 
             if (!armed) {
+                if (sbufBytesRemaining(src) < 3) {
+                    return MSP_RESULT_ERROR;
+                }
                 const uint8_t commandType = sbufReadU8(src);
                 const uint8_t motorIndex = sbufReadU8(src);
                 const uint8_t commandCount = sbufReadU8(src);
+                if (sbufBytesRemaining(src) < commandCount) {
+                    return MSP_RESULT_ERROR;
+                }
 
                 if (DSHOT_CMD_TYPE_BLOCKING == commandType) {
                     motorDisable();
@@ -4143,6 +4164,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             return MSP_RESULT_ERROR;
         }
         unsigned count = sbufReadU8(src);
+        if (count == 0) {
+            return MSP_RESULT_ERROR;
+        }
         unsigned portConfigSize = (dataSize - 1) / count;
         unsigned expectedPortSize = sizeof(uint8_t) + sizeof(uint32_t) + (sizeof(uint8_t) * 4);
         if (portConfigSize < expectedPortSize) {
@@ -4249,6 +4273,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
     case MSP_SET_BOARD_INFO:
         if (!boardInformationIsSet()) {
             uint8_t length = sbufReadU8(src);
+            if (sbufBytesRemaining(src) < length) {
+                return MSP_RESULT_ERROR;
+            }
             char boardName[MAX_BOARD_NAME_LENGTH + 1];
             sbufReadData(src, boardName, MIN(length, MAX_BOARD_NAME_LENGTH));
             if (length > MAX_BOARD_NAME_LENGTH) {
@@ -4257,6 +4284,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             }
             boardName[length] = '\0';
             length = sbufReadU8(src);
+            if (sbufBytesRemaining(src) < length) {
+                return MSP_RESULT_ERROR;
+            }
             char manufacturerId[MAX_MANUFACTURER_ID_LENGTH + 1];
             sbufReadData(src, manufacturerId, MIN(length, MAX_MANUFACTURER_ID_LENGTH));
             if (length > MAX_MANUFACTURER_ID_LENGTH) {
@@ -4421,6 +4451,9 @@ static mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, int16_t cm
     case MSP_SET_TRANSPONDER_CONFIG: {
         // Backward compatibility to BFC 3.1.1 is lost for this message type
 
+        if (dataSize < 1) {
+            return MSP_RESULT_ERROR;
+        }
         uint8_t provider = sbufReadU8(src);
         uint8_t bytesRemaining = dataSize - 1;
 

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -3731,6 +3731,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             char bandName[VTX_TABLE_BAND_NAME_LENGTH + 1];
             memset(bandName, 0, VTX_TABLE_BAND_NAME_LENGTH + 1);
             uint16_t frequencies[VTX_TABLE_MAX_CHANNELS];
+            memset(frequencies, 0, sizeof(frequencies));
             const uint8_t band = sbufReadU8(src);
             const uint8_t bandNameLength = sbufReadU8(src);
             if (sbufBytesRemaining(src) < bandNameLength) {
@@ -3741,6 +3742,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
                 if (i < VTX_TABLE_BAND_NAME_LENGTH) {
                     bandName[i] = toupper(nameChar);
                 }
+            }
+            if (sbufBytesRemaining(src) < 3) {
+                return MSP_RESULT_ERROR;
             }
             const char bandLetter = toupper(sbufReadU8(src));
             const bool isFactoryBand = (bool)sbufReadU8(src);
@@ -3813,6 +3817,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 
     case MSP2_SET_MOTOR_OUTPUT_REORDERING:
         {
+            if (dataSize < 1) {
+                return MSP_RESULT_ERROR;
+            }
             const uint8_t arraySize = sbufReadU8(src);
             if (sbufBytesRemaining(src) < MIN(arraySize, MAX_SUPPORTED_MOTORS)) {
                 return MSP_RESULT_ERROR;
@@ -4164,7 +4171,7 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
             return MSP_RESULT_ERROR;
         }
         unsigned count = sbufReadU8(src);
-        if (count == 0) {
+        if (count == 0 || (dataSize - 1) % count != 0) {
             return MSP_RESULT_ERROR;
         }
         unsigned portConfigSize = (dataSize - 1) / count;
@@ -4272,6 +4279,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
 #if defined(USE_BOARD_INFO)
     case MSP_SET_BOARD_INFO:
         if (!boardInformationIsSet()) {
+            if (sbufBytesRemaining(src) < 1) {
+                return MSP_RESULT_ERROR;
+            }
             uint8_t length = sbufReadU8(src);
             if (sbufBytesRemaining(src) < length) {
                 return MSP_RESULT_ERROR;
@@ -4283,6 +4293,9 @@ static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, 
                 length = MAX_BOARD_NAME_LENGTH;
             }
             boardName[length] = '\0';
+            if (sbufBytesRemaining(src) < 1) {
+                return MSP_RESULT_ERROR;
+            }
             length = sbufReadU8(src);
             if (sbufBytesRemaining(src) < length) {
                 return MSP_RESULT_ERROR;

--- a/src/test/unit/telemetry_crsf_msp_unittest.cc
+++ b/src/test/unit/telemetry_crsf_msp_unittest.cc
@@ -230,10 +230,10 @@ TEST(CrossFireMSPTest, WriteResponseTest)
 
 }
 
-void testSendMspResponse(uint8_t *payload, const uint8_t )
+void testSendMspResponse(uint8_t *payload, const uint8_t payloadSize)
 {
     sbuf_t *plOut = sbufInit(&payloadOutputBuf, payloadOutput, payloadOutput + 64);
-    sbufWriteData(plOut, payload, *payload + 64);
+    sbufWriteData(plOut, payload, payloadSize);
     sbufSwitchToReader(&payloadOutputBuf, payloadOutput);
 }
 


### PR DESCRIPTION
MSP SET command handlers read from the input stream without bounds checks. The `sbuf` readers (`sbufReadU8/U16/U32`, `sbufReadData`) dereferenced and advanced the pointer with no regard for the buffer end, so any handler that read more than the received payload read past it — into stale bytes of the 192-byte `inBuf`, and, where the read count is driven by a payload field (e.g. `MSP2_SEND_DSHOT_COMMAND`, `MSP_SET_VTXTABLE_BAND`), past the buffer into adjacent memory. Around fifty handlers read a fixed prefix with no length guard, so this is a whole-class issue rather than a handful of sites.

Fixed at the primitive level so the entire class is covered: readers are now bounded by `end` — over-reads return 0, `sbufReadData` copies only what is available and zero-fills the remainder, and `sbufAdvance` clamps to `end`. Well-formed messages are byte-for-byte unchanged; only under-payload reads differ, returning zeros instead of exposing adjacent memory.

Added explicit length guards to the handlers whose read counts come from an attacker-controlled field, so a truncated message is rejected with `MSP_RESULT_ERROR` rather than partially applied: `MSP_SET_MOTOR`, `MSP2_SET_MOTOR_OUTPUT_REORDERING`, `MSP2_SEND_DSHOT_COMMAND`, `MSP_SET_VTXTABLE_BAND`, `MSP_SET_VTXTABLE_POWERLEVEL` and `MSP_SET_BOARD_INFO`.

Also fixed two related robustness bugs in the same dispatcher: a divide-by-zero in `MSP2_COMMON_SET_SERIAL_CONFIG` when the entry count is zero, and an unsigned underflow of `bytesRemaining` in `MSP_SET_TRANSPONDER_CONFIG` when the payload is empty.

Verified with a host SITL build (no new warnings) and a unit test compiling the real `streambuf.c` and exercising the readers at and past the buffer end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety for buffer reads and advancing by adding bounds-aware behavior and safer length handling to prevent out-of-range access.
  * Strengthened validation of incoming MSP payloads to reject incomplete or malformed requests before reading expected fields.
* **Documentation**
  * Clarified buffer serializer/deserializer expectations, including reader behavior when reaching the end of the buffer.
* **Tests**
  * Fixed MSP response test helper to write the intended payload size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->