### PR TITLE
bus_quadspi_hal: capture HAL status in quadSpiSequence()

### DIFF
--- a/src/platform/STM32/bus_quadspi_hal.c
+++ b/src/platform/STM32/bus_quadspi_hal.c
@@ -808,7 +808,7 @@ void quadSpiSequence(const extDevice_t *dev, busSegment_t *segments)
     }
 
     quadSpiDevice_e device = quadSpiDeviceByInstance(dev->bus->busType_u.qspi.instance);
-    HAL_StatusTypeDef status;
+    HAL_StatusTypeDef status = HAL_OK;
 
     busSegment_t *curSegment = segments;
 

--- a/src/platform/STM32/bus_quadspi_hal.c
+++ b/src/platform/STM32/bus_quadspi_hal.c
@@ -808,10 +808,12 @@ void quadSpiSequence(const extDevice_t *dev, busSegment_t *segments)
     }
 
     quadSpiDevice_e device = quadSpiDeviceByInstance(dev->bus->busType_u.qspi.instance);
+    HAL_StatusTypeDef status;
 
     busSegment_t *curSegment = segments;
 
     bool csNegated = true;
+    bool timeout = false;
 
     while (curSegment->len) {
         if (csNegated) {
@@ -822,12 +824,18 @@ void quadSpiSequence(const extDevice_t *dev, busSegment_t *segments)
         if (curSegment->u.buffers.txData) {
             /* Configure QSPI: DLR register with the number of data to write */
             WRITE_REG(quadSpiDevice[device].halHandle->hal.Instance->DLR, curSegment->len - 1U);
-            HAL_QSPI_Transmit(&quadSpiDevice[device].halHandle->hal, (uint8_t *)curSegment->u.buffers.txData, QUADSPI_DEFAULT_TIMEOUT);
+            status = HAL_QSPI_Transmit(&quadSpiDevice[device].halHandle->hal, (uint8_t *)curSegment->u.buffers.txData, QUADSPI_DEFAULT_TIMEOUT);
+            timeout = (status != HAL_OK);
         }
-        if (curSegment->u.buffers.rxData) {
+        if (!timeout && curSegment->u.buffers.rxData) {
             /* Configure QSPI: DLR register with the number of data to read */
             WRITE_REG(quadSpiDevice[device].halHandle->hal.Instance->DLR, curSegment->len - 1U);
-            HAL_QSPI_Receive(&quadSpiDevice[device].halHandle->hal, (uint8_t *)curSegment->u.buffers.rxData, QUADSPI_DEFAULT_TIMEOUT);
+            status = HAL_QSPI_Receive(&quadSpiDevice[device].halHandle->hal, (uint8_t *)curSegment->u.buffers.rxData, QUADSPI_DEFAULT_TIMEOUT);
+            timeout = (status != HAL_OK);
+        }
+
+        if (timeout) {
+            break;
         }
 
         if (curSegment->negateCS) {
@@ -841,6 +849,10 @@ void quadSpiSequence(const extDevice_t *dev, busSegment_t *segments)
 
     if (!csNegated) {
         quadSpiDeselectDevice(dev->bus->busType_u.qspi.instance);
+    }
+
+    if (timeout) {
+        quadSpiTimeoutUserCallback(dev->bus->busType_u.qspi.instance);
     }
 }
 #endif


### PR DESCRIPTION
AI Generated pull-request

## Summary
- `quadSpiSequence()` in `src/platform/STM32/bus_quadspi_hal.c` discarded the return values of `HAL_QSPI_Transmit()` and `HAL_QSPI_Receive()`, unlike every other single-transfer function in the file (`quadSpiTransmit1LINE`, `quadSpiReceiveWithAddress4LINES`, etc.), which capture the HAL status and propagate a timeout.
- On a HAL timeout mid-sequence, CS stayed asserted and remaining segments still executed with no error indication to the caller.
- Fix captures the HAL status per transfer, stops the sequence on failure, and invokes the existing `quadSpiTimeoutUserCallback()` — matching the established pattern in the rest of the file. CS is still correctly deasserted via the existing end-of-function cleanup path.

## Test plan
- [x] Builds cleanly: `make CONFIG=SPRACINGH7EXTREME` (H7 board using `USE_QUADSPI` + `USE_FLASH_W25Q128FV`) — no warnings/errors
- [ ] Hardware verified: not yet — requires triggering an actual QuadSPI HAL timeout (latent/edge-case path)

Fixes #15274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QSPI transfer handling by checking each command and data transfer result during multi-segment operations.
  * Added clearer timeout handling so processing stops after a failed segment and a timeout callback is triggered when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->