### PR TITLE
Formatting cleanup following GPS Rescue rework

### DIFF
--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -198,7 +198,7 @@ void autopilotCaptureHoverThrottleForAltHold(void)
 {
     if (autopilotConfig()->hoverThrottle != 0) {
         altHoldCapturedHoverPwm = 0;
-         return;
+        return;
     }
     altHoldCapturedHoverPwm = (uint16_t)lrintf(constrainf(rcCommand[THROTTLE], (float)AP_HOVER_THROTTLE_CAPTURE_MIN, (float)AP_HOVER_THROTTLE_CAPTURE_MAX));
 }
@@ -228,7 +228,7 @@ void altitudeControl(float targetAltitudeCm, float taskIntervalS, float targetAl
     const float absVerticalVelocity = fabsf(verticalVelocity);
     if (absVerticalVelocity > boostThreshold) {
         const float ratio = absVerticalVelocity / boostThreshold;
-         dBoost = (3.0f * ratio - 2.0f) / ratio; // 1 at 5m/s, 2 at 10m/s...
+        dBoost = (3.0f * ratio - 2.0f) / ratio; // 1 at 5m/s, 2 at 10m/s...
     }
     const float altitudeD = velocityError * altitudeKd * dBoost;
     const float altitudeF = targetVerticalVelocity * altitudeKf;
@@ -280,19 +280,19 @@ void moveTargetLocation(const vector2_t *stepEF, unsigned taskRateHz, bool force
         abortNavRequested = true;
     } else {
         // Force the flag back to false when a normal tracking pass runs
-        abortNavRequested = false; 
+        abortNavRequested = false;
 
         if (stepEF != NULL) {
-             targetPosition.v[EF_EAST]  += stepEF->v[EF_EAST];
+            targetPosition.v[EF_EAST]  += stepEF->v[EF_EAST];
             targetPosition.v[EF_NORTH] += stepEF->v[EF_NORTH];
             targetVelocity.v[EF_EAST]  = stepEF->v[EF_EAST] * taskRateHz;
-            targetVelocity.v[EF_NORTH] = stepEF->v[EF_NORTH] * taskRateHz ;
+            targetVelocity.v[EF_NORTH] = stepEF->v[EF_NORTH] * taskRateHz;
             posHoldStartPosition = targetPosition; // update start point to new target to prevent poshold sanity failure
         }
     }
 }
 
-void pitchForwardOverride (bool request)
+void pitchForwardOverride(bool request)
 {
     forcePitchForward = request;
 }
@@ -315,7 +315,7 @@ static void resetDistanceErrorIntegral(void)
 
 void initPositionHold(void)
 {
-     updatePositionHoldTarget();
+    updatePositionHoldTarget();
     resetDistanceError();
     isPosHoldStarting[EF_EAST]  = true;
     isPosHoldStarting[EF_NORTH] = true;
@@ -376,7 +376,7 @@ void sticksMoveTarget(void)
     targetPosition.v[EF_NORTH] += targetVelocity.v[EF_NORTH] * dt;
     targetPosition.v[EF_EAST]  += targetVelocity.v[EF_EAST] * dt;
 
-    posHoldStartPosition = targetPosition; 
+    posHoldStartPosition = targetPosition;
 }
 
 
@@ -390,7 +390,7 @@ bool positionControl(void)
     if (!est->isValidXY) {
         return false;
     }
-     if (abortNavRequested) {
+    if (abortNavRequested) {
         handlepositionControlFailure();
         return false; // Return failure and show pos hold fail message in OSD
     }
@@ -434,7 +434,7 @@ bool positionControl(void)
             // In posHold
             if (ap.sticksActive) {
                 if (!ap.wasSticksActive) {
-                    initPositionHold(); // resets hold point and enables strong braking mode 
+                    initPositionHold(); // resets hold point and enables strong braking mode
                     initialVelocity = velocity; // Captures current speed for the deceleration math
                 }
                 sticksMoveTarget();
@@ -491,7 +491,7 @@ bool positionControl(void)
         const float velocityFiltered = pt2FilterApply(&posDtermLpf[axis], velocity.v[axis]);
         velocityError.v[axis] = targetVelocity.v[axis] - velocityFiltered;
         velocityError.v[axis] *= dTermRamp.v[axis];
-        const float accelerationRaw = (previousVelocity.v[axis] - velocityFiltered) * POSHOLD_TASK_RATE_HZ * dTermRamp.v[axis]; 
+        const float accelerationRaw = (previousVelocity.v[axis] - velocityFiltered) * POSHOLD_TASK_RATE_HZ * dTermRamp.v[axis];
         previousVelocity.v[axis] = velocityFiltered;
         const float acceleration = pt2FilterApply(&posAccelLpf[axis], accelerationRaw);
 
@@ -531,12 +531,12 @@ bool positionControl(void)
         vector2Scale(&angleV, &angleV, scale);
     }
 
-    autopilotAngle[AI_ROLL]  = -angleV.v[AI_ROLL];  
-    autopilotAngle[AI_PITCH] =  angleV.v[AI_PITCH]; 
+    autopilotAngle[AI_ROLL]  = -angleV.v[AI_ROLL];
+    autopilotAngle[AI_PITCH] =  angleV.v[AI_PITCH];
 
     int statusValue = 0;
     if (ap.navActive)       statusValue += 10;
-    if(abortNavRequested)   statusValue += 100;
+    if (abortNavRequested)  statusValue += 100;
     if (isPositionHeld)     statusValue += 3; // plus 1, ie 4,  if stopping
     if (ap.sticksActive)    statusValue += 5;
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 0, lrintf(velocityError.v[ap.debugAxis])); // velocity error

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -154,7 +154,7 @@ void gpsRescueInit(void)
 
 static void rescueStart(void)
 {
-     initPositionHold(); // initialise position hold at current location
+    initPositionHold(); // initialise position hold at current location
 
     rescueState.phase = RESCUE_INITIALIZE;
 }
@@ -164,7 +164,7 @@ static void rescueStop(void)
     rescueState.phase = RESCUE_IDLE;
     pitchForwardOverride(false);
 }
-// While idle, update the altitude targets 
+// While idle, update the altitude targets
 static void updateMaxAltitude(void)
 {
     // While disarmed, force maxAltitude to zero, unless set_home_point_once is true, when maxAlt is only reset on a power cycle
@@ -368,7 +368,7 @@ static void performSanityChecks(void)
         rescueDisarmNow();
     }
 
-    const bool hardFailsafe = !isRxReceivingSignal(); 
+    const bool hardFailsafe = !isRxReceivingSignal();
 
     if (rescueState.failure == RESCUE_HEALTHY) {
         rescueState.isOK = true;
@@ -384,7 +384,7 @@ static void performSanityChecks(void)
                 return;
             }
             break;
-        default: 
+        default:
             if ((!rescueState.isAvailable) && hardFailsafe) {
                 rescueEmergDescent();
                 return;
@@ -403,7 +403,7 @@ static void performSanityChecks(void)
     if (!rescueState.sensor.gpsHealthy) {
         rescueState.failure = RESCUE_GPSLOST;
     }
-    
+
     secondsLowSats += (!STATE(GPS_FIX) || (gpsSol.numSat < GPS_MIN_SAT_COUNT)) ? 1 : -1;
     secondsLowSats = MAX(0, secondsLowSats);
     if (secondsLowSats >= 15) {
@@ -422,7 +422,7 @@ static void performSanityChecks(void)
         altitudeControlError = measuredAltitudeChange / targetAltitudeChange;
     }
 
-    const float velocityToHomeCmS = previousDistanceToHomeCm - rescueState.sensor.distanceToHomeCm; 
+    const float velocityToHomeCmS = previousDistanceToHomeCm - rescueState.sensor.distanceToHomeCm;
     previousDistanceToHomeCm = rescueState.sensor.distanceToHomeCm;
 
     switch (rescueState.phase) {
@@ -446,7 +446,7 @@ static void performSanityChecks(void)
         }
         break;
 
-     case RESCUE_ROTATE:
+    case RESCUE_ROTATE:
         rescueState.intent.secondsFailing += 1;
         if (rescueState.intent.secondsFailing >= 10) {
             //almost never fails to rotate to the required angle, so this should never trigger
@@ -455,7 +455,7 @@ static void performSanityChecks(void)
             rescueState.intent.targetVelocityCmS = gpsRescueConfig()->groundSpeedCmS;
             rescueState.intent.secondsFailing = 0;
         }
-         break;
+        break;
 
     case RESCUE_FLY_HOME:
         rescueState.intent.secondsFailing += (velocityToHomeCmS < 0.2f * rescueState.intent.targetVelocityCmS) ? 1 : -1;
@@ -499,9 +499,10 @@ static void initDescent(void)
         rescueState.intent.descentDistanceCm = rescueState.sensor.distanceToHomeCm;
     }
 }
+
 static void descend(void)
 {
-   if (rescueState.intent.descentDistanceCm > GPS_RESCUE_ACCEPT_RADIUS) {
+    if (rescueState.intent.descentDistanceCm > GPS_RESCUE_ACCEPT_RADIUS) {
         float attenuator = rescueState.sensor.distanceToHomeCm / rescueState.intent.descentDistanceCm;
         attenuator = constrainf(attenuator, 0.0f, 1.0f);
         rescueState.intent.targetVelocityCmS = gpsRescueConfig()->groundSpeedCmS * attenuator;
@@ -516,7 +517,7 @@ static void descend(void)
 
 void initRescueValues(void)
 {
-   rescueState.intent.descentDistanceCm = gpsRescueConfig()->descentDistanceM * 100.0f;
+    rescueState.intent.descentDistanceCm = gpsRescueConfig()->descentDistanceM * 100.0f;
     if (rescueState.sensor.distanceToHomeCm < gpsRescueConfig()->minStartDistM * 100.0f) {
         // 7.5m high for close-range headroom
         rescueState.intent.returnAltitudeCm = fmaxf(750.0f, rescueState.sensor.currentAltitudeCm + rescueState.intent.initialClimbCm);
@@ -577,7 +578,7 @@ void gpsRescueUpdate(void) // called from core.c at TASK_GPS_RESCUE_RATE_HZ
     case RESCUE_IDLE:
         updateMaxAltitude();
         break;
-        
+
     case RESCUE_INITIALIZE:
         returnAltitudeLow = getAltitudeCm() < rescueState.intent.returnAltitudeCm;
         if (!STATE(GPS_FIX_HOME)) {
@@ -629,7 +630,7 @@ void gpsRescueUpdate(void) // called from core.c at TASK_GPS_RESCUE_RATE_HZ
         updateYawStartupAttenuator();
         controlYaw();
         if (fabsf(rescueState.sensor.errorAngleDeg) < GPS_RESCUE_ALLOWED_YAW_RANGE) {
-            rescueState.phase = RESCUE_FLY_HOME; 
+            rescueState.phase = RESCUE_FLY_HOME;
             rescueState.intent.targetVelocityCmS = gpsRescueConfig()->groundSpeedCmS;
             rescueState.intent.secondsFailing = 0;
         }
@@ -671,10 +672,10 @@ void gpsRescueUpdate(void) // called from core.c at TASK_GPS_RESCUE_RATE_HZ
         break;
 
     case RESCUE_DO_NOTHING:
-    clearTargetStep();
-    rescueState.intent.targetAltitudeVelCmS = 0.0f;
-    rescueYawRate = 0.0f;
-    // altitude control with no change in height or heading,  position control at zero target velocity
+        clearTargetStep();
+        rescueState.intent.targetAltitudeVelCmS = 0.0f;
+        rescueYawRate = 0.0f;
+        // altitude control with no change in height or heading, position control at zero target velocity
 
         break;
 

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -422,7 +422,7 @@ static float imuCalcGroundspeedGain(float dt)
     const float speedRatio = 0.5f * gpsSol.groundSpeed / GPS_COG_MIN_GROUNDSPEED;
     float speedBasedGain = speedRatio > 1.0f ? fminf(speedRatio, 10.0f) : sq(speedRatio);
     // speedBasedGain is 0 at 0.0m/s, 1.0 at 2.0 m/s,rising towards 5.0 at 10m/s, to max 10.0 at 20m/s
-    // need a lot of speed since forward flight speed must exceed lateral wind drift by a significant margin 
+    // need a lot of speed since forward flight speed must exceed lateral wind drift by a significant margin
 
     // 2. suppress heading correction during and after yaw movements, down to zero at more than 10 deg/s
     float yawGyroRateFactor = fminf(fabsf(gyro.gyroADCf[FD_YAW] * 0.1f), 1.0f);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -585,7 +585,7 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_
 
 #ifdef USE_GPS_RESCUE
     if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
-        angleTarget = autopilotAngle[axis]; // autopilotAngle in degrees             
+        angleTarget = autopilotAngle[axis]; // autopilotAngle in degrees
         angleLimit = (float)autopilotConfig()->maxAngle;
         angleFeedforward = 0.0f;
     }

--- a/src/main/flight/pos_hold_multirotor.c
+++ b/src/main/flight/pos_hold_multirotor.c
@@ -99,13 +99,12 @@ void updatePosHold(timeUs_t currentTimeUs) {
         posHold.isEnabled = false;
     }
 
-    if (posHold.isEnabled) { 
+    if (posHold.isEnabled) {
         posHoldCheckSticks();
         posHold.areSensorsOk = sensorsOk();
         if (posHold.areSensorsOk) {
             posHold.isControlOk = positionControl();
         } else {
-
             for (unsigned i = 0; i < RP_AXIS_COUNT; i++) {
                 autopilotAngle[i] = 0.0f;
             }

--- a/src/test/unit/althold_unittest.cc
+++ b/src/test/unit/althold_unittest.cc
@@ -238,10 +238,10 @@ extern "C" {
         UNUSED(*gpsStamp);
         return true;
     }
-float getSetpointRate(int axis)
-{
-    UNUSED(axis);
-    return 0.0f; 
+    float getSetpointRate(int axis)
+    {
+        UNUSED(axis);
+        return 0.0f;
     }
 
     void GPS_distance2d(const gpsLocation_t* /*from*/, const gpsLocation_t* /*to*/, vector2_t* /*dest*/) { }

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1192,10 +1192,10 @@ void GPS_distance2d(const gpsLocation_t* /*from*/, const gpsLocation_t* /*to*/, 
         UNUSED(*gpsStamp);
         return true;
     }
-float getSetpointRate(int axis)
-{
-    UNUSED(axis);
-    return 0.0f; 
+    float getSetpointRate(int axis)
+    {
+        UNUSED(axis);
+        return 0.0f;
     }
 
     float getGpsCosLat(void) { return 1.0f; }

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -96,18 +96,18 @@ extern "C" {
     }
 
 
-float simulatedStickRoll = 0.0f;
-float simulatedStickPitch = 0.0f;
-float getSetpointRate(int axis)
-{
-    if ( axis == FD_ROLL) {
-        return simulatedStickRoll;
+    float simulatedStickRoll = 0.0f;
+    float simulatedStickPitch = 0.0f;
+    float getSetpointRate(int axis)
+    {
+        if (axis == FD_ROLL) {
+            return simulatedStickRoll;
+        }
+        if (axis == FD_PITCH) {
+            return simulatedStickPitch;
+        }
+        return 0.0f;
     }
-    if (axis == FD_PITCH) {
-        return simulatedStickPitch;
-    }
-    return 0.0f;
-}
 
     timeDelta_t getTaskDeltaTimeUs(taskId_e taskId)
     {
@@ -344,17 +344,17 @@ TEST_F(PosHoldTest, SticksActiveButCentered)
     initAndSettleAt(0, 0, 0);
     testEstimate.position.x = 100.0f; // Drone is offset to the right
     runIterations(SETTLE_ITERATIONS);
-    
+
     // Ensure sticks are simulated as perfectly centered
     simulatedStickRoll = 0.0f;
     simulatedStickPitch = 0.0f;
-    
-    setSticksActiveStatus(true); 
+
+    setSticksActiveStatus(true);
     runIterations(SETTLE_ITERATIONS);
-    
+
     // Assert your new baseline calculation output
-    EXPECT_NEAR(autopilotAngle[AI_ROLL], -0.9045f, 0.01f);   
-    EXPECT_NEAR(autopilotAngle[AI_PITCH], 0.0f, 0.01f); 
+    EXPECT_NEAR(autopilotAngle[AI_ROLL], -0.9045f, 0.01f);
+    EXPECT_NEAR(autopilotAngle[AI_PITCH], 0.0f, 0.01f);
 }
 
 TEST_F(PosHoldTest, EstimateValidityTransitionsUnavailableAvailableUnavailable)
@@ -402,7 +402,7 @@ TEST_F(PosHoldTest, ReleasingSticksBrakes)
     testEstimate.velocity.x = 120.0f;
 
     // Ensure sticks are centered for this baseline cruise test
-    simulatedStickRoll = 0.0f; 
+    simulatedStickRoll = 0.0f;
 
     runIterations(SETTLE_ITERATIONS);
 
@@ -413,10 +413,10 @@ TEST_F(PosHoldTest, ReleasingSticksBrakes)
     // Stick release should cause a greater angle
     setSticksActiveStatus(false);
     runIterations(SETTLE_ITERATIONS);
-    
-    float expectedBrakeAngle = -14.4f; 
+
+    float expectedBrakeAngle = -14.4f;
     EXPECT_NEAR(autopilotAngle[AI_ROLL], expectedBrakeAngle, 0.1f);
-    
+
     runIterations(SETTLE_ITERATIONS);
     EXPECT_NEAR(autopilotAngle[AI_PITCH], 0.0f, 0.1f);
 }


### PR DESCRIPTION
Formatting-only follow-up to #15382: indentation fixes, trailing whitespace, space before parens, and re-indenting the new unit test stubs to match their surrounding extern C blocks. No functional change, the diff is whitespace only. Affected unit tests (poshold, althold, arming_prevention) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Cleaned up formatting and spacing across several flight control and support files for improved consistency and readability.
* **Tests**
  * Reformatted a few unit test helpers and assertions without changing test behavior or coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->