### PR TITLE
RTC is not set from GPS time using UBLOX M10

### DIFF
--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -2448,7 +2448,7 @@ static void gpsWeekTimeToDateTime(gpsDateTime_t *dt, int16_t week, uint32_t time
 
 #ifdef USE_RTC_TIME
 // Set system clock once when GPS time is available
-static void setRtcDateTimeFromGps(void)
+static void setRtcDateTimeFromGps(void) {
     if (!rtcHasTime() && gpsSol.dateTime.valid) {
         dateTime_t dt;
         dt.year = gpsSol.dateTime.year;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -2448,8 +2448,7 @@ static void gpsWeekTimeToDateTime(gpsDateTime_t *dt, int16_t week, uint32_t time
 
 #ifdef USE_RTC_TIME
 // Set system clock once when GPS time is available
-static void set_rtc_date_time_from_gps(void)
-{
+static void setRtcDateTimeFromGps(void)
     if (!rtcHasTime() && gpsSol.dateTime.valid) {
         dateTime_t dt;
         dt.year = gpsSol.dateTime.year;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -2446,6 +2446,24 @@ static void gpsWeekTimeToDateTime(gpsDateTime_t *dt, int16_t week, uint32_t time
     unixSecondsToDateTime(dt, unixSeconds, (uint16_t)millis);
 }
 
+#ifdef USE_RTC_TIME
+// Set system clock once when GPS time is available
+static void set_rtc_date_time_from_gps(void)
+{
+    if (!rtcHasTime() && gpsSol.dateTime.valid) {
+        dateTime_t dt;
+        dt.year = gpsSol.dateTime.year;
+        dt.month = gpsSol.dateTime.month;
+        dt.day = gpsSol.dateTime.day;
+        dt.hours = gpsSol.dateTime.hour;
+        dt.minutes = gpsSol.dateTime.min;
+        dt.seconds = gpsSol.dateTime.sec;
+        dt.millis = gpsSol.dateTime.millis;
+        rtcSetDateTime(&dt);
+    }
+}
+#endif
+
 static bool UBLOX_parse_gps(void)
 {
 //    lastUbxRcvMsgClass = ubxRcvMsgClass;
@@ -2490,6 +2508,9 @@ static bool UBLOX_parse_gps(void)
         ubxHaveNewSpeed = true;
         // Store GPS date/time for telemetry, applying nano correction per u-blox spec.
         gpsDateTimeFromNavPvt(&gpsSol.dateTime, &ubxRcvMsgPayload.ubxNavPvt);
+#ifdef USE_RTC_TIME
+        set_rtc_date_time_from_gps();
+#endif
         break;
     case CLSMSG(CLASS_NAV, MSG_NAV_SAT):
 #ifdef USE_DASHBOARD
@@ -2577,11 +2598,7 @@ static bool UBLOX_parse_gps(void)
                                   ubxRcvMsgPayload.ubxNavSol.time_nsec);
         }
 #ifdef USE_RTC_TIME
-        // Set system clock once when GPS time is available
-        if (!rtcHasTime() && gpsSol.dateTime.valid) {
-            rtcTime_t temp_time = (((int64_t) ubxRcvMsgPayload.ubxNavSol.week) * 7 * 24 * 60 * 60 * 1000) + ubxRcvMsgPayload.ubxNavSol.time + (ubxRcvMsgPayload.ubxNavSol.time_nsec / 1000000) + 315964800000LL - 18000;
-            rtcSet(&temp_time);
-        }
+        set_rtc_date_time_from_gps();
 #endif
         break;
     case CLSMSG(CLASS_NAV, MSG_NAV_VELNED):
@@ -2596,18 +2613,7 @@ static bool UBLOX_parse_gps(void)
         gpsSol.velned.velD = (int16_t)ubxRcvMsgPayload.ubxNavVelned.ned_down; // cm/s
         ubxHaveNewSpeed = true;
 #ifdef USE_RTC_TIME
-        // Set system clock once when GPS time is available
-        if (!rtcHasTime() && gpsSol.dateTime.valid) {
-            dateTime_t dt;
-            dt.year = gpsSol.dateTime.year;
-            dt.month = gpsSol.dateTime.month;
-            dt.day = gpsSol.dateTime.day;
-            dt.hours = gpsSol.dateTime.hour;
-            dt.minutes = gpsSol.dateTime.min;
-            dt.seconds = gpsSol.dateTime.sec;
-            dt.millis = gpsSol.dateTime.millis;
-            rtcSetDateTime(&dt);
-        }
+        set_rtc_date_time_from_gps();
 #endif
         break;
     case CLSMSG(CLASS_NAV, MSG_NAV_SVINFO):

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -2508,7 +2508,7 @@ static bool UBLOX_parse_gps(void)
         // Store GPS date/time for telemetry, applying nano correction per u-blox spec.
         gpsDateTimeFromNavPvt(&gpsSol.dateTime, &ubxRcvMsgPayload.ubxNavPvt);
 #ifdef USE_RTC_TIME
-        set_rtc_date_time_from_gps();
+        setRtcDateTimeFromGps();
 #endif
         break;
     case CLSMSG(CLASS_NAV, MSG_NAV_SAT):
@@ -2597,7 +2597,7 @@ static bool UBLOX_parse_gps(void)
                                   ubxRcvMsgPayload.ubxNavSol.time_nsec);
         }
 #ifdef USE_RTC_TIME
-        set_rtc_date_time_from_gps();
+        setRtcDateTimeFromGps();
 #endif
         break;
     case CLSMSG(CLASS_NAV, MSG_NAV_VELNED):
@@ -2612,7 +2612,7 @@ static bool UBLOX_parse_gps(void)
         gpsSol.velned.velD = (int16_t)ubxRcvMsgPayload.ubxNavVelned.ned_down; // cm/s
         ubxHaveNewSpeed = true;
 #ifdef USE_RTC_TIME
-        set_rtc_date_time_from_gps();
+        setRtcDateTimeFromGps();
 #endif
         break;
     case CLSMSG(CLASS_NAV, MSG_NAV_SVINFO):


### PR DESCRIPTION
This fixes https://github.com/betaflight/betaflight/issues/15393

@CapnBry feel free to push into this branch if you have any changes/suggestions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic clock synchronization from GPS data: the system time is now set only when GPS time is valid and the RTC doesn’t already contain a time value.
  * Reduced inconsistent time-setting across different GPS message paths by using a single shared update flow, making clock updates more reliable and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->