### PR TITLE
Autopilot: nav velocity mode with drag feedforward

### DIFF
--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -56,7 +56,19 @@
 // 4 - D term * 10 // velocity factor ( distance error derivative)
 // 5 - A term * 10 // velocity derivative factor (acceleration in distance terms)
 // 6 - PIDsum * 10
-// 7 - Status - encodes navActive+ 10, SticksActive +5, PositionHeld +3, +1 when starting,
+// 7 - Status - encodes navActive+ 10, velocityMode +20, SticksActive +5, PositionHeld +3, +1 when starting,
+// In velocity mode slots 2-5 carry the velocity-loop terms: P/I on velocity error,
+// D damping, A the drag feedforward; slot 1 reads ~0. See also DEBUG_POSITION_NAV.
+
+// DEBUG_POSITION_NAV, axis set by gyro_filter_debug_axis
+// 0 - target velocity cm/s
+// 1 - filtered measured velocity cm/s
+// 2 - velocity error cm/s
+// 3 - P term * 10 (post buildup clamp)
+// 4 - I term * 10
+// 5 - D term * 10 (damping)
+// 6 - drag feedforward * 10
+// 7 - velocityMode * 10, +1 while the buildup clamp engages
 
 // DEBUG_AUTOPILOT_STOP
 // 0 - distance from position-hold target (cm)
@@ -93,7 +105,22 @@
 #define AP_YAW_D_SCALE         0.01f
 #define AP_YAW_RAMP_TIME_S     1.0f
 
+// Nav velocity loop (cm/s error -> degrees of lean)
+#define VELOCITY_P_SCALE       0.0004f   // default 50 -> 2 deg per m/s of error
+#define VELOCITY_I_SCALE       0.001f
+#define VELOCITY_D_SCALE       0.0004f
+#define VELOCITY_DRAG_SCALE    0.0001f   // default 50 -> 2.5 deg at 5 m/s target
+#define VELOCITY_I_LIMIT_DEG    15.0f
+#define VELOCITY_I_RELAX_CMS   250.0f    // integrate only near the target speed, so the
+                                         // integral cannot wind up during the accel phase
+
 static pidCoefficient_t positionPidCoeffs;
+
+static float velocityKp;
+static float velocityKi;
+static float velocityKd;
+static float velocityDragKff;
+static vector2_t velocityIntegral;       // nav velocity-loop I term, degrees, earth frame
 
 static float altitudeKp;
 static float altitudeKi;
@@ -183,6 +210,11 @@ void autopilotInit(void)
     positionPidCoeffs.Ki  = cfg->positionI  * POSITION_I_SCALE;
     positionPidCoeffs.Kd  = cfg->positionD  * POSITION_D_SCALE;
     positionPidCoeffs.Ka  = cfg->positionA  * POSITION_A_SCALE;
+
+    velocityKp      = cfg->velocityP * VELOCITY_P_SCALE;
+    velocityKi      = cfg->velocityI * VELOCITY_I_SCALE;
+    velocityKd      = cfg->velocityD * VELOCITY_D_SCALE;
+    velocityDragKff = cfg->velocityDragCoeff * VELOCITY_DRAG_SCALE;
     ap.sticksActive = false;
     ap.wasSticksActive = false;
     abortNavRequested = false;
@@ -329,6 +361,11 @@ static void resetDistanceErrorIntegral(void)
     distanceErrorIntegral = (vector2_t){{ 0.0f, 0.0f }};
 }
 
+static void resetVelocityIntegral(void)
+{
+    velocityIntegral = (vector2_t){{ 0.0f, 0.0f }};
+}
+
 void initPositionHold(void)
 {
     updatePositionHoldTarget();
@@ -345,6 +382,7 @@ static void initNavMode(void)
     initPidLpfs();
     resetDistanceError();
     resetDistanceErrorIntegral();
+    resetVelocityIntegral();
     isPosHoldStarting[EF_EAST]  = false;
     isPosHoldStarting[EF_NORTH] = false;
 }
@@ -367,6 +405,7 @@ void resetPositionControl(unsigned taskRateHz)
     initPositionHold(); // sets target location, resets distance error, enables start mode
     previousVelocity = *(const vector2_t *)&positionEstimatorGetEstimate()->velocity.v; // for smooth A in any mode
     resetDistanceErrorIntegral();
+    resetVelocityIntegral();
 }
 
 void handlepositionControlFailure(void)
@@ -591,6 +630,9 @@ bool positionControl(void)
     wasNavActive = ap.navActive;
     ap.wasSticksActive = ap.sticksActive; // Main frame-to-frame history update
 
+    const bool velocityMode = ap.navActive && autopilotConfig()->velocityControlEnable;
+    vector2_t velocityFilteredV = { { 0 } };
+
     for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
         if (isPositionHeld) {
             if (isPosHoldStarting[axis]) {
@@ -625,37 +667,73 @@ bool positionControl(void)
         }
 
         const float velocityFiltered = pt2FilterApply(&posDtermLpf[axis], velocity.v[axis]);
+        velocityFilteredV.v[axis] = velocityFiltered;
         velocityError.v[axis] = targetVelocity.v[axis] - velocityFiltered;
-        velocityError.v[axis] *= dTermRamp.v[axis];
-        const float accelerationRaw = (previousVelocity.v[axis] - velocityFiltered) * POSHOLD_TASK_RATE_HZ * dTermRamp.v[axis];
+        const float accelerationRaw = (previousVelocity.v[axis] - velocityFiltered) * POSHOLD_TASK_RATE_HZ;
         previousVelocity.v[axis] = velocityFiltered;
-        const float acceleration = pt2FilterApply(&posAccelLpf[axis], accelerationRaw);
 
-        if (ap.navActive) {
-            // Anti-windup: while the angle output is saturated (accelerating
-            // toward cruise), only integrate toward unwinding, or metres of
-            // pseudo distance error accumulate that can only be shed by
-            // flying well past the commanded speed.
-            if (!wasAngleSaturated || (velocityError.v[axis] * distanceError.v[axis]) < 0.0f) {
-                distanceError.v[axis] += velocityError.v[axis] * dt;
+        if (velocityMode) {
+            // Track the nav velocity target directly; dTermRamp is pos-hold
+            // start-up state and holds a stale value during nav, so the raw
+            // error and acceleration are used here.
+            const float acceleration = pt2FilterApply(&posAccelLpf[axis], accelerationRaw);
+            if (fabsf(velocityError.v[axis]) < VELOCITY_I_RELAX_CMS
+                && (!wasAngleSaturated || (velocityError.v[axis] * velocityIntegral.v[axis]) < 0.0f)) {
+                velocityIntegral.v[axis] += velocityError.v[axis] * velocityKi * dt;
+                velocityIntegral.v[axis] = constrainf(velocityIntegral.v[axis], -VELOCITY_I_LIMIT_DEG, VELOCITY_I_LIMIT_DEG);
             }
-        } else if (!isPositionHeld) {
-            // sticks active
-            distanceErrorIntegral.v[axis] *= 0.99f;
-            distanceError.v[axis] = 0.0f;
+            pidP.v[axis] = velocityError.v[axis] * velocityKp;
+            pidI.v[axis] = velocityIntegral.v[axis];
+            pidD.v[axis] = acceleration * velocityKd;
+            pidA.v[axis] = targetVelocity.v[axis] * velocityDragKff; // drag feedforward carries the cruise tilt
+        } else {
+            velocityError.v[axis] *= dTermRamp.v[axis];
+            const float acceleration = pt2FilterApply(&posAccelLpf[axis], accelerationRaw * dTermRamp.v[axis]);
+
+            if (ap.navActive) {
+                // Anti-windup: while the angle output is saturated (accelerating
+                // toward cruise), only integrate toward unwinding, or metres of
+                // pseudo distance error accumulate that can only be shed by
+                // flying well past the commanded speed.
+                if (!wasAngleSaturated || (velocityError.v[axis] * distanceError.v[axis]) < 0.0f) {
+                    distanceError.v[axis] += velocityError.v[axis] * dt;
+                }
+            } else if (!isPositionHeld) {
+                // sticks active
+                distanceErrorIntegral.v[axis] *= 0.99f;
+                distanceError.v[axis] = 0.0f;
+            }
+
+            distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
+            distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt * (isPosHoldStarting[axis] ? 0.0f : 1.0f);
+            distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
+
+            pidP.v[axis] = distanceError.v[axis] * positionPidCoeffs.Kp;
+            pidI.v[axis] = distanceErrorIntegral.v[axis] * positionPidCoeffs.Ki;
+            pidD.v[axis] = velocityError.v[axis] * positionPidCoeffs.Kd * dTermRamp.v[axis];
+            pidA.v[axis] = acceleration * positionPidCoeffs.Ka;
         }
-
-        distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
-        distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt * (isPosHoldStarting[axis] ? 0.0f : 1.0f);
-        distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
-
-        pidP.v[axis] = distanceError.v[axis] * positionPidCoeffs.Kp;
-        pidI.v[axis] = distanceErrorIntegral.v[axis] * positionPidCoeffs.Ki;
-        pidD.v[axis] = velocityError.v[axis] * positionPidCoeffs.Kd * dTermRamp.v[axis];
-        pidA.v[axis] = acceleration * positionPidCoeffs.Ka;
 
         pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis];
     } // End for loop
+
+    bool buildupClamped = false;
+    if (velocityMode) {
+        // velocityBuildupMaxPitch bounds the P vector, the acceleration-demand
+        // term, so the pitch bias while building up to speed is limited; the
+        // drag feedforward, integral trim and damping ride on top, with the
+        // maxAngle clamp below as the hard limit on the total.
+        const float buildupMaxDeg = autopilotConfig()->velocityBuildupMaxPitch;
+        const float pMag = vector2Norm(&pidP);
+        if (pMag > buildupMaxDeg) {
+            buildupClamped = true;
+            const float scale = (pMag > 0.001f) ? buildupMaxDeg / pMag : 0.0f;
+            vector2Scale(&pidP, &pidP, scale);
+            for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
+                pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis];
+            }
+        }
+    }
 
     // Rotation from Earth Frame to Body Frame
     const float headingRad = DECIDEGREES_TO_RADIANS(attitude.values.yaw);
@@ -679,6 +757,7 @@ bool positionControl(void)
 
     int statusValue = 0;
     if (ap.navActive)       statusValue += 10;
+    if (velocityMode)       statusValue += 20;
     if (abortNavRequested)  statusValue += 100;
     if (isPositionHeld)     statusValue += 3; // plus 1, ie 4,  if stopping
     if (ap.sticksActive)    statusValue += 5;
@@ -699,6 +778,15 @@ bool positionControl(void)
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 5, lrintf(autopilotAngle[AI_PITCH] * 10));
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 6, statusValue + (isPosHoldStarting[EF_EAST] ? 1 : 0));
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 7, statusValue + (isPosHoldStarting[EF_NORTH] ? 1 : 0));
+
+    DEBUG_SET(DEBUG_POSITION_NAV, 0, lrintf(targetVelocity.v[ap.debugAxis]));
+    DEBUG_SET(DEBUG_POSITION_NAV, 1, lrintf(velocityFilteredV.v[ap.debugAxis]));
+    DEBUG_SET(DEBUG_POSITION_NAV, 2, lrintf(velocityError.v[ap.debugAxis]));
+    DEBUG_SET(DEBUG_POSITION_NAV, 3, lrintf(pidP.v[ap.debugAxis] * 10));
+    DEBUG_SET(DEBUG_POSITION_NAV, 4, lrintf(pidI.v[ap.debugAxis] * 10));
+    DEBUG_SET(DEBUG_POSITION_NAV, 5, lrintf(pidD.v[ap.debugAxis] * 10));
+    DEBUG_SET(DEBUG_POSITION_NAV, 6, lrintf(pidA.v[ap.debugAxis] * 10));
+    DEBUG_SET(DEBUG_POSITION_NAV, 7, (velocityMode ? 10 : 0) + (buildupClamped ? 1 : 0));
 
     return true;
 }

--- a/src/main/pg/autopilot.h
+++ b/src/main/pg/autopilot.h
@@ -67,12 +67,12 @@ typedef struct autopilotConfig_s {
     uint8_t stopThreshold;       // cm/s, speed below which braking captures a position hold target
     uint8_t maxAngle;
 
-    // Velocity-based position control with drag compensation
-    uint8_t velocityControlEnable;    // 0=position→angle, 1=position→velocity→angle (default 1)
+    // Velocity-based position control with drag compensation (nav path only; pos-hold is unaffected)
+    uint8_t velocityControlEnable;    // 0=legacy pseudo-distance→angle, 1=velocity-PID→angle (default 1)
     uint8_t velocityP;                // velocity loop P gain, scaled by 10 (default 50 = 5.0)
     uint8_t velocityI;                // velocity loop I gain, scaled by 10 (default 10 = 1.0)
     uint8_t velocityD;                // velocity loop D gain, scaled by 10 (default 5 = 0.5)
-    uint16_t velocityDragCoeff;       // drag coefficient, scaled by 10000 (default 50 = 0.0050)
+    uint16_t velocityDragCoeff;       // linear drag feedforward: degrees = coeff * target cm/s, scaled by 10000 (default 50 = 0.0050, 2.5 deg at 5 m/s)
     uint16_t maxVelocity;             // cm/s, maximum velocity setpoint (default 1000 = 10 m/s)
 
     // Waypoint navigation parameters
@@ -89,7 +89,7 @@ typedef struct autopilotConfig_s {
     uint16_t minForwardVelocity;      // cm/s, minimum forward velocity: GPS course reliability (multirotor) / stall prevention (wing)
 
     // Velocity buildup (acceleration from stationary)
-    uint8_t velocityBuildupMaxPitch;  // degrees, max pitch bias for acceleration (default 8)
+    uint8_t velocityBuildupMaxPitch;  // degrees, clamp on the velocity-loop P vector, so the pitch bias while accelerating; drag FF/I/D ride on top, maxAngle bounds the total (default 8)
 
     // Turn rate and holding patterns
     uint8_t maxTurnRate;              // deg/s, maximum turn rate (default 3 for rate-1 turn, configurable 1-90)

--- a/src/test/sitl/sitl_harness.py
+++ b/src/test/sitl/sitl_harness.py
@@ -130,11 +130,10 @@ GRAVITY = 9.80665
 HOVER_THRUST = 0.30        # just above the FC hoverThrottle default (1275 -> 0.275)
 RATE_GAIN = 12.0           # rad/s of body rate per unit differential thrust
 RATE_TAU = 0.08            # attitude response time constant, seconds
-# Deliberately draggy (a real 5-inch holds 5 m/s at ~20 deg, not ~50): the
-# nav position controller tracks its velocity target through an integrator
-# and oscillates against a low-drag plant until the velocity-mode loop
-# (ap_velocity_*, currently unconsumed) exists.
-K_DRAG = 2.4               # 1/s, linear drag: 50 deg of tilt holds ~4.9 m/s
+# Low-drag plant: the nav velocity loop (ap_velocity_*) enforces cruise speed,
+# so the drag no longer needs to mask integrator overshoot. base_config sets
+# ap_velocity_drag_coeff to match this plant (atan(K_DRAG*v/g) over 5-7.5 m/s).
+K_DRAG = 0.8               # 1/s, linear drag: 22 deg of tilt holds ~5 m/s
 VERT_V_GAIN = 6.0          # terminal climb rate per unit thrust above hover
 VEL_TAU_V = 0.3            # vertical velocity response, seconds
 
@@ -545,6 +544,8 @@ def base_config(extra):
         "aux 0 0 0 1700 2100 0 0",   # ARM on AUX1
         "aux 1 56 1 1700 2100 0 0",  # AUTOPILOT on AUX2
         "aux 2 1 2 1700 2100 0 0",   # ANGLE on AUX3 (heading-validation flight)
+        # matches the MotionModel plant: atan(K_DRAG * v / g) over cruise speeds
+        "set ap_velocity_drag_coeff = 440",
         # 10 m above home, 5 m/s — low and quick keeps landing scenarios short
         f"waypoint insert 0 {WP_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyover 0 orbit",
     ] + extra
@@ -609,12 +610,29 @@ def scenario_mission_flight(sitl, rc, fdm):
     )
     # Assertions use the model's ground truth; the FC estimator tracks it,
     # while MSP_RAW_GPS leads the true position (virtual-GPS extrapolation).
+    # Mid-leg cruise: sample in the plateau (past the accel ramp, before the
+    # ~42 m braking taper) and check the velocity loop holds the commanded
+    # 5 m/s without overshoot.
+    cruise_samples = []
+
+    def reached_or_sample():
+        d = fdm.distance_to_wp(0.0, 300.0)
+        if fdm.distance_from_home() > 50.0 and d > 100.0:
+            cruise_samples.append(math.hypot(fdm.model.vel[0], fdm.model.vel[1]))
+        return d < 8.0
+
     wait_for(
         "waypoint reached (within 8 m, ground truth)",
-        lambda: fdm.distance_to_wp(0.0, 300.0) < 8.0,
+        lambda: reached_or_sample(),
         timeout=150,
         interval=1.0,
     )
+    assert len(cruise_samples) >= 5, f"cruise plateau too short: {len(cruise_samples)} samples"
+    cruise_avg = sum(cruise_samples) / len(cruise_samples)
+    cruise_max = max(cruise_samples)
+    assert 0.8 * 5.0 <= cruise_avg <= 1.2 * 5.0, f"cruise speed off target: avg {cruise_avg:.2f} m/s"
+    assert cruise_max <= 1.3 * 5.0, f"cruise overshoot: peak {cruise_max:.2f} m/s"
+    log(f"cruise avg {cruise_avg:.2f} m/s, peak {cruise_max:.2f} m/s over {len(cruise_samples)} samples")
     # Mission complete: executor parks in position hold at the waypoint.
     # Legs complete on radius entry; the hold-mode braking parks a short
     # distance past the point at cruise speed.

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -67,13 +67,14 @@ extern "C" {
     // yaw-control tests drive them via the mockNav* variables.
     static bool mockNavHasActiveTarget = false;
     static positionNavCommand_t mockNavCommand;
+    static vector3_t mockTargetVelCmS;
 
     void positionNavInit(void) { }
     void positionNavReset(void) { }
     void positionNavUpdate(float /*dt*/, const positionEstimate3d_t * /*est*/) { }
     bool positionNavHasActiveTarget(void) { return mockNavHasActiveTarget; }
     bool positionNavTargetReached(void) { return false; }
-    vector3_t positionNavGetTargetVelocityCmS(void) { return (vector3_t){{0, 0, 0}}; }
+    vector3_t positionNavGetTargetVelocityCmS(void) { return mockTargetVelCmS; }
     const positionNavCommand_t *positionNavGetActiveCommand(void) { return mockNavHasActiveTarget ? &mockNavCommand : NULL; }
 
     float getAltitudeCm(void) { return 0.0f; }
@@ -180,6 +181,7 @@ protected:
         memset(&gyro, 0, sizeof(gyro));
         memset(&mockNavCommand, 0, sizeof(mockNavCommand));
         mockNavHasActiveTarget = false;
+        mockTargetVelCmS = (vector3_t){{0.0f, 0.0f, 0.0f}};
         flightModeFlags = 0;
     }
 };
@@ -652,4 +654,183 @@ TEST_F(AutopilotYawTest, EngageRampsRateIn)
     EXPECT_TRUE(autopilotYawControlActive());
     EXPECT_GT(autopilotGetYawRate(), -15.0f);
     EXPECT_LT(autopilotGetYawRate(), 0.0f);
+}
+
+// -- Nav velocity mode --
+
+static uint16_t dragCoeffForTarget(float kDragPerS, float targetCmS)
+{
+    const float ffDeg = RADIANS_TO_DEGREES(atanf(kDragPerS * targetCmS / 981.0f));
+    return (uint16_t)lrintf(ffDeg / (targetCmS * 0.0001f));
+}
+
+static void stepVelocityPlant(float kDragPerS, float *vNorthCmS)
+{
+    positionControl();
+    const float pitchRad = DEGREES_TO_RADIANS(autopilotAngle[AI_PITCH]);
+    *vNorthCmS += (981.0f * tanf(pitchRad) - kDragPerS * (*vNorthCmS)) * 0.01f;
+    testEstimate.velocity.y = *vNorthCmS;
+}
+
+class VelocityModeTest : public PosHoldTest {
+protected:
+    void engageVelocityNav(uint8_t velocityP, uint8_t velocityI, uint8_t velocityD,
+                            uint16_t velocityDragCoeff, uint8_t velocityBuildupMaxPitch,
+                            uint8_t maxAngle = 45, bool enable = true)
+    {
+        initAndSettleAt(0, 0, 0);
+
+        autopilotConfig_t *cfg = autopilotConfigMutable();
+        cfg->maxAngle = maxAngle;
+        cfg->positionCutoff = 30;
+        cfg->velocityControlEnable = enable ? 1 : 0;
+        cfg->velocityP = velocityP;
+        cfg->velocityI = velocityI;
+        cfg->velocityD = velocityD;
+        cfg->velocityDragCoeff = velocityDragCoeff;
+        cfg->velocityBuildupMaxPitch = velocityBuildupMaxPitch;
+        autopilotInit();
+
+        mockNavHasActiveTarget = true;
+        mockNavCommand.active = true;
+    }
+
+    void setTargetVelocityNorth(float cmS)
+    {
+        mockTargetVelCmS = (vector3_t){{0.0f, cmS, 0.0f}};
+    }
+};
+
+TEST_F(VelocityModeTest, CruiseConvergence)
+{
+    const float kDrag = 0.8f;
+    const float targetCmS = 500.0f;
+    engageVelocityNav(50, 20, 0, dragCoeffForTarget(kDrag, targetCmS), 30);
+    setTargetVelocityNorth(targetCmS);
+
+    float vNorth = 0.0f;
+    for (int i = 0; i < 1500; i++) {
+        stepVelocityPlant(kDrag, &vNorth);
+    }
+
+    EXPECT_NEAR(vNorth, targetCmS, targetCmS * 0.05f);
+}
+
+TEST_F(VelocityModeTest, NoOvershoot)
+{
+    const float kDrag = 0.8f;
+    const float targetCmS = 500.0f;
+    engageVelocityNav(50, 20, 0, dragCoeffForTarget(kDrag, targetCmS), 30);
+    setTargetVelocityNorth(targetCmS);
+
+    float vNorth = 0.0f;
+    float maxV = 0.0f;
+    for (int i = 0; i < 1500; i++) {
+        stepVelocityPlant(kDrag, &vNorth);
+        maxV = fmaxf(maxV, vNorth);
+    }
+
+    EXPECT_LE(maxV, targetCmS * 1.10f);
+}
+
+TEST_F(VelocityModeTest, DragFeedforwardMagnitude)
+{
+    const float targetCmS = 400.0f;
+    const uint16_t dragCoeff = 300;
+    engageVelocityNav(30, 10, 20, dragCoeff, 30);
+    setTargetVelocityNorth(targetCmS);
+    testEstimate.velocity.y = targetCmS;
+
+    runIterations(300);
+
+    const float expectedFFDeg = dragCoeff * 0.0001f * targetCmS;
+    EXPECT_NEAR(autopilotAngle[AI_PITCH], expectedFFDeg, 1.0f);
+}
+
+TEST_F(VelocityModeTest, BuildupClampBoundsP)
+{
+    const uint8_t buildupMaxPitch = 10;
+    engageVelocityNav(50, 0, 0, 0, buildupMaxPitch, 45);
+    setTargetVelocityNorth(1500.0f);
+
+    for (int i = 0; i < 30; i++) {
+        positionControl();
+        EXPECT_LE(fabsf(autopilotAngle[AI_PITCH]), buildupMaxPitch + 0.05f);
+    }
+}
+
+TEST_F(VelocityModeTest, IntegralSeparationAndFreeze)
+{
+    engageVelocityNav(30, 50, 0, 0, 30, 45);
+    setTargetVelocityNorth(2000.0f); // filtered velocity stays near 0: error stays well above the 250 cm/s relax gate
+
+    positionControl();
+    const float pitchFirst = autopilotAngle[AI_PITCH];
+    runIterations(100);
+    EXPECT_NEAR(autopilotAngle[AI_PITCH], pitchFirst, 0.05f);
+
+    testEstimate.velocity.y = 2000.0f - 100.0f; // step to a small, sustained error
+    runIterations(40); // let the velocity filter settle into the relax gate
+    const float pitchSmallErrEarly = autopilotAngle[AI_PITCH];
+    runIterations(100);
+    const float pitchSmallErrLater = autopilotAngle[AI_PITCH];
+    EXPECT_GT(fabsf(pitchSmallErrLater), fabsf(pitchSmallErrEarly) + 0.5f);
+}
+
+TEST_F(VelocityModeTest, VelocityModeDisabledUsesLegacyPath)
+{
+    engageVelocityNav(30, 50, 0, 0, 30, 45, false);
+    setTargetVelocityNorth(300.0f);
+
+    runIterations(20);
+    const float pitchEarly = autopilotAngle[AI_PITCH];
+
+    runIterations(100);
+    const float pitchLater = autopilotAngle[AI_PITCH];
+
+    EXPECT_GT(fabsf(pitchLater), fabsf(pitchEarly) + 1.0f);
+}
+
+TEST_F(VelocityModeTest, ResetOnNavReentry)
+{
+    engageVelocityNav(30, 50, 0, 0, 30, 45);
+    setTargetVelocityNorth(150.0f); // stays inside the relax gate throughout: the integral builds every cycle
+
+    runIterations(150);
+    const float pitchBeforeReentry = autopilotAngle[AI_PITCH];
+
+    mockNavHasActiveTarget = false;
+    positionControl(); // one cycle of pos-hold fallback
+
+    mockNavHasActiveTarget = true;
+    positionControl(); // nav re-entry: initNavMode() resets the velocity integral
+
+    EXPECT_LT(fabsf(autopilotAngle[AI_PITCH]), fabsf(pitchBeforeReentry) * 0.5f);
+}
+
+TEST_F(VelocityModeTest, PosHoldUnaffectedByDefaultOn)
+{
+    const int cycles = 50;
+    float baselineRoll[cycles];
+    float baselinePitch[cycles];
+
+    initAndSettleAt(0, 0, 0);
+    autopilotConfigMutable()->velocityControlEnable = 0;
+    autopilotInit();
+    testEstimate.position.x = 100.0f;
+    for (int i = 0; i < cycles; i++) {
+        positionControl();
+        baselineRoll[i] = autopilotAngle[AI_ROLL];
+        baselinePitch[i] = autopilotAngle[AI_PITCH];
+    }
+
+    initAndSettleAt(0, 0, 0);
+    autopilotConfigMutable()->velocityControlEnable = 1;
+    autopilotInit();
+    testEstimate.position.x = 100.0f;
+    for (int i = 0; i < cycles; i++) {
+        positionControl();
+        EXPECT_FLOAT_EQ(autopilotAngle[AI_ROLL], baselineRoll[i]);
+        EXPECT_FLOAT_EQ(autopilotAngle[AI_PITCH], baselinePitch[i]);
+    }
 }


### PR DESCRIPTION
Implements the velocity control loop the ap_velocity_* parameters were added for in #15030. The nav path previously tracked its velocity target through a pseudo-distance integrator, so nothing bounded actual speed and cruise overshot badly on low-drag airframes.

In nav mode the controller now tracks the positionNav velocity target directly: P and I on velocity error (integral separation keeps the acceleration phase windup free), damping on measured acceleration, and a linear drag feedforward that carries the cruise tilt (degrees = ap_velocity_drag_coeff x target cm/s). ap_velocity_buildup_max_pitch clamps the P vector to bound acceleration authority, with ap_max_angle the hard limit on the total. The legacy path is retained for ap_velocity_control_enable = 0. Pos-hold is untouched: the loop only engages when a nav target is active, which only the flight plan executor sets, so the default-on field is inert outside missions.

The SITL plant drag drops to a realistic 0.8/s (it was kept artificially draggy to mask the overshoot) and mission_flight now asserts mid-leg cruise speed: 5 m/s commanded, 4.96 avg / 5.02 peak measured. DEBUG_POSITION_NAV carries the velocity loop terms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added navigation velocity mode for improved target-speed control.
  * Added drag compensation, velocity-based pitch buildup limits, and smoother integrator handling.
  * Expanded navigation debug information for velocity mode and pitch limiting.

* **Bug Fixes**
  * Reset velocity control state when navigation or position control restarts.
  * Preserved existing position-hold behavior when velocity mode is disabled.

* **Tests**
  * Added coverage for cruise-speed convergence, overshoot limits, drag compensation, pitch clamps, integrator behavior, and mode transitions.
  * Improved flight simulation validation for sustained cruise speed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of the autopilot programme tracked in #15411.
