### PR TITLE
Autopilot: injected runtime plans, geofence RTH return mission, LAND loiter

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1054,12 +1054,7 @@ void processRxModes(timeUs_t currentTimeUs)
 
 #ifdef USE_GPS_RESCUE
     if (ARMING_FLAG(ARMED) && (IS_RC_MODE_ACTIVE(BOXGPSRESCUE)
-        || (failsafeIsActive() && failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE)
-#if ENABLE_FLIGHT_PLAN && !defined(USE_WING)
-        // geofence breach with the RTH action requests a rescue
-        || flightPlanNavRescueRequested()
-#endif
-        )) {
+        || (failsafeIsActive() && failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE))) {
         if (!FLIGHT_MODE(GPS_RESCUE_MODE)) {
             ENABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
         }
@@ -1069,15 +1064,26 @@ void processRxModes(timeUs_t currentTimeUs)
 #endif
 
 #if ENABLE_FLIGHT_PLAN && !defined(USE_WING)
+    // During failsafe the mission flies only while the failsafe state machine
+    // has chosen to (rx-loss policy). In the stage-1 window before failsafe
+    // activates, rxfail substitution already drives the aux channels, so the
+    // switch is only pilot intent while channel data is real — otherwise hold
+    // the current mode and let the policy decide at stage-2 entry.
+    bool autopilotRequested;
+    if (failsafeIsActive()) {
+        autopilotRequested = (failsafePhase() == FAILSAFE_AUTOPILOT);
+    } else if (rxAreFlightChannelsValid()) {
+        autopilotRequested = IS_RC_MODE_ACTIVE(BOXAUTOPILOT);
+    } else {
+        autopilotRequested = FLIGHT_MODE(AUTOPILOT_MODE);
+    }
+
     // Before the hold modes: AUTOPILOT_MODE activates both, so they must see
     // its state from the same cycle.
     if (ARMING_FLAG(ARMED)
-        // GPS Rescue has priority over the mission, including a rescue the
-        // mission itself requested (geofence RTH)
+        // GPS Rescue has priority over the mission
         && !FLIGHT_MODE(GPS_RESCUE_MODE)
-        // during failsafe the switch state is synthetic; fly the mission only
-        // while the failsafe state machine has chosen to (rx-loss policy)
-        && (failsafeIsActive() ? (failsafePhase() == FAILSAFE_AUTOPILOT) : IS_RC_MODE_ACTIVE(BOXAUTOPILOT))
+        && autopilotRequested
         && sensors(SENSOR_ACC)
         && sensors(SENSOR_GPS) && STATE(GPS_FIX)
         // waypoints carry altitude; without altitude data the mission must not run
@@ -1092,13 +1098,6 @@ void processRxModes(timeUs_t currentTimeUs)
         if (FLIGHT_MODE(AUTOPILOT_MODE)) {
             DISABLE_FLIGHT_MODE(AUTOPILOT_MODE);
             flightPlanNavDisengage();
-        }
-        // A geofence RTH request stays latched while the rescue it triggered
-        // runs; the pilot cancels it with the mode switch, or it dies on disarm.
-        // On RX loss the aux channels are substituted with rxfail values, not
-        // pilot intent, so switch-off only counts while channel data is real.
-        if (!ARMING_FLAG(ARMED) || (!IS_RC_MODE_ACTIVE(BOXAUTOPILOT) && rxAreFlightChannelsValid())) {
-            flightPlanNavClearRescueRequest();
         }
     }
 #endif

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -23,6 +23,7 @@
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "platform.h"
 
@@ -31,6 +32,7 @@
 
 #include "common/maths.h"
 #include "common/time.h"
+#include "common/utils.h"
 #include "common/vector.h"
 
 #include "drivers/time.h"
@@ -47,6 +49,9 @@
 
 #include "pg/autopilot.h"
 #include "pg/flight_plan.h"
+#ifdef USE_GPS_RESCUE
+#include "pg/gps_rescue.h"
+#endif
 
 #define FP_MIN_CRUISE_MPS         1.0f
 // Legs complete on acceptance-radius entry at any speed: the position
@@ -83,6 +88,10 @@
 // vehicle that cannot descend must keep trying, not disarm mid-air.
 #define FP_LANDING_ESTABLISH_TIMEOUT_US 5000000u
 
+// Injected runtime plans are small synthesised sequences (geofence RTH today,
+// rescue-as-mission later); MAVLink-scale plans stay in the PG store.
+#define FP_INJECTED_PLAN_MAX 4
+
 static struct {
     flightPlanNavState_e state;
     uint8_t currentIndex;
@@ -104,7 +113,11 @@ static struct {
     float    yawRateCapDps;
 
     flightPlanAbortReason_e abortReason;
-    bool rescueRequested;
+
+    // Injected runtime plan; while injectedCount > 0 it replaces the PG
+    // mission as the executor's waypoint source.
+    waypoint_t injected[FP_INJECTED_PLAN_MAX];
+    uint8_t injectedCount;
 
     // Leg progress tracking for stall/flyaway detection
     float bestDistanceToTargetM;
@@ -121,13 +134,22 @@ static flightPlanWaypointReachedFn reachedListener = NULL;
 
 static void onWaypointReached(void *userData);
 
-static const waypoint_t *currentWaypoint(void)
+static uint8_t activePlanCount(void)
 {
-    const flightPlanConfig_t *plan = flightPlanConfig();
-    if (fp.currentIndex >= plan->waypointCount) {
+    return (fp.injectedCount > 0) ? fp.injectedCount : flightPlanConfig()->waypointCount;
+}
+
+static const waypoint_t *activePlanWaypoint(uint8_t index)
+{
+    if (index >= activePlanCount()) {
         return NULL;
     }
-    return &plan->waypoints[fp.currentIndex];
+    return (fp.injectedCount > 0) ? &fp.injected[index] : &flightPlanConfig()->waypoints[index];
+}
+
+static const waypoint_t *currentWaypoint(void)
+{
+    return activePlanWaypoint(fp.currentIndex);
 }
 
 static bool computeTargetEnuM(const waypoint_t *wp, vector3_t *out)
@@ -185,7 +207,7 @@ static const waypoint_t *drainModifiers(void)
         default:
             return wp;
         }
-        if (++fp.currentIndex >= flightPlanConfig()->waypointCount) {
+        if (++fp.currentIndex >= activePlanCount()) {
             return NULL;
         }
     }
@@ -365,8 +387,63 @@ static void updateLanding(timeUs_t currentTimeUs)
     }
 }
 
+// Descend at the leg's target (the waypoint itself), not wherever the arrival
+// gate tripped. If the position command has been wiped (a position-control
+// re-init), a zeroed target would descend at the GPS origin — re-fly the LAND
+// waypoint instead.
+static void startLandingAtNavTarget(timeUs_t currentTimeUs)
+{
+    if (!positionNavHasActiveTarget()) {
+        dispatchWaypoint();
+        return;
+    }
+    const positionNavCommand_t *cmd = positionNavGetActiveCommand();
+    startLanding(currentTimeUs, cmd->targetPosEfM.v[ENU_E], cmd->targetPosEfM.v[ENU_N]);
+}
+
+// Geofence RTH response: [fly home at return altitude, land at home]. Return
+// altitude never commands an en-route descent (rescue's ALT_MODE_MAX
+// behaviour). Falls back to landing in place if the plan can't be injected.
+static void injectReturnHomePlan(timeUs_t currentTimeUs)
+{
+#ifdef USE_GPS_RESCUE
+    const int32_t returnAltCm = MAX(GPS_home_llh.altCm + (int32_t)gpsRescueConfig()->returnAltitudeM * 100, gpsSol.llh.altCm);
+    const uint16_t speedCmS = gpsRescueConfig()->groundSpeedCmS;
+#else
+    const int32_t returnAltCm = gpsSol.llh.altCm;
+    const uint16_t speedCmS = 0;    // waypoint default: autopilot maxVelocity
+#endif
+    const waypoint_t plan[] = {
+        {
+            .latitude = GPS_home_llh.lat,
+            .longitude = GPS_home_llh.lon,
+            .altitude = returnAltCm,
+            .speed = speedCmS,
+            .type = WAYPOINT_TYPE_FLYOVER,
+        },
+        {
+            .latitude = GPS_home_llh.lat,
+            .longitude = GPS_home_llh.lon,
+            .altitude = returnAltCm,
+            .speed = speedCmS,
+            .type = WAYPOINT_TYPE_LAND,
+        },
+    };
+
+    if (!flightPlanNavInjectPlan(plan, ARRAYLEN(plan))) {
+        const positionEstimate3d_t *est = positionEstimatorGetEstimate();
+        startLanding(currentTimeUs, est->position.v[ENU_E] * 0.01f, est->position.v[ENU_N] * 0.01f);
+    }
+}
+
 static void checkGeofence(timeUs_t currentTimeUs)
 {
+    // An injected plan is itself the geofence response; evaluating the fence
+    // while flying it would re-trigger every cycle.
+    if (fp.injectedCount > 0) {
+        return;
+    }
+
     const autopilotConfig_t *cfg = autopilotConfig();
     if (cfg->maxDistanceFromHomeM == 0 || !STATE(GPS_FIX_HOME)) {
         return;
@@ -376,7 +453,7 @@ static void checkGeofence(timeUs_t currentTimeUs)
     }
 
     if (cfg->geofenceAction == AP_GEOFENCE_RTH) {
-        fp.rescueRequested = true;
+        injectReturnHomePlan(currentTimeUs);
     } else {
         const positionEstimate3d_t *est = positionEstimatorGetEstimate();
         startLanding(currentTimeUs, est->position.v[ENU_E] * 0.01f, est->position.v[ENU_N] * 0.01f);
@@ -390,7 +467,7 @@ static void advanceToNext(void)
     // staged cleanly for the upcoming leg.
     fp.altOverridePending = false;
 
-    if (fp.currentIndex + 1 >= flightPlanConfig()->waypointCount) {
+    if (fp.currentIndex + 1 >= activePlanCount()) {
         fp.state = FP_NAV_COMPLETE;
         positionNavClearTarget();
         return;
@@ -416,22 +493,24 @@ static void onWaypointReached(void *userData)
         return;
     }
 
-    if (reachedListener) {
+    // Listener indices refer to the PG mission; injected-plan progress is
+    // meaningless to a MAVLink partner tracking the uploaded plan.
+    if (reachedListener && fp.injectedCount == 0) {
         reachedListener(fp.currentIndex);
     }
 
-    if (wp->type == WAYPOINT_TYPE_HOLD && fp.holdDurationDs > 0) {
+    // A LAND duration is a pre-descent loiter; the hold-expiry path starts
+    // the descent instead of advancing.
+    const bool holdsOnArrival = (wp->type == WAYPOINT_TYPE_HOLD) || (wp->type == WAYPOINT_TYPE_LAND);
+    if (holdsOnArrival && fp.holdDurationDs > 0) {
         fp.state = FP_NAV_HOLDING;
         fp.holdStartUs = micros();
         return;
     }
 
     if (wp->type == WAYPOINT_TYPE_LAND) {
-        // Descend at the waypoint itself, not wherever the arrival gate
-        // tripped: the active nav command still carries the leg's ENU target.
         // Touchdown completes the plan, so a mid-plan LAND is terminal.
-        const positionNavCommand_t *cmd = positionNavGetActiveCommand();
-        startLanding(micros(), cmd->targetPosEfM.v[ENU_E], cmd->targetPosEfM.v[ENU_N]);
+        startLandingAtNavTarget(micros());
         return;
     }
 
@@ -458,7 +537,7 @@ void flightPlanNavInit(void)
     fp.active = false;
     fp.zBiasM = 0.0f;
     fp.abortReason = FP_ABORT_NONE;
-    fp.rescueRequested = false;
+    fp.injectedCount = 0;
     clearModifierState();
 }
 
@@ -467,6 +546,9 @@ void flightPlanNavEngage(void)
     fp.currentIndex = 0;
     fp.state = FP_NAV_IDLE;
     fp.abortReason = FP_ABORT_NONE;
+    // Engagement always starts the PG mission; an injected plan does not
+    // survive a switch cycle (no resume).
+    fp.injectedCount = 0;
     clearModifierState();
 
     // Capture the estimator's current Z so subsequent waypoint altitudes are
@@ -495,8 +577,31 @@ void flightPlanNavDisengage(void)
 {
     fp.active = false;
     fp.state = FP_NAV_IDLE;
+    fp.injectedCount = 0;
     clearModifierState();
     positionNavClearTarget();
+}
+
+bool flightPlanNavInjectPlan(const waypoint_t *waypoints, uint8_t count)
+{
+    if (!fp.active || waypoints == NULL || count == 0 || count > FP_INJECTED_PLAN_MAX) {
+        return false;
+    }
+
+    memcpy(fp.injected, waypoints, count * sizeof(*waypoints));
+    fp.injectedCount = count;
+    fp.currentIndex = 0;
+    fp.abortReason = FP_ABORT_NONE;
+    clearModifierState();
+    // If dispatch fails (GPS origin lost) the state falls back to IDLE and
+    // the update loop retries against the injected plan.
+    dispatchWaypoint();
+    return true;
+}
+
+bool flightPlanNavIsInjectedPlanActive(void)
+{
+    return fp.active && fp.injectedCount > 0;
 }
 
 void flightPlanNavUpdate(timeUs_t currentTimeUs)
@@ -506,7 +611,7 @@ void flightPlanNavUpdate(timeUs_t currentTimeUs)
     }
 
     // Retry dispatch if we engaged before the estimator had an origin.
-    if (fp.state == FP_NAV_IDLE && flightPlanConfig()->waypointCount > 0) {
+    if (fp.state == FP_NAV_IDLE && activePlanCount() > 0) {
         dispatchWaypoint();
         return;
     }
@@ -532,7 +637,7 @@ void flightPlanNavUpdate(timeUs_t currentTimeUs)
         }
 
         checkGeofence(currentTimeUs);
-        if (fp.state == FP_NAV_LANDING || fp.rescueRequested) {
+        if (fp.state == FP_NAV_LANDING) {
             return;
         }
     }
@@ -554,7 +659,12 @@ void flightPlanNavUpdate(timeUs_t currentTimeUs)
         const uint32_t holdUs = (uint32_t)fp.holdDurationDs * 100000u;
         const uint32_t elapsedUs = (uint32_t)(currentTimeUs - fp.holdStartUs);
         if (elapsedUs >= holdUs) {
-            advanceToNext();
+            const waypoint_t *wp = currentWaypoint();
+            if (wp != NULL && wp->type == WAYPOINT_TYPE_LAND) {
+                startLandingAtNavTarget(currentTimeUs);
+            } else {
+                advanceToNext();
+            }
         }
     }
 }
@@ -577,16 +687,6 @@ uint8_t flightPlanNavGetCurrentIndex(void)
 flightPlanAbortReason_e flightPlanNavGetAbortReason(void)
 {
     return fp.abortReason;
-}
-
-bool flightPlanNavRescueRequested(void)
-{
-    return fp.rescueRequested;
-}
-
-void flightPlanNavClearRescueRequest(void)
-{
-    fp.rescueRequested = false;
 }
 
 void flightPlanNavSetReachedListener(flightPlanWaypointReachedFn fn)

--- a/src/main/flight/flight_plan_nav.h
+++ b/src/main/flight/flight_plan_nav.h
@@ -26,6 +26,8 @@
 
 #include "common/time.h"
 
+#include "pg/flight_plan.h"
+
 typedef enum {
     FP_NAV_IDLE = 0,
     FP_NAV_TARGETING,
@@ -63,11 +65,12 @@ flightPlanNavState_e flightPlanNavGetState(void);
 uint8_t flightPlanNavGetCurrentIndex(void);
 flightPlanAbortReason_e flightPlanNavGetAbortReason(void);
 
-// Geofence RTH latch. Set when a geofence breach with AP_GEOFENCE_RTH occurs;
-// consumed by the GPS rescue mode gate. Stays latched (rescue outranks the
-// mission and disengages it) until cleared on disarm or AUTOPILOT switch-off.
-bool flightPlanNavRescueRequested(void);
-void flightPlanNavClearRescueRequest(void);
+// Replace the active mission with a small synthesised runtime plan (at most 4
+// waypoints, copied). Only valid while the executor is active. The injected
+// plan does not survive a switch cycle: engage and disengage revert to the
+// stored mission, with no resume of what was preempted.
+bool flightPlanNavInjectPlan(const waypoint_t *waypoints, uint8_t count);
+bool flightPlanNavIsInjectedPlanActive(void);
 
 // Single observer slot for "waypoint reached" — invoked with the index of the
 // waypoint that was just reached, before any HOLD timer or advance. Pass NULL

--- a/src/main/telemetry/mavlink_mission.c
+++ b/src/main/telemetry/mavlink_mission.c
@@ -165,7 +165,10 @@ static void sendMissionItem(uint8_t partnerSys, uint8_t partnerComp, uint16_t se
         break;
     }
 
-    const uint8_t current = (flightPlanNavIsActive() && seq == flightPlanNavGetCurrentIndex()) ? 1 : 0;
+    // While an injected runtime plan flies, the executor index does not refer
+    // to the stored mission this download describes.
+    const uint8_t current = (flightPlanNavIsActive() && !flightPlanNavIsInjectedPlanActive()
+        && seq == flightPlanNavGetCurrentIndex()) ? 1 : 0;
 
     mavlink_msg_mission_item_int_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
         partnerSys, partnerComp, seq, MAV_FRAME_GLOBAL_INT, command, current, 1,
@@ -638,7 +641,8 @@ void mavMissionUpdate(timeMs_t nowMs)
     if ((nowMs - m.lastCurrentTxMs) >= MISSION_CURRENT_PERIOD_MS) {
         const uint16_t total = flightPlanConfig()->waypointCount;
         const bool active = flightPlanNavIsActive();
-        const uint16_t seq = (total && active) ? flightPlanNavGetCurrentIndex() : 0;
+        const uint16_t seq = (total && active && !flightPlanNavIsInjectedPlanActive())
+            ? flightPlanNavGetCurrentIndex() : 0;
         const uint8_t missionMode = active ? 1 : 2;
         uint8_t missionState;
         if (total == 0) {

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -522,11 +522,13 @@ flight_plan_nav_unittest_SRC := \
 		$(USER_DIR)/flight/flight_plan_nav.c \
 		$(USER_DIR)/pg/autopilot.c \
 		$(USER_DIR)/pg/flight_plan.c \
+		$(USER_DIR)/pg/gps_rescue_multirotor.c \
 		$(USER_DIR)/common/maths.c \
 		$(USER_DIR)/common/vector.c
 
 flight_plan_nav_unittest_DEFINES := \
 		USE_GPS= \
+		USE_GPS_RESCUE= \
 		USE_FLIGHT_PLAN= \
 		ENABLE_FLIGHT_PLAN=1
 rcdevice_unittest_DEFINES := \

--- a/src/test/sitl/sitl_harness.py
+++ b/src/test/sitl/sitl_harness.py
@@ -672,8 +672,9 @@ def scenario_mission_yaw(sitl, rc, fdm):
 
 def scenario_mission_land(sitl, rc, fdm):
     """LAND waypoint: fly the first leg north, divert to the offset LAND
-    waypoint, arrive through the 3D hold gate, descend there, and disarm on
-    touchdown (impact jerk; the estimator's vz is unreliable when grounded)."""
+    waypoint, arrive through the 3D hold gate, loiter for the waypoint
+    duration, descend, and disarm on touchdown (impact jerk; the estimator's
+    vz is unreliable when grounded)."""
     boot_and_engage(sitl, rc, fdm)
 
     wait_for(
@@ -687,6 +688,12 @@ def scenario_mission_land(sitl, rc, fdm):
         timeout=120,
         interval=1.0,
     )
+    # 5 s pre-descent loiter: shortly after arrival the vehicle must still be
+    # holding altitude (an immediate 2 m/s descent would be ~4 m down by now)
+    time.sleep(2.0)
+    assert BOX_ARM in sitl.modes(), "disarmed during the loiter"
+    assert fdm.model.pos[2] > 7.0, f"descended during the loiter: alt {fdm.model.pos[2]:.1f} m"
+    log(f"loitering at {fdm.model.pos[2]:.1f} m before descent")
     wait_for(
         "touchdown disarms",
         lambda: BOX_ARM not in sitl.modes(),
@@ -734,16 +741,28 @@ def scenario_geofence(sitl, rc, fdm, action):
     wait_for("mission departs toward the fence", lambda: fdm.distance_from_home() > 25.0, timeout=60)
 
     if action == "RTH":
-        wait_for(
-            "GPS rescue engaged, mission disengaged",
-            lambda: (lambda m: BOX_GPSRESCUE in m and BOX_AUTOPILOT not in m)(sitl.modes()),
-            timeout=60,
-        )
+        # Plan swap, not rescue: the mission keeps flying (an injected
+        # [fly home, land] plan) and the vehicle comes back inside the fence.
         time.sleep(3)
         modes = sitl.modes()
-        assert BOX_GPSRESCUE in modes and BOX_AUTOPILOT not in modes, \
-            f"geofence rescue did not remain latched: {modes}"
-        log("rescue remains latched")
+        assert BOX_GPSRESCUE not in modes, f"rescue engaged instead of plan swap: {modes}"
+        assert BOX_AUTOPILOT in modes, f"mission dropped on breach: {modes}"
+        wait_for(
+            "vehicle returns inside the fence",
+            lambda: fdm.distance_from_home() < 25.0,
+            timeout=120,
+            interval=1.0,
+        )
+        wait_for(
+            "touchdown at home disarms",
+            lambda: BOX_ARM not in sitl.modes(),
+            timeout=120,
+            interval=1.0,
+        )
+        dist = fdm.distance_from_home()
+        assert fdm.model.on_ground(), f"disarmed in the air: alt {fdm.model.pos[2]:.1f} m"
+        assert dist < 10.0, f"landed {dist:.1f} m from home"
+        log(f"returned and landed {dist:.1f} m from home")
     else:  # LAND
         time.sleep(8)
         modes = sitl.modes()
@@ -762,23 +781,35 @@ def scenario_geofence(sitl, rc, fdm, action):
 
 
 def scenario_geofence_rth_rxloss(sitl, rc, fdm):
-    """The RTH latch must survive RX loss: stage-2 rxfail values force the
-    AUTOPILOT switch low (rxfail preset in this scenario's config), which must
-    not read as the pilot cancelling the rescue."""
+    """The geofence return must survive RX loss: with rx-loss policy CONTINUE
+    the failsafe keeps flying the injected return plan while stage-2 rxfail
+    values force the AUTOPILOT switch low."""
     boot_and_engage(sitl, rc, fdm)
+    wait_for("mission departs toward the fence", lambda: fdm.distance_from_home() > 40.0, timeout=60)
     wait_for(
-        "GPS rescue engaged after geofence breach",
-        lambda: BOX_GPSRESCUE in sitl.modes(),
-        timeout=60,
+        "return leg underway (heading back inside 40 m)",
+        lambda: fdm.distance_from_home() < 40.0,
+        timeout=90,
+        interval=0.5,
     )
 
-    log("killing RC stream mid-rescue")
+    log("killing RC stream mid-return")
     rc.stop_stream()
     wait_for("failsafe active", lambda: BOX_FAILSAFE in sitl.modes())
     time.sleep(3)
     modes = sitl.modes()
-    assert {BOX_FAILSAFE, BOX_GPSRESCUE} <= modes, f"rescue dropped when rxfail cleared the switch: {modes}"
-    log("rescue persists through RX loss")
+    assert {BOX_FAILSAFE, BOX_AUTOPILOT} <= modes, f"return plan dropped on RX loss: {modes}"
+    assert BOX_GPSRESCUE not in modes, f"unexpected rescue: {modes}"
+    log("return continues through RX loss")
+    wait_for(
+        "lands at home under failsafe",
+        lambda: BOX_ARM not in sitl.modes(),
+        timeout=150,
+        interval=1.0,
+    )
+    dist = fdm.distance_from_home()
+    assert dist < 10.0, f"landed {dist:.1f} m from home"
+    log(f"landed {dist:.1f} m from home under failsafe")
 
 
 SCENARIOS = {
@@ -799,7 +830,8 @@ SCENARIOS = {
             # short north leg, then LAND at an offset so the executor must fly
             # to the landing point before descending
             f"waypoint update 0 {WP_NORTH40_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyover 0 orbit",
-            f"waypoint insert 1 {WP_NORTH40_LAT:.7f} {WP_EAST25_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 land 0 orbit",
+            # 5 s pre-descent loiter at the LAND waypoint
+            f"waypoint insert 1 {WP_NORTH40_LAT:.7f} {WP_EAST25_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 land 50 orbit",
             # SITL's 15-20 Hz position loop wanders during braking; a fatter
             # 3D gate keeps arrival deterministic
             "set ap_waypoint_hold_radius = 400",
@@ -821,14 +853,28 @@ SCENARIOS = {
     ),
     "geofence_rth": (
         lambda s, r, f: scenario_geofence(s, r, f, "RTH"),
-        ["set ap_max_distance_from_home = 50", "set ap_geofence_action = RTH"],
+        [
+            "set ap_max_distance_from_home = 50",
+            "set ap_geofence_action = RTH",
+            "set ap_yaw_mode = FIXED",
+            "set gps_rescue_return_alt = 15",     # short climb keeps the return quick
+            "set ap_waypoint_hold_radius = 400",
+            "set ap_landing_descent_rate = 200",
+            "set landing_disarm_threshold = 10",
+        ],
     ),
     "geofence_rth_rxloss": (
         scenario_geofence_rth_rxloss,
         [
             "set ap_max_distance_from_home = 50",
             "set ap_geofence_action = RTH",
+            "set ap_rx_loss_policy = CONTINUE",
             "rxfail 5 s 1000",  # stage 2 forces the AUTOPILOT switch low
+            "set ap_yaw_mode = FIXED",
+            "set gps_rescue_return_alt = 15",
+            "set ap_waypoint_hold_radius = 400",
+            "set ap_landing_descent_rate = 200",
+            "set landing_disarm_threshold = 10",
         ],
     ),
 }

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -37,6 +37,7 @@ extern "C" {
 
     #include "pg/autopilot.h"
     #include "pg/flight_plan.h"
+    #include "pg/gps_rescue.h"
     #include "pg/pg.h"
 
     int16_t debug[DEBUG16_VALUE_COUNT];
@@ -44,6 +45,8 @@ extern "C" {
 
     uint8_t stateFlags;
     uint16_t GPS_distanceToHome;
+    gpsSolutionData_t gpsSol;
+    gpsLocation_t GPS_home_llh;
 }
 
 #include "unittest_macros.h"
@@ -233,6 +236,17 @@ protected:
         g_stubGpsOrigin.altCm = 10000;
         g_stubGpsOriginSet = true;
 
+        // Home at the origin; current GPS altitude at home altitude.
+        memset(&GPS_home_llh, 0, sizeof(GPS_home_llh));
+        GPS_home_llh.altCm = 10000;
+        memset(&gpsSol, 0, sizeof(gpsSol));
+        gpsSol.llh.altCm = 10000;
+
+        gpsRescueConfig_t *rescueCfg = gpsRescueConfigMutable();
+        memset(rescueCfg, 0, sizeof(*rescueCfg));
+        rescueCfg->returnAltitudeM = 30;
+        rescueCfg->groundSpeedCmS = 750;
+
         flightPlanConfig_t *plan = flightPlanConfigMutable();
         memset(plan, 0, sizeof(*plan));
 
@@ -246,6 +260,24 @@ protected:
         cfg->landingVelocityThreshold = 50; // 0.5 m/s
 
         flightPlanNavInit();
+    }
+
+    void TearDown() override {
+        flightPlanNavSetReachedListener(nullptr);
+    }
+
+    static waypoint_t makeWaypoint(int32_t lat, int32_t lon, int32_t altCm,
+                                   uint8_t type, uint16_t speed = 0, uint16_t duration = 0)
+    {
+        waypoint_t wp = {};
+        wp.latitude = lat;
+        wp.longitude = lon;
+        wp.altitude = altCm;
+        wp.speed = speed;
+        wp.duration = duration;
+        wp.type = type;
+        wp.pattern = WAYPOINT_PATTERN_ORBIT;
+        return wp;
     }
 
     void addWaypoint(int32_t lat, int32_t lon, int32_t altCm,
@@ -469,6 +501,105 @@ TEST_F(FlightPlanNavTest, YawRateCapClearsOnDisengageAndEngage)
     EXPECT_FLOAT_EQ(g_yawRateLimitDps, 0.0f);
 }
 
+// --- Injected runtime plans ---
+
+namespace {
+int g_reachedCalls;
+void recordReached(uint8_t index) { (void)index; g_reachedCalls++; }
+} // namespace
+
+TEST_F(FlightPlanNavTest, InjectedPlanReplacesMissionAndRunsToTermination)
+{
+    // Single-waypoint PG mission with a yaw-rate cap staged: injection must
+    // clear the cap and must not be truncated by the shorter PG count.
+    addWaypoint(0, 0, 0, WAYPOINT_TYPE_YAW_RATE, 45);
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    flightPlanNavEngage();
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_FLOAT_EQ(g_yawRateLimitDps, 45.0f);
+    const int callsBefore = g_setTargetCalls;
+
+    const int32_t lonUnitsFor10m = (int32_t)((10.0f / 111319.49f) * 1.0e7f);
+    const waypoint_t plan[] = {
+        makeWaypoint(0, lonUnitsFor10m, 12000, WAYPOINT_TYPE_FLYOVER),
+        makeWaypoint(0, lonUnitsFor10m, 12000, WAYPOINT_TYPE_LAND),
+    };
+    ASSERT_TRUE(flightPlanNavInjectPlan(plan, 2));
+
+    EXPECT_TRUE(flightPlanNavIsInjectedPlanActive());
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_EQ(g_setTargetCalls, callsBefore + 1);
+    EXPECT_FLOAT_EQ(g_yawRateLimitDps, 0.0f);
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, 10.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 20.0f, 0.1f); // 120 m AMSL - 100 m origin
+
+    // The injected plan advances past the PG waypoint count (1 positional wp).
+    triggerReached();
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+
+    triggerReached();
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+}
+
+TEST_F(FlightPlanNavTest, InjectRejectsInvalidRequests)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    const waypoint_t wp = makeWaypoint(0, 0, 12000, WAYPOINT_TYPE_LAND);
+    const waypoint_t five[5] = { wp, wp, wp, wp, wp };
+
+    // Executor not active.
+    EXPECT_FALSE(flightPlanNavInjectPlan(&wp, 1));
+
+    flightPlanNavEngage();
+    EXPECT_FALSE(flightPlanNavInjectPlan(&wp, 0));
+    EXPECT_FALSE(flightPlanNavInjectPlan(five, 5));
+    EXPECT_FALSE(flightPlanNavInjectPlan(NULL, 1));
+    EXPECT_FALSE(flightPlanNavIsInjectedPlanActive());
+
+    EXPECT_TRUE(flightPlanNavInjectPlan(&wp, 1));
+    EXPECT_TRUE(flightPlanNavIsInjectedPlanActive());
+}
+
+TEST_F(FlightPlanNavTest, EngageAfterInjectRevertsToPgPlan)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    flightPlanNavEngage();
+    const waypoint_t wp = makeWaypoint(0, 0, 12000, WAYPOINT_TYPE_LAND);
+    ASSERT_TRUE(flightPlanNavInjectPlan(&wp, 1));
+
+    flightPlanNavDisengage();
+    EXPECT_FALSE(flightPlanNavIsInjectedPlanActive());
+
+    flightPlanNavEngage();
+    EXPECT_FALSE(flightPlanNavIsInjectedPlanActive());
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 50.0f, 0.1f); // PG waypoint: 150 m AMSL - 100 m origin
+}
+
+TEST_F(FlightPlanNavTest, ReachedListenerSuppressedWhileInjected)
+{
+    g_reachedCalls = 0;
+    flightPlanNavSetReachedListener(recordReached);
+
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
+    flightPlanNavEngage();
+    triggerReached();
+    EXPECT_EQ(g_reachedCalls, 1); // PG mission progress is reported
+
+    const waypoint_t plan[] = {
+        makeWaypoint(0, 0, 12000, WAYPOINT_TYPE_FLYOVER),
+        makeWaypoint(0, 0, 12000, WAYPOINT_TYPE_LAND),
+    };
+    ASSERT_TRUE(flightPlanNavInjectPlan(plan, 2));
+    triggerReached();
+    EXPECT_EQ(g_reachedCalls, 1); // injected-plan progress is not
+}
+
 // --- LAND waypoint type ---
 
 TEST_F(FlightPlanNavTest, LandWaypointDispatchesWithHoldGate)
@@ -538,6 +669,56 @@ TEST_F(FlightPlanNavTest, LandWaypointTouchdownDisarmsAndCompletes)
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_COMPLETE);
     // LAND is terminal: the trailing waypoint is never dispatched.
     EXPECT_EQ(g_setTargetCalls, dispatchesBeforeTouchdown);
+}
+
+TEST_F(FlightPlanNavTest, LandWaypointWithDurationLoitersThenDescends)
+{
+    const int32_t lonUnitsFor10m = (int32_t)((10.0f / 111319.49f) * 1.0e7f);
+    addWaypoint(0, lonUnitsFor10m, 5000, WAYPOINT_TYPE_LAND, 0, 20 /* 2.0 s loiter */);
+
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    triggerReached();
+
+    // Pre-descent loiter, exactly like HOLD.
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_HOLDING);
+
+    g_stubMicros += 1'000'000; // 1 s: still loitering
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_HOLDING);
+
+    g_stubEstimate.position.v[ENU_U] = 30.0f * 100.0f;
+    g_stubMicros += 1'500'000; // 2.5 s: loiter expired, descend at the waypoint
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, 10.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 200.0f, 0.1f);
+}
+
+TEST_F(FlightPlanNavTest, LandLoiterExpiryWithLostTargetRedispatchesLeg)
+{
+    const int32_t lonUnitsFor10m = (int32_t)((10.0f / 111319.49f) * 1.0e7f);
+    addWaypoint(0, lonUnitsFor10m, 5000, WAYPOINT_TYPE_LAND, 0, 20);
+
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    triggerReached();
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_HOLDING);
+
+    // The position command is wiped during the loiter (position-control
+    // re-init). A zeroed target must not be used as the descent anchor —
+    // the leg is re-flown instead.
+    positionNavClearTarget();
+    const int callsBefore = g_setTargetCalls;
+
+    g_stubMicros += 2'500'000;
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_EQ(g_setTargetCalls, callsBefore + 1);
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, 10.0f, 0.1f); // the LAND leg again, not a descent
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, -50.0f, 0.1f);
 }
 
 // --- Safety behaviour ---
@@ -644,7 +825,7 @@ TEST_F(FlightPlanNavSafetyTest, GeofenceBreachWithLandActionStartsLanding)
     EXPECT_NEAR(g_lastTarget.targetEfM.y, 34.0f, 0.1f);
     EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 200.0f, 0.1f);
     EXPECT_NEAR(g_lastTarget.cruiseSpeedMps, 0.5f, 0.01f);
-    EXPECT_FALSE(flightPlanNavRescueRequested());
+    EXPECT_FALSE(flightPlanNavIsInjectedPlanActive());
 }
 
 TEST_F(FlightPlanNavSafetyTest, GeofenceInsideLimitDoesNothing)
@@ -672,23 +853,62 @@ TEST_F(FlightPlanNavSafetyTest, GeofenceWithoutHomeFixDoesNothing)
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
 }
 
-TEST_F(FlightPlanNavSafetyTest, GeofenceBreachWithRthActionLatchesRescueRequest)
+TEST_F(FlightPlanNavSafetyTest, GeofenceBreachWithRthActionInjectsReturnPlan)
 {
     autopilotConfigMutable()->maxDistanceFromHomeM = 100;
     autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_RTH;
     stateFlags |= GPS_FIX_HOME;
     engageDistantLeg();
+    const int callsBeforeBreach = g_setTargetCalls;
+
+    GPS_distanceToHome = 150;
+    g_stubEstimate.position.v[ENU_N] = 150.0f * 100.0f; // 150 m out, en route
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+
+    // The return plan replaces the mission: fly to home at the rescue return
+    // altitude (30 m above the 100 m home altitude) at the rescue ground speed.
+    EXPECT_TRUE(flightPlanNavIsInjectedPlanActive());
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_EQ(g_setTargetCalls, callsBeforeBreach + 1);
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, 0.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.y, 0.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.cruiseSpeedMps, 7.5f, 0.01f);
+
+    // Still outside the fence on the way home: no re-injection.
+    g_stubMicros += 1'000'000;
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(g_setTargetCalls, callsBeforeBreach + 1);
+
+    // Home arrival dispatches the plan's LAND leg; its arrival descends there.
+    triggerReached();
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    triggerReached();
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, 0.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.y, 0.0f, 0.1f);
+
+    // No resume: the injected plan dies with disengagement.
+    flightPlanNavDisengage();
+    EXPECT_FALSE(flightPlanNavIsInjectedPlanActive());
+}
+
+TEST_F(FlightPlanNavSafetyTest, GeofenceRthAboveReturnAltReturnsAtCurrentAltitude)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_RTH;
+    stateFlags |= GPS_FIX_HOME;
+    gpsSol.llh.altCm = 15000; // 150 m AMSL: 20 m above home + returnAltitudeM
+    engageDistantLeg();
 
     GPS_distanceToHome = 150;
     flightPlanNavUpdate(g_stubMicros + 10'000);
 
-    EXPECT_TRUE(flightPlanNavRescueRequested());
-    // The request survives disengagement (rescue outranks and disengages the mission).
-    flightPlanNavDisengage();
-    EXPECT_TRUE(flightPlanNavRescueRequested());
-
-    flightPlanNavClearRescueRequest();
-    EXPECT_FALSE(flightPlanNavRescueRequested());
+    ASSERT_TRUE(flightPlanNavIsInjectedPlanActive());
+    // Never descend en route: return at the higher of the two altitudes.
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 50.0f, 0.1f);
 }
 
 TEST_F(FlightPlanNavSafetyTest, LandingTouchdownDisarms)


### PR DESCRIPTION
Follow-up to #15408. The flight plan executor can now fly a small synthesised runtime plan in place of the stored mission (`flightPlanNavInjectPlan`, up to four waypoints, copied; no resume, engage or disengage reverts to the stored mission).

First consumer: a geofence breach with the RTH action no longer latches GPS rescue. It injects a return mission (fly home at `gps_rescue_return_alt` or current altitude, whichever is higher, at `gps_rescue_ground_speed`, then land at home) and the rescue-request latch is gone. MAVLink MISSION_CURRENT and mission download suppress the live cursor while an injected plan flies, since the executor index no longer refers to the uploaded mission. LAND waypoints now honour their duration as a pre-descent loiter.

The rewritten SITL scenarios caught a real bug on the way: stage-1 rxfail substitution could force the AUTOPILOT switch low and disengage a mission before the rx-loss policy ran, so the switch now only counts as pilot intent while channel data is real. The geofence RTH scenario is now a full end-to-end RTL, returning and landing within metres of home, including under RX loss with the CONTINUE policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Geofence return-to-home now uses a temporary flight plan to guide the vehicle home and land.
  * Temporary return plans remain active during receiver signal loss and resume normal mission operation afterward.
  * Landing at navigation targets now includes improved loiter and descent behavior.

* **Bug Fixes**
  * Prevented navigation telemetry from reporting temporary plan waypoints as uploaded mission progress.
  * Improved autopilot activation behavior during failsafe and invalid receiver input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of the autopilot programme tracked in #15411.
