### PR TITLE
docs: add supported-versions and backport policy to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,3 +14,31 @@ For the full policy — scope, what to include, our disclosure timeline, and saf
 harbour — see the canonical Betaflight security policy:
 
 https://github.com/betaflight/.github/blob/main/SECURITY.md
+
+## Supported versions
+
+The firmware uses calendar-based versioning, `YEAR.MONTH.PATCH` (for example
+`2025.12.1`). The firmware and the
+[configurator app](https://github.com/betaflight/betaflight-configurator) are
+released in lockstep on the same `YEAR.MONTH` versions and are supported
+together.
+
+We provide security support for the **two most recent major (year) releases** —
+a rolling window of roughly the last two years. Security fixes are made on
+`master` and backported to each supported series as point releases.
+
+| Firmware series          | Security support                             |
+| ------------------------ | -------------------------------------------- |
+| `2026.x`                 | ✅ Supported                                  |
+| `2025.x`                 | ✅ Supported                                  |
+| `4.5.x`                  | ✅ Supported — retained as an exception       |
+| `4.4.x` and older `4.x`  | ❌ Not supported                              |
+| `3.x`, `2.x`, `1.x`      | ❌ Not supported                              |
+
+The `4.5.x` series is kept as a deliberate exception because of its widespread
+use, and will continue to receive security backports for as long as that
+remains practical. Older series are no longer maintained; users should upgrade
+to a supported release.
+
+See the [organisation-wide policy](https://github.com/betaflight/.github/blob/main/SECURITY.md#supported-versions)
+for the full support rule.


### PR DESCRIPTION
Adds a Supported versions section to the firmware SECURITY.md.

Betaflight uses CalVer (`YEAR.MONTH.PATCH`); firmware and the configurator app ship in lockstep on the same `YEAR.MONTH` versions and are supported together. Policy: the two most recent major (year) releases — a ~2-year rolling window — with security fixes backported to supported series as point releases. `4.5.x` is retained as a deliberate exception given its popularity; older series are unmaintained.

The authoritative rule will live in the org-wide `betaflight/.github/SECURITY.md` (separate PR); this file links to it and shows the concrete firmware table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a clear security support policy with supported firmware versions and a rolling support window.
  * Clarified that security fixes land on the main development line and are backported to supported releases.
  * Included a support table showing which firmware series remain covered and which older versions are no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->