### PR TITLE
rx: detect sbus frame boundary via interbyte timeout

### DIFF
--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -73,9 +73,10 @@
 #define SBUS_TIME_NEEDED_PER_BYTE (SBUS_TIME_NEEDED_PER_FRAME / SBUS_FRAME_SIZE) // ~120us per byte at 100k baud 8E2
 
 // An interbyte gap larger than this marks a frame boundary. Bytes within a frame
-// arrive about one byte period apart. The shortest inter-frame gap is fast mode's
-// 6000us refresh less the 3000us frame, ie 3000us, so this sits well clear of both.
-#define SBUS_INTERBYTE_TIMEOUT_US (5 * SBUS_TIME_NEEDED_PER_BYTE) // ~600us
+// arrive about one byte period apart (~120us at 100k baud, ~60us at 200k). The
+// shortest inter-frame gap is ~1000us on fast-refresh receivers, so this sits
+// well clear of both.
+#define SBUS_INTERBYTE_TIMEOUT_US ((timeDelta_t)(5 * SBUS_TIME_NEEDED_PER_BYTE)) // ~600us
 
 #if !defined(SBUS_PORT_OPTIONS)
 #define SBUS_PORT_OPTIONS (SERIAL_STOPBITS_2 | SERIAL_PARITY_EVEN)

--- a/src/main/rx/sbus.c
+++ b/src/main/rx/sbus.c
@@ -70,7 +70,12 @@
 
 #define SBUS_FRAME_BEGIN_BYTE 0x0F
 
-#define SBUS_TIME_NEEDED_PER_BYTE SBUS_TIME_NEEDED_PER_FRAME / SBUS_FRAME_SIZE
+#define SBUS_TIME_NEEDED_PER_BYTE (SBUS_TIME_NEEDED_PER_FRAME / SBUS_FRAME_SIZE) // ~120us per byte at 100k baud 8E2
+
+// An interbyte gap larger than this marks a frame boundary. Bytes within a frame
+// arrive about one byte period apart. The shortest inter-frame gap is fast mode's
+// 6000us refresh less the 3000us frame, ie 3000us, so this sits well clear of both.
+#define SBUS_INTERBYTE_TIMEOUT_US (5 * SBUS_TIME_NEEDED_PER_BYTE) // ~600us
 
 #if !defined(SBUS_PORT_OPTIONS)
 #define SBUS_PORT_OPTIONS (SERIAL_STOPBITS_2 | SERIAL_PARITY_EVEN)
@@ -106,6 +111,7 @@ typedef union sbusFrame_u {
 typedef struct sbusFrameData_s {
     sbusFrame_t frame;
     timeUs_t startAtUs;
+    timeUs_t lastByteAtUs;
     uint8_t position;
     bool done;
 } sbusFrameData_t;
@@ -117,9 +123,13 @@ static void sbusDataReceive(uint16_t c, void *data)
 
     const timeUs_t nowUs = microsISR();
 
-    const timeDelta_t sbusFrameTime = cmpTimeUs(nowUs, sbusFrameData->startAtUs);
+    // Resync on a frame boundary detected from the gap since the previous byte.
+    // A gap beyond the timeout means a new frame has started, so drop back to
+    // hunting for the begin byte. Total packet time is not tracked.
+    const timeDelta_t interByteUs = cmpTimeUs(nowUs, sbusFrameData->lastByteAtUs);
+    sbusFrameData->lastByteAtUs = nowUs;
 
-    if (sbusFrameTime > (long)(SBUS_TIME_NEEDED_PER_FRAME + 500) || sbusFrameTime > (long)(sbusFrameData->position * SBUS_TIME_NEEDED_PER_BYTE + 240)) {
+    if (interByteUs > SBUS_INTERBYTE_TIMEOUT_US) {
         sbusFrameData->position = 0;
     }
 
@@ -136,7 +146,7 @@ static void sbusDataReceive(uint16_t c, void *data)
             sbusFrameData->done = false;
         } else {
             sbusFrameData->done = true;
-            DEBUG_SET(DEBUG_SBUS, DEBUG_SBUS_FRAME_TIME, sbusFrameTime);
+            DEBUG_SET(DEBUG_SBUS, DEBUG_SBUS_FRAME_TIME, cmpTimeUs(nowUs, sbusFrameData->startAtUs));
         }
     }
 }


### PR DESCRIPTION
Follow up to #14322, per @ledvinap's comment: https://github.com/betaflight/betaflight/pull/14322#issuecomment-2757027588

Detects the sbus frame boundary from the interbyte gap instead of total packet time. Keeps the last byte timestamp, and resyncs to the begin byte when the gap since the previous byte exceeds a timeout. Frame length still bounds the frame.

Timeout is `5 * SBUS_TIME_NEEDED_PER_BYTE` (~600us). Bytes within a frame are ~120us apart. The shortest inter-frame gap is fast mode's 6000us refresh less the 3000us frame, ie 3000us. So the timeout sits well clear of both.

Replaces the `position * SBUS_TIME_NEEDED_PER_BYTE + 240` heuristic. Also parenthesises the `SBUS_TIME_NEEDED_PER_BYTE` macro.

Builds SITL. Timeout value is easy to tune if bench testing wants it tighter or looser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBUS frame synchronization by resetting frame hunting when the gap between consecutive bytes exceeds the configured inter-byte timeout, improving recovery after noise or interruptions.
  * Refined frame timing measurement to better align debug/diagnostic frame timing with the actual receive timing, reducing the chance of missing valid frames.

* **Documentation**
  * Clarified the timing assumptions behind inter-byte gap detection for SBUS reception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->