### PR TITLE
fix: prevent spurious blackbox erase before RX link

### DIFF
--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -143,6 +143,7 @@ void updateActivatedModes(void)
     memset(&newMask, 0, sizeof(newMask));
     memset(&stickyModes, 0, sizeof(stickyModes));
     bitArraySet(&stickyModes, BOXPARALYZE);
+    bitArraySet(&stickyModes, BOXBLACKBOXERASE);
 
     // determine which conditions set/clear the mode
     for (int i = 0; i < activeMacCount; i++) {

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -44,8 +44,6 @@
 
 #include "rc_modes.h"
 
-#define STICKY_MODE_BOOT_DELAY_US (5 * 1000 * 1000)
-
 boxBitmask_t rcModeActivationMask; // one bit per mode defined in boxId_e
 static boxBitmask_t stickyModesEverDisabled;
 

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -118,39 +118,42 @@ static void updateMasksForMac(const modeActivationCondition_t *mac, boxBitmask_t
     }
 }
 
-static void updateMasksForStickyModes(const modeActivationCondition_t *mac, boxBitmask_t *andMask, boxBitmask_t *newMask)
+static void updateMasksForStickyModes(const modeActivationCondition_t *mac, boxBitmask_t *andMask, boxBitmask_t *newMask, bool latchForever)
 {
-    if (IS_RC_MODE_ACTIVE(mac->modeId)) {
+    if (latchForever && IS_RC_MODE_ACTIVE(mac->modeId)) {
         bitArrayClr(andMask, mac->modeId);
         bitArraySet(newMask, mac->modeId);
-    } else {
-        bool bActive = isRangeActive(mac->auxChannelIndex, &mac->range);
+        return;
+    }
 
-        if (bitArrayGet(&stickyModesEverDisabled, mac->modeId)) {
-            updateMasksForMac(mac, andMask, newMask, bActive);
-        } else {
-            if (micros() >= STICKY_MODE_BOOT_DELAY_US && !bActive) {
-                bitArraySet(&stickyModesEverDisabled, mac->modeId);
-            }
+    bool bActive = isRangeActive(mac->auxChannelIndex, &mac->range);
+
+    if (bitArrayGet(&stickyModesEverDisabled, mac->modeId)) {
+        updateMasksForMac(mac, andMask, newMask, bActive);
+    } else {
+        if (micros() >= STICKY_MODE_BOOT_DELAY_US && !bActive) {
+            bitArraySet(&stickyModesEverDisabled, mac->modeId);
         }
     }
 }
 
 void updateActivatedModes(void)
 {
-    boxBitmask_t newMask, andMask, stickyModes;
+    boxBitmask_t newMask, andMask, stickyModes, latchModes;
     memset(&andMask, 0, sizeof(andMask));
     memset(&newMask, 0, sizeof(newMask));
     memset(&stickyModes, 0, sizeof(stickyModes));
+    memset(&latchModes, 0, sizeof(latchModes));
     bitArraySet(&stickyModes, BOXPARALYZE);
     bitArraySet(&stickyModes, BOXBLACKBOXERASE);
+    bitArraySet(&latchModes, BOXPARALYZE);
 
     // determine which conditions set/clear the mode
     for (int i = 0; i < activeMacCount; i++) {
         const modeActivationCondition_t *mac = modeActivationConditions(activeMacArray[i]);
 
         if (bitArrayGet(&stickyModes, mac->modeId)) {
-            updateMasksForStickyModes(mac, &andMask, &newMask);
+            updateMasksForStickyModes(mac, &andMask, &newMask, bitArrayGet(&latchModes, mac->modeId));
         } else if (mac->modeId < CHECKBOX_ITEM_COUNT) {
             bool bActive = isRangeActive(mac->auxChannelIndex, &mac->range);
             updateMasksForMac(mac, &andMask, &newMask, bActive);

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -24,6 +24,8 @@
 
 #include "platform.h"
 
+#include "build/build_config.h"
+
 #include "common/bitarray.h"
 #include "common/maths.h"
 
@@ -45,7 +47,7 @@
 #include "rc_modes.h"
 
 boxBitmask_t rcModeActivationMask; // one bit per mode defined in boxId_e
-static boxBitmask_t stickyModesEverDisabled;
+STATIC_UNIT_TESTED boxBitmask_t stickyModesEverDisabled;
 
 static bool airmodeEnabled;
 

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -96,6 +96,8 @@ typedef struct boxBitmask_s { uint32_t bits[(CHECKBOX_ITEM_COUNT + 31) / 32]; } 
 
 #define MAX_MODE_ACTIVATION_CONDITION_COUNT 20
 
+#define STICKY_MODE_BOOT_DELAY_US (5 * 1000 * 1000)
+
 #define CHANNEL_RANGE_MIN 900
 #define CHANNEL_RANGE_MAX 2100
 

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -244,6 +244,111 @@ void resetMillis(void)
     fixedMillis = 0;
 }
 
+TEST_F(RcControlsModesTest, updateActivatedModesBoxParalyzeLatchesForeverOnceActivated)
+{
+    // given
+    modeActivationConditionsMutable(7)->modeId = BOXPARALYZE;
+    modeActivationConditionsMutable(7)->auxChannelIndex = AUX1 - NON_AUX_CHANNEL_COUNT;
+    modeActivationConditionsMutable(7)->range.startStep = CHANNEL_VALUE_TO_STEP(1700);
+    modeActivationConditionsMutable(7)->range.endStep = CHANNEL_VALUE_TO_STEP(2100);
+
+    boxBitmask_t mask;
+    memset(&mask, 0, sizeof(mask));
+    rcModeUpdate(&mask);
+
+    memset(&rxRuntimeState, 0, sizeof(rxRuntimeState_t));
+    rxRuntimeState.channelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT - NON_AUX_CHANNEL_COUNT;
+
+    for (int index = AUX1; index < MAX_SUPPORTED_RC_CHANNEL_COUNT; index++) {
+        rcData[index] = PWM_RANGE_MIDDLE;
+    }
+
+    analyzeModeActivationConditions();
+
+    // when: switch is in-range before the boot guard has ever seen it off
+    resetMillis();
+    rcData[AUX1] = PWM_RANGE_MAX;
+    updateActivatedModes();
+
+    // then: activation is withheld until the switch has been observed off
+    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXPARALYZE));
+
+    // when: switch goes off and the boot delay elapses
+    rcData[AUX1] = PWM_RANGE_MIDDLE;
+    fixedMillis = STICKY_MODE_BOOT_DELAY_US / 1000 + 1;
+    updateActivatedModes();
+
+    // then: still inactive, but the guard is now armed
+    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXPARALYZE));
+
+    // when: switch is moved into range
+    rcData[AUX1] = PWM_RANGE_MAX;
+    updateActivatedModes();
+
+    // then: mode activates normally
+    EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXPARALYZE));
+
+    // when: switch is moved back out of range
+    rcData[AUX1] = PWM_RANGE_MIDDLE;
+    updateActivatedModes();
+
+    // then: BOXPARALYZE is a kill switch and must stay active until reboot
+    EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXPARALYZE));
+}
+
+TEST_F(RcControlsModesTest, updateActivatedModesBoxBlackboxEraseDoesNotLatchForever)
+{
+    // given
+    modeActivationConditionsMutable(8)->modeId = BOXBLACKBOXERASE;
+    modeActivationConditionsMutable(8)->auxChannelIndex = AUX2 - NON_AUX_CHANNEL_COUNT;
+    modeActivationConditionsMutable(8)->range.startStep = CHANNEL_VALUE_TO_STEP(1700);
+    modeActivationConditionsMutable(8)->range.endStep = CHANNEL_VALUE_TO_STEP(2100);
+
+    boxBitmask_t mask;
+    memset(&mask, 0, sizeof(mask));
+    rcModeUpdate(&mask);
+
+    memset(&rxRuntimeState, 0, sizeof(rxRuntimeState_t));
+    rxRuntimeState.channelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT - NON_AUX_CHANNEL_COUNT;
+
+    for (int index = AUX1; index < MAX_SUPPORTED_RC_CHANNEL_COUNT; index++) {
+        rcData[index] = PWM_RANGE_MIDDLE;
+    }
+
+    analyzeModeActivationConditions();
+
+    // when: switch is in-range before RX has ever been seen off (rcData defaults, e.g. before RX link)
+    resetMillis();
+    rcData[AUX2] = PWM_RANGE_MAX;
+    updateActivatedModes();
+
+    // then: erase is withheld (this is the #15173 boot-time spurious-erase bug)
+    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXBLACKBOXERASE));
+
+    // when: switch goes off and the boot delay elapses
+    rcData[AUX2] = PWM_RANGE_MIDDLE;
+    fixedMillis = STICKY_MODE_BOOT_DELAY_US / 1000 + 1;
+    updateActivatedModes();
+
+    // then: still inactive, but the guard is now armed
+    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXBLACKBOXERASE));
+
+    // when: switch is moved into range
+    rcData[AUX2] = PWM_RANGE_MAX;
+    updateActivatedModes();
+
+    // then: mode activates normally
+    EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXBLACKBOXERASE));
+
+    // when: switch is moved back out of range
+    rcData[AUX2] = PWM_RANGE_MIDDLE;
+    updateActivatedModes();
+
+    // then: unlike BOXPARALYZE, this must turn off again so blackboxUpdate() can
+    // leave BLACKBOX_STATE_ERASED and resume normal logging
+    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXBLACKBOXERASE));
+}
+
 #define DEFAULT_MIN_CHECK 1100
 #define DEFAULT_MAX_CHECK 1900
 

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -55,6 +55,8 @@ extern "C" {
     #include "fc/core.h"
 
     #include "scheduler/scheduler.h"
+
+    extern boxBitmask_t stickyModesEverDisabled;
 }
 
 #include "unittest_macros.h"
@@ -68,6 +70,7 @@ void unsetArmingDisabled(armingDisableFlags_e flag)
 class RcControlsModesTest : public ::testing::Test {
 protected:
     virtual void SetUp() {
+        memset(&stickyModesEverDisabled, 0, sizeof(stickyModesEverDisabled));
     }
 };
 


### PR DESCRIPTION
AI Generated pull-request

Resolves https://github.com/betaflight/betaflight/issues/15173

## Summary

`BOXBLACKBOXERASE` was evaluated like any ordinary switch-activated mode in `updateActivatedModes()` (`src/main/fc/rc_modes.c`), reading `rcData[]` directly via `isRangeActive()`. `rcData[]` defaults to `1500` until the first valid RX frame arrives, and some protocols (e.g. ELRS) can take 5-6s to link. If a pilot's blackbox-erase AUX range happens to overlap the `1500` default, the erase fires on boot before RX has ever linked — with no user intent.

`BOXPARALYZE` already guards against this exact class of bug via the `stickyModes` mechanism in `updateActivatedModes()`: a sticky mode can only first activate after being observed in the OFF position (or after `STICKY_MODE_BOOT_DELAY_US` has elapsed with the switch off). This PR extends that same protection to `BOXBLACKBOXERASE`, with one difference: `BOXPARALYZE` also permanently latches active forever once triggered (a kill switch, by design). `BOXBLACKBOXERASE` needs the boot-guard but not the permanent latch, since `blackboxUpdate()` depends on the mode going inactive again to leave `BLACKBOX_STATE_ERASED` and resume normal logging. `updateMasksForStickyModes()` now takes a `latchForever` flag so only `BOXPARALYZE` keeps the original latch-forever behavior.

## Context

Addresses #15173. The issue was originally reported as "cannot arm after clearing blackbox via OSD", and a commenter (`zenmetsu`) subsequently identified the pre-RX-link accidental-erase mechanism this PR fixes (their blackbox-erase switch sat at the FC's default 1500 rcData position, so the erase ran every boot before their ELRS receiver linked).

Note: the original reporter's exact repro path was the OSD-menu "erase flash" action (not an AUX switch), and their symptom was a stuck `ARMING_DISABLED_ANGLE` flag after the erase completed. Every blackbox-erase code path (OSD menu `cmsx_EraseFlash()`, MSP `MSP_DATAFLASH_ERASE`, and the `BOXBLACKBOXERASE` state machine in `blackbox.c`) was traced and none of them trigger an MCU reset, so this PR does not attempt to address that specific symptom — it only fixes the confirmed, reproducible pre-RX-link mode-activation bug.

## Commits

- `99aaff022e`: adds `BOXBLACKBOXERASE` to `stickyModes`
- `5fada0abeb`: fixes a permanent-latch regression in the above (caught in review by GitHub Copilot and CodeRabbit) by splitting boot-guard from latch-forever behavior
- `0961a4f6b3`: unit test coverage for both behaviors (`BOXPARALYZE`'s latch, `BOXBLACKBOXERASE`'s no-latch), and moves `STICKY_MODE_BOOT_DELAY_US` into `rc_modes.h` as a shared constant
- `4ca0b77a1f`: fixes test isolation for `stickyModesEverDisabled` between test runs (`STATIC_UNIT_TESTED`, matching the existing pattern in `flight/imu.c`)

## Test plan

- [x] Builds clean for the original reporter's exact hardware (`make CONFIG=BETAFPVG473_V2`)
- [x] Unit tests added covering the boot-guard and latch-forever/no-latch behaviors, verified via mutation testing
- [x] Full unit test suite passes (`make test`, 59/59 binaries)
- [ ] Hardware verification: confirm `BOXBLACKBOXERASE` no longer activates from the switch's boot-time rcData default before RX link
- [ ] Confirm normal (post-link) `BOXBLACKBOXERASE` activation still works as expected once the switch is deliberately moved, and turns off again when released


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RC mode handling so selected modes now behave more predictably after being activated, including stronger “stay on” behavior for one mode and safer reset behavior for another.
  * Reduced unintended activation at startup by adding a boot-time delay guard for sticky modes.

* **Tests**
  * Added coverage for sticky mode behavior to verify activation, range changes, and startup edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->