### PR TITLE
iOS support with USB-NCM phoneconfig and firmware USB flashing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,39 @@ jobs:
       - name: Run all unit tests
         run: make EXTRA_FLAGS=-Werror test-all
 
+  phone-config:
+    name: Phone-config (FOXEERF722V4)
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Init config submodule
+        run: git submodule update --init -- src/config
+
+      - name: Restore ARM toolchain from cache
+        uses: actions/cache/restore@v5
+        id: cache-tools
+        with:
+          path: tools
+          key: ${{ needs.setup.outputs.tools-cache-key }}-arm
+
+      - name: Install tools (fallback)
+        if: steps.cache-tools.outputs.cache-hit != 'true'
+        run: make SDK=arm platform-tools-install
+
+      - name: Hydrate configuration
+        run: make configs
+
+      # USE_PHONE_CONFIG is an OPTIONS flag no plain target build exercises, so build one representative
+      # F7 target with it here to keep the phone-config usb-ncm / lwip / burn code compiling under -Werror
+      - name: Build FOXEERF722V4 with USE_PHONE_CONFIG
+        run: make EXTRA_FLAGS=-Werror FOXEERF722V4 OPTIONS='USE_PHONE_CONFIG'
+
   result:
     name: Complete
-    needs: [sdk-pipeline, test]
+    needs: [sdk-pipeline, test, phone-config]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -99,4 +129,8 @@ jobs:
 
       - name: Check test result
         if: ${{ needs.test.result != 'success' }}
+        run: exit 1
+
+      - name: Check phone-config result
+        if: ${{ needs.phone-config.result != 'success' }}
         run: exit 1

--- a/.gitmodules
+++ b/.gitmodules
@@ -51,3 +51,6 @@
 	url = https://github.com/X-CORE-LABS-PTE-LTD/X32M7_Std_SDK.git
 	ignore = dirty
 	update = none
+[submodule "lib/main/lwip"]
+	path = lib/main/lwip
+	url = https://github.com/lwip-tcpip/lwip.git

--- a/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
+++ b/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
@@ -168,6 +168,9 @@ USBD_ClassTypeDef  USBD_CDC =
   USBD_CDC_GetFSCfgDesc,
   USBD_CDC_GetOtherSpeedCfgDesc,
   USBD_CDC_GetDeviceQualifierDescriptor,
+#if (USBD_SUPPORT_USER_STRING == 1U)
+  NULL,   /* GetUsrStrDescriptor */
+#endif
 };
 
 /* USB CDC device Configuration Descriptor */

--- a/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Class/HID/Src/usbd_hid.c
+++ b/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Class/HID/Src/usbd_hid.c
@@ -132,6 +132,9 @@ USBD_ClassTypeDef  USBD_HID =
   USBD_HID_GetFSCfgDesc,
   USBD_HID_GetOtherSpeedCfgDesc,
   USBD_HID_GetDeviceQualifierDesc,
+#if (USBD_SUPPORT_USER_STRING == 1U)
+  NULL,   /* GetUsrStrDescriptor */
+#endif
 };
 
 /* USB HID device FS Configuration Descriptor */

--- a/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
+++ b/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
@@ -131,6 +131,9 @@ USBD_ClassTypeDef  USBD_MSC =
   USBD_MSC_GetFSCfgDesc,
   USBD_MSC_GetOtherSpeedCfgDesc,
   USBD_MSC_GetDeviceQualifierDescriptor,
+#if (USBD_SUPPORT_USER_STRING == 1U)
+  NULL,   /* GetUsrStrDescriptor */
+#endif
 };
 
 /* USB Mass storage device Configuration Descriptor */

--- a/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ctlreq.c
+++ b/lib/main/STM32F7/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ctlreq.c
@@ -460,8 +460,18 @@ static void USBD_GetDescriptor(USBD_HandleTypeDef *pdev ,
 
     default:
 #if (USBD_SUPPORT_USER_STRING == 1U)
-      pbuf = pdev->pClass->GetUsrStrDescriptor(pdev, (req->wValue) , &len);
-      break;
+      /* betaflight: guard against classes without a user-string handler (matches the h7 core); a
+         windows 0xEE probe in normal vcp/msc mode would otherwise call through a NULL pointer */
+      if (pdev->pClass->GetUsrStrDescriptor != NULL)
+      {
+        pbuf = pdev->pClass->GetUsrStrDescriptor(pdev, (req->wValue), &len);
+        break;
+      }
+      else
+      {
+        USBD_CtlError(pdev, req);
+        return;
+      }
 #else
        USBD_CtlError(pdev , req);
       return;

--- a/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
+++ b/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
@@ -153,6 +153,9 @@ USBD_ClassTypeDef  USBD_CDC =
   USBD_CDC_GetFSCfgDesc,
   USBD_CDC_GetOtherSpeedCfgDesc,
   USBD_CDC_GetDeviceQualifierDescriptor,
+#if (USBD_SUPPORT_USER_STRING_DESC == 1U)
+  NULL,   /* GetUsrStrDescriptor */
+#endif
 };
 
 /* USB CDC device Configuration Descriptor */

--- a/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/HID/Src/usbd_hid.c
+++ b/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/HID/Src/usbd_hid.c
@@ -120,6 +120,9 @@ USBD_ClassTypeDef USBD_HID = {
   USBD_HID_GetFSCfgDesc,
   USBD_HID_GetOtherSpeedCfgDesc,
   USBD_HID_GetDeviceQualifierDesc,
+#if (USBD_SUPPORT_USER_STRING_DESC == 1U)
+  NULL,   /* GetUsrStrDescriptor */
+#endif
 };
 
 /* USB HID device FS Configuration Descriptor */

--- a/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
+++ b/lib/main/STM32H7/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Src/usbd_msc.c
@@ -117,6 +117,9 @@ USBD_ClassTypeDef  USBD_MSC =
   USBD_MSC_GetFSCfgDesc,
   USBD_MSC_GetOtherSpeedCfgDesc,
   USBD_MSC_GetDeviceQualifierDescriptor,
+#if (USBD_SUPPORT_USER_STRING_DESC == 1U)
+  NULL,   /* GetUsrStrDescriptor */
+#endif
 };
 
 /* USB Mass storage device Configuration Descriptor */

--- a/mk/source.mk
+++ b/mk/source.mk
@@ -119,6 +119,7 @@ COMMON_SRC = \
             drivers/serial_lcd_console.c \
             drivers/sound_beeper.c \
             drivers/stack_check.c \
+            io/phoneconfig.c \
             drivers/timer_common.c \
             drivers/transponder_ir_arcitimer.c \
             drivers/transponder_ir_ilap.c \

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -80,6 +80,7 @@ bool cliMode = false;
 #include "drivers/lcd_console.h"
 #include "drivers/light_led.h"
 #include "drivers/motor.h"
+#include "io/phoneconfig.h"
 #include "drivers/rangefinder/rangefinder_hcsr04.h"
 #include "drivers/resource.h"
 #include "drivers/sdcard.h"
@@ -4244,7 +4245,18 @@ static void cliRebootEx(rebootTarget_e rebootTarget)
 {
     cliPrint("\r\nRebooting");
     cliWriterFlush();
-    waitForSerialPortToFinishTransmitting(cliPort);
+
+#ifdef USE_PHONE_CONFIG
+    // in phone-config the virtual msp port is drained by a scheduler task that can't run while we
+    // spin in waitForSerialPortToFinishTransmitting(), so skip that wait here or it would hang. a
+    // firmware reboot (e.g. 'save') re-enters phone-config below rather than normal mode, so the
+    // usb-ncm link comes straight back and the configurator reconnects with the saved config applied.
+    if (!phoneConfigCheckBootAndReset())
+#endif
+    {
+        waitForSerialPortToFinishTransmitting(cliPort);
+    }
+
     motorShutdown();
 
     switch (rebootTarget) {
@@ -4260,6 +4272,11 @@ static void cliRebootEx(rebootTarget_e rebootTarget)
 #endif
     case REBOOT_TARGET_FIRMWARE:
     default:
+#ifdef USE_PHONE_CONFIG
+        if (phoneConfigCheckBootAndReset()) {
+            systemResetToPhoneConfig();   // re-enter phone-config so the link returns (never returns)
+        }
+#endif
         systemReset();
 
         break;
@@ -8119,6 +8136,25 @@ static void cliMsc(const char *cmdName, char *cmdline)
 }
 #endif
 
+#if defined(USE_PHONE_CONFIG)
+static void cliPhoneConfig(const char *cmdName, char *cmdline)
+{
+    UNUSED(cmdName);
+    UNUSED(cmdline);
+
+    cliPrintHashLine("Restarting in phone-config (USB network) mode");
+    cliPrint("\r\nRebooting. Power-cycle the board to return to normal Betaflight.");
+    cliPrint("\r\nRecover any time via DFU: hold the BOOT button while plugging in USB.");
+    cliWriterFlush();
+    if (!phoneConfigCheckBootAndReset()) {
+        waitForSerialPortToFinishTransmitting(cliPort);
+    }
+    motorShutdown();
+
+    systemResetToPhoneConfig();
+}
+#endif
+
 typedef void cliCommandFn(const char* name, char *cmdline);
 
 typedef struct {
@@ -8261,6 +8297,9 @@ const clicmd_t cmdTable[] = {
 #endif
 #endif
     CLI_COMMAND_DEF("options", "show build options", NULL, cliOptions),
+#ifdef USE_PHONE_CONFIG
+    CLI_COMMAND_DEF("phoneconfig", "reboot into phone usb-network mode", NULL, cliPhoneConfig),
+#endif
 #ifndef MINIMAL_CLI
     CLI_COMMAND_DEF("play_sound", NULL, "[<index>]", cliPlaySound),
 #endif
@@ -8520,7 +8559,13 @@ bool cliProcess(void)
 static void cliExit(const bool reboot)
 {
     cliWriterFlush();
-    waitForSerialPortToFinishTransmitting(cliPort);
+#ifdef USE_PHONE_CONFIG
+    // the virtual msp port drains from a scheduler task, so the busy-wait below would hang
+    if (!phoneConfigCheckBootAndReset())
+#endif
+    {
+        waitForSerialPortToFinishTransmitting(cliPort);
+    }
     cliClearInputBuffer();
     cliMode = false;
     cliInteractive = false;
@@ -8544,7 +8589,14 @@ void cliEnter(serialPort_t *serialPort, bool interactive)
         setPrintfSerialPort(cliPort);
     }
 
-    bufWriterInit(&cliWriterDesc, cliWriteBuffer, sizeof(cliWriteBuffer), (bufWrite_t)serialWriteBufBlockingShim, serialPort);
+#ifdef USE_PHONE_CONFIG
+    const bufWrite_t cliWriteFn = phoneConfigCheckBootAndReset()
+        ? (bufWrite_t)serialWriteBufShim
+        : (bufWrite_t)serialWriteBufBlockingShim;
+#else
+    const bufWrite_t cliWriteFn = (bufWrite_t)serialWriteBufBlockingShim;
+#endif
+    bufWriterInit(&cliWriterDesc, cliWriteBuffer, sizeof(cliWriteBuffer), cliWriteFn, serialPort);
     cliErrorWriter = cliWriter = &cliWriterDesc;
 
     if (interactive) {

--- a/src/main/drivers/persistent.h
+++ b/src/main/drivers/persistent.h
@@ -52,6 +52,7 @@ typedef enum {
 #define RESET_MSC_REQUEST               3  // MSC invocation was requested
 #define RESET_FORCED                    4  // Reset due to unknown reset reason
 #define RESET_BOOTLOADER_REQUEST_FLASH  5
+#define RESET_PHONECONFIG_REQUEST       6  // Phone-config (USB network) mode was requested
 
 void persistentObjectInit(void);
 uint32_t persistentObjectRead(persistentObjectId_e id);

--- a/src/main/drivers/serial_usb_vcp.h
+++ b/src/main/drivers/serial_usb_vcp.h
@@ -37,3 +37,4 @@ serialPort_t *usbVcpOpen(void);
 struct serialPort_s;
 uint32_t usbVcpGetBaudRate(struct serialPort_s *instance);
 uint8_t usbVcpIsConnected(void);
+uint8_t usbVcpIsConfigured(void);

--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -82,6 +82,7 @@
 #ifdef USE_USB_MSC
 #include "drivers/usb_msc.h"
 #endif
+#include "io/phoneconfig.h"
 #include "drivers/vtx_common.h"
 #include "drivers/vtx_rtc6705.h"
 #include "drivers/vtx_table.h"
@@ -918,6 +919,15 @@ void initPhase3(void)
     // Initialize MSP
     mspInit();
     mspSerialInit();
+
+#ifdef USE_PHONE_CONFIG
+    // bring up lwip, the dhcp server and the msp-over-tcp server, and register the tcp link as a
+    // virtual msp serial port. must run after mspSerialInit(), which clears the msp ports array.
+    // from here the stock TASK_SERIAL serves msp and cli over it against the fully-running fc.
+    if (phoneConfigCheckBootAndReset()) {
+        phoneConfigNetStart();
+    }
+#endif
 
 /*
  * CMS, display devices and OSD

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -93,6 +93,8 @@
 
 #include "scheduler/scheduler.h"
 
+#include "io/phoneconfig.h"
+
 #include "sensors/acceleration.h"
 #include "sensors/adcinternal.h"
 #include "sensors/barometer.h"
@@ -397,6 +399,11 @@ task_attribute_t task_attributes[TASK_COUNT] = {
     [TASK_BEEPER] = DEFINE_TASK("BEEPER", NULL, NULL, beeperUpdate, TASK_PERIOD_HZ(100), TASK_PRIORITY_LOW),
 #endif
 
+#ifdef USE_PHONE_CONFIG
+    [TASK_PHONE_CONFIG] = DEFINE_TASK("PHONECONFIG", NULL, NULL, phoneConfigGestureUpdate, TASK_PERIOD_HZ(50), TASK_PRIORITY_LOWEST),
+    [TASK_PHONE_CONFIG_NET] = DEFINE_TASK("PHONENET", NULL, NULL, phoneConfigNetTask, TASK_PERIOD_HZ(1000), TASK_PRIORITY_LOW),
+#endif
+
 #ifdef USE_GPS
     [TASK_GPS] = DEFINE_TASK("GPS", NULL, NULL, gpsUpdate, TASK_PERIOD_HZ(TASK_GPS_RATE), TASK_PRIORITY_MEDIUM), // Required to prevent buffer overruns if running at 115200 baud (115 bytes / period < 256 bytes buffer)
 #endif
@@ -573,6 +580,11 @@ void tasksInit(void)
 #endif
 
     setTaskEnabled(TASK_RX, true);
+
+#ifdef USE_PHONE_CONFIG
+    setTaskEnabled(TASK_PHONE_CONFIG, true);
+    setTaskEnabled(TASK_PHONE_CONFIG_NET, phoneConfigCheckBootAndReset());   // pump the usb-ncm/tcp link only in phone-config mode
+#endif
 
     setTaskEnabled(TASK_DISPATCH, dispatchIsEnabled());
 

--- a/src/main/io/lwip_port/arch/cc.h
+++ b/src/main/io/lwip_port/arch/cc.h
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * lwip compiler/architecture port for betaflight (gcc, arm cortex-m7, little-endian, no_sys).
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <inttypes.h>
+
+#define LWIP_NO_UNISTD_H        1
+#define LWIP_TIMEVAL_PRIVATE    0
+
+/* lwip diagnostics/asserts become no-ops, no console in phone-config mode */
+#define LWIP_PLATFORM_DIAG(x)
+#define LWIP_PLATFORM_ASSERT(x) do { } while (0)

--- a/src/main/io/lwip_port/lwipopts.h
+++ b/src/main/io/lwip_port/lwipopts.h
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * lwip options for betaflight phone-config mode (usb cdc-ncm network gadget). no_sys (bare-metal, no
+ * rtos), ipv4 only, tcp and udp, with the fc acting as a tiny dhcp server.
+ */
+
+#pragma once
+
+#define NO_SYS                          1
+#define SYS_LIGHTWEIGHT_PROT            0
+#define LWIP_NETCONN                    0
+#define LWIP_SOCKET                     0
+
+#define LWIP_IPV4                       1
+#define LWIP_IPV6                       0
+#define LWIP_ARP                        1
+#define LWIP_ETHERNET                   1
+#define LWIP_ICMP                       1
+#define LWIP_RAW                        0
+#define LWIP_UDP                        1
+#define LWIP_TCP                        1
+#define LWIP_DHCP                       0   /* the fc is the dhcp server, not a client */
+#define LWIP_DNS                        0
+#define LWIP_AUTOIP                     0
+
+/* accept the dhcp discover (udp:67) that arrives from 0.0.0.0 before the client has an address, else
+ * lwip drops it. PP_NTOHS is expanded later in ip4.c, where it is defined. */
+#define LWIP_IP_ACCEPT_UDP_PORT(port)   ((port) == PP_NTOHS(67))
+
+#define LWIP_SINGLE_NETIF               1
+#define LWIP_NETIF_TX_SINGLE_PBUF       1
+#define LWIP_NETIF_STATUS_CALLBACK      0
+#define LWIP_NETIF_LINK_CALLBACK        0
+#define LWIP_NETIF_HOSTNAME             0
+
+#define MEM_ALIGNMENT                   4
+#define MEM_SIZE                        (10 * 1024)
+#define MEMP_NUM_PBUF                   16
+#define MEMP_NUM_UDP_PCB                4
+#define MEMP_NUM_TCP_PCB                4
+#define MEMP_NUM_TCP_PCB_LISTEN         2
+#define MEMP_NUM_TCP_SEG                16
+#define PBUF_POOL_SIZE                  16
+#define PBUF_POOL_BUFSIZE               1536
+
+#define TCP_MSS                         1460
+#define TCP_SND_BUF                     (4 * TCP_MSS)
+#define TCP_SND_QUEUELEN                ((4 * TCP_SND_BUF) / TCP_MSS)
+#define TCP_WND                         (4 * TCP_MSS)
+
+#define LWIP_STATS                      0
+#define LWIP_STATS_DISPLAY              0
+
+/* compute all checksums in software, the otg-fs has no checksum offload */
+#define CHECKSUM_GEN_IP                 1
+#define CHECKSUM_GEN_UDP                1
+#define CHECKSUM_GEN_TCP                1
+#define CHECKSUM_GEN_ICMP               1
+#define CHECKSUM_CHECK_IP               1
+#define CHECKSUM_CHECK_UDP              1
+#define CHECKSUM_CHECK_TCP              1
+#define CHECKSUM_CHECK_ICMP             1
+
+#define LWIP_NETCONN_FULLDUPLEX         0
+#define LWIP_PROVIDE_ERRNO              1

--- a/src/main/io/phoneconfig.c
+++ b/src/main/io/phoneconfig.c
@@ -1,0 +1,141 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * phone-config mode: an opt-in usb mode for configuring betaflight over a cable from a phone (e.g. an
+ * iphone, which can't open a usb cdc serial port but can talk to a usb-cdc-ncm network gadget). the
+ * `phoneconfig` cli command or the flip-and-hold gesture sets an rtc-backup flag and reboots, then
+ * init() boots the full fc and adds the usb-ncm/lwip link as a scheduler task serving msp/cli over tcp.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "platform.h"
+
+#ifdef USE_PHONE_CONFIG
+
+#include "common/axis.h"
+#include "common/time.h"
+
+#include "drivers/nvic.h"
+#include "drivers/persistent.h"
+#include "drivers/serial_usb_vcp.h"
+#include "drivers/system.h"
+#include "drivers/time.h"
+
+#include "fc/runtime_config.h"
+
+#include "io/phoneflash.h"
+
+#include "sensors/acceleration.h"
+
+bool phoneConfigCheckBootAndReset(void)
+{
+    static bool firstCheck = true;
+    static bool phoneConfigMode = false;
+
+    if (firstCheck) {
+        firstCheck = false;
+        if (persistentObjectRead(PERSISTENT_OBJECT_RESET_REASON) == RESET_PHONECONFIG_REQUEST) {
+            phoneConfigMode = true;
+            // clear it so the next power-up boots normally
+            persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_NONE);
+        }
+    }
+
+    return phoneConfigMode;
+}
+
+void systemResetToPhoneConfig(void)
+{
+    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_PHONECONFIG_REQUEST);
+
+    __disable_irq();
+    NVIC_SystemReset();
+}
+
+// weak default, overridden per-mcu (phoneconfig_usb_<mcu>.c). returns 0 on success
+__attribute__((weak)) uint8_t phoneConfigUsbStart(void)
+{
+    return 1;
+}
+
+// weak defaults, overridden by phoneconfig_net.c (lwip) and the per-mcu usb layer when present.
+__attribute__((weak)) void phoneConfigNetPoll(void) { }
+__attribute__((weak)) void phoneConfigUsbProcess(void) { }
+__attribute__((weak)) void phoneConfigUsbLock(void) { }
+__attribute__((weak)) void phoneConfigUsbUnlock(void) { }
+
+// scheduler task: pump bytes between usb-ncm and lwip and run the lwip timers. the st usb low level
+// must run only in the otg isr, so mask it around this work. TASK_SERIAL serves msp/cli over the port.
+void phoneConfigNetTask(timeUs_t currentTimeUs)
+{
+    (void)currentTimeUs;
+
+    phoneConfigUsbLock();
+    phoneConfigUsbProcess();   // usb-ncm rx into lwip
+    phoneConfigNetPoll();      // lwip timers, flush the msp tx ring
+    phoneConfigUsbUnlock();
+
+    // hand off to the ram burn engine on a reflash request (does not return unless the host never commits)
+    if (phoneFlashPending() && !ARMING_FLAG(ARMED)) {
+        phoneFlashRun();
+    }
+}
+
+// flip-and-hold gesture: held mostly inverted for ~3 s while disarmed and usb-connected, reboots into
+// phone-config. lets you trigger it from the phone, since the `phoneconfig` cli command needs a pc.
+#define PHONE_CONFIG_GESTURE_Z_THRESHOLD  0.7f          // fraction of 1g, z < -0.7g is within ~45 deg of inverted
+#define PHONE_CONFIG_GESTURE_HOLD_US      (3 * 1000000)
+
+void phoneConfigGestureUpdate(timeUs_t currentTimeUs)
+{
+#if defined(USE_ACC)
+    static timeUs_t invertedSinceUs = 0;
+
+    // require a configured usb host rather than usbCableIsInserted(): on a board with no vbus sense pin
+    // the latter reduces to "device left the default state" and stays true after an unplug (nothing sees
+    // the disconnect). a configured device means a host really enumerated us, and any unplug drops it
+    // (vbus loss, or usb suspend once frames stop), so this holds with or without vbus sensing. also
+    // skip once already in phone-config, else a crashed quad carried in inverted reboots or reboot-loops.
+    const bool eligible = !ARMING_FLAG(ARMED)
+        && accIsCalibrationComplete()
+        && usbVcpIsConfigured()
+        && !phoneConfigCheckBootAndReset();
+    const bool inverted = eligible &&
+        (acc.accADC.z < -PHONE_CONFIG_GESTURE_Z_THRESHOLD * (float)acc.dev.acc_1G);
+
+    if (!inverted) {
+        invertedSinceUs = 0;
+        return;
+    }
+
+    if (invertedSinceUs == 0) {
+        invertedSinceUs = currentTimeUs;
+    } else if (cmpTimeUs(currentTimeUs, invertedSinceUs) >= PHONE_CONFIG_GESTURE_HOLD_US) {
+        systemResetToPhoneConfig();   // never returns
+    }
+#else
+    (void)currentTimeUs;
+#endif
+}
+
+#endif // USE_PHONE_CONFIG

--- a/src/main/io/phoneconfig.h
+++ b/src/main/io/phoneconfig.h
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "common/time.h"
+
+// true (cached, once per boot) if booted into phone-config mode. clears the request on first read
+bool phoneConfigCheckBootAndReset(void);
+
+// phoneConfigNetStart() brings up lwip and the msp-over-tcp server, call once after mspSerialInit().
+// phoneConfigNetTask() is the scheduler task that pumps the usb-ncm/lwip link.
+void phoneConfigNetStart(void);
+void phoneConfigNetTask(timeUs_t currentTimeUs);
+
+// sets the phone-config request flag (rtc backup register) and resets the mcu.
+void systemResetToPhoneConfig(void);
+
+// brings up the usb network device (cdc-ncm), implemented per-mcu. returns 0 on success
+uint8_t phoneConfigUsbStart(void);
+
+// scheduler task for the flip-and-hold gesture that reboots into phone-config mode
+void phoneConfigGestureUpdate(timeUs_t currentTimeUs);
+
+// mask/unmask the usb (otg) interrupt around main-loop usb work, the st usb low level is not
+// re-entrant. weak no-ops unless the per-mcu usb layer overrides them.
+void phoneConfigUsbLock(void);
+void phoneConfigUsbUnlock(void);
+
+// true while the usb in endpoint is still sending a datagram. the tx flush gates on this
+bool phoneConfigUsbTxBusy(void);

--- a/src/main/io/phoneconfig_net.c
+++ b/src/main/io/phoneconfig_net.c
@@ -1,0 +1,464 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * usb-ncm + lwip link for phone-config. the fc is 192.168.7.1 with a tiny dhcp server (the host gets
+ * 192.168.7.2) and an msp-over-tcp server on 5761 that the betaflight configurator connects to.
+ */
+
+#include <string.h>
+
+#include "platform.h"
+
+#ifdef USE_PHONE_CONFIG
+
+#include "drivers/time.h"
+#include "io/phoneconfig.h"
+#include "drivers/serial.h"
+
+#include "msp/msp.h"
+#include "msp/msp_serial.h"
+
+#include "pg/pg.h"
+
+#include "lwip/init.h"
+#include "lwip/timeouts.h"
+#include "lwip/netif.h"
+#include "lwip/etharp.h"
+#include "lwip/pbuf.h"
+#include "lwip/udp.h"
+#include "lwip/tcp.h"
+#include "netif/ethernet.h"
+
+#include "io/phoneconfig_net.h"
+#include "io/phoneflash.h"
+
+#define NET_FC_IP        LWIP_MAKEU32(192, 168, 7, 1)
+#define NET_HOST_IP      LWIP_MAKEU32(192, 168, 7, 2)
+#define NET_NETMASK      LWIP_MAKEU32(255, 255, 255, 0)
+
+static struct netif phoneNetif;
+static struct udp_pcb *dhcpPcb;
+static uint8_t macAddr[6];
+static bool netInitDone = false;
+
+#define NET_MSP_PORT  5761
+#define MSP_RX_RING   8192U    // must exceed TCP_WND (5840) so a full receive window always fits, see mspRecv
+#define MSP_TX_RING   8192U
+
+typedef struct {
+    serialPort_t port;          // must be first, cast to/from serialPort_t*
+    uint8_t rxBuf[MSP_RX_RING];
+    uint8_t txBuf[MSP_TX_RING];
+    volatile uint16_t rxHead, rxTail;
+    volatile uint16_t txHead, txTail;
+} mspSerial_t;
+
+static mspSerial_t mspSerial;
+static struct tcp_pcb *mspListenPcb;
+static struct tcp_pcb *mspConnPcb;        // one connection at a time
+
+static void mspFlushTx(void);
+
+u32_t sys_now(void)
+{
+    return millis();
+}
+
+static err_t phoneNetifLinkOutput(struct netif *netif, struct pbuf *p)
+{
+    (void)netif;
+    static uint8_t txBuf[1600];
+    if (p->tot_len > sizeof(txBuf)) {
+        return ERR_BUF;
+    }
+    pbuf_copy_partial(p, txBuf, p->tot_len, 0);
+    if (!phoneConfigUsbTransmitFrame(txBuf, p->tot_len)) {
+        return ERR_IF;   // usb tx busy, frame dropped (tcp retransmits)
+    }
+    return ERR_OK;
+}
+
+static err_t phoneNetifInit(struct netif *netif)
+{
+    netif->name[0] = 'n';
+    netif->name[1] = 'c';
+    netif->output = etharp_output;
+    netif->linkoutput = phoneNetifLinkOutput;
+    netif->mtu = 1500;
+    netif->hwaddr_len = 6;
+    memcpy(netif->hwaddr, macAddr, 6);
+    netif->flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_LINK_UP;
+    return ERR_OK;
+}
+
+// called by the usb-ncm class on each frame from the host
+void phoneConfigNetRxFrame(const uint8_t *frame, uint32_t length)
+{
+    if (!netInitDone || length == 0) {
+        return;
+    }
+    struct pbuf *p = pbuf_alloc(PBUF_RAW, (u16_t)length, PBUF_POOL);
+    if (p == NULL) {
+        return;
+    }
+    pbuf_take(p, frame, (u16_t)length);
+    if (phoneNetif.input(p, &phoneNetif) != ERR_OK) {
+        pbuf_free(p);
+    }
+}
+
+void phoneConfigNetLinkChange(uint8_t up)
+{
+    if (!netInitDone) {
+        return;
+    }
+    if (up) {
+        netif_set_link_up(&phoneNetif);
+    } else {
+        netif_set_link_down(&phoneNetif);
+    }
+}
+
+// minimal dhcp server
+#define DHCP_BOOTREQUEST   1
+#define DHCP_BOOTREPLY     2
+#define DHCP_DISCOVER      1
+#define DHCP_OFFER         2
+#define DHCP_REQUEST       3
+#define DHCP_ACK           5
+#define DHCP_MAGIC_COOKIE  0x63825363U
+
+static uint8_t dhcpFindMsgType(const uint8_t *opt, uint16_t len)
+{
+    uint16_t i = 0;
+    while (i + 1 < len) {
+        const uint8_t code = opt[i];
+        if (code == 0xFF) break;     // end
+        if (code == 0x00) { i++; continue; }  // pad
+        const uint8_t l = opt[i + 1];
+        if (code == 53 && l >= 1 && i + 2 < len) {
+            return opt[i + 2];
+        }
+        i += 2 + l;
+    }
+    return 0;
+}
+
+static void dhcpRecv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port)
+{
+    (void)arg; (void)addr; (void)port;
+
+    // bootp/dhcp fixed header is 240 bytes incl. the magic cookie, options follow
+    if (p->tot_len < 240) {
+        pbuf_free(p);
+        return;
+    }
+
+    static uint8_t in[548];
+    const uint16_t inLen = (p->tot_len > sizeof(in)) ? sizeof(in) : p->tot_len;
+    pbuf_copy_partial(p, in, inLen, 0);
+    pbuf_free(p);
+
+    const uint8_t msgType = dhcpFindMsgType(in + 240, inLen - 240);
+    if (msgType != DHCP_DISCOVER && msgType != DHCP_REQUEST) {
+        return;
+    }
+
+    static uint8_t out[300];
+    memset(out, 0, sizeof(out));
+    out[0] = DHCP_BOOTREPLY;
+    out[1] = 1;        // htype ethernet
+    out[2] = 6;        // hlen
+    memcpy(out + 4, in + 4, 4);     // xid
+    memcpy(out + 10, in + 10, 2);   // flags
+    const uint32_t y = lwip_htonl(NET_HOST_IP);
+    memcpy(out + 16, &y, 4);        // yiaddr = host ip
+    const uint32_t s = lwip_htonl(NET_FC_IP);
+    memcpy(out + 20, &s, 4);        // siaddr = server ip
+    memcpy(out + 28, in + 28, 16);  // chaddr
+    uint32_t cookie = lwip_htonl(DHCP_MAGIC_COOKIE);
+    memcpy(out + 236, &cookie, 4);
+
+    uint16_t o = 240;
+    out[o++] = 53; out[o++] = 1; out[o++] = (msgType == DHCP_DISCOVER) ? DHCP_OFFER : DHCP_ACK;
+    out[o++] = 54; out[o++] = 4; memcpy(out + o, &s, 4); o += 4;   // server id
+    const uint32_t mask = lwip_htonl(NET_NETMASK);
+    out[o++] = 1;  out[o++] = 4; memcpy(out + o, &mask, 4); o += 4; // subnet mask
+    out[o++] = 3;  out[o++] = 4; memcpy(out + o, &s, 4); o += 4;    // router
+    out[o++] = 51; out[o++] = 4;
+    out[o++] = 0x00; out[o++] = 0x01; out[o++] = 0x51; out[o++] = 0x80; // lease 86400s
+    out[o++] = 0xFF;  // end
+
+    struct pbuf *resp = pbuf_alloc(PBUF_TRANSPORT, o, PBUF_RAM);
+    if (resp == NULL) {
+        return;
+    }
+    memcpy(resp->payload, out, o);
+    ip_addr_t bcast;
+    IP_ADDR4(&bcast, 255, 255, 255, 255);
+    udp_sendto(pcb, resp, &bcast, 68);
+    pbuf_free(resp);
+}
+
+// virtual serial port backed by the rx/tx rings
+static void mspPumpTx(void)
+{
+    phoneConfigUsbLock();
+    phoneConfigUsbProcess();
+    sys_check_timeouts();
+    mspFlushTx();
+    phoneConfigUsbUnlock();
+}
+
+static void mspVWrite(serialPort_t *p, uint8_t ch)
+{
+    mspSerial_t *s = (mspSerial_t *)p;
+
+    uint16_t next = (uint16_t)((s->txHead + 1) & (MSP_TX_RING - 1));
+    while (next == s->txTail) {
+        mspPumpTx();
+        next = (uint16_t)((s->txHead + 1) & (MSP_TX_RING - 1));
+    }
+
+    s->txBuf[s->txHead] = ch;
+    s->txHead = next;
+}
+
+static void mspVWriteBuf(serialPort_t *p, const void *data, int count)
+{
+    const uint8_t *bytes = data;
+
+    while (count-- > 0) {
+        mspVWrite(p, *bytes++);
+    }
+}
+
+static uint32_t mspVRxWaiting(const serialPort_t *p)
+{
+    const mspSerial_t *s = (const mspSerial_t *)p;
+    return (uint32_t)((uint16_t)(s->rxHead - s->rxTail) & (MSP_RX_RING - 1));
+}
+
+static uint32_t mspVTxFree(const serialPort_t *p)
+{
+    const mspSerial_t *s = (const mspSerial_t *)p;
+    const uint16_t used = (uint16_t)(s->txHead - s->txTail) & (MSP_TX_RING - 1);
+    return (uint32_t)(MSP_TX_RING - 1 - used);
+}
+
+static uint8_t mspVRead(serialPort_t *p)
+{
+    mspSerial_t *s = (mspSerial_t *)p;
+    const uint8_t c = s->rxBuf[s->rxTail];
+    s->rxTail = (uint16_t)((s->rxTail + 1) & (MSP_RX_RING - 1));
+    return c;
+}
+
+static bool mspVTxEmpty(const serialPort_t *p)
+{
+    const mspSerial_t *s = (const mspSerial_t *)p;
+    return s->txHead == s->txTail;
+}
+
+static const struct serialPortVTable mspVTable = {
+    .serialWrite                 = mspVWrite,
+    .serialTotalRxWaiting        = mspVRxWaiting,
+    .serialTotalTxFree           = mspVTxFree,
+    .serialRead                  = mspVRead,
+    .serialSetBaudRate           = NULL,
+    .isSerialTransmitBufferEmpty = mspVTxEmpty,
+    .setMode                     = NULL,
+    .setCtrlLineStateCb          = NULL,
+    .setBaudRateCb               = NULL,
+    .writeBuf                    = mspVWriteBuf,
+    .beginWrite                  = NULL,
+    .endWrite                    = NULL,
+};
+
+// one tcp segment per call, only when the usb in endpoint is idle: the ncm tx is single-buffered
+static void mspFlushTx(void)
+{
+    if (!mspConnPcb) {
+        mspSerial.txTail = mspSerial.txHead;   // no client, discard
+        return;
+    }
+    if (mspSerial.txTail == mspSerial.txHead) {
+        return;
+    }
+    if (phoneConfigUsbTxBusy()) {
+        return;
+    }
+    const uint16_t snd = tcp_sndbuf(mspConnPcb);
+    if (snd == 0) {
+        tcp_output(mspConnPcb);   // window full, push pending ack
+        return;
+    }
+    const uint16_t head = mspSerial.txHead;
+    uint16_t contig = (head > mspSerial.txTail)
+                    ? (uint16_t)(head - mspSerial.txTail)
+                    : (uint16_t)(MSP_TX_RING - mspSerial.txTail);
+    if (contig > snd)     { contig = snd; }
+    if (contig > TCP_MSS) { contig = TCP_MSS; }   // one segment per usb frame
+    if (tcp_write(mspConnPcb, &mspSerial.txBuf[mspSerial.txTail], contig, TCP_WRITE_FLAG_COPY) != ERR_OK) {
+        return;
+    }
+    mspSerial.txTail = (uint16_t)((mspSerial.txTail + contig) & (MSP_TX_RING - 1));
+    tcp_output(mspConnPcb);
+}
+
+static void mspConnErr(void *arg, err_t err)
+{
+    (void)arg; (void)err;
+    mspConnPcb = NULL;   // pcb already freed by lwip
+}
+
+static err_t mspRecv(void *arg, struct tcp_pcb *pcb, struct pbuf *p, err_t err)
+{
+    (void)arg;
+    if (err != ERR_OK || p == NULL) {
+        if (mspConnPcb == pcb) {
+            mspConnPcb = NULL;
+        }
+        tcp_close(pcb);
+        return ERR_OK;
+    }
+    // accept the segment only if all of it fits the ring, else refuse it whole and let lwip redeliver
+    // once the msp task drains room. acking bytes we couldn't store (the old behaviour) desynced the
+    // stream with no retransmit. the ring is sized >= TCP_WND so a full window can never deadlock here.
+    const uint16_t used = (uint16_t)(mspSerial.rxHead - mspSerial.rxTail) & (MSP_RX_RING - 1);
+    if (p->tot_len > (uint16_t)(MSP_RX_RING - 1 - used)) {
+        return ERR_MEM;
+    }
+    for (struct pbuf *q = p; q != NULL; q = q->next) {
+        const uint8_t *d = (const uint8_t *)q->payload;
+        for (uint16_t i = 0; i < q->len; i++) {
+            mspSerial.rxBuf[mspSerial.rxHead] = d[i];
+            mspSerial.rxHead = (uint16_t)((mspSerial.rxHead + 1) & (MSP_RX_RING - 1));
+        }
+    }
+    tcp_recved(pcb, p->tot_len);
+    pbuf_free(p);
+    return ERR_OK;
+}
+
+static err_t mspAccept(void *arg, struct tcp_pcb *pcb, err_t err)
+{
+    (void)arg;
+    if (err != ERR_OK || pcb == NULL) {
+        return ERR_VAL;
+    }
+    if (mspConnPcb) {
+        tcp_abort(mspConnPcb);
+        mspConnPcb = NULL;
+    }
+    mspConnPcb = pcb;
+    mspSerial.rxHead = mspSerial.rxTail = 0;
+    mspSerial.txHead = mspSerial.txTail = 0;
+    tcp_recv(pcb, mspRecv);
+    tcp_err(pcb, mspConnErr);
+    return ERR_OK;
+}
+
+// boot already ran mspInit(), just register the tcp-backed port
+static void mspBridgeInit(void)
+{
+    memset(&mspSerial, 0, sizeof(mspSerial));
+    mspSerial.port.vTable       = &mspVTable;
+    mspSerial.port.mode         = MODE_RXTX;
+    mspSerial.port.baudRate     = 115200;
+    // usb-vcp id (the real vcp is suppressed) so it differs from the msp displayport's none-sentinel,
+    // otherwise mspSerialProcess treats this as the vtx port and never evaluates '#' to enter the cli
+    mspSerial.port.identifier   = SERIAL_PORT_USB_VCP;
+    mspSerial.port.rxBuffer     = mspSerial.rxBuf;
+    mspSerial.port.txBuffer     = mspSerial.txBuf;
+    mspSerial.port.rxBufferSize = MSP_RX_RING;
+    mspSerial.port.txBufferSize = MSP_TX_RING;
+
+    mspSerialRegisterPort(&mspSerial.port);
+}
+
+static struct udp_pcb *flashPcb;
+
+// a PF_HELLO datagram means the host wants to reflash; note it, the phone-config task hands off
+static void flashRecv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port)
+{
+    (void)arg;
+    (void)pcb;
+    (void)addr;
+    (void)port;
+
+    if (p) {
+        uint8_t buf[16];
+        uint16_t n = pbuf_copy_partial(p, buf, sizeof(buf), 0);
+        phoneFlashNoteHello(buf, n);
+        pbuf_free(p);
+    }
+}
+
+void phoneConfigNetInit(const uint8_t *mac)
+{
+    memcpy(macAddr, mac, 6);
+
+    lwip_init();
+
+    ip4_addr_t ip, mask, gw;
+    ip4_addr_set_u32(&ip, lwip_htonl(NET_FC_IP));
+    ip4_addr_set_u32(&mask, lwip_htonl(NET_NETMASK));
+    ip4_addr_set_u32(&gw, lwip_htonl(NET_FC_IP));
+
+    netif_add(&phoneNetif, &ip, &mask, &gw, NULL, phoneNetifInit, ethernet_input);
+    netif_set_default(&phoneNetif);
+    netif_set_up(&phoneNetif);
+    netif_set_link_up(&phoneNetif);
+
+    dhcpPcb = udp_new();
+    if (dhcpPcb) {
+        udp_bind(dhcpPcb, IP_ADDR_ANY, 67);
+        udp_recv(dhcpPcb, dhcpRecv, NULL);
+    }
+
+    mspListenPcb = tcp_new();
+    if (mspListenPcb) {
+        tcp_bind(mspListenPcb, IP_ADDR_ANY, NET_MSP_PORT);
+        mspListenPcb = tcp_listen(mspListenPcb);
+        tcp_accept(mspListenPcb, mspAccept);
+    }
+
+    flashPcb = udp_new();
+    if (flashPcb) {
+        udp_bind(flashPcb, IP_ADDR_ANY, PHONE_FLASH_UDP_PORT);
+        udp_recv(flashPcb, flashRecv, NULL);
+    }
+
+    mspBridgeInit();
+
+    netInitDone = true;
+}
+
+void phoneConfigNetPoll(void)
+{
+    if (netInitDone) {
+        sys_check_timeouts();   // lwip timers
+        mspFlushTx();
+    }
+}
+
+#endif // USE_PHONE_CONFIG

--- a/src/main/io/phoneconfig_net.h
+++ b/src/main/io/phoneconfig_net.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// bring up lwip, the netif, dhcp server and tcp server. `mac` is the 6-byte hardware address
+void phoneConfigNetInit(const uint8_t *mac);
+
+// pump lwip timers and deferred work, called repeatedly from the net task
+void phoneConfigNetPoll(void);
+
+// called from the usb-ncm class when an ethernet frame arrives from the host
+void phoneConfigNetRxFrame(const uint8_t *frame, uint32_t length);
+
+// called from the usb-ncm class when the usb link state changes
+void phoneConfigNetLinkChange(uint8_t up);
+
+// send an ethernet frame over usb-ncm, implemented by the per-mcu usb layer. false if the tx path
+// is busy and the frame was dropped
+bool phoneConfigUsbTransmitFrame(const uint8_t *frame, uint16_t length);
+
+// drain deferred usb-ncm rx into lwip, implemented by the per-mcu usb layer
+void phoneConfigUsbProcess(void);

--- a/src/main/io/phoneflash.h
+++ b/src/main/io/phoneflash.h
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * phone-flash: firmware update over the phone-config usb-ncm link, so an iphone can reflash the fc over
+ * a cable without dfu (ios can't drive usb dfu). the host streams the image to a udp service, a routine
+ * copied into ram erases and programs the flash while all flash access is stalled. see phoneflash_burn.
+ *
+ * wire format is little-endian to match the arm core. every packet starts with the 4-byte magic and an
+ * opcode, replies echo the opcode with the high bit set.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define PHONE_FLASH_UDP_PORT     5762
+#define PHONE_FLASH_MAGIC        0x48534C46U   // "FLSH"
+#define PHONE_FLASH_REPLY_BIT    0x80U
+
+// max firmware bytes per PF_WRITE. keeps the ncm datagram under the 2048-byte ntb limit.
+#define PHONE_FLASH_CHUNK        1024U
+
+// ncm block buffer size for the ram burn engine, matches the class' NCM_NTB_OUT_MAX_SIZE
+#define NCM_BURN_NTB             2048U
+
+enum {
+    PF_HELLO   = 0x01,   // host -> fc: request flash. reply carries the flash geometry
+    PF_BEGIN   = 0x02,   // host -> fc: {u32 totalSize, u32 imageCrc}
+    PF_WRITE   = 0x03,   // host -> fc: {u32 offset, u16 len, bytes[len]} offset from 0x08000000
+    PF_END     = 0x04,   // host -> fc: verify the readback crc over totalSize
+    PF_REBOOT  = 0x05,   // host -> fc: reset into the freshly flashed firmware
+    PF_ABORT   = 0x06,   // host -> fc: give up, reboot back to normal (only valid before any erase)
+};
+
+enum {
+    PF_ERR_NONE       = 0,
+    PF_ERR_BADMAGIC   = 1,
+    PF_ERR_BADOP      = 2,
+    PF_ERR_RANGE      = 3,   // offset/len outside the writable firmware region
+    PF_ERR_ALIGN      = 4,   // offset or len not word aligned
+    PF_ERR_SEQ        = 5,   // non-sequential write (host must stream in order)
+    PF_ERR_FLASH      = 6,   // erase/program/verify failed
+    PF_ERR_CRC        = 7,   // whole-image crc mismatch at PF_END
+    PF_ERR_STATE      = 8,   // opcode not valid in the current state
+};
+
+// flash geometry reported in the PF_HELLO reply, so the host does not hard-code the target.
+// {u32 magic}{u8 op|reply}{u8 err}{u32 configStart}{u32 configEnd}{u32 flashSize}{u16 maxChunk}{u16 mcu}
+#define PHONE_FLASH_FC_BASE       0x08000000U
+
+// note a PF_HELLO seen by the flash-resident lwip listener, so the phone-config task can hand off to the
+// ram burn engine. implemented in phoneflash_burn_<mcu>.c.
+void phoneFlashNoteHello(const uint8_t *payload, uint16_t len);
+bool phoneFlashPending(void);
+void phoneFlashRun(void);

--- a/src/main/io/serial.c
+++ b/src/main/io/serial.c
@@ -49,6 +49,10 @@
 #include "drivers/serial_usb_vcp.h"
 #endif
 
+#ifdef USE_PHONE_CONFIG
+#include "io/phoneconfig.h"
+#endif
+
 #include "config/config.h"
 
 #include "io/serial.h"
@@ -667,8 +671,20 @@ void serialInit(bool softserialEnabled)
 {
     memset(&serialPortUsageList, 0, sizeof(serialPortUsageList));
 
+#ifdef USE_PHONE_CONFIG
+    // in phone-config mode usb is a cdc-ncm gadget, not the cdc-acm vcp, so the vcp port is dropped
+    const bool dropVcpPort = phoneConfigCheckBootAndReset();
+#endif
+
     for (int index = 0; index < SERIAL_PORT_COUNT; index++) {
         serialPortUsageList[index].identifier = serialPortIdentifiers[index];
+
+#ifdef USE_PHONE_CONFIG
+        if (dropVcpPort && serialPortUsageList[index].identifier == SERIAL_PORT_USB_VCP) {
+            serialPortUsageList[index].identifier = SERIAL_PORT_NONE;
+            continue;
+        }
+#endif
 
 #if SERIAL_TRAIT_PIN_CONFIG
         const int resourceIndex = serialResourceIndex(serialPortUsageList[index].identifier);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -54,6 +54,10 @@
 #include "drivers/usb_msc.h"
 #endif
 
+#ifdef USE_PHONE_CONFIG
+#include "io/phoneconfig.h"
+#endif
+
 #include "scheduler/scheduler.h"
 
 #ifdef CONFIG_IN_FILE
@@ -99,11 +103,19 @@ int main(int argc, char * argv[])
     }
 #endif
 
-#ifdef USE_VCP
-    // initialise the USB CDC interface using core 0 all USB code, including
-    // interrupts, must run on core 0
-    usbVcpInit();
+#ifdef USE_PHONE_CONFIG
+    if (phoneConfigCheckBootAndReset()) {
+        // usb comes up as a cdc-ncm gadget instead of the cdc-acm vcp, the full fc still boots
+        phoneConfigUsbStart();
+    } else
 #endif
+    {
+#ifdef USE_VCP
+        // initialise the USB CDC interface using core 0 all USB code, including
+        // interrupts, must run on core 0
+        usbVcpInit();
+#endif
+    }
 
 #ifdef ENABLE_MULTICORE_INIT
     // Now perform the final initialisation

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -98,6 +98,9 @@
 #include "io/gimbal.h"
 #include "io/gps.h"
 #include "io/ledstrip.h"
+#if defined(USE_PHONE_CONFIG)
+#include "io/phoneconfig.h"
+#endif
 #include "io/serial.h"
 #include "io/serial_4way.h"
 #include "io/transponder_ir.h"
@@ -385,6 +388,12 @@ static void mspRebootFn(serialPort_t *serialPort)
         if (fontHasBeenUpdated) {
             fontUpdateCompletion();
             fontHasBeenUpdated = false;
+        }
+#endif
+
+#ifdef USE_PHONE_CONFIG
+        if (phoneConfigCheckBootAndReset()) {
+            systemResetToPhoneConfig();
         }
 #endif
 

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -42,6 +42,10 @@
 
 #include "pg/msp.h"
 
+#if defined(USE_PHONE_CONFIG)
+#include "io/phoneconfig.h"
+#endif
+
 static mspPort_t mspPorts[MAX_MSP_PORT_COUNT];
 
 static void resetMspPort(mspPort_t *mspPortToReset, serialPort_t *serialPort, bool sharedWithTelemetry)
@@ -88,6 +92,21 @@ void mspSerialAllocatePorts(void)
         portConfig = findNextSerialPortConfig(FUNCTION_MSP);
     }
 }
+
+#if defined(USE_PHONE_CONFIG)
+// register an externally-owned serial port as an msp port, used by phone-config mode's tcp/msp
+// bridge which has no uart serial-port config to drive mspSerialAllocatePorts().
+mspPort_t *mspSerialRegisterPort(serialPort_t *serialPort)
+{
+    for (int i = 0; i < MAX_MSP_PORT_COUNT; i++) {
+        if (mspPorts[i].port == NULL) {
+            resetMspPort(&mspPorts[i], serialPort, false);
+            return &mspPorts[i];
+        }
+    }
+    return NULL;
+}
+#endif
 
 void mspSerialReleasePortIfAllocated(serialPort_t *serialPort)
 {
@@ -515,7 +534,14 @@ static void mspProcessPacket(mspPort_t *mspPort, mspProcessCommandFnPtr mspProce
     }
 
     if (mspPostProcessFn) {
-        waitForSerialPortToFinishTransmitting(mspPort->port);
+#if defined(USE_PHONE_CONFIG)
+        // the phone-config virtual msp port drains from a scheduler task, so this wait would hang here;
+        // the reboot it precedes (e.g. after a 'save') re-enters phone-config and the link comes back
+        if (!phoneConfigCheckBootAndReset())
+#endif
+        {
+            waitForSerialPortToFinishTransmitting(mspPort->port);
+        }
         mspPostProcessFn(mspPort->port);
     }
 }

--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -130,6 +130,10 @@ void mspSerialInit(void);
 bool mspSerialWaiting(void);
 void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessCommandFnPtr mspProcessCommandFn, mspProcessReplyFnPtr mspProcessReplyFn);
 void mspSerialAllocatePorts(void);
+#if defined(USE_PHONE_CONFIG)
+// register an externally-owned serial port as an msp port (phone-config tcp/msp bridge)
+mspPort_t *mspSerialRegisterPort(serialPort_t *serialPort);
+#endif
 void mspSerialReleasePortIfAllocated(struct serialPort_s *serialPort);
 void mspSerialReleaseSharedTelemetryPorts(void);
 mspDescriptor_t getMspSerialPortDescriptor(const serialPortIdentifier_e portIdentifier);

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -199,6 +199,11 @@ typedef enum {
     TASK_DRONECAN,
 #endif
 
+#ifdef USE_PHONE_CONFIG
+    TASK_PHONE_CONFIG,
+    TASK_PHONE_CONFIG_NET,
+#endif
+
     /* Count of real tasks */
     TASK_COUNT,
 

--- a/src/platform/STM32/link/stm32_flash_f7_split.ld
+++ b/src/platform/STM32/link/stm32_flash_f7_split.ld
@@ -123,6 +123,19 @@ SECTIONS
     __bss_end__ = _ebss;
   } >RAM
 
+  /* phone-flash updater: its code and rodata are copied to RAM at burn time and run from there, so the */
+  /* erase/program loop keeps executing while all flash access is stalled. empty unless USE_PHONE_CONFIG. */
+  _siram_flash = LOADADDR(.ram_flash);
+  .ram_flash :
+  {
+    . = ALIGN(4);
+    _sram_flash = .;
+    *(.ram_flash)
+    *(.ram_flash*)
+    . = ALIGN(4);
+    _eram_flash = .;
+  } >SRAM2 AT >WRITABLE_FLASH1
+
   /* Uninitialized data section */
   . = ALIGN(4);
   .sram2 (NOLOAD) :

--- a/src/platform/STM32/link/stm32_flash_h743_2m.ld
+++ b/src/platform/STM32/link/stm32_flash_h743_2m.ld
@@ -168,6 +168,19 @@ SECTIONS
     __bss_end__ = _ebss;
   } >RAM
 
+  /* phone-flash updater: its code and rodata are copied to RAM at burn time and run from there, so the */
+  /* erase/program loop keeps executing while all flash access is stalled. empty unless USE_PHONE_CONFIG. */
+  _siram_flash = LOADADDR(.ram_flash);
+  .ram_flash :
+  {
+    . = ALIGN(4);
+    _sram_flash = .;
+    *(.ram_flash)
+    *(.ram_flash*)
+    . = ALIGN(4);
+    _eram_flash = .;
+  } >RAM AT >FLASH1
+
   /* Uninitialized data section */
   . = ALIGN(4);
   .sram2 (NOLOAD) :

--- a/src/platform/STM32/mk/STM32F7.mk
+++ b/src/platform/STM32/mk/STM32F7.mk
@@ -144,6 +144,22 @@ VCP_SRC = \
             STM32/serial_usb_vcp.c \
             drivers/usb_io.c
 
+# phone-config (usb cdc-ncm network gadget + lwip), enabled via OPTIONS
+ifneq (,$(findstring USE_PHONE_CONFIG,$(OPTIONS)))
+LWIP_DIR = $(LIB_MAIN_DIR)/lwip/src
+VPATH := $(VPATH):$(LWIP_DIR)/core:$(LWIP_DIR)/core/ipv4:$(LWIP_DIR)/netif
+INCLUDE_DIRS += $(LWIP_DIR)/include $(SRC_DIR)/io/lwip_port
+VCP_SRC += \
+            STM32/vcp_hal/usbd_cdc_ncm.c \
+            STM32/phoneconfig_usb_stm32.c \
+            STM32/phoneflash_burn_f7xx.c \
+            io/phoneconfig_net.c \
+            init.c def.c inet_chksum.c ip.c mem.c memp.c netif.c pbuf.c raw.c stats.c sys.c \
+            tcp.c tcp_in.c tcp_out.c timeouts.c udp.c \
+            acd.c etharp.c icmp.c ip4.c ip4_addr.c ip4_frag.c \
+            ethernet.c
+endif
+
 MCU_COMMON_SRC = \
             drivers/accgyro/accgyro_mpu.c \
             drivers/bus_i2c_timing.c \

--- a/src/platform/STM32/mk/STM32H7.mk
+++ b/src/platform/STM32/mk/STM32H7.mk
@@ -296,6 +296,22 @@ VCP_SRC = \
             STM32/serial_usb_vcp.c \
             drivers/usb_io.c
 
+# phone-config (usb cdc-ncm network gadget + lwip), enabled via OPTIONS
+ifneq (,$(findstring USE_PHONE_CONFIG,$(OPTIONS)))
+LWIP_DIR = $(LIB_MAIN_DIR)/lwip/src
+VPATH := $(VPATH):$(LWIP_DIR)/core:$(LWIP_DIR)/core/ipv4:$(LWIP_DIR)/netif
+INCLUDE_DIRS += $(LWIP_DIR)/include $(SRC_DIR)/io/lwip_port
+VCP_SRC += \
+            STM32/vcp_hal/usbd_cdc_ncm.c \
+            STM32/phoneconfig_usb_stm32.c \
+            STM32/phoneflash_burn_h7xx.c \
+            io/phoneconfig_net.c \
+            init.c def.c inet_chksum.c ip.c mem.c memp.c netif.c pbuf.c raw.c stats.c sys.c \
+            tcp.c tcp_in.c tcp_out.c timeouts.c udp.c \
+            acd.c etharp.c icmp.c ip4.c ip4_addr.c ip4_frag.c \
+            ethernet.c
+endif
+
 MCU_COMMON_SRC = \
             drivers/bus_i2c_timing.c \
             drivers/bus_quadspi.c \

--- a/src/platform/STM32/phoneconfig_usb_stm32.c
+++ b/src/platform/STM32/phoneconfig_usb_stm32.c
@@ -1,0 +1,189 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * phone-config usb bring-up (stm32 hal usbd, f7/h7): brings the usb device up as a cdc-ncm network
+ * gadget instead of the normal cdc-acm serial port. modelled on mscStart() in usb_msc_f7xx.c.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "platform.h"
+
+#ifdef USE_PHONE_CONFIG
+
+#include "drivers/io.h"
+#include "drivers/nvic.h"
+#include "drivers/serial_usb_vcp.h"
+#include "drivers/system.h"
+#include "drivers/time.h"
+#include "drivers/usb_io.h"
+
+#include "pg/usb.h"
+
+#include "vcp_hal/usbd_cdc_interface.h"
+
+#include "usbd_core.h"
+#include "vcp_hal/usbd_cdc_ncm.h"
+
+#include "io/phoneconfig.h"
+#include "io/phoneconfig_net.h"
+
+extern USBD_HandleTypeDef USBD_Device;
+
+// h7 parts that run the vcp on usb1 otg-hs (in fs mode) take their interrupt on OTG_HS_IRQn,
+// everything else (all f7, h743) uses otg-fs on pa11/pa12. mirrors usbd_conf_stm32h7xx.c.
+#if defined(STM32H7A3xx) || defined(STM32H7A3xxQ) || defined(STM32H723xx) || defined(STM32H725xx) || defined(STM32H730xx) || defined(STM32H735xx)
+#define PHONECONFIG_USB_IRQ OTG_HS_IRQn
+#else
+#define PHONECONFIG_USB_IRQ OTG_FS_IRQn
+#endif
+
+// iad/miscellaneous device descriptor with its own product id, ios is strict about this
+static const uint8_t ncmDeviceDescriptor[18] = {
+    0x12,                   // bLength
+    0x01,                   // bDescriptorType: Device
+    0x00, 0x02,             // bcdUSB 2.00
+    0xEF,                   // bDeviceClass: Miscellaneous Device
+    0x02,                   // bDeviceSubClass: Common Class
+    0x01,                   // bDeviceProtocol: Interface Association Descriptor
+    0x40,                   // bMaxPacketSize0: 64
+    0x83, 0x04,             // idVendor: 0x0483 (STMicroelectronics)
+    0x42, 0x57,             // idProduct: 0x5742 (distinct from serial 0x5740 / ECM 0x5741)
+    0x00, 0x02,             // bcdDevice 2.00
+    0x01,                   // iManufacturer
+    0x02,                   // iProduct
+    0x03,                   // iSerialNumber
+    0x01,                   // bNumConfigurations
+};
+
+static uint8_t *ncmDeviceDescriptorCb(USBD_SpeedTypeDef speed, uint16_t *length)
+{
+    (void)speed;
+    *length = sizeof(ncmDeviceDescriptor);
+    return (uint8_t *)ncmDeviceDescriptor;
+}
+
+// reuse betaflight's vcp string-descriptor providers
+extern uint8_t *USBD_VCP_LangIDStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
+extern uint8_t *USBD_VCP_ManufacturerStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
+extern uint8_t *USBD_VCP_ProductStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
+extern uint8_t *USBD_VCP_SerialStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
+extern uint8_t *USBD_VCP_ConfigStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
+extern uint8_t *USBD_VCP_InterfaceStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length);
+
+static USBD_DescriptorsTypeDef ncmDescriptors = {
+    ncmDeviceDescriptorCb,
+    USBD_VCP_LangIDStrDescriptor,
+    USBD_VCP_ManufacturerStrDescriptor,
+    USBD_VCP_ProductStrDescriptor,
+    USBD_VCP_SerialStrDescriptor,
+    USBD_VCP_ConfigStrDescriptor,
+    USBD_VCP_InterfaceStrDescriptor,
+};
+
+// network glue: bridge the ncm class to the lwip stack in phoneconfig_net.c
+static int8_t ncmGlueInit(void) { return 0; }
+static int8_t ncmGlueDeInit(void) { return 0; }
+static int8_t ncmGlueReceive(uint8_t *frame, uint32_t length) { phoneConfigNetRxFrame(frame, length); return 0; }
+static void   ncmGlueLinkChange(uint8_t up) { phoneConfigNetLinkChange(up); }
+// the host's usb-ncm interface mac (imacaddress descriptor), becomes the phone's ethernet mac
+static const uint8_t ncmMacString[] = "020000000001";
+// the fc's own lwip mac. must differ from the host mac above or ios drops the gateway's arp reply as
+// bogus (linux tolerates the clash, ios doesn't), so differ by the last byte.
+static const uint8_t ncmMacBytes[6] = { 0x02, 0x00, 0x00, 0x00, 0x00, 0x02 };
+
+// lwip netif tx. mspFlushTx() only calls here when the in endpoint is idle, so the ntb is taken at once
+bool phoneConfigUsbTransmitFrame(const uint8_t *frame, uint16_t length)
+{
+    return USBD_CDC_NCM_TransmitFrame(&USBD_Device, frame, length) == USBD_OK;
+}
+
+bool phoneConfigUsbTxBusy(void)
+{
+    return USBD_CDC_NCM_IsTxBusy() != 0;
+}
+
+// drain deferred usb-ncm rx into lwip, called from the main loop
+void phoneConfigUsbProcess(void)
+{
+    USBD_CDC_NCM_Process(&USBD_Device);
+}
+
+// the st usb low level is not re-entrant, so mask the otg interrupt while the main loop drives it
+void phoneConfigUsbLock(void)
+{
+    NVIC_DisableIRQ(PHONECONFIG_USB_IRQ);
+    __DSB();
+    __ISB();
+}
+
+void phoneConfigUsbUnlock(void)
+{
+    NVIC_EnableIRQ(PHONECONFIG_USB_IRQ);
+}
+
+static USBD_CDC_NCM_ItfTypeDef ncmFops = {
+    ncmGlueInit,
+    ncmGlueDeInit,
+    ncmGlueReceive,
+    ncmGlueLinkChange,
+    ncmMacString,
+};
+
+uint8_t phoneConfigUsbStart(void)
+{
+    usbGenerateDisconnectPulse();
+
+    IOInit(IOGetByTag(IO_TAG(PA11)), OWNER_USB, 0);
+    IOInit(IOGetByTag(IO_TAG(PA12)), OWNER_USB, 0);
+
+    USBD_Init(&USBD_Device, &ncmDescriptors, 0);
+
+    // bf's fifo layout only allocates tx fifos for ep0/ep1 (its vcp never transmits on the notification
+    // endpoint). ncm does (link-up notification on ep2), and without a tx fifo there it hard-faults, so
+    // re-partition the 320-word otg-fs fifo ram to add one. words: 0x80+0x20+0x80+0x10 = 0x130.
+    PCD_HandleTypeDef *hpcd = (PCD_HandleTypeDef *)USBD_Device.pData;
+    HAL_PCDEx_SetRxFiFo(hpcd, 0x80);
+    HAL_PCDEx_SetTxFiFo(hpcd, 0, 0x20);   // ep0 control
+    HAL_PCDEx_SetTxFiFo(hpcd, 1, 0x80);   // ep1 bulk data (ntbs)
+    HAL_PCDEx_SetTxFiFo(hpcd, 2, 0x10);   // ep2 interrupt, link notifications (was missing)
+
+    USBD_RegisterClass(&USBD_Device, USBD_CDC_NCM_CLASS);
+    USBD_CDC_NCM_RegisterInterface(&USBD_Device, &ncmFops);
+    USBD_Start(&USBD_Device);
+
+    // net stack starts later in phoneConfigNetStart(), after mspSerialInit()
+
+    NVIC_DisableIRQ(SysTick_IRQn);
+    NVIC_SetPriority(SysTick_IRQn, NVIC_BUILD_PRIORITY(0, 0));
+    NVIC_EnableIRQ(SysTick_IRQn);
+
+    return 0;
+}
+
+// bring up lwip and the msp-over-tcp server. called from init() after mspSerialInit()
+void phoneConfigNetStart(void)
+{
+    phoneConfigNetInit(ncmMacBytes);
+}
+
+#endif // USE_PHONE_CONFIG

--- a/src/platform/STM32/phoneflash_burn.h
+++ b/src/platform/STM32/phoneflash_burn.h
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * phone-flash burn engine: shared state and byte helpers. included by each per-mcu wrapper
+ * (phoneflash_burn_<mcu>.c) after it defines the RF/RFI macros, before the wrapper's flash ops that
+ * fold the running crc. the mcu-independent bulk of the engine (usb, ncm, ip, protocol) lives in
+ * phoneflash_burn_impl.c, included after the flash ops. not a standalone translation unit.
+ */
+
+#pragma once
+
+enum { ST_WAIT_HELLO = 0, ST_READY, ST_FLASHING, ST_DONE };
+
+static uint8_t  hostMac[6];
+static uint32_t hostIp;
+static uint16_t hostPort;
+static uint16_t txSeq;
+
+static uint8_t  state;
+static uint32_t totalSize;
+static uint32_t imageCrc;
+static uint32_t writtenUpTo;
+static uint32_t programmedBytes;
+static uint32_t crcState;
+static uint32_t erasedMask;
+static uint8_t  rebootReq;
+static uint8_t  abortReq;
+
+RFI uint32_t rd32(const uint8_t *p)  { return (uint32_t)p[0] | (uint32_t)p[1] << 8 | (uint32_t)p[2] << 16 | (uint32_t)p[3] << 24; }
+RFI uint16_t rd16(const uint8_t *p)  { return (uint16_t)(p[0] | p[1] << 8); }
+RFI void     wr32(uint8_t *p, uint32_t v) { p[0] = v; p[1] = v >> 8; p[2] = v >> 16; p[3] = v >> 24; }
+RFI void     wr16(uint8_t *p, uint16_t v) { p[0] = v; p[1] = v >> 8; }
+RFI uint32_t rd32be(const uint8_t *p) { return (uint32_t)p[0] << 24 | (uint32_t)p[1] << 16 | (uint32_t)p[2] << 8 | (uint32_t)p[3]; }
+RFI void     wr32be(uint8_t *p, uint32_t v) { p[0] = v >> 24; p[1] = v >> 16; p[2] = v >> 8; p[3] = v; }
+RFI void     wr16be(uint8_t *p, uint16_t v) { p[0] = v >> 8; p[1] = v; }
+
+// crc-32 (reflected, poly 0xedb88320) fold of one verified byte, matches the host's whole-image crc
+RFI void rfCrc32Byte(uint8_t b)
+{
+    crcState ^= b;
+    for (uint32_t k = 0; k < 8; k++) {
+        crcState = (crcState >> 1) ^ (0xEDB88320U & (uint32_t)-(int32_t)(crcState & 1U));
+    }
+}
+
+static RF void rfMemcpy(uint8_t *d, const uint8_t *s, uint32_t n)
+{
+    while (n--) {
+        *d++ = *s++;
+    }
+}
+
+static RF void rfReboot(void)
+{
+    __DSB();
+    SCB->AIRCR = (0x5FAUL << SCB_AIRCR_VECTKEY_Pos) | SCB_AIRCR_SYSRESETREQ_Msk;
+    __DSB();
+    for (;;) { }
+}

--- a/src/platform/STM32/phoneflash_burn_f7xx.c
+++ b/src/platform/STM32/phoneflash_burn_f7xx.c
@@ -1,0 +1,240 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * phone-flash burn engine, stm32f7 wrapper: the register-level flash driver plus the mcu constants for
+ * the shared engine in phoneflash_burn_impl.c. these parts are single-bank, so all flash access stalls
+ * during an erase or program and the code being erased is the code we run from; the whole receive-and-
+ * program path therefore runs from a copy in .ram_flash with interrupts masked and polled usb, touching
+ * no flash/hal/libc mid-burn. nothing is erased until the host completes a live round trip against this
+ * ram code, so a broken build reboots to the intact firmware; rom dfu is the final backstop.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "platform.h"
+
+#ifdef USE_PHONE_CONFIG
+
+#include "drivers/persistent.h"
+
+#include "io/phoneflash.h"
+
+// single-bank f7 parts whose sector geometry is known here. other f7 targets get inert stubs.
+#if defined(STM32F722xx) || defined(STM32F745xx) || defined(STM32F746xx)
+
+// burn code must never become a memcpy/memset call back into flash, hence no-tree-loop-distribute-patterns
+#define RF __attribute__((section(".ram_flash"), noinline, used, \
+                          optimize("no-tree-loop-distribute-patterns")))
+
+// must never exist out-of-line in flash, the burn path calls them mid-erase
+#define RFI static inline __attribute__((always_inline))
+
+#define PF_REPLY   PHONE_FLASH_REPLY_BIT
+
+#define OUR_IP     0xC0A80701U     // 192.168.7.1
+#define OUR_MAC_5  0x02U           // fc mac low byte, differs from the host's ..:01
+#define PF_OUT_EPNUM   1U
+#define RF_HZ           216000000U      // f7 core clock
+#define RF_IDLE_TIMEOUT (RF_HZ * 15U)   // host-idle reboot timeout, well below the u32 cyccnt wrap at ~19s
+
+#if defined(STM32F722xx)
+#define PF_FLASH_SIZE  (512U * 1024U)
+#define PF_CHIP_ID     0xF722U
+#elif defined(STM32F745xx)
+#define PF_FLASH_SIZE  (1024U * 1024U)
+#define PF_CHIP_ID     0xF745U
+#else
+#define PF_FLASH_SIZE  (1024U * 1024U)
+#define PF_CHIP_ID     0xF746U
+#endif
+
+// config sector bounds (__config_start/__config_end, declared in common_post.h) come from the
+// linker script. sector 1 on every supported part.
+
+// FLASH_KEY1 / FLASH_KEY2 come from the hal flash header
+#define FLASH_SR_ERRORS 0x000000F2U   // OPERR|WRPERR|PGAERR|PGPERR|ERSERR
+#define FLASH_SR_CLEAR  0x000000F3U   // above plus EOP, write-1-to-clear
+
+#define OTG          ((USB_OTG_GlobalTypeDef *)USB_OTG_FS_PERIPH_BASE)
+#define OTG_INEP(i)  ((USB_OTG_INEndpointTypeDef *)(USB_OTG_FS_PERIPH_BASE + USB_OTG_IN_ENDPOINT_BASE + (i) * USB_OTG_EP_REG_SIZE))
+#define OTG_OUTEP(i) ((USB_OTG_OUTEndpointTypeDef *)(USB_OTG_FS_PERIPH_BASE + USB_OTG_OUT_ENDPOINT_BASE + (i) * USB_OTG_EP_REG_SIZE))
+#define OTG_FIFO(i)  (*(volatile uint32_t *)(USB_OTG_FS_PERIPH_BASE + USB_OTG_FIFO_BASE + (i) * USB_OTG_FIFO_SIZE))
+
+// buffers sit in sram2 (unused on this target) to spare the tight sram1
+#define BURN_BUF __attribute__((section(".sram2")))
+
+static BURN_BUF uint8_t rxNtb[NCM_BURN_NTB];
+static BURN_BUF uint8_t txNtb[NCM_BURN_NTB];
+static BURN_BUF uint8_t txFrame[1536];
+static BURN_BUF uint8_t replyBuf[64];
+
+extern uint32_t _siram_flash[];
+extern uint32_t _sram_flash[];
+extern uint32_t _eram_flash[];
+
+#include "phoneflash_burn.h"
+
+// keep the watchdog fed through a multi-second erase, where nothing else runs
+static RF void rfKickWdg(void)
+{
+    IWDG->KR = 0x0000AAAAU;
+}
+
+// ---- flash driver (register level, no hal) ----
+
+static RF void rfWaitBsy(void)
+{
+    uint32_t start = DWT->CYCCNT;
+    while (FLASH->SR & FLASH_SR_BSY) {
+        rfKickWdg();
+        if ((uint32_t)(DWT->CYCCNT - start) > RF_HZ * 8U) {   // f74x worst-case 256k sector erase is ~4s
+            rfReboot();
+        }
+    }
+}
+
+static RF uint32_t rfSectorOf(uint32_t addr)
+{
+    uint32_t off = addr - PHONE_FLASH_FC_BASE;
+#if defined(STM32F722xx)
+    if (off < 0x04000) return 0;   // 16k, vector table
+    if (off < 0x08000) return 1;   // 16k, config (never erased)
+    if (off < 0x0C000) return 2;   // 16k
+    if (off < 0x10000) return 3;   // 16k
+    if (off < 0x20000) return 4;   // 64k
+    if (off < 0x40000) return 5;   // 128k
+    if (off < 0x60000) return 6;   // 128k
+    if (off < 0x80000) return 7;   // 128k
+#else // f745/f746
+    if (off < 0x08000) return 0;   // 32k, vector table
+    if (off < 0x10000) return 1;   // 32k, config (never erased)
+    if (off < 0x18000) return 2;   // 32k
+    if (off < 0x20000) return 3;   // 32k
+    if (off < 0x40000) return 4;   // 128k
+    if (off < 0x80000) return 5;   // 256k
+    if (off < 0xC0000) return 6;   // 256k
+    if (off < 0x100000) return 7;  // 256k
+#endif
+    return 0xFF;
+}
+
+static RF void rfFlashUnlock(void)
+{
+    if (FLASH->CR & FLASH_CR_LOCK) {
+        FLASH->KEYR = FLASH_KEY1;
+        FLASH->KEYR = FLASH_KEY2;
+    }
+}
+
+static RF void rfFlashLock(void)
+{
+    FLASH->CR |= FLASH_CR_LOCK;
+}
+
+static RF uint32_t rfEraseSector(uint32_t sector)
+{
+    rfWaitBsy();
+    FLASH->SR = FLASH_SR_CLEAR;
+    FLASH->CR &= ~FLASH_CR_PSIZE;
+    FLASH->CR |= (2U << FLASH_CR_PSIZE_Pos);          // x32 program/erase, needs 2.7v+
+    FLASH->CR &= ~FLASH_CR_SNB;
+    FLASH->CR |= FLASH_CR_SER | (sector << FLASH_CR_SNB_Pos);
+    FLASH->CR |= FLASH_CR_STRT;
+    rfWaitBsy();
+    FLASH->CR &= ~(FLASH_CR_SER | FLASH_CR_SNB);
+    return (FLASH->SR & FLASH_SR_ERRORS) ? 1U : 0U;
+}
+
+static RF uint32_t rfProgramWord(uint32_t addr, uint32_t word)
+{
+    rfWaitBsy();
+    FLASH->SR = FLASH_SR_CLEAR;
+    FLASH->CR &= ~FLASH_CR_PSIZE;
+    FLASH->CR |= (2U << FLASH_CR_PSIZE_Pos);
+    FLASH->CR |= FLASH_CR_PG;
+    *(volatile uint32_t *)addr = word;
+    __DSB();
+    rfWaitBsy();
+    FLASH->CR &= ~FLASH_CR_PG;
+    return (FLASH->SR & FLASH_SR_ERRORS) ? 1U : 0U;
+}
+
+// program word-aligned len at addr, erasing each sector on first touch and verifying every word by
+// readback into the running crc. returns non-zero on failure.
+static RF uint32_t rfProgram(uint32_t addr, const uint8_t *data, uint32_t len)
+{
+    for (uint32_t i = 0; i < len; i += 4) {
+        uint32_t sec = rfSectorOf(addr + i);
+        if (sec == 1 || sec == 0xFF) {
+            return 1;                                  // never touch config or run off the end
+        }
+    }
+    for (uint32_t i = 0; i < len; i += 4) {
+        uint32_t a = addr + i;
+        uint32_t sec = rfSectorOf(a);
+        if (!(erasedMask & (1U << sec))) {
+            if (rfEraseSector(sec)) {
+                return 1;
+            }
+            erasedMask |= (1U << sec);
+        }
+        uint32_t w = rd32(data + i);
+        if (rfProgramWord(a, w)) {
+            return 1;
+        }
+        uint32_t rb = *(volatile uint32_t *)a;
+        if (rb != w) {
+            return 1;
+        }
+        for (uint32_t b = 0; b < 4; b++) {
+            rfCrc32Byte((rb >> (8 * b)) & 0xFF);
+        }
+    }
+    return 0;
+}
+
+// f7 programs a word at a time, so there is no partial-row staging to reset or flush
+static RF void rfProgramBegin(void) { }
+static RF uint32_t rfProgramFinish(void) { return 0; }
+
+#include "phoneflash_burn_impl.c"
+
+#else // unsupported f7 part
+
+void phoneFlashNoteHello(const uint8_t *payload, uint16_t len)
+{
+    (void)payload;
+    (void)len;
+}
+
+bool phoneFlashPending(void)
+{
+    return false;
+}
+
+void phoneFlashRun(void)
+{
+}
+
+#endif // supported f7 part
+
+#endif // USE_PHONE_CONFIG

--- a/src/platform/STM32/phoneflash_burn_h7xx.c
+++ b/src/platform/STM32/phoneflash_burn_h7xx.c
@@ -1,0 +1,285 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * phone-flash burn engine, stm32h7 wrapper: the register-level flash driver plus the mcu constants for
+ * the shared engine in phoneflash_burn_impl.c. same design as the f7 wrapper (the whole receive-and-
+ * program path runs from a copy in .ram_flash, interrupts masked, polled usb, no flash/hal/libc
+ * mid-burn); the h7 differences are the dual-bank flash controller (per-bank registers, 128k sectors)
+ * and the 256-bit program word, which forces staging bytes into a 32-byte row before each program.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "platform.h"
+
+#ifdef USE_PHONE_CONFIG
+
+#include "drivers/persistent.h"
+
+#include "io/phoneflash.h"
+
+// h7 parts whose flash geometry and usb instance are known here. others get inert stubs.
+#if defined(STM32H743xx)
+
+// burn code must never become a memcpy/memset call back into flash, hence no-tree-loop-distribute-patterns
+#define RF __attribute__((section(".ram_flash"), noinline, used, \
+                          optimize("no-tree-loop-distribute-patterns")))
+
+// must never exist out-of-line in flash, the burn path calls them mid-erase
+#define RFI static inline __attribute__((always_inline))
+
+#define PF_REPLY   PHONE_FLASH_REPLY_BIT
+
+#define OUR_IP     0xC0A80701U     // 192.168.7.1
+#define OUR_MAC_5  0x02U           // fc mac low byte, differs from the host's ..:01
+#define PF_OUT_EPNUM   1U
+#define RF_HZ           480000000U     // h743 core clock
+#define RF_IDLE_TIMEOUT (RF_HZ * 8U)   // host-idle reboot timeout, below the u32 cyccnt wrap at ~8.9s
+
+#define PF_FLASH_SIZE  (2048U * 1024U)
+#define PF_CHIP_ID     0x0743U
+
+// config sector bounds (__config_start/__config_end, declared in common_post.h) come from the
+// linker script. bank 1 sector 1.
+
+// FLASH_KEY1 / FLASH_KEY2 come from the hal flash header
+#define PF_SR_ERRMASK (FLASH_SR_WRPERR | FLASH_SR_PGSERR | FLASH_SR_STRBERR | FLASH_SR_INCERR | \
+                       FLASH_SR_OPERR | FLASH_SR_RDPERR | FLASH_SR_RDSERR | FLASH_SR_SNECCERR | \
+                       FLASH_SR_DBECCERR)
+#define PF_SR_CLEAR   (PF_SR_ERRMASK | FLASH_SR_EOP)   // ccr bits mirror the sr layout
+
+// vcp runs on usb2 otg-fs (pa11/pa12) on the h743
+#define OTG          ((USB_OTG_GlobalTypeDef *)USB2_OTG_FS_PERIPH_BASE)
+#define OTG_INEP(i)  ((USB_OTG_INEndpointTypeDef *)(USB2_OTG_FS_PERIPH_BASE + USB_OTG_IN_ENDPOINT_BASE + (i) * USB_OTG_EP_REG_SIZE))
+#define OTG_OUTEP(i) ((USB_OTG_OUTEndpointTypeDef *)(USB2_OTG_FS_PERIPH_BASE + USB_OTG_OUT_ENDPOINT_BASE + (i) * USB_OTG_EP_REG_SIZE))
+#define OTG_FIFO(i)  (*(volatile uint32_t *)(USB2_OTG_FS_PERIPH_BASE + USB_OTG_FIFO_BASE + (i) * USB_OTG_FIFO_SIZE))
+
+static uint8_t rxNtb[NCM_BURN_NTB];
+static uint8_t txNtb[NCM_BURN_NTB];
+static uint8_t txFrame[1536];
+static uint8_t replyBuf[64];
+
+// 256-bit program word staging
+static uint8_t  rowBuf[32];
+static uint32_t rowAddr;
+static uint32_t rowFill;
+
+extern uint32_t _siram_flash[];
+extern uint32_t _sram_flash[];
+extern uint32_t _eram_flash[];
+
+#include "phoneflash_burn.h"
+
+// keep the watchdog fed through a multi-second erase, where nothing else runs
+static RF void rfKickWdg(void)
+{
+    IWDG1->KR = 0x0000AAAAU;
+}
+
+// per-bank flash registers, sectors 0-7 bank 1, 8-15 bank 2
+RFI volatile uint32_t *rfCrReg(uint32_t sec)  { return (sec >= 8U) ? &FLASH->CR2 : &FLASH->CR1; }
+RFI volatile uint32_t *rfSrReg(uint32_t sec)  { return (sec >= 8U) ? &FLASH->SR2 : &FLASH->SR1; }
+RFI volatile uint32_t *rfCcrReg(uint32_t sec) { return (sec >= 8U) ? &FLASH->CCR2 : &FLASH->CCR1; }
+
+// ---- flash driver (register level, no hal) ----
+
+static RF void rfWaitIdle(uint32_t sec)
+{
+    uint32_t start = DWT->CYCCNT;
+    while (*rfSrReg(sec) & (FLASH_SR_BSY | FLASH_SR_QW)) {
+        rfKickWdg();
+        if ((uint32_t)(DWT->CYCCNT - start) > RF_HZ * 8U) {
+            rfReboot();
+        }
+    }
+}
+
+static RF uint32_t rfSectorOf(uint32_t addr)
+{
+    uint32_t off = addr - PHONE_FLASH_FC_BASE;
+    if (off >= PF_FLASH_SIZE) {
+        return 0xFF;
+    }
+    return off >> 17;   // 128k sectors. sector 1 holds the config, never erased
+}
+
+static RF void rfFlashUnlock(void)
+{
+    if (FLASH->CR1 & FLASH_CR_LOCK) {
+        FLASH->KEYR1 = FLASH_KEY1;
+        FLASH->KEYR1 = FLASH_KEY2;
+    }
+    if (FLASH->CR2 & FLASH_CR_LOCK) {
+        FLASH->KEYR2 = FLASH_KEY1;
+        FLASH->KEYR2 = FLASH_KEY2;
+    }
+}
+
+static RF void rfFlashLock(void)
+{
+    FLASH->CR1 |= FLASH_CR_LOCK;
+    FLASH->CR2 |= FLASH_CR_LOCK;
+}
+
+static RF uint32_t rfEraseSector(uint32_t sector)
+{
+    volatile uint32_t *cr = rfCrReg(sector);
+    rfWaitIdle(sector);
+    *rfCcrReg(sector) = PF_SR_CLEAR;
+    *cr &= ~(FLASH_CR_PSIZE | FLASH_CR_SNB);
+    *cr |= FLASH_CR_SER | (2U << FLASH_CR_PSIZE_Pos)                     // x32 program/erase, needs 2.7v+
+           | ((sector & 7U) << FLASH_CR_SNB_Pos) | FLASH_CR_START;
+    rfWaitIdle(sector);
+    *cr &= ~(FLASH_CR_SER | FLASH_CR_SNB);
+    return (*rfSrReg(sector) & PF_SR_ERRMASK) ? 1U : 0U;
+}
+
+// program one 32-byte flash word. the h7 write buffer fills from 8 consecutive word stores and
+// programs automatically on the 8th
+static RF uint32_t rfProgramRow(uint32_t addr, const uint8_t *data)
+{
+    uint32_t sec = rfSectorOf(addr);
+    volatile uint32_t *cr = rfCrReg(sec);
+    rfWaitIdle(sec);
+    *rfCcrReg(sec) = PF_SR_CLEAR;
+    *cr &= ~FLASH_CR_PSIZE;
+    *cr |= (2U << FLASH_CR_PSIZE_Pos);
+    *cr |= FLASH_CR_PG;
+    __ISB();
+    __DSB();
+    volatile uint32_t *dst = (volatile uint32_t *)addr;
+    for (uint32_t i = 0; i < 8U; i++) {
+        dst[i] = rd32(data + 4U * i);
+    }
+    __ISB();
+    __DSB();
+    rfWaitIdle(sec);
+    *cr &= ~FLASH_CR_PG;
+    return (*rfSrReg(sec) & PF_SR_ERRMASK) ? 1U : 0U;
+}
+
+// program the staged row, erasing its sector on first touch and verifying by readback. only the
+// first `valid` bytes came from the host: they feed the running crc, the 0xff pad just gets verified
+static RF uint32_t rfFlushRow(uint32_t valid)
+{
+    uint32_t sec = rfSectorOf(rowAddr);
+    if (sec == 1U || sec == 0xFFU) {
+        return 1;
+    }
+    for (uint32_t i = valid; i < 32U; i++) {
+        rowBuf[i] = 0xFF;
+    }
+    if (!(erasedMask & (1U << sec))) {
+        if (rfEraseSector(sec)) {
+            return 1;
+        }
+        erasedMask |= (1U << sec);
+    }
+    if (rfProgramRow(rowAddr, rowBuf)) {
+        return 1;
+    }
+    for (uint32_t i = 0; i < 32U; i++) {
+        uint8_t rb = *(volatile uint8_t *)(rowAddr + i);
+        if (rb != rowBuf[i]) {
+            return 1;
+        }
+        if (i < valid) {
+            rfCrc32Byte(rb);
+        }
+    }
+    rowAddr += 32U;
+    rowFill = 0;
+    return 0;
+}
+
+// stage word-aligned len at addr into 32-byte rows. addr is sequential except for the config-region
+// jump (validated by the protocol layer), which must land on a fresh row: any partially staged row is
+// finished 0xff-padded first. returns non-zero on failure.
+static RF uint32_t rfProgram(uint32_t addr, const uint8_t *data, uint32_t len)
+{
+    for (uint32_t i = 0; i < len; i += 4) {
+        uint32_t sec = rfSectorOf(addr + i);
+        if (sec == 1U || sec == 0xFFU) {
+            return 1;                                  // never touch config or run off the end
+        }
+    }
+    if (rowFill != 0 && addr != rowAddr + rowFill) {
+        if (addr < rowAddr + 32U) {
+            return 1;                                  // a row can only be programmed once
+        }
+        if (rfFlushRow(rowFill)) {
+            return 1;
+        }
+    }
+    if (rowFill == 0) {
+        if (addr & 31U) {
+            return 1;
+        }
+        rowAddr = addr;
+    }
+    for (uint32_t i = 0; i < len; i++) {
+        rowBuf[rowFill++] = data[i];
+        if (rowFill == 32U) {
+            if (rfFlushRow(32U)) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+static RF void rfProgramBegin(void)
+{
+    rowFill = 0;
+}
+
+// flush the final partial row, 0xff padded, at the end of the image
+static RF uint32_t rfProgramFinish(void)
+{
+    if (rowFill != 0) {
+        return rfFlushRow(rowFill);
+    }
+    return 0;
+}
+
+#include "phoneflash_burn_impl.c"
+
+#else // unsupported h7 part
+
+void phoneFlashNoteHello(const uint8_t *payload, uint16_t len)
+{
+    (void)payload;
+    (void)len;
+}
+
+bool phoneFlashPending(void)
+{
+    return false;
+}
+
+void phoneFlashRun(void)
+{
+}
+
+#endif // supported h7 part
+
+#endif // USE_PHONE_CONFIG

--- a/src/platform/STM32/phoneflash_burn_impl.c
+++ b/src/platform/STM32/phoneflash_burn_impl.c
@@ -1,0 +1,517 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * phone-flash burn engine, mcu-independent core: a polled otg bulk endpoint, single-datagram ncm
+ * framing, a tiny arp/ip/udp stack and the flash protocol state machine. included by each per-mcu
+ * wrapper (phoneflash_burn_<mcu>.c) after it has defined the RF/RFI macros, the otg register accessors,
+ * the burn buffers (rxNtb/txNtb/txFrame/replyBuf), rfKickWdg, the flash ops (rfFlashUnlock/rfFlashLock/
+ * rfProgram/rfProgramBegin/rfProgramFinish) and the RF_HZ / RF_IDLE_TIMEOUT / PF_FLASH_SIZE / PF_CHIP_ID
+ * and mac/ip/endpoint constants. shared state and byte helpers come from phoneflash_burn.h. not a
+ * standalone translation unit.
+ */
+
+// ---- polled otg bulk endpoint ----
+
+static RF void rfArmOut(void)
+{
+    OTG_OUTEP(PF_OUT_EPNUM)->DOEPTSIZ = (32U << 19) | (2048U & 0x7FFFFU);   // 32 packets of 64
+    OTG_OUTEP(PF_OUT_EPNUM)->DOEPCTL |= USB_OTG_DOEPCTL_EPENA | USB_OTG_DOEPCTL_CNAK;
+}
+
+// take the endpoints back from the hal: flush the fifos left mid-transfer and re-arm out
+static RF void rfUsbTakeover(void)
+{
+    uint32_t start = DWT->CYCCNT;
+    OTG->GRSTCTL = USB_OTG_GRSTCTL_RXFFLSH;
+    while (OTG->GRSTCTL & USB_OTG_GRSTCTL_RXFFLSH) {
+        rfKickWdg();
+        if ((uint32_t)(DWT->CYCCNT - start) > RF_HZ) {
+            rfReboot();                                                     // nothing erased yet, firmware intact
+        }
+    }
+    start = DWT->CYCCNT;
+    OTG->GRSTCTL = (0x10U << 6) | USB_OTG_GRSTCTL_TXFFLSH;                  // txfnum 0x10 = all fifos
+    while (OTG->GRSTCTL & USB_OTG_GRSTCTL_TXFFLSH) {
+        rfKickWdg();
+        if ((uint32_t)(DWT->CYCCNT - start) > RF_HZ) {
+            rfReboot();
+        }
+    }
+    rfArmOut();
+}
+
+// pull one ncm block (ended by a short or zero-length packet) into rxNtb, or -1 on timeout
+static RF int rfUsbPoll(uint32_t timeoutCycles)
+{
+    uint32_t start = DWT->CYCCNT;
+    uint32_t rxLen = 0;
+    for (;;) {
+        rfKickWdg();
+        if (!(OTG->GINTSTS & USB_OTG_GINTSTS_RXFLVL)) {
+            if ((uint32_t)(DWT->CYCCNT - start) > timeoutCycles) {
+                return -1;
+            }
+            continue;
+        }
+        uint32_t sts = OTG->GRXSTSP;
+        uint32_t ep = sts & USB_OTG_GRXSTSP_EPNUM;
+        uint32_t bcnt = (sts & USB_OTG_GRXSTSP_BCNT) >> 4;
+        uint32_t pktsts = (sts & USB_OTG_GRXSTSP_PKTSTS) >> 17;
+        if (pktsts == 2 && ep == PF_OUT_EPNUM) {                           // out data packet
+            uint32_t i = 0;
+            for (; i + 4 <= bcnt; i += 4) {
+                uint32_t w = OTG_FIFO(0);
+                if (rxLen + 4 <= sizeof(rxNtb)) {
+                    rxNtb[rxLen] = w; rxNtb[rxLen + 1] = w >> 8; rxNtb[rxLen + 2] = w >> 16; rxNtb[rxLen + 3] = w >> 24;
+                    rxLen += 4;
+                }
+            }
+            if (i < bcnt) {
+                uint32_t w = OTG_FIFO(0);
+                for (uint32_t k = 0; i + k < bcnt; k++) {
+                    if (rxLen < sizeof(rxNtb)) {
+                        rxNtb[rxLen++] = w >> (8 * k);
+                    }
+                }
+            }
+            if (bcnt < 64) {                                               // short packet ends the block
+                rfArmOut();
+                return (int)rxLen;
+            }
+        } else if (pktsts == 3 && ep == PF_OUT_EPNUM) {                    // out transfer complete
+            rfArmOut();
+        } else {
+            for (uint32_t i = 0; i + 4 <= bcnt; i += 4) {
+                (void)OTG_FIFO(0);
+            }
+            if (bcnt & 3) {
+                (void)OTG_FIFO(0);
+            }
+        }
+        if ((uint32_t)(DWT->CYCCNT - start) > timeoutCycles) {
+            return -1;
+        }
+    }
+}
+
+static RF void rfUsbSend(const uint8_t *buf, uint32_t len)
+{
+    uint32_t pkts = (len + 63) / 64;
+    if (pkts == 0) {
+        pkts = 1;
+    }
+    OTG_INEP(PF_OUT_EPNUM)->DIEPTSIZ = (pkts << 19) | (len & 0x7FFFFU);
+    OTG_INEP(PF_OUT_EPNUM)->DIEPCTL |= USB_OTG_DIEPCTL_EPENA | USB_OTG_DIEPCTL_CNAK;
+    uint32_t off = 0;
+    while (off < len) {
+        uint32_t chunk = len - off;
+        if (chunk > 64) {
+            chunk = 64;
+        }
+        uint32_t words = (chunk + 3) / 4;
+        uint32_t guard = 0;
+        while ((OTG_INEP(PF_OUT_EPNUM)->DTXFSTS & 0xFFFF) < words) {
+            rfKickWdg();
+            if (++guard > 4000000) {
+                return;                                                    // host stopped reading, give up
+            }
+        }
+        for (uint32_t i = 0; i < chunk; i += 4) {
+            uint32_t w = buf[off + i];
+            if (i + 1 < chunk) w |= (uint32_t)buf[off + i + 1] << 8;
+            if (i + 2 < chunk) w |= (uint32_t)buf[off + i + 2] << 16;
+            if (i + 3 < chunk) w |= (uint32_t)buf[off + i + 3] << 24;
+            OTG_FIFO(PF_OUT_EPNUM) = w;
+        }
+        off += chunk;
+    }
+}
+
+// ---- ncm framing (single datagram per block) ----
+
+static RF int rfNcmFrame(uint32_t ntbLen, uint8_t **frame, uint32_t *frameLen)
+{
+    if (ntbLen < 12 || rd32(rxNtb) != 0x484D434EU) {                       // "NCMH"
+        return 1;
+    }
+    uint32_t ndpIndex = rd16(rxNtb + 10);
+    if (ndpIndex + 12 > ntbLen) {
+        return 1;
+    }
+    uint8_t *ndp = rxNtb + ndpIndex;
+    uint32_t sig = rd32(ndp);
+    if (sig != 0x304D434EU && sig != 0x314D434EU) {                        // "NCM0" / "NCM1"
+        return 1;
+    }
+    uint32_t dgIndex = rd16(ndp + 8);
+    uint32_t dgLen = rd16(ndp + 10);
+    if (dgLen == 0 || dgIndex + dgLen > ntbLen) {
+        return 1;
+    }
+    *frame = rxNtb + dgIndex;
+    *frameLen = dgLen;
+    return 0;
+}
+
+static RF uint32_t rfNcmWrap(const uint8_t *frame, uint32_t frameLen)
+{
+    wr32(txNtb + 0, 0x484D434EU);
+    wr16(txNtb + 4, 12);
+    wr16(txNtb + 6, txSeq++);
+    uint32_t o = 12;
+    rfMemcpy(txNtb + o, frame, frameLen);
+    o += frameLen;
+    while (o & 3) {
+        txNtb[o++] = 0;
+    }
+    uint32_t ndp = o;
+    wr32(txNtb + ndp + 0, 0x304D434EU);
+    wr16(txNtb + ndp + 4, 16);
+    wr16(txNtb + ndp + 6, 0);
+    wr16(txNtb + ndp + 8, 12);
+    wr16(txNtb + ndp + 10, frameLen);
+    wr16(txNtb + ndp + 12, 0);
+    wr16(txNtb + ndp + 14, 0);
+    o = ndp + 16;
+    wr16(txNtb + 8, o);
+    wr16(txNtb + 10, ndp);
+    return o;
+}
+
+// ---- eth / arp / ip / udp ----
+
+static RF uint16_t rfIpCksum(const uint8_t *h, uint32_t n)
+{
+    uint32_t s = 0;
+    for (uint32_t i = 0; i + 1 < n; i += 2) {
+        s += (uint32_t)(h[i] << 8 | h[i + 1]);
+    }
+    if (n & 1) {
+        s += (uint32_t)h[n - 1] << 8;
+    }
+    while (s >> 16) {
+        s = (s & 0xFFFF) + (s >> 16);
+    }
+    return (uint16_t)~s;
+}
+
+static RF void rfPutOurMac(uint8_t *p)
+{
+    p[0] = 0x02; p[1] = 0x00; p[2] = 0x00; p[3] = 0x00; p[4] = 0x00; p[5] = OUR_MAC_5;
+}
+
+static RF void rfHandleArp(const uint8_t *fr, uint32_t frLen)
+{
+    if (frLen < 42) {
+        return;
+    }
+    const uint8_t *a = fr + 14;
+    uint16_t op = (uint16_t)(a[6] << 8 | a[7]);
+    uint32_t tpa = rd32be(a + 24);
+    if (op != 1 || tpa != OUR_IP) {
+        return;
+    }
+    uint8_t *o = txFrame;
+    for (int i = 0; i < 6; i++) o[i] = fr[6 + i];
+    rfPutOurMac(o + 6);
+    o[12] = 0x08; o[13] = 0x06;
+    o[14] = 0x00; o[15] = 0x01; o[16] = 0x08; o[17] = 0x00; o[18] = 6; o[19] = 4; o[20] = 0x00; o[21] = 0x02;
+    rfPutOurMac(o + 22);
+    wr32be(o + 28, OUR_IP);
+    for (int i = 0; i < 6; i++) o[32 + i] = a[8 + i];   // arp target hw/ip = the requester (sha at a+8, spa at a+14)
+    for (int i = 0; i < 4; i++) o[38 + i] = a[14 + i];
+    uint32_t ntbLen = rfNcmWrap(o, 42);
+    rfUsbSend(txNtb, ntbLen);
+}
+
+static RF void rfSendUdp(const uint8_t *pay, uint32_t payLen)
+{
+    uint8_t *o = txFrame;
+    for (int i = 0; i < 6; i++) o[i] = hostMac[i];
+    rfPutOurMac(o + 6);
+    o[12] = 0x08; o[13] = 0x00;
+    uint8_t *ip = o + 14;
+    uint32_t ipLen = 20 + 8 + payLen;
+    ip[0] = 0x45; ip[1] = 0x00; wr16be(ip + 2, (uint16_t)ipLen); wr16be(ip + 4, 0);
+    ip[6] = 0x40; ip[7] = 0x00; ip[8] = 64; ip[9] = 17; wr16be(ip + 10, 0);
+    wr32be(ip + 12, OUR_IP); wr32be(ip + 16, hostIp);
+    wr16be(ip + 10, rfIpCksum(ip, 20));
+    uint8_t *udp = ip + 20;
+    wr16be(udp + 0, PHONE_FLASH_UDP_PORT); wr16be(udp + 2, hostPort);
+    wr16be(udp + 4, (uint16_t)(8 + payLen)); wr16be(udp + 6, 0);          // udp checksum optional in ipv4
+    rfMemcpy(udp + 8, pay, payLen);
+    uint32_t ntbLen = rfNcmWrap(o, 14 + ipLen);
+    rfUsbSend(txNtb, ntbLen);
+}
+
+// ---- protocol ----
+
+static RF uint32_t rfAck(uint8_t op)
+{
+    wr32(replyBuf, PHONE_FLASH_MAGIC);
+    replyBuf[4] = op | PF_REPLY;
+    replyBuf[5] = PF_ERR_NONE;
+    return 6;
+}
+
+static RF uint32_t rfErr(uint8_t op, uint8_t code)
+{
+    wr32(replyBuf, PHONE_FLASH_MAGIC);
+    replyBuf[4] = op | PF_REPLY;
+    replyBuf[5] = code;
+    return 6;
+}
+
+// if/else, not switch, to keep gcc from emitting a jump table in flash rodata
+static RF uint32_t rfProto(const uint8_t *p, uint32_t n)
+{
+    if (n < 5 || rd32(p) != PHONE_FLASH_MAGIC) {
+        return 0;
+    }
+    uint8_t op = p[4];
+
+    if (op == PF_HELLO) {
+        wr32(replyBuf, PHONE_FLASH_MAGIC);
+        replyBuf[4] = PF_HELLO | PF_REPLY;
+        replyBuf[5] = PF_ERR_NONE;
+        wr32(replyBuf + 6, (uint32_t)(uintptr_t)&__config_start);
+        wr32(replyBuf + 10, (uint32_t)(uintptr_t)&__config_end);
+        wr32(replyBuf + 14, PF_FLASH_SIZE);
+        wr16(replyBuf + 18, PHONE_FLASH_CHUNK);
+        wr16(replyBuf + 20, PF_CHIP_ID);
+        if (state == ST_WAIT_HELLO) {
+            state = ST_READY;                          // a late duplicate must not regress an active session
+        }
+        return 22;
+    }
+    if (op == PF_BEGIN) {
+        if (state == ST_WAIT_HELLO) {                  // a hello must establish the session first
+            return rfErr(op, PF_ERR_STATE);
+        }
+        if (n < 13) return rfErr(op, PF_ERR_BADOP);
+        totalSize = rd32(p + 5);
+        imageCrc = rd32(p + 9);
+        if (totalSize == 0 || totalSize > PF_FLASH_SIZE) return rfErr(op, PF_ERR_RANGE);
+        // begin (re)starts the session from scratch, so a failed end (or any mid-flash fault) is simply
+        // retried by sending begin again rather than being unrecoverable short of dfu
+        writtenUpTo = 0;
+        programmedBytes = 0;
+        crcState = 0xFFFFFFFFU;
+        erasedMask = 0;
+        rfProgramBegin();
+        rfFlashUnlock();
+        state = ST_FLASHING;
+        return rfAck(op);
+    }
+    if (op == PF_WRITE) {
+        if (state != ST_FLASHING) return rfErr(op, PF_ERR_STATE);
+        if (n < 11) return rfErr(op, PF_ERR_BADOP);
+        uint32_t off = rd32(p + 5);
+        uint32_t len = rd16(p + 9);
+        if (n < 11 + len) return rfErr(op, PF_ERR_BADOP);
+        if ((off & 3) || (len & 3)) return rfErr(op, PF_ERR_ALIGN);
+        if (off + len > PF_FLASH_SIZE) return rfErr(op, PF_ERR_RANGE);
+        if (off > writtenUpTo) {
+            // the host streams strictly in order, so the only legitimate forward jump is over the
+            // preserved config region. any other gap means a write was lost and programming past it
+            // would silently leave that hole erased, surfacing only as a crc failure at the end.
+            const uint32_t cfgLo = (uint32_t)(uintptr_t)&__config_start - PHONE_FLASH_FC_BASE;
+            const uint32_t cfgHi = (uint32_t)(uintptr_t)&__config_end - PHONE_FLASH_FC_BASE;
+            if (!(writtenUpTo < cfgHi && off > cfgLo)) {
+                return rfErr(op, PF_ERR_SEQ);
+            }
+        }
+        if (off >= writtenUpTo) {                       // new data, sequential or the config-region jump
+            if (rfProgram(PHONE_FLASH_FC_BASE + off, p + 11, len)) return rfErr(op, PF_ERR_FLASH);
+            writtenUpTo = off + len;
+            programmedBytes += len;
+        }
+        // off < writtenUpTo is a lost-ack retransmit of already-programmed data, just re-ack
+        wr32(replyBuf, PHONE_FLASH_MAGIC);
+        replyBuf[4] = PF_WRITE | PF_REPLY;
+        replyBuf[5] = PF_ERR_NONE;
+        wr32(replyBuf + 6, writtenUpTo);
+        return 10;
+    }
+    if (op == PF_END) {
+        if (state != ST_FLASHING) return rfErr(op, PF_ERR_STATE);
+        if (rfProgramFinish()) {                        // flush any staged partial row (h7)
+            return rfErr(op, PF_ERR_FLASH);
+        }
+        uint32_t crc = crcState ^ 0xFFFFFFFFU;
+        const uint32_t ok = (crc == imageCrc) && (programmedBytes == totalSize);
+        wr32(replyBuf, PHONE_FLASH_MAGIC);
+        replyBuf[4] = PF_END | PF_REPLY;
+        replyBuf[5] = ok ? PF_ERR_NONE : PF_ERR_CRC;
+        wr32(replyBuf + 6, crc);
+        if (ok) {
+            rfFlashLock();
+            state = ST_DONE;
+        }
+        return 10;
+    }
+    if (op == PF_REBOOT) {
+        if (state == ST_DONE) {
+            rebootReq = 1;
+            return rfAck(op);
+        }
+        return rfErr(op, PF_ERR_STATE);
+    }
+    if (op == PF_ABORT) {
+        if (state < ST_FLASHING) {
+            abortReq = 1;
+            return rfAck(op);
+        }
+        return rfErr(op, PF_ERR_STATE);
+    }
+    return rfErr(op, PF_ERR_BADOP);
+}
+
+static RF void rfHandleFrame(uint8_t *fr, uint32_t frLen)
+{
+    if (frLen < 14) {
+        return;
+    }
+    uint16_t ethType = (uint16_t)(fr[12] << 8 | fr[13]);
+    if (ethType == 0x0806) {
+        rfHandleArp(fr, frLen);
+        return;
+    }
+    if (ethType != 0x0800 || frLen < 34) {
+        return;
+    }
+    uint8_t *ip = fr + 14;
+    if ((ip[0] >> 4) != 4) {
+        return;
+    }
+    uint32_t ihl = (uint32_t)(ip[0] & 0x0F) * 4;
+    if (ihl < 20 || 14 + ihl + 8 > frLen) {
+        return;
+    }
+    if (ip[9] != 17 || rd32be(ip + 16) != OUR_IP) {
+        return;
+    }
+    uint8_t *udp = ip + ihl;
+    if (((udp[2] << 8) | udp[3]) != PHONE_FLASH_UDP_PORT) {
+        return;
+    }
+    uint32_t udpLen = (uint32_t)(udp[4] << 8 | udp[5]);
+    if (udpLen < 8 || (uint32_t)(udp - fr) + udpLen > frLen) {
+        return;
+    }
+    for (int i = 0; i < 6; i++) {
+        hostMac[i] = fr[6 + i];
+    }
+    hostIp = rd32be(ip + 12);
+    hostPort = (uint16_t)(udp[0] << 8 | udp[1]);
+    uint32_t rl = rfProto(udp + 8, udpLen - 8);
+    if (rl) {
+        rfSendUdp(replyBuf, rl);
+    }
+}
+
+// ram entry, interrupts masked. runs until the burn reboots, or returns if the host never engages.
+static RF void rfMain(void)
+{
+    state = ST_WAIT_HELLO;
+    txSeq = 0;
+    rebootReq = 0;
+    abortReq = 0;
+    writtenUpTo = 0;
+    programmedBytes = 0;
+    erasedMask = 0;
+    rfProgramBegin();
+
+    rfUsbTakeover();
+
+    uint32_t lastRx = DWT->CYCCNT;
+    for (;;) {
+        int len = rfUsbPoll(RF_HZ / 10);
+        if (len > 0) {
+            lastRx = DWT->CYCCNT;
+            uint8_t *frame;
+            uint32_t frameLen;
+            if (rfNcmFrame((uint32_t)len, &frame, &frameLen) == 0) {
+                rfHandleFrame(frame, frameLen);
+            }
+            if (rebootReq) {
+                rfReboot();
+            }
+            if (abortReq) {
+                return;
+            }
+        }
+        if ((uint32_t)(DWT->CYCCNT - lastRx) > RF_IDLE_TIMEOUT) {
+            if (state < ST_FLASHING) {
+                return;                                // nothing erased yet, fall back to the intact firmware
+            }
+            rfReboot();                                // stalled mid-flash, reboot (dfu recovers a bad image)
+        }
+    }
+}
+
+// ---- flash-resident glue (runs before the takeover, while flash is still live) ----
+
+static volatile bool flashPending;
+
+void phoneFlashNoteHello(const uint8_t *payload, uint16_t len)
+{
+    if (len >= 5 && rd32(payload) == PHONE_FLASH_MAGIC && payload[4] == PF_HELLO) {
+        flashPending = true;
+    }
+}
+
+bool phoneFlashPending(void)
+{
+    return flashPending;
+}
+
+// does not return on success (the engine reboots into the new firmware, or back to normal)
+void phoneFlashRun(void)
+{
+    // must be set here: after the takeover the flash-resident persistent code is gone. the rtc flag
+    // survives the reflash and brings the fc back up in phone-config so the host reconnects.
+    persistentObjectWrite(PERSISTENT_OBJECT_RESET_REASON, RESET_PHONECONFIG_REQUEST);
+
+    __disable_irq();
+
+    // verify reads must hit flash, not stale cache lines over reprogrammed sectors
+    SCB_DisableDCache();
+    SCB_DisableICache();
+
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+    DWT->CYCCNT = 0;
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+
+    for (uint32_t *s = _siram_flash, *d = _sram_flash; d < _eram_flash; ) {
+        *d++ = *s++;
+    }
+    __DSB();
+    __ISB();
+
+    rfMain();
+
+    // host never committed; reboot into the untouched firmware
+    __DSB();
+    SCB->AIRCR = (0x5FAUL << SCB_AIRCR_VECTKEY_Pos) | SCB_AIRCR_SYSRESETREQ_Msk;
+    for (;;) { }
+}

--- a/src/platform/STM32/serial_usb_vcp.c
+++ b/src/platform/STM32/serial_usb_vcp.c
@@ -290,4 +290,9 @@ uint8_t usbVcpIsConnected(void)
 {
     return usbIsConnected();
 }
+
+uint8_t usbVcpIsConfigured(void)
+{
+    return usbIsConfigured();
+}
 #endif

--- a/src/platform/STM32/vcp_hal/usbd_cdc_hid.c
+++ b/src/platform/STM32/vcp_hal/usbd_cdc_hid.c
@@ -266,6 +266,9 @@ USBD_ClassTypeDef  USBD_HID_CDC =
     USBD_HID_CDC_GetFSCfgDesc,
     NULL,
     USBD_HID_CDC_GetDeviceQualifierDescriptor,
+#if (USBD_SUPPORT_USER_STRING == 1U) || (USBD_SUPPORT_USER_STRING_DESC == 1U)
+    NULL,   /* GetUsrStrDescriptor */
+#endif
 };
 
 static uint8_t USBD_HID_CDC_Init(USBD_HandleTypeDef *pdev, uint8_t cfgidx)

--- a/src/platform/STM32/vcp_hal/usbd_cdc_ncm.c
+++ b/src/platform/STM32/vcp_hal/usbd_cdc_ncm.c
@@ -1,0 +1,634 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * minimal cdc-ncm device class for the st usb device library, used by phone-config mode. the
+ * descriptors are standards-compliant (iad, data interface alt0 empty / alt1 bulk, ncm functional
+ * descriptor, mac string) and the ntb framing follows ncm 1.0 (cross-checked against tinyusb's ncm.h).
+ * a single static instance is enough since only one usb device is ever active.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+// UNUSED comes from the hal (the h7 hal defines it unguarded, so common/utils.h must stay out),
+// MIN from common/maths.h via usbd_conf.h
+
+#include "usbd_core.h"
+#include "usbd_ctlreq.h"
+
+#include "usbd_cdc_ncm.h"
+
+// ncm class-specific request codes (ncm 1.0, table 6.2)
+#define NCM_SET_ETHERNET_PACKET_FILTER   0x43U
+#define NCM_GET_NTB_PARAMETERS           0x80U
+#define NCM_GET_NTB_INPUT_SIZE           0x85U
+#define NCM_SET_NTB_INPUT_SIZE           0x86U
+#define NCM_GET_NTB_FORMAT               0x83U
+#define NCM_SET_NTB_FORMAT               0x84U
+
+#define NTH16_SIGNATURE        0x484D434EU   // "NCMH"
+#define NDP16_SIGNATURE        0x304D434EU   // "NCM0" (datagram pointer table, no crc)
+#define NDP16_SIGNATURE_NCM1   0x314D434EU   // "NCM1" (with crc), also accepted on rx
+
+// ntb structures (ncm 1.0)
+typedef struct __attribute__((packed)) {
+    uint16_t wLength;
+    uint16_t bmNtbFormatsSupported;
+    uint32_t dwNtbInMaxSize;
+    uint16_t wNdbInDivisor;
+    uint16_t wNdbInPayloadRemainder;
+    uint16_t wNdbInAlignment;
+    uint16_t wReserved;
+    uint32_t dwNtbOutMaxSize;
+    uint16_t wNdbOutDivisor;
+    uint16_t wNdbOutPayloadRemainder;
+    uint16_t wNdbOutAlignment;
+    uint16_t wNtbOutMaxDatagrams;
+} ntb_parameters_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t dwSignature;
+    uint16_t wHeaderLength;
+    uint16_t wSequence;
+    uint16_t wBlockLength;
+    uint16_t wNdpIndex;
+} nth16_t;
+
+typedef struct __attribute__((packed)) {
+    uint16_t wDatagramIndex;
+    uint16_t wDatagramLength;
+} ndp16_datagram_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t dwSignature;
+    uint16_t wLength;
+    uint16_t wNextNdpIndex;
+} ndp16_t;
+
+static __ALIGN_BEGIN const ntb_parameters_t ntbParameters __ALIGN_END = {
+    .wLength                 = sizeof(ntb_parameters_t),
+    .bmNtbFormatsSupported   = 0x0001,        // 16-bit NTB only
+    .dwNtbInMaxSize          = NCM_NTB_IN_MAX_SIZE,
+    .wNdbInDivisor           = 1,
+    .wNdbInPayloadRemainder  = 0,
+    .wNdbInAlignment         = 4,
+    .wReserved               = 0,
+    .dwNtbOutMaxSize         = NCM_NTB_OUT_MAX_SIZE,
+    .wNdbOutDivisor          = 1,
+    .wNdbOutPayloadRemainder = 0,
+    .wNdbOutAlignment        = 4,
+    .wNtbOutMaxDatagrams     = NCM_OUT_MAX_DATAGRAMS,
+};
+
+// configuration descriptor (full speed)
+#define NCM_CONFIG_DESC_SIZE  94U
+
+static __ALIGN_BEGIN uint8_t ncmConfigDesc[NCM_CONFIG_DESC_SIZE] __ALIGN_END = {
+    // Configuration descriptor
+    0x09, USB_DESC_TYPE_CONFIGURATION, LOBYTE(NCM_CONFIG_DESC_SIZE), HIBYTE(NCM_CONFIG_DESC_SIZE),
+    0x02,                       // bNumInterfaces
+    0x01,                       // bConfigurationValue
+    0x00,                       // iConfiguration
+    0xC0,                       // bmAttributes: self powered
+    0x32,                       // bMaxPower: 100 mA
+
+    // Interface Association Descriptor (NCM function = control + data interface)
+    0x08, 0x0B, NCM_NOTIF_ITF, 0x02, 0x02, 0x0D, 0x00, 0x00,
+
+    // Communication (control) interface
+    0x09, USB_DESC_TYPE_INTERFACE, NCM_NOTIF_ITF, 0x00, 0x01, 0x02, 0x0D, 0x00, 0x00,
+    // CDC Header functional descriptor
+    0x05, 0x24, 0x00, 0x10, 0x01,
+    // CDC Union functional descriptor (master = control itf, slave = data itf)
+    0x05, 0x24, 0x06, NCM_NOTIF_ITF, NCM_DATA_ITF,
+    // CDC Ethernet Networking functional descriptor
+    0x0D, 0x24, 0x0F, NCM_MAC_STRING_INDEX, 0x00, 0x00, 0x00, 0x00,
+    LOBYTE(1514), HIBYTE(1514),  // wMaxSegmentSize = 1514
+    0x00, 0x00,                  // wNumberMCFilters
+    0x00,                        // bNumberPowerFilters
+    // CDC NCM functional descriptor
+    0x06, 0x24, 0x1A, 0x00, 0x01, 0x00,   // bcdNcmVersion 1.00, bmNetworkCapabilities 0
+
+    // Notification endpoint (interrupt IN)
+    0x07, USB_DESC_TYPE_ENDPOINT, NCM_NOTIF_EP, 0x03,
+    LOBYTE(NCM_NOTIF_PACKET_SIZE), HIBYTE(NCM_NOTIF_PACKET_SIZE), NCM_FS_BINTERVAL,
+
+    // Data interface, alternate setting 0 (no endpoints, network idle)
+    0x09, USB_DESC_TYPE_INTERFACE, NCM_DATA_ITF, 0x00, 0x00, 0x0A, 0x00, 0x01, 0x00,
+
+    // Data interface, alternate setting 1 (two bulk endpoints, network active)
+    0x09, USB_DESC_TYPE_INTERFACE, NCM_DATA_ITF, 0x01, 0x02, 0x0A, 0x00, 0x01, 0x00,
+    // Bulk OUT endpoint
+    0x07, USB_DESC_TYPE_ENDPOINT, NCM_OUT_EP, 0x02,
+    LOBYTE(NCM_DATA_FS_PACKET_SIZE), HIBYTE(NCM_DATA_FS_PACKET_SIZE), 0x00,
+    // Bulk IN endpoint
+    0x07, USB_DESC_TYPE_ENDPOINT, NCM_IN_EP, 0x02,
+    LOBYTE(NCM_DATA_FS_PACKET_SIZE), HIBYTE(NCM_DATA_FS_PACKET_SIZE), 0x00,
+};
+
+static __ALIGN_BEGIN uint8_t ncmDeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_DESC] __ALIGN_END = {
+    USB_LEN_DEV_QUALIFIER_DESC, USB_DESC_TYPE_DEVICE_QUALIFIER, 0x00, 0x02,
+    0x00, 0x00, 0x00, 0x40, 0x01, 0x00,
+};
+
+// class instance state
+typedef enum { NOTIFY_IDLE = 0, NOTIFY_SPEED, NOTIFY_CONNECTION, NOTIFY_DONE } ncmNotifyState_e;
+
+typedef struct {
+    uint8_t  dataAltSet;        // 0 = idle, 1 = active
+    uint8_t  linkUp;
+    ncmNotifyState_e notifyState;
+    uint8_t  notifyBusy;
+    uint8_t  cmdOpCode;         // pending EP0 OUT class request (0xFF = none)
+    uint16_t cmdLength;
+    uint8_t  txBusy;
+    uint16_t txSeq;
+    uint16_t txLastLen;              // length of the last bulk-in transfer, for zlp termination
+    volatile uint8_t  rxReady;       // an ntb arrived, set in irq and cleared in the main loop
+    volatile uint32_t rxLen;
+    volatile uint8_t  linkPending;   // deferred link-state change for the glue layer
+    volatile uint8_t  notifyPending; // deferred link-up notification (sent from the main loop)
+    USBD_CDC_NCM_ItfTypeDef *fops;
+    __ALIGN_BEGIN uint8_t ctrlBuf[64] __ALIGN_END;
+    __ALIGN_BEGIN uint8_t notifBuf[16] __ALIGN_END;
+    __ALIGN_BEGIN uint8_t rxNtb[NCM_NTB_OUT_MAX_SIZE] __ALIGN_END;
+    __ALIGN_BEGIN uint8_t txNtb[NCM_NTB_IN_MAX_SIZE] __ALIGN_END;
+} ncmHandle_t;
+
+static ncmHandle_t ncm;
+
+// forward declarations of the class callbacks
+static uint8_t ncmInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx);
+static uint8_t ncmDeInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx);
+static uint8_t ncmSetup(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req);
+static uint8_t ncmEP0RxReady(USBD_HandleTypeDef *pdev);
+static uint8_t ncmDataIn(USBD_HandleTypeDef *pdev, uint8_t epnum);
+static uint8_t ncmDataOut(USBD_HandleTypeDef *pdev, uint8_t epnum);
+static uint8_t *ncmGetCfgDesc(uint16_t *length);
+static uint8_t *ncmGetDeviceQualifierDesc(uint16_t *length);
+#if (USBD_SUPPORT_USER_STRING == 1U)
+static uint8_t *ncmGetUsrStrDesc(USBD_HandleTypeDef *pdev, uint8_t index, uint16_t *length);
+#endif
+
+USBD_ClassTypeDef USBD_CDC_NCM = {
+    ncmInit,
+    ncmDeInit,
+    ncmSetup,
+    NULL,               // EP0_TxSent
+    ncmEP0RxReady,
+    ncmDataIn,
+    ncmDataOut,
+    NULL,               // SOF
+    NULL,               // IsoINIncomplete
+    NULL,               // IsoOUTIncomplete
+    ncmGetCfgDesc,      // GetHSConfigDescriptor
+    ncmGetCfgDesc,      // GetFSConfigDescriptor
+    ncmGetCfgDesc,      // GetOtherSpeedConfigDescriptor
+    ncmGetDeviceQualifierDesc,
+#if (USBD_SUPPORT_USER_STRING == 1U)
+    ncmGetUsrStrDesc,
+#endif
+};
+
+// notification chain (speed change then network connection)
+static void ncmSendNextNotification(USBD_HandleTypeDef *pdev, bool forceNext)
+{
+    if (!forceNext && ncm.notifyBusy) {
+        return;
+    }
+
+    if (ncm.notifyState == NOTIFY_SPEED) {
+        // CONNECTION_SPEED_CHANGE: 8-byte header + 8-byte payload (down/up bit/s)
+        uint8_t *b = ncm.notifBuf;
+        b[0] = 0xA1; b[1] = NCM_NOTIFY_CONNECTION_SPEED;
+        b[2] = 0x00; b[3] = 0x00;                 // wValue
+        b[4] = NCM_NOTIF_ITF; b[5] = 0x00;        // wIndex
+        b[6] = 0x08; b[7] = 0x00;                 // wLength = 8
+        const uint32_t speed = 12000000U;         // 12 Mbit/s (full speed)
+        memcpy(&b[8], &speed, 4);
+        memcpy(&b[12], &speed, 4);
+        if (USBD_LL_Transmit(pdev, NCM_NOTIF_EP, ncm.notifBuf, 16) == USBD_OK) {
+            ncm.notifyState = NOTIFY_CONNECTION;
+            ncm.notifyBusy = 1;
+        } else {
+            ncm.notifyBusy = 0;   // failed submit means no completion irq, don't wedge the chain
+        }
+    } else if (ncm.notifyState == NOTIFY_CONNECTION) {
+        // NETWORK_CONNECTION: 8-byte header, wValue = link state
+        uint8_t *b = ncm.notifBuf;
+        b[0] = 0xA1; b[1] = NCM_NOTIFY_NETWORK_CONNECTION;
+        b[2] = ncm.linkUp ? 0x01 : 0x00; b[3] = 0x00;
+        b[4] = NCM_NOTIF_ITF; b[5] = 0x00;
+        b[6] = 0x00; b[7] = 0x00;
+        if (USBD_LL_Transmit(pdev, NCM_NOTIF_EP, ncm.notifBuf, 8) == USBD_OK) {
+            ncm.notifyState = NOTIFY_DONE;
+            ncm.notifyBusy = 1;
+        } else {
+            ncm.notifyBusy = 0;
+        }
+    } else {
+        ncm.notifyBusy = 0;
+    }
+}
+
+void USBD_CDC_NCM_SetLinkState(USBD_HandleTypeDef *pdev, uint8_t up)
+{
+    ncm.linkUp = up ? 1 : 0;
+    ncm.notifyState = NOTIFY_SPEED;
+    ncmSendNextNotification(pdev, false);
+    ncm.linkPending = 1;   // defer the lwip link-change to the main loop
+}
+
+// class callbacks
+static uint8_t ncmInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
+{
+    UNUSED(cfgidx);
+
+    USBD_LL_OpenEP(pdev, NCM_NOTIF_EP, USBD_EP_TYPE_INTR, NCM_NOTIF_PACKET_SIZE);
+    pdev->ep_in[NCM_NOTIF_EP & 0xFU].is_used = 1U;
+
+    ncm.dataAltSet = 0;
+    ncm.linkUp = 0;
+    ncm.notifyState = NOTIFY_IDLE;
+    ncm.notifyBusy = 0;
+    ncm.notifyPending = 0;
+    ncm.linkPending = 0;
+    ncm.txBusy = 0;
+    ncm.txSeq = 0;
+    ncm.txLastLen = 0;
+    ncm.rxReady = 0;
+    ncm.rxLen = 0;
+    ncm.cmdOpCode = 0xFF;
+    ncm.cmdLength = 0;
+
+    if (ncm.fops && ncm.fops->Init) {
+        ncm.fops->Init();
+    }
+    return USBD_OK;
+}
+
+static uint8_t ncmDeInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
+{
+    UNUSED(cfgidx);
+
+    USBD_LL_CloseEP(pdev, NCM_NOTIF_EP);
+    pdev->ep_in[NCM_NOTIF_EP & 0xFU].is_used = 0U;
+
+    if (ncm.dataAltSet) {
+        USBD_LL_CloseEP(pdev, NCM_IN_EP);
+        USBD_LL_CloseEP(pdev, NCM_OUT_EP);
+        pdev->ep_in[NCM_IN_EP & 0xFU].is_used = 0U;
+        pdev->ep_out[NCM_OUT_EP & 0xFU].is_used = 0U;
+        ncm.dataAltSet = 0;
+    }
+
+    if (ncm.fops && ncm.fops->DeInit) {
+        ncm.fops->DeInit();
+    }
+    return USBD_OK;
+}
+
+static void ncmSetDataInterface(USBD_HandleTypeDef *pdev, uint8_t alt)
+{
+    if (alt == ncm.dataAltSet) {
+        return;
+    }
+    if (alt == 1) {
+        USBD_LL_OpenEP(pdev, NCM_IN_EP, USBD_EP_TYPE_BULK, NCM_DATA_FS_PACKET_SIZE);
+        USBD_LL_OpenEP(pdev, NCM_OUT_EP, USBD_EP_TYPE_BULK, NCM_DATA_FS_PACKET_SIZE);
+        pdev->ep_in[NCM_IN_EP & 0xFU].is_used = 1U;
+        pdev->ep_out[NCM_OUT_EP & 0xFU].is_used = 1U;
+        USBD_LL_PrepareReceive(pdev, NCM_OUT_EP, ncm.rxNtb, NCM_NTB_OUT_MAX_SIZE);
+    } else {
+        USBD_LL_CloseEP(pdev, NCM_IN_EP);
+        USBD_LL_CloseEP(pdev, NCM_OUT_EP);
+        pdev->ep_in[NCM_IN_EP & 0xFU].is_used = 0U;
+        pdev->ep_out[NCM_OUT_EP & 0xFU].is_used = 0U;
+        ncm.txBusy = 0;
+        ncm.rxReady = 0;
+    }
+    ncm.dataAltSet = alt;
+
+    if (alt == 1) {
+        // defer the link-up notification to the main loop. sending it here, on the interrupt endpoint
+        // mid control-transfer in the usb irq, corrupts the st usb core and hard-faults.
+        if (!ncm.linkUp) {
+            ncm.notifyPending = 1;
+        }
+    } else {
+        ncm.notifyPending = 0;
+        if (ncm.linkUp) {
+            ncm.linkUp = 0;      // re-activation must re-notify
+            ncm.linkPending = 1; // tell the glue layer the link went down
+        }
+    }
+}
+
+static uint8_t ncmSetup(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req)
+{
+    USBD_StatusTypeDef ret = USBD_OK;
+    uint16_t len;
+
+    // control replies are served from ncm.ctrlBuf, not a stack local: USBD_CtlSendData only stores the
+    // pointer, the fifo copy is deferred to the TXFE irq, by which time a stack buffer is gone
+    switch (req->bmRequest & USB_REQ_TYPE_MASK) {
+    case USB_REQ_TYPE_CLASS:
+        switch (req->bRequest) {
+        case NCM_GET_NTB_PARAMETERS:
+            len = MIN(sizeof(ntbParameters), req->wLength);
+            USBD_CtlSendData(pdev, (uint8_t *)&ntbParameters, len);
+            break;
+
+        case NCM_GET_NTB_INPUT_SIZE:
+            ncm.ctrlBuf[0] = LOBYTE(NCM_NTB_IN_MAX_SIZE); ncm.ctrlBuf[1] = HIBYTE(NCM_NTB_IN_MAX_SIZE);
+            ncm.ctrlBuf[2] = 0; ncm.ctrlBuf[3] = 0;
+            USBD_CtlSendData(pdev, ncm.ctrlBuf, MIN(4, req->wLength));
+            break;
+
+        case NCM_GET_NTB_FORMAT:
+            ncm.ctrlBuf[0] = 0x00; ncm.ctrlBuf[1] = 0x00;   // 16-bit NTB
+            USBD_CtlSendData(pdev, ncm.ctrlBuf, MIN(2, req->wLength));
+            break;
+
+        case NCM_SET_NTB_INPUT_SIZE:
+        case NCM_SET_NTB_FORMAT:
+        case NCM_SET_ETHERNET_PACKET_FILTER:
+            if (req->wLength != 0 && (req->bmRequest & 0x80U) == 0) {
+                // data stage follows on EP0 OUT
+                ncm.cmdOpCode = (uint8_t)req->bRequest;
+                ncm.cmdLength = MIN(req->wLength, sizeof(ncm.ctrlBuf));
+                USBD_CtlPrepareRx(pdev, ncm.ctrlBuf, ncm.cmdLength);
+            } else {
+                if (req->bRequest == NCM_SET_ETHERNET_PACKET_FILTER && !ncm.linkUp) {
+                    ncm.notifyPending = 1;
+                }
+            }
+            break;
+
+        default:
+            USBD_CtlError(pdev, req);
+            ret = USBD_FAIL;
+            break;
+        }
+        break;
+
+    case USB_REQ_TYPE_STANDARD:
+        switch (req->bRequest) {
+        case USB_REQ_GET_STATUS:
+            if (pdev->dev_state == USBD_STATE_CONFIGURED) {
+                ncm.ctrlBuf[0] = 0; ncm.ctrlBuf[1] = 0;
+                USBD_CtlSendData(pdev, ncm.ctrlBuf, 2);
+            } else {
+                USBD_CtlError(pdev, req);
+                ret = USBD_FAIL;
+            }
+            break;
+
+        case USB_REQ_GET_INTERFACE:
+            if (pdev->dev_state == USBD_STATE_CONFIGURED) {
+                ncm.ctrlBuf[0] = (req->wIndex == NCM_DATA_ITF) ? ncm.dataAltSet : 0;
+                USBD_CtlSendData(pdev, ncm.ctrlBuf, 1);
+            } else {
+                USBD_CtlError(pdev, req);
+                ret = USBD_FAIL;
+            }
+            break;
+
+        case USB_REQ_SET_INTERFACE:
+            if (pdev->dev_state == USBD_STATE_CONFIGURED) {
+                if (req->wIndex == NCM_DATA_ITF) {
+                    if (req->wValue <= 1) {   // the data interface only has alternates 0 and 1
+                        ncmSetDataInterface(pdev, (uint8_t)req->wValue);
+                    } else {
+                        USBD_CtlError(pdev, req);
+                        ret = USBD_FAIL;
+                    }
+                }
+            } else {
+                USBD_CtlError(pdev, req);
+                ret = USBD_FAIL;
+            }
+            break;
+
+        case USB_REQ_CLEAR_FEATURE:
+            break;
+
+        default:
+            USBD_CtlError(pdev, req);
+            ret = USBD_FAIL;
+            break;
+        }
+        break;
+
+    default:
+        USBD_CtlError(pdev, req);
+        ret = USBD_FAIL;
+        break;
+    }
+
+    return (uint8_t)ret;
+}
+
+static uint8_t ncmEP0RxReady(USBD_HandleTypeDef *pdev)
+{
+    UNUSED(pdev);
+    if (ncm.cmdOpCode != 0xFF) {
+        // the only out class requests we take are the SET_NTB_* / packet-filter ones, just ack them
+        if (ncm.cmdOpCode == NCM_SET_ETHERNET_PACKET_FILTER && !ncm.linkUp) {
+            ncm.notifyPending = 1;
+        }
+        ncm.cmdOpCode = 0xFF;
+    }
+    return USBD_OK;
+}
+
+static uint8_t ncmDataIn(USBD_HandleTypeDef *pdev, uint8_t epnum)
+{
+    if (epnum == (NCM_NOTIF_EP & 0x7FU)) {
+        ncm.notifyBusy = 0;
+        ncmSendNextNotification(pdev, true);
+    } else if (epnum == (NCM_IN_EP & 0x7FU)) {
+        // a bulk-in transfer that is a non-zero multiple of the max packet size needs a terminating
+        // zlp or the host waits forever. the st usb layer doesn't auto-zlp, so issue it here.
+        if (ncm.txLastLen != 0 && (ncm.txLastLen % NCM_DATA_FS_PACKET_SIZE) == 0) {
+            ncm.txLastLen = 0;
+            if (USBD_LL_Transmit(pdev, NCM_IN_EP, NULL, 0) != USBD_OK) {   // length 0, NULL buffer is safe
+                ncm.txBusy = 0;
+            }
+        } else {
+            ncm.txLastLen = 0;
+            ncm.txBusy = 0;
+        }
+    }
+    return USBD_OK;
+}
+
+static uint8_t ncmDataOut(USBD_HandleTypeDef *pdev, uint8_t epnum)
+{
+    if (epnum == NCM_OUT_EP) {
+        // defer to the main loop, lwip (NO_SYS) must not be touched from the irq. the out endpoint is
+        // not re-armed until USBD_CDC_NCM_Process() consumes this ntb, so the host is flow-controlled.
+        ncm.rxLen = USBD_LL_GetRxDataSize(pdev, epnum);
+        ncm.rxReady = 1;
+    }
+    return USBD_OK;
+}
+
+// called from the main loop. delivers rx datagrams to the glue layer and runs deferred link changes
+void USBD_CDC_NCM_Process(USBD_HandleTypeDef *pdev)
+{
+    if (ncm.notifyPending) {
+        ncm.notifyPending = 0;
+        USBD_CDC_NCM_SetLinkState(pdev, 1);   // send link-up from the main loop, not the irq
+    }
+
+    if (ncm.linkPending) {
+        ncm.linkPending = 0;
+        if (ncm.fops && ncm.fops->LinkChange) {
+            ncm.fops->LinkChange(ncm.linkUp);
+        }
+    }
+
+    if (ncm.rxReady) {
+        const uint32_t rxLen = ncm.rxLen;
+        const nth16_t *nth = (const nth16_t *)ncm.rxNtb;
+        // validate the whole ntb before walking it so a malformed header can't read past rxNtb.
+        // all offsets are bounded by the declared block length, itself bounded by the transfer
+        const uint32_t minNtb = sizeof(nth16_t) + sizeof(ndp16_t) + 2U * sizeof(ndp16_datagram_t);
+        if (ncm.fops && ncm.fops->Receive &&
+            rxLen >= minNtb &&
+            nth->wHeaderLength == sizeof(nth16_t) &&
+            nth->dwSignature == NTH16_SIGNATURE &&
+            nth->wBlockLength >= minNtb &&
+            nth->wBlockLength <= rxLen &&
+            nth->wNdpIndex >= sizeof(nth16_t) &&
+            (uint32_t)nth->wNdpIndex + sizeof(ndp16_t) + 2U * sizeof(ndp16_datagram_t) <= nth->wBlockLength) {
+
+            const uint32_t blockLen = nth->wBlockLength;
+            const ndp16_t *ndp = (const ndp16_t *)(ncm.rxNtb + nth->wNdpIndex);
+            if ((ndp->dwSignature == NDP16_SIGNATURE || ndp->dwSignature == NDP16_SIGNATURE_NCM1) &&
+                ndp->wLength >= sizeof(ndp16_t) + 2U * sizeof(ndp16_datagram_t) &&
+                (uint32_t)nth->wNdpIndex + ndp->wLength <= blockLen) {
+                // walk only the datagram pointers the ndp declares, not everything up to rxLen
+                uint32_t entries = (uint32_t)(ndp->wLength - sizeof(ndp16_t)) / sizeof(ndp16_datagram_t);
+                if (entries > NCM_OUT_MAX_DATAGRAMS) {
+                    entries = NCM_OUT_MAX_DATAGRAMS;
+                }
+                const ndp16_datagram_t *dg = (const ndp16_datagram_t *)(ncm.rxNtb + nth->wNdpIndex + sizeof(ndp16_t));
+                for (uint32_t i = 0; i < entries && dg[i].wDatagramIndex != 0 && dg[i].wDatagramLength != 0; i++) {
+                    if ((uint32_t)dg[i].wDatagramIndex + dg[i].wDatagramLength <= blockLen) {
+                        ncm.fops->Receive(ncm.rxNtb + dg[i].wDatagramIndex, dg[i].wDatagramLength);
+                    }
+                }
+            }
+        }
+        ncm.rxReady = 0;
+        USBD_LL_PrepareReceive(pdev, NCM_OUT_EP, ncm.rxNtb, NCM_NTB_OUT_MAX_SIZE);
+    }
+}
+
+uint8_t USBD_CDC_NCM_TransmitFrame(USBD_HandleTypeDef *pdev, const uint8_t *frame, uint16_t length)
+{
+    if (ncm.txBusy || !ncm.dataAltSet) {
+        return USBD_BUSY;
+    }
+
+    // build a single-datagram ntb: nth16 | datagram | ndp16 | datagram pointers.
+    // size math in 32 bits, the offsets must not wrap before the bounds check
+    const uint32_t dgOffset = sizeof(nth16_t);
+    const uint32_t ndpOffset = (dgOffset + length + 3U) & ~3U;
+    const uint32_t total = ndpOffset + sizeof(ndp16_t) + 2U * sizeof(ndp16_datagram_t);
+    if (total > NCM_NTB_IN_MAX_SIZE) {
+        return USBD_FAIL;
+    }
+
+    memset(ncm.txNtb, 0, total);
+
+    nth16_t *nth = (nth16_t *)ncm.txNtb;
+    nth->dwSignature = NTH16_SIGNATURE;
+    nth->wHeaderLength = sizeof(nth16_t);
+    nth->wSequence = ncm.txSeq++;
+    nth->wBlockLength = (uint16_t)total;
+    nth->wNdpIndex = (uint16_t)ndpOffset;
+
+    memcpy(ncm.txNtb + dgOffset, frame, length);
+
+    ndp16_t *ndp = (ndp16_t *)(ncm.txNtb + ndpOffset);
+    ndp->dwSignature = NDP16_SIGNATURE;
+    ndp->wLength = sizeof(ndp16_t) + 2U * sizeof(ndp16_datagram_t);
+    ndp->wNextNdpIndex = 0;
+
+    ndp16_datagram_t *dg = (ndp16_datagram_t *)(ncm.txNtb + ndpOffset + sizeof(ndp16_t));
+    dg[0].wDatagramIndex = (uint16_t)dgOffset;
+    dg[0].wDatagramLength = length;
+    dg[1].wDatagramIndex = 0;
+    dg[1].wDatagramLength = 0;
+
+    ncm.txBusy = 1;
+    ncm.txLastLen = (uint16_t)total;
+    if (USBD_LL_Transmit(pdev, NCM_IN_EP, ncm.txNtb, (uint16_t)total) != USBD_OK) {
+        ncm.txBusy = 0;      // don't wedge the tx path on a failed submit
+        ncm.txLastLen = 0;
+        return USBD_FAIL;
+    }
+    return USBD_OK;
+}
+
+uint8_t USBD_CDC_NCM_IsTxBusy(void)
+{
+    return ncm.txBusy;
+}
+
+static uint8_t *ncmGetCfgDesc(uint16_t *length)
+{
+    *length = sizeof(ncmConfigDesc);
+    return ncmConfigDesc;
+}
+
+static uint8_t *ncmGetDeviceQualifierDesc(uint16_t *length)
+{
+    *length = sizeof(ncmDeviceQualifierDesc);
+    return ncmDeviceQualifierDesc;
+}
+
+#if (USBD_SUPPORT_USER_STRING == 1U)
+static uint8_t *ncmGetUsrStrDesc(USBD_HandleTypeDef *pdev, uint8_t index, uint16_t *length)
+{
+    UNUSED(pdev);
+    static __ALIGN_BEGIN uint8_t strDesc[64] __ALIGN_END;
+    if (index == NCM_MAC_STRING_INDEX && ncm.fops && ncm.fops->macStringDescriptor) {
+        USBD_GetString((uint8_t *)ncm.fops->macStringDescriptor, strDesc, length);
+        return strDesc;
+    }
+    return NULL;
+}
+#endif
+
+uint8_t USBD_CDC_NCM_RegisterInterface(USBD_HandleTypeDef *pdev, USBD_CDC_NCM_ItfTypeDef *fops)
+{
+    UNUSED(pdev);
+    if (fops == NULL) {
+        return USBD_FAIL;
+    }
+    ncm.fops = fops;
+    return USBD_OK;
+}

--- a/src/platform/STM32/vcp_hal/usbd_cdc_ncm.h
+++ b/src/platform/STM32/vcp_hal/usbd_cdc_ncm.h
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * minimal cdc-ncm (network control model) usb device class for the st usb device library, written for
+ * betaflight's phone-config mode so an iphone enumerates the fc as usb ethernet. ntb structures and
+ * parameter values come from the ncm 1.0 spec and tinyusb's ncm.h.
+ */
+
+#pragma once
+
+#include "usbd_ioreq.h"
+
+// endpoints, same numbering as the normal vcp (only one usb class is active at a time)
+#define NCM_IN_EP                    0x81U   // bulk in  (datagrams device to host)
+#define NCM_OUT_EP                   0x01U   // bulk out (datagrams host to device)
+#define NCM_NOTIF_EP                 0x82U   // interrupt in (notifications)
+
+#define NCM_NOTIF_ITF                0x00U   // communication (control) interface number
+#define NCM_DATA_ITF                 0x01U   // data interface number
+
+#define NCM_NOTIF_PACKET_SIZE        16U
+#define NCM_DATA_FS_PACKET_SIZE      64U
+#define NCM_FS_BINTERVAL             0x10U
+
+#define NCM_MAC_STRING_INDEX         6U
+
+// ntb sizing, kept small since this is a low-bandwidth cli link not a nic
+#define NCM_NTB_OUT_MAX_SIZE         2048U
+#define NCM_NTB_IN_MAX_SIZE          2048U
+#define NCM_OUT_MAX_DATAGRAMS        4U
+
+// cdc class-specific notification codes
+#define NCM_NOTIFY_NETWORK_CONNECTION   0x00U
+#define NCM_NOTIFY_CONNECTION_SPEED     0x2AU
+
+#define NCM_NET_DISCONNECTED            0x00U
+#define NCM_NET_CONNECTED               0x01U
+
+extern USBD_ClassTypeDef USBD_CDC_NCM;
+#define USBD_CDC_NCM_CLASS &USBD_CDC_NCM
+
+// interface callbacks supplied by the platform/glue layer (the network side, e.g. lwip)
+typedef struct {
+    int8_t (*Init)(void);
+    int8_t (*DeInit)(void);
+    int8_t (*Receive)(uint8_t *frame, uint32_t length);   // one ethernet datagram received from the host
+    void   (*LinkChange)(uint8_t up);
+    const uint8_t *macStringDescriptor;                   // 12 upper-case hex chars, e.g. "020000000001"
+} USBD_CDC_NCM_ItfTypeDef;
+
+uint8_t USBD_CDC_NCM_RegisterInterface(USBD_HandleTypeDef *pdev, USBD_CDC_NCM_ItfTypeDef *fops);
+
+// queue one ethernet datagram for transmission to the host (wrapped in an ntb). returns USBD_OK / USBD_BUSY.
+uint8_t USBD_CDC_NCM_TransmitFrame(USBD_HandleTypeDef *pdev, const uint8_t *frame, uint16_t length);
+
+// non-zero while a datagram (and its zlp) is still going out. lets the tx side send one frame at a time
+uint8_t USBD_CDC_NCM_IsTxBusy(void);
+
+// set the link state and (re)send the connection notifications
+void USBD_CDC_NCM_SetLinkState(USBD_HandleTypeDef *pdev, uint8_t up);
+
+// process deferred rx and link-change from the main loop (lwip must not be touched from the irq)
+void USBD_CDC_NCM_Process(USBD_HandleTypeDef *pdev);

--- a/src/platform/STM32/vcp_hal/usbd_conf.h
+++ b/src/platform/STM32/vcp_hal/usbd_conf.h
@@ -85,7 +85,14 @@
 #define USBD_MAX_NUM_INTERFACES               3
 #define USBD_MAX_NUM_CONFIGURATION            1
 #define USBD_MAX_STR_DESC_SIZ                 0x100
+#ifdef USE_PHONE_CONFIG
+/* cdc-ncm needs a mac-address user string (ios). the h7 usb device library spells the macro
+ * USBD_SUPPORT_USER_STRING_DESC, the f7 one USBD_SUPPORT_USER_STRING, so set both */
+#define USBD_SUPPORT_USER_STRING              1
+#define USBD_SUPPORT_USER_STRING_DESC         1
+#else
 #define USBD_SUPPORT_USER_STRING              0
+#endif
 #define USBD_SELF_POWERED                     1
 #define USBD_DEBUG_LEVEL                      0
 #define MSC_MEDIA_PACKET                      512U


### PR DESCRIPTION
iOS gives apps no access to USB CDC-ACM, so the configurator can't reach an FC over a cable. This adds an opt-in mode USE_PHONE_CONFIG, off by default where the FC comes up as a USB CDC-NCM device instead of the VCP. lwIP runs a tiny DHCP server, the FC is 192.168.7.1, and MSP plus the CLI are served over TCP 5761.

You turn it on by holding the quad/FC upside down for about 3s while disarmed, which sets an RTC backup flag and reboots into the mode, there is also the phoneconfig CLI command but this is rather to be useful in the future if this implementation is used for giving support to non Serial-API browsers. With a power cycle it goes back to normal and ROM DFU is untouched.

Flashing works over the same link with no DFU, since iOS can't drive DFU. A routine copied into RAM (the .ram_flash section ran from SRAM2) erases and programs the flash while the host streams the image over UDP 5762. On singlebank F7 all flash access stalls during an erase, so the whole receive and program path runs from RAM with interrupts masked. Nothing gets erased until a live handshake completes, so a bad flash just reboots to the intact firmware. and ROM DFU is always there as a backup. The config sector is left alone.

lwIP is a submodule under lib/main/lwip. Tested on a Foxeer F722V4, connects, live data everywhere, CLI with autocomplete (worth mentioning because large dumps were tricky) and flashing a new firmware over the cable. Also 4.5.2 build on branch ncm albeit no flashing yet

With support of https://github.com/betaflight/betaflight-configurator/pull/5221

### Supported targets

F722 tested on hardware (Foxeer F722 V4)
F745 untested, low risk (identical code path to F722, only the sector table differs)
H743 untested (shared stack is proven on F722, new H7 flash driver is not)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional phone-config mode that lets the device boot into a USB network interface instead of standard serial-only USB.
  * Added support for network-based firmware flashing and a reboot command into phone-config mode.
  * Added a new USB CDC-NCM connection mode with network, DHCP, and MSP-over-TCP support.

* **Bug Fixes**
  * Improved reboot handling to avoid hangs during phone-config re-entry.
  * Updated build settings to prevent warning-related build failures in phone-config configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->