### PR TITLE
Autopilot: rescue as a synthesised mission, TAKEOFF and hold patterns, SITL fidelity

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2576,8 +2576,9 @@ static const char * const waypointTypeNames[] = {
 STATIC_ASSERT(WAYPOINT_TYPE_COUNT == ARRAYLEN(waypointTypeNames), waypointTypeNames_array_length_mismatch);
 
 static const char * const waypointPatternNames[] = {
-    "ORBIT", "FIGURE8"
+    "NONE", "ORBIT", "FIGURE8"
 };
+STATIC_ASSERT(WAYPOINT_PATTERN_COUNT == ARRAYLEN(waypointPatternNames), waypointPatternNames_array_length_mismatch);
 
 // Parse decimal coordinate string to int32 (degrees * 10^7)
 // Accepts formats like: -33.5429890, 151.6664560, -33.5, 151
@@ -3011,7 +3012,7 @@ static void cliWaypoint(const char *cmdName, char *cmdline)
         }
     }
     if (!patternFound) {
-        cliPrintErrorLinef(cmdName, "INVALID PATTERN. USE: ORBIT, FIGURE8");
+        cliPrintErrorLinef(cmdName, "INVALID PATTERN. USE: NONE, ORBIT, FIGURE8");
         return;
     }
 

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1053,8 +1053,14 @@ void processRxModes(timeUs_t currentTimeUs)
     }
 
 #ifdef USE_GPS_RESCUE
+    // With ENABLE_RESCUE_PLAN the failsafe procedure flies a rescue mission
+    // under AUTOPILOT_MODE instead; only the pilot's switch selects legacy
+    // rescue, which then preempts the mission via the gate below.
     if (ARMING_FLAG(ARMED) && (IS_RC_MODE_ACTIVE(BOXGPSRESCUE)
-        || (failsafeIsActive() && failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE))) {
+#if !ENABLE_RESCUE_PLAN
+        || (failsafeIsActive() && failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE)
+#endif
+        )) {
         if (!FLIGHT_MODE(GPS_RESCUE_MODE)) {
             ENABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
         }

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -74,6 +74,10 @@ PG_REGISTER_WITH_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig, PG_FAILSAFE_CO
 #define DEFAULT_FAILSAFE_RECOVERY_DELAY 5            // 500ms of valid rx data needed to allow recovery from failsafe and arming block
 #endif
 
+#if ENABLE_RESCUE_PLAN
+#define FAILSAFE_AUTOPILOT_ENGAGE_GRACE_MS 1000      // core.c engages a staged rescue mission within a cycle; this bounds the wait
+#endif
+
 PG_RESET_TEMPLATE(failsafeConfig_t, failsafeConfig,
     .failsafe_throttle = 1000,                           // default throttle off.
     .failsafe_throttle_low_delay = 100,                  // default throttle low delay for "just disarm" on failsafe condition
@@ -117,6 +121,9 @@ void failsafeReset(void)
     failsafeState.phase = FAILSAFE_IDLE;
     failsafeState.rxLinkState = FAILSAFE_RXLINK_DOWN;
     failsafeState.boxFailsafeSwitchWasOn = false;
+#if ENABLE_RESCUE_PLAN
+    failsafeState.autopilotEngageDeadline = 0;
+#endif
 }
 
 void failsafeInit(void)
@@ -248,8 +255,21 @@ static void failsafeStartProcedure(failsafeProcedure_e procedure)
             break;
 #ifdef USE_GPS_RESCUE
         case FAILSAFE_PROCEDURE_GPS_RESCUE:
+#if ENABLE_RESCUE_PLAN
+            if (flightPlanNavStageRescuePlan()) {
+                // core.c engages the executor when it sees FAILSAFE_AUTOPILOT;
+                // the deadline bounds how long we wait for that to happen.
+                ENABLE_FLIGHT_MODE(FAILSAFE_MODE);
+                failsafeState.phase = FAILSAFE_AUTOPILOT;
+                failsafeState.autopilotEngageDeadline = millis() + FAILSAFE_AUTOPILOT_ENGAGE_GRACE_MS;
+            } else {
+                // no home/fix to build a rescue plan: baro-only auto-landing
+                failsafeStartProcedure(FAILSAFE_PROCEDURE_AUTO_LANDING);
+            }
+#else
             ENABLE_FLIGHT_MODE(GPS_RESCUE_MODE);
             failsafeState.phase = FAILSAFE_GPS_RESCUE;
+#endif
             break;
 #endif
     }
@@ -354,6 +374,10 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                         // and falls back to the configured procedure when it ends
                         ENABLE_FLIGHT_MODE(FAILSAFE_MODE);
                         failsafeState.phase = FAILSAFE_AUTOPILOT;
+#if ENABLE_RESCUE_PLAN
+                        // mission already engaged: no engage grace applies
+                        failsafeState.autopilotEngageDeadline = millis();
+#endif
                     } else if (FLIGHT_MODE(AUTOPILOT_MODE)
                         && autopilotConfig()->rxLossPolicy == AP_RX_LOSS_LAND) {
                         // land at the current position: the mission disengages, and
@@ -426,6 +450,28 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                 } else if (!armed) {
                     failsafeState.phase = FAILSAFE_LANDED;
                     reprocessState = true;
+#if ENABLE_RESCUE_PLAN
+                } else if (!FLIGHT_MODE(AUTOPILOT_MODE)
+                    && flightPlanNavGetState() != FP_NAV_COMPLETE
+                    && flightPlanNavGetState() != FP_NAV_ABORTED
+                    && cmp32(millis(), failsafeState.autopilotEngageDeadline) < 0) {
+                    // a staged rescue mission is waiting for core.c to engage
+                    // the executor; give it the grace window before degrading
+                    beeperMode = BEEPER_RX_LOST_LANDING;
+                } else if (!FLIGHT_MODE(AUTOPILOT_MODE)
+                    || flightPlanNavGetState() == FP_NAV_COMPLETE
+                    || flightPlanNavGetState() == FP_NAV_ABORTED) {
+                    // mission ended, aborted, never engaged, or lost its
+                    // requirements while the link is still down. Re-selecting
+                    // GPS-RESCUE would re-stage the mission that just failed,
+                    // so degrade to the baro-only auto-landing instead.
+                    failsafeProcedure_e fallback = failsafeConfig()->failsafe_procedure;
+                    if (fallback == FAILSAFE_PROCEDURE_GPS_RESCUE) {
+                        fallback = FAILSAFE_PROCEDURE_AUTO_LANDING;
+                    }
+                    failsafeStartProcedure(fallback);
+                    reprocessState = true;
+#else
                 } else if (!FLIGHT_MODE(AUTOPILOT_MODE)
                     || flightPlanNavGetState() == FP_NAV_COMPLETE
                     || flightPlanNavGetState() == FP_NAV_ABORTED) {
@@ -433,6 +479,7 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
                     // while the link is still down: fall back to the configured procedure
                     failsafeStartProcedure(failsafeConfig()->failsafe_procedure);
                     reprocessState = true;
+#endif
                 } else {
                     beeperMode = BEEPER_RX_LOST_LANDING;
                 }

--- a/src/main/flight/failsafe.h
+++ b/src/main/flight/failsafe.h
@@ -92,6 +92,9 @@ typedef struct failsafeState_s {
     failsafePhase_e phase;
     failsafeRxLinkState_e rxLinkState;
     bool boxFailsafeSwitchWasOn;
+#if ENABLE_RESCUE_PLAN
+    uint32_t autopilotEngageDeadline;       // grace window for core.c to engage a staged rescue mission
+#endif
 } failsafeState_t;
 
 void failsafeInit(void);

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -52,6 +52,10 @@
 #ifdef USE_GPS_RESCUE
 #include "pg/gps_rescue.h"
 #endif
+#if ENABLE_RESCUE_PLAN
+#include "flight/gps_rescue.h"
+#include "flight/imu.h"
+#endif
 
 #define FP_MIN_CRUISE_MPS         1.0f
 // Legs complete on acceptance-radius entry at any speed: the position
@@ -88,9 +92,14 @@
 // vehicle that cannot descend must keep trying, not disarm mid-air.
 #define FP_LANDING_ESTABLISH_TIMEOUT_US 5000000u
 
-// Injected runtime plans are small synthesised sequences (geofence RTH today,
-// rescue-as-mission later); MAVLink-scale plans stay in the PG store.
+// Injected runtime plans are small synthesised sequences (geofence RTH,
+// failsafe rescue); MAVLink-scale plans stay in the PG store.
 #define FP_INJECTED_PLAN_MAX 4
+
+#if ENABLE_RESCUE_PLAN
+// Legacy PITCH_FORWARD gives up after 15 s of heading recovery
+#define FP_RESCUE_HEADING_TIMEOUT_US 15000000u
+#endif
 
 static struct {
     flightPlanNavState_e state;
@@ -98,7 +107,7 @@ static struct {
     timeUs_t holdStartUs;
     uint16_t holdDurationDs;
     bool active;
-    float zBiasM;               // estimator Z at engage, so waypoint Z shares the estimator baseline
+    float zBiasM;               // estimator-vs-GPS altitude frame offset, captured at engage
 
     // Staged modifiers — populated by drainModifiers(), consumed by the next
     // positional dispatch. altOverride is one-shot; delay arms a timer that
@@ -119,6 +128,16 @@ static struct {
     waypoint_t injected[FP_INJECTED_PLAN_MAX];
     uint8_t injectedCount;
 
+#if ENABLE_RESCUE_PLAN
+    // Failsafe rescue plan staged before the executor engages; drained by
+    // flightPlanNavEngage() in place of the PG mission.
+    waypoint_t staged[FP_INJECTED_PLAN_MAX];
+    uint8_t stagedCount;
+    bool isRescuePlan;          // the active injected plan is a failsafe rescue
+    bool rescueHeadingHold;     // pitch-forward heading recovery in progress
+    timeUs_t rescueHeadingStartUs;
+#endif
+
     // Leg progress tracking for stall/flyaway detection
     float bestDistanceToTargetM;
     float flyawayMarginM;
@@ -133,6 +152,7 @@ static struct {
 static flightPlanWaypointReachedFn reachedListener = NULL;
 
 static void onWaypointReached(void *userData);
+static void clearModifierState(void);
 
 static uint8_t activePlanCount(void)
 {
@@ -172,8 +192,8 @@ static bool computeTargetEnuM(const waypoint_t *wp, vector3_t *out)
     out->v[ENU_E] = enuCm.v[EF_EAST] * 0.01f;
     out->v[ENU_N] = enuCm.v[EF_NORTH] * 0.01f;
     // Waypoint altitude is AMSL (GPS frame); the estimator's Z is zeroed to
-    // whichever source armed it first (baro or GPS). zBiasM is the estimator
-    // reading at engage time, which aligns the target Up with the feedback Up.
+    // whichever source armed it first (baro or GPS). zBiasM is the frame
+    // offset between the two, which aligns the target Up with the feedback Up.
     out->v[ENU_U] = (wp->altitude - origin.altCm) * 0.01f + fp.zBiasM;
     return true;
 }
@@ -436,6 +456,101 @@ static void injectReturnHomePlan(timeUs_t currentTimeUs)
     }
 }
 
+#if ENABLE_RESCUE_PLAN
+// Failsafe rescue mission: [climb-in-place HOLD at the current position ->
+// FLYOVER home -> LAND home]. The leading HOLD gates on altitude arrival
+// (dispatchWaypoint sets altitudeArrivalRequired for HOLD), so the climb
+// completes before the return leg starts — legacy ATTAIN_ALT semantics.
+static uint8_t buildRescuePlan(waypoint_t out[FP_INJECTED_PLAN_MAX])
+{
+    if (!STATE(GPS_FIX_HOME) || !STATE(GPS_FIX)) {
+        return 0;
+    }
+
+    const int32_t homeAltCm = GPS_home_llh.altCm;
+    const int32_t currentAltCm = gpsSol.llh.altCm;
+    const int32_t climbCm = (int32_t)gpsRescueConfig()->initialClimbM * 100;
+    const int32_t fixedCm = (int32_t)gpsRescueConfig()->returnAltitudeM * 100;
+
+    int32_t returnAltCm;
+    if (GPS_distanceToHome < gpsRescueConfig()->minStartDistM) {
+        // Legacy close-range branch: modest headroom rather than a full climb
+        returnAltCm = MAX(homeAltCm + 750, currentAltCm + climbCm);
+    } else {
+        switch (gpsRescueConfig()->altitudeMode) {
+        case GPS_RESCUE_ALT_MODE_FIXED:
+            returnAltCm = homeAltCm + fixedCm;
+            break;
+        case GPS_RESCUE_ALT_MODE_CURRENT:
+            returnAltCm = currentAltCm + climbCm;
+            break;
+        case GPS_RESCUE_ALT_MODE_MAX:
+        default:
+            // Legacy tracks max altitude relative to the arming point; home
+            // altitude anchors it back to the AMSL frame waypoints use.
+            returnAltCm = homeAltCm + (int32_t)gpsRescueGetMaxAltitudeCm() + climbCm;
+            break;
+        }
+    }
+    returnAltCm = MAX(returnAltCm, currentAltCm); // never command an en-route descent
+
+    const uint16_t speedCmS = gpsRescueConfig()->groundSpeedCmS;
+    out[0] = (waypoint_t){
+        .latitude = gpsSol.llh.lat,
+        .longitude = gpsSol.llh.lon,
+        .altitude = returnAltCm,
+        .type = WAYPOINT_TYPE_HOLD,
+    };
+    out[1] = (waypoint_t){
+        .latitude = GPS_home_llh.lat,
+        .longitude = GPS_home_llh.lon,
+        .altitude = returnAltCm,
+        .speed = speedCmS,
+        .type = WAYPOINT_TYPE_FLYOVER,
+    };
+    out[2] = (waypoint_t){
+        .latitude = GPS_home_llh.lat,
+        .longitude = GPS_home_llh.lon,
+        .altitude = returnAltCm,
+        .speed = speedCmS,
+        .type = WAYPOINT_TYPE_LAND,
+    };
+    return 3;
+}
+
+bool flightPlanNavStageRescuePlan(void)
+{
+    waypoint_t plan[FP_INJECTED_PLAN_MAX];
+    const uint8_t count = buildRescuePlan(plan);
+    if (count == 0) {
+        return false;
+    }
+
+    if (fp.active) {
+        // Already flying (rx-loss during a mission): replace it immediately.
+        memcpy(fp.injected, plan, count * sizeof(plan[0]));
+        fp.injectedCount = count;
+        fp.currentIndex = 0;
+        fp.abortReason = FP_ABORT_NONE;
+        fp.isRescuePlan = true;
+        fp.rescueHeadingHold = false;
+        fp.stagedCount = 0;
+        clearModifierState();
+        dispatchWaypoint();
+        return true;
+    }
+
+    memcpy(fp.staged, plan, count * sizeof(plan[0]));
+    fp.stagedCount = count;
+    return true;
+}
+
+bool flightPlanNavIsRescuePlanActive(void)
+{
+    return fp.active && fp.isRescuePlan;
+}
+#endif // ENABLE_RESCUE_PLAN
+
 static void checkGeofence(timeUs_t currentTimeUs)
 {
     // An injected plan is itself the geofence response; evaluating the fence
@@ -499,6 +614,18 @@ static void onWaypointReached(void *userData)
         reachedListener(fp.currentIndex);
     }
 
+#if ENABLE_RESCUE_PLAN
+    // Rescue climb complete but the IMU heading is untrusted: hold here and
+    // pitch forward so GPS course-over-ground can teach the estimator its
+    // heading before the return leg (legacy PITCH_FORWARD semantics).
+    if (fp.isRescuePlan && fp.currentIndex == 0 && activePlanCount() > 1 && !imuIsHeadingValid()) {
+        fp.rescueHeadingHold = true;
+        fp.rescueHeadingStartUs = micros();
+        pitchForwardOverride(true);
+        return;
+    }
+#endif
+
     // A LAND duration is a pre-descent loiter; the hold-expiry path starts
     // the descent instead of advancing.
     const bool holdsOnArrival = (wp->type == WAYPOINT_TYPE_HOLD) || (wp->type == WAYPOINT_TYPE_LAND);
@@ -538,6 +665,11 @@ void flightPlanNavInit(void)
     fp.zBiasM = 0.0f;
     fp.abortReason = FP_ABORT_NONE;
     fp.injectedCount = 0;
+#if ENABLE_RESCUE_PLAN
+    fp.stagedCount = 0;
+    fp.isRescuePlan = false;
+    fp.rescueHeadingHold = false;
+#endif
     clearModifierState();
 }
 
@@ -551,14 +683,38 @@ void flightPlanNavEngage(void)
     fp.injectedCount = 0;
     clearModifierState();
 
-    // Capture the estimator's current Z so subsequent waypoint altitudes are
-    // referenced to the same baseline the position controller uses.
-    fp.zBiasM = positionEstimatorGetAltitudeCm() * 0.01f;
+    // Reconcile the estimator's altitude baseline with the GPS frame waypoint
+    // altitudes are computed in. The pure frame offset (estimator reading
+    // minus GPS height above origin) is valid at any engagement altitude —
+    // a failsafe rescue engages mid-flight, where the raw estimator reading
+    // would shift the whole plan up by the current height.
+    gpsLocation_t origin;
+    if (positionEstimatorGetGpsOrigin(&origin)) {
+        fp.zBiasM = positionEstimatorGetAltitudeCm() * 0.01f - (gpsSol.llh.altCm - origin.altCm) * 0.01f;
+    } else {
+        fp.zBiasM = positionEstimatorGetAltitudeCm() * 0.01f;
+    }
 
     // HOLD waypoints keep the position target live for the hold duration; a
     // new target replaces the previous on advance anyway, so this module
     // never wants positionNav to auto-clear the target on reach.
     positionNavSetAutoClearOnReach(false);
+
+#if ENABLE_RESCUE_PLAN
+    fp.isRescuePlan = false;
+    fp.rescueHeadingHold = false;
+    if (fp.stagedCount > 0) {
+        // A staged failsafe rescue plan replaces the PG mission entirely;
+        // rescue waypoint 0 is dispatched, never PG waypoint 0.
+        memcpy(fp.injected, fp.staged, fp.stagedCount * sizeof(fp.injected[0]));
+        fp.injectedCount = fp.stagedCount;
+        fp.stagedCount = 0;
+        fp.isRescuePlan = true;
+        fp.active = true;
+        dispatchWaypoint();
+        return;
+    }
+#endif
 
     if (flightPlanConfig()->waypointCount == 0) {
         fp.state = FP_NAV_COMPLETE;
@@ -578,6 +734,14 @@ void flightPlanNavDisengage(void)
     fp.active = false;
     fp.state = FP_NAV_IDLE;
     fp.injectedCount = 0;
+#if ENABLE_RESCUE_PLAN
+    fp.stagedCount = 0;
+    fp.isRescuePlan = false;
+    if (fp.rescueHeadingHold) {
+        fp.rescueHeadingHold = false;
+        pitchForwardOverride(false);
+    }
+#endif
     clearModifierState();
     positionNavClearTarget();
 }
@@ -592,6 +756,9 @@ bool flightPlanNavInjectPlan(const waypoint_t *waypoints, uint8_t count)
     fp.injectedCount = count;
     fp.currentIndex = 0;
     fp.abortReason = FP_ABORT_NONE;
+#if ENABLE_RESCUE_PLAN
+    fp.isRescuePlan = false;
+#endif
     clearModifierState();
     // If dispatch fails (GPS origin lost) the state falls back to IDLE and
     // the update loop retries against the injected plan.
@@ -609,6 +776,23 @@ void flightPlanNavUpdate(timeUs_t currentTimeUs)
     if (!fp.active) {
         return;
     }
+
+#if ENABLE_RESCUE_PLAN
+    if (fp.rescueHeadingHold) {
+        // Leg progress/stall checks are meaningless while deliberately
+        // pitching forward away from the climb waypoint.
+        if (imuIsHeadingValid()) {
+            pitchForwardOverride(false);
+            fp.rescueHeadingHold = false;
+            advanceToNext();
+        } else if (cmpTimeUs(currentTimeUs, fp.rescueHeadingStartUs) >= (timeDelta_t)FP_RESCUE_HEADING_TIMEOUT_US) {
+            pitchForwardOverride(false);
+            fp.rescueHeadingHold = false;
+            abortMission(FP_ABORT_HEADING);
+        }
+        return;
+    }
+#endif
 
     // Retry dispatch if we engaged before the estimator had an origin.
     if (fp.state == FP_NAV_IDLE && activePlanCount() > 0) {

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -96,6 +96,22 @@
 // failsafe rescue); MAVLink-scale plans stay in the PG store.
 #define FP_INJECTED_PLAN_MAX 4
 
+// HOLD patterns chase a time-parametrised carrot around the hold point. The
+// angular rate cap keeps small radii flyable (full cruise on the default 2 m
+// radius would demand a 2.5 rad/s spin) and holds the rotation slow enough
+// for the position->velocity->attitude chain to phase-track: each loop adds
+// lag, and a carrot the vehicle cannot angularly follow balloons the pursuit
+// orbit far outside the ring. The position-to-velocity gain means the vehicle
+// self-paces roughly patternSpeed metres behind the carrot.
+#define FP_PATTERN_MAX_RATE_RADS  0.25f
+#define FP_PATTERN_UPDATE_US      200000u
+// Legs complete on radius entry at any speed, so the hold is entered carrying
+// cruise momentum. The pattern waits for the reached command's own braking to
+// park the vehicle first — a carrot started at cruise entry speed balloons
+// the pursuit orbit far outside the ring. The timeout bounds a windy day.
+#define FP_PATTERN_START_SPEED_MPS  1.5f
+#define FP_PATTERN_START_TIMEOUT_US 5000000u
+
 #if ENABLE_RESCUE_PLAN
 // Legacy PITCH_FORWARD gives up after 15 s of heading recovery
 #define FP_RESCUE_HEADING_TIMEOUT_US 15000000u
@@ -137,6 +153,16 @@ static struct {
     bool rescueHeadingHold;     // pitch-forward heading recovery in progress
     timeUs_t rescueHeadingStartUs;
 #endif
+
+    // HOLD pattern sub-target generation
+    bool patternPending;        // waiting for the arrival braking to settle
+    bool patternActive;
+    uint8_t patternType;        // waypointPattern_e
+    vector3_t patternCentreM;   // hold point, ENU metres
+    float patternPhaseRad;
+    float patternSpeedMps;      // carrot path speed
+    float patternCruiseMps;     // chase speed cap (the leg's cruise)
+    timeUs_t patternLastUpdateUs;
 
     // Leg progress tracking for stall/flyaway detection
     float bestDistanceToTargetM;
@@ -261,9 +287,20 @@ static bool dispatchWaypoint(void)
         return false;
     }
 
+    // TAKEOFF climbs in place: the waypoint's lat/lon are advisory (MAVLink
+    // marks them optional) — the target is the current position at the
+    // waypoint's altitude.
+    if (effective.type == WAYPOINT_TYPE_TAKEOFF) {
+        const positionEstimate3d_t *est = positionEstimatorGetEstimate();
+        targetEnuM.v[ENU_E] = est->position.v[ENU_E] * 0.01f;
+        targetEnuM.v[ENU_N] = est->position.v[ENU_N] * 0.01f;
+    }
+
     const autopilotConfig_t *cfg = autopilotConfig();
-    const bool isHoldOrLand = (effective.type == WAYPOINT_TYPE_HOLD) || (effective.type == WAYPOINT_TYPE_LAND);
-    const float arrivalRadiusM = (isHoldOrLand ? cfg->waypointHoldRadius : cfg->waypointArrivalRadius) * 0.01f;
+    const bool isStationKeeping = (effective.type == WAYPOINT_TYPE_HOLD)
+                               || (effective.type == WAYPOINT_TYPE_LAND)
+                               || (effective.type == WAYPOINT_TYPE_TAKEOFF);
+    const float arrivalRadiusM = (isStationKeeping ? cfg->waypointHoldRadius : cfg->waypointArrivalRadius) * 0.01f;
 
     float cruiseMps = (effective.speed > 0) ? effective.speed * 0.01f : cfg->maxVelocity * 0.01f;
     if (cruiseMps < FP_MIN_CRUISE_MPS) {
@@ -290,13 +327,15 @@ static bool dispatchWaypoint(void)
         }
     }
 
+    fp.patternPending = false;
+    fp.patternActive = false;
     positionNavSetTargetEf(&targetEnuM, cruiseMps, arrivalRadiusM,
                            FP_COMPLETION_ANY_MPS, true, onWaypointReached, NULL);
     positionNavSetAccelLimits(0.0f, FP_APPROACH_DECEL_MPS2);
     // En-route waypoints advance on horizontal arrival; a vehicle that cannot
-    // reach the commanded altitude must not orbit forever. HOLD and LAND are
-    // station-keeping targets and keep the altitude gate.
-    positionNavSetAltitudeArrivalRequired(isHoldOrLand);
+    // reach the commanded altitude must not orbit forever. HOLD, LAND and
+    // TAKEOFF are station-keeping targets and keep the altitude gate.
+    positionNavSetAltitudeArrivalRequired(isStationKeeping);
 
     fp.state = FP_NAV_TARGETING;
     fp.holdDurationDs = effective.duration;
@@ -309,6 +348,8 @@ static void abortMission(flightPlanAbortReason_e reason)
 {
     fp.state = FP_NAV_ABORTED;
     fp.abortReason = reason;
+    fp.patternPending = false;
+    fp.patternActive = false;
     // Dropping the nav target makes positionControl() fall back to holding
     // position at the current location; the pilot exits via the mode switch.
     positionNavClearTarget();
@@ -575,12 +616,104 @@ static void checkGeofence(timeUs_t currentTimeUs)
     }
 }
 
+static void patternCarrot(float phaseRad, float radiusM, vector3_t *out)
+{
+    out->v[ENU_U] = fp.patternCentreM.v[ENU_U];
+    if (fp.patternType == WAYPOINT_PATTERN_FIGURE8) {
+        // Lemniscate of Gerono — crosses the centre twice per cycle
+        out->v[ENU_E] = fp.patternCentreM.v[ENU_E] + radiusM * sin_approx(phaseRad);
+        out->v[ENU_N] = fp.patternCentreM.v[ENU_N] + radiusM * sin_approx(phaseRad) * cos_approx(phaseRad);
+    } else {
+        out->v[ENU_E] = fp.patternCentreM.v[ENU_E] + radiusM * cos_approx(phaseRad);
+        out->v[ENU_N] = fp.patternCentreM.v[ENU_N] + radiusM * sin_approx(phaseRad);
+    }
+}
+
+// The carrot command must never complete: completion would refire
+// onWaypointReached (restarting the hold timer) and zero the velocity target.
+// completionSpeed 0 keeps it permanently unreachable. Accel limits are lifted
+// because the approach-decel braking term would cap chase speed to a crawl at
+// carrot-lead distances; the next leg's dispatch restores them.
+static void issuePatternCommand(float radiusM)
+{
+    vector3_t carrot;
+    patternCarrot(fp.patternPhaseRad, radiusM, &carrot);
+    positionNavSetTargetEf(&carrot, fp.patternCruiseMps, radiusM, 0.0f, true, NULL, NULL);
+    positionNavSetAccelLimits(0.0f, 0.0f);
+}
+
+static void startHoldPattern(const waypoint_t *wp)
+{
+    const positionNavCommand_t *cmd = positionNavGetActiveCommand();
+    const float radiusM = autopilotConfig()->waypointHoldRadius * 0.01f;
+
+    fp.patternType = wp->pattern;
+    fp.patternCentreM = cmd->targetPosEfM;
+    fp.patternCruiseMps = cmd->cruiseSpeedMps;
+    fp.patternSpeedMps = MIN(cmd->cruiseSpeedMps, radiusM * FP_PATTERN_MAX_RATE_RADS);
+
+    if (wp->pattern == WAYPOINT_PATTERN_FIGURE8) {
+        // The curve passes through the centre, which is where the vehicle is
+        fp.patternPhaseRad = 0.0f;
+    } else {
+        // Start the carrot at the vehicle's azimuth from the centre so the
+        // first move is outward onto the ring, not a dash across it
+        const positionEstimate3d_t *est = positionEstimatorGetEstimate();
+        fp.patternPhaseRad = atan2_approx(est->position.v[ENU_N] * 0.01f - fp.patternCentreM.v[ENU_N],
+                                          est->position.v[ENU_E] * 0.01f - fp.patternCentreM.v[ENU_E]);
+    }
+    fp.patternLastUpdateUs = micros();
+    fp.patternActive = true;
+    issuePatternCommand(radiusM);
+}
+
+static void updateHoldPattern(timeUs_t currentTimeUs)
+{
+    const timeDelta_t sinceUs = cmpTimeUs(currentTimeUs, fp.patternLastUpdateUs);
+    if (sinceUs < (timeDelta_t)FP_PATTERN_UPDATE_US) {
+        return;
+    }
+    fp.patternLastUpdateUs = currentTimeUs;
+
+    const float radiusM = autopilotConfig()->waypointHoldRadius * 0.01f;
+    fp.patternPhaseRad += (fp.patternSpeedMps / radiusM) * MIN(sinceUs * 1e-6f, 1.0f);
+    if (fp.patternPhaseRad > M_PIf) {
+        fp.patternPhaseRad -= 2.0f * M_PIf;
+    }
+
+    if (positionNavHasActiveTarget()) {
+        vector3_t carrot;
+        patternCarrot(fp.patternPhaseRad, radiusM, &carrot);
+        positionNavMoveTargetEf(&carrot);
+    } else {
+        // A position-control re-init wiped the carrot command; re-issue it
+        issuePatternCommand(radiusM);
+    }
+}
+
+// Orbit period at the configured pattern radius for a leg flown at speedCmS
+// (0 = autopilot max velocity — the same cruise derivation dispatch uses).
+// MAVLink converts LOITER_TURNS turn counts to and from hold durations here.
+uint16_t flightPlanNavOrbitPeriodDs(uint16_t speedCmS)
+{
+    const float radiusM = autopilotConfig()->waypointHoldRadius * 0.01f;
+    float cruiseMps = (speedCmS > 0) ? speedCmS * 0.01f : autopilotConfig()->maxVelocity * 0.01f;
+    if (cruiseMps < FP_MIN_CRUISE_MPS) {
+        cruiseMps = FP_MIN_CRUISE_MPS;
+    }
+    const float rateRads = MIN(cruiseMps, radiusM * FP_PATTERN_MAX_RATE_RADS) / radiusM;
+    const float periodDs = 10.0f * 2.0f * M_PIf / rateRads;
+    return (periodDs >= (float)UINT16_MAX) ? UINT16_MAX : (uint16_t)lrintf(periodDs);
+}
+
 static void advanceToNext(void)
 {
     // The leg that's ending consumed any staged altitude override; clear it
     // before the next drainModifiers() pass so a new override (or none) is
     // staged cleanly for the upcoming leg.
     fp.altOverridePending = false;
+    fp.patternPending = false;
+    fp.patternActive = false;
 
     if (fp.currentIndex + 1 >= activePlanCount()) {
         fp.state = FP_NAV_COMPLETE;
@@ -626,12 +759,20 @@ static void onWaypointReached(void *userData)
     }
 #endif
 
-    // A LAND duration is a pre-descent loiter; the hold-expiry path starts
-    // the descent instead of advancing.
-    const bool holdsOnArrival = (wp->type == WAYPOINT_TYPE_HOLD) || (wp->type == WAYPOINT_TYPE_LAND);
+    // A LAND duration is a pre-descent loiter and a TAKEOFF duration a
+    // post-climb loiter; the hold-expiry path starts the descent (LAND) or
+    // advances (HOLD, TAKEOFF).
+    const bool holdsOnArrival = (wp->type == WAYPOINT_TYPE_HOLD)
+                             || (wp->type == WAYPOINT_TYPE_LAND)
+                             || (wp->type == WAYPOINT_TYPE_TAKEOFF);
     if (holdsOnArrival && fp.holdDurationDs > 0) {
         fp.state = FP_NAV_HOLDING;
         fp.holdStartUs = micros();
+        if (wp->type == WAYPOINT_TYPE_HOLD && wp->pattern != WAYPOINT_PATTERN_NONE) {
+            // Deferred: the update loop starts the pattern once the arrival
+            // braking has settled (see FP_PATTERN_START_SPEED_MPS).
+            fp.patternPending = true;
+        }
         return;
     }
 
@@ -641,7 +782,6 @@ static void onWaypointReached(void *userData)
         return;
     }
 
-    // TODO: WAYPOINT_PATTERN_ORBIT / FIGURE8 sub-target generation for HOLD.
     advanceToNext();
 }
 
@@ -665,6 +805,8 @@ void flightPlanNavInit(void)
     fp.zBiasM = 0.0f;
     fp.abortReason = FP_ABORT_NONE;
     fp.injectedCount = 0;
+    fp.patternPending = false;
+    fp.patternActive = false;
 #if ENABLE_RESCUE_PLAN
     fp.stagedCount = 0;
     fp.isRescuePlan = false;
@@ -681,6 +823,8 @@ void flightPlanNavEngage(void)
     // Engagement always starts the PG mission; an injected plan does not
     // survive a switch cycle (no resume).
     fp.injectedCount = 0;
+    fp.patternPending = false;
+    fp.patternActive = false;
     clearModifierState();
 
     // Reconcile the estimator's altitude baseline with the GPS frame waypoint
@@ -734,6 +878,8 @@ void flightPlanNavDisengage(void)
     fp.active = false;
     fp.state = FP_NAV_IDLE;
     fp.injectedCount = 0;
+    fp.patternPending = false;
+    fp.patternActive = false;
 #if ENABLE_RESCUE_PLAN
     fp.stagedCount = 0;
     fp.isRescuePlan = false;
@@ -840,6 +986,24 @@ void flightPlanNavUpdate(timeUs_t currentTimeUs)
     }
 
     if (fp.state == FP_NAV_HOLDING) {
+        if (fp.patternPending) {
+            const waypoint_t *wp = currentWaypoint();
+            if (!positionNavHasActiveTarget() || wp == NULL) {
+                // The hold command was wiped while settling; degrade to a
+                // plain hold rather than orbit an unknown centre.
+                fp.patternPending = false;
+            } else {
+                const positionEstimate3d_t *est = positionEstimatorGetEstimate();
+                const float hSpeedMps = sqrtf(sq(est->velocity.v[ENU_E]) + sq(est->velocity.v[ENU_N])) * 0.01f;
+                if (hSpeedMps < FP_PATTERN_START_SPEED_MPS
+                    || cmpTimeUs(currentTimeUs, fp.holdStartUs) >= (timeDelta_t)FP_PATTERN_START_TIMEOUT_US) {
+                    fp.patternPending = false;
+                    startHoldPattern(wp);
+                }
+            }
+        } else if (fp.patternActive) {
+            updateHoldPattern(currentTimeUs);
+        }
         const uint32_t holdUs = (uint32_t)fp.holdDurationDs * 100000u;
         const uint32_t elapsedUs = (uint32_t)(currentTimeUs - fp.holdStartUs);
         if (elapsedUs >= holdUs) {

--- a/src/main/flight/flight_plan_nav.h
+++ b/src/main/flight/flight_plan_nav.h
@@ -66,6 +66,11 @@ flightPlanNavState_e flightPlanNavGetState(void);
 uint8_t flightPlanNavGetCurrentIndex(void);
 flightPlanAbortReason_e flightPlanNavGetAbortReason(void);
 
+// Orbit period (deciseconds) at the configured pattern radius for a leg flown
+// at speedCmS (0 = autopilot max velocity). Converts MAVLink LOITER_TURNS turn
+// counts to and from hold durations.
+uint16_t flightPlanNavOrbitPeriodDs(uint16_t speedCmS);
+
 // Replace the active mission with a small synthesised runtime plan (at most 4
 // waypoints, copied). Only valid while the executor is active. The injected
 // plan does not survive a switch cycle: engage and disengage revert to the

--- a/src/main/flight/flight_plan_nav.h
+++ b/src/main/flight/flight_plan_nav.h
@@ -42,6 +42,7 @@ typedef enum {
     FP_ABORT_ESTIMATOR,     // XY position estimate became invalid mid-mission
     FP_ABORT_STALLED,       // no progress toward the target within the stall window
     FP_ABORT_FLYAWAY,       // distance to target grew past the flyaway margin
+    FP_ABORT_HEADING,       // rescue heading recovery did not converge in time
 } flightPlanAbortReason_e;
 
 void flightPlanNavInit(void);
@@ -71,6 +72,16 @@ flightPlanAbortReason_e flightPlanNavGetAbortReason(void);
 // stored mission, with no resume of what was preempted.
 bool flightPlanNavInjectPlan(const waypoint_t *waypoints, uint8_t count);
 bool flightPlanNavIsInjectedPlanActive(void);
+
+#if ENABLE_RESCUE_PLAN
+// Synthesise a failsafe rescue mission (climb-in-place, fly home, land) from
+// the current position and home, staged for the next flightPlanNavEngage() to
+// consume in place of the PG mission; injected immediately if the executor is
+// already active. Returns false when no home or fix exists to build a plan —
+// the failsafe caller then degrades to auto-landing.
+bool flightPlanNavStageRescuePlan(void);
+bool flightPlanNavIsRescuePlanActive(void);
+#endif
 
 // Single observer slot for "waypoint reached" — invoked with the index of the
 // waypoint that was just reached, before any HOLD timer or advance. Pass NULL

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -704,6 +704,11 @@ float gpsRescueGetYawRate(void)
     return rescueYawRate; // the control yaw value for rc.c to be used while flightMode gps_rescue is active.
 }
 
+float gpsRescueGetMaxAltitudeCm(void)
+{
+    return rescueState.intent.maxAltitudeCm; // running max since arming, tracked while the rescue task idles
+}
+
 bool gpsRescueIsConfigured(void)
 {
     return failsafeConfig()->failsafe_procedure == FAILSAFE_PROCEDURE_GPS_RESCUE || isModeActivationConditionPresent(BOXGPSRESCUE);

--- a/src/main/flight/gps_rescue_multirotor.h
+++ b/src/main/flight/gps_rescue_multirotor.h
@@ -44,6 +44,7 @@ typedef enum {
 void gpsRescueInit(void);
 void gpsRescueUpdate(void);
 float gpsRescueGetYawRate(void);
+float gpsRescueGetMaxAltitudeCm(void);
 bool gpsRescueIsConfigured(void);
 bool gpsRescueIsAvailable(void);
 bool gpsRescueIsHeadingOK(void);

--- a/src/main/flight/position_nav.c
+++ b/src/main/flight/position_nav.c
@@ -87,6 +87,14 @@ void positionNavSetTargetEf(
     withinAcceptanceAltitude = false;
 }
 
+void positionNavMoveTargetEf(const vector3_t *targetPosEfM)
+{
+    if (!cmd.active) {
+        return;
+    }
+    cmd.targetPosEfM = *targetPosEfM;
+}
+
 void positionNavClearTarget(void)
 {
     cmd.active = false;

--- a/src/main/flight/position_nav.h
+++ b/src/main/flight/position_nav.h
@@ -64,6 +64,11 @@ void positionNavSetTargetEf(
     void *userData
 );
 
+// Moves the active command's target position without disturbing the velocity
+// ramp, completion state, or callback — for continuously moving targets (hold
+// pattern carrots). No-op when there is no active command.
+void positionNavMoveTargetEf(const vector3_t *targetPosEfM);
+
 void positionNavClearTarget(void);
 
 bool positionNavHasActiveTarget(void);

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -1368,25 +1368,40 @@ static void updateVirtualGPS(void)
     static uint32_t nextUpdateTime = 0;
 
     if (cmp32(gpsData.now, nextUpdateTime) > 0) {
-        if (gpsData.state == GPS_STATE_INITIALIZED) {
-            gpsSetState(GPS_STATE_RECEIVING_DATA);
+        // Freshness is a feeder-thread counter, checked against this task's
+        // own clock: a stale feed leaves lastNavMessage frozen so the
+        // RECEIVING_DATA timeout below trips, exactly as a real receiver
+        // going dark. Fresh data recovers from the post-timeout DETECT_BAUD
+        // parking state.
+        static uint32_t lastCount = 0;
+        static uint32_t lastCountChangeMs = 0;
+        const uint32_t count = getVirtualGPSUpdateCount();
+        if (count != lastCount) {
+            lastCount = count;
+            lastCountChangeMs = gpsData.now;
         }
+        const bool fresh = (lastCountChangeMs != 0) && (cmp32(gpsData.now, lastCountChangeMs) < GPS_TIMEOUT_MS);
 
-        getVirtualGPS(&gpsSol);
-        gpsSol.time = gpsData.now;
+        if (fresh) {
+            if (gpsData.state == GPS_STATE_INITIALIZED || gpsData.state == GPS_STATE_DETECT_BAUD) {
+                gpsSetState(GPS_STATE_RECEIVING_DATA);
+            }
+            getVirtualGPS(&gpsSol);
+            gpsSol.time = gpsData.now;
 
-        gpsData.lastNavMessage = gpsData.now;
-        sensorsSet(SENSOR_GPS);
+            gpsData.lastNavMessage = gpsData.now;
+            sensorsSet(SENSOR_GPS);
 
-        if (gpsSol.numSat > 3) {
-            gpsSetFixState(GPS_FIX);
-        } else {
-            gpsSetFixState(0);
+            if (gpsSol.numSat > 3) {
+                gpsSetFixState(GPS_FIX);
+            } else {
+                gpsSetFixState(0);
+            }
+            GPS_update ^= GPS_DIRECT_TICK;
+
+            calculateNavInterval();
+            onGpsNewData();
         }
-        GPS_update ^= GPS_DIRECT_TICK;
-
-        calculateNavInterval();
-        onGpsNewData();
 
         nextUpdateTime = gpsData.now + updateInterval;
     }

--- a/src/main/io/gps_virtual.c
+++ b/src/main/io/gps_virtual.c
@@ -29,9 +29,14 @@
 #include "io/gps_virtual.h"
 
 static gpsSolutionData_t gpsVirtualData;
+static uint32_t updateCount = 0;
 
 void setVirtualGPS(double latitude, double longitude, double altiutude, double speed, double speed3D, double course, double velNorth, double velEast, double velDown)
 {
+    // May be called from a feeder thread (SITL UDP receive); the counter is a
+    // single word so the GPS task can detect freshness without a cross-thread
+    // clock read.
+    updateCount++;
     gpsVirtualData.numSat = 12;    // satellites_in_view
     gpsVirtualData.acc.hAcc = 500; // horizontal_pos_accuracy - convert cm to mm
     gpsVirtualData.acc.vAcc = 500; // vertical_pos_accuracy - convert cm to mm
@@ -53,5 +58,10 @@ void setVirtualGPS(double latitude, double longitude, double altiutude, double s
 void getVirtualGPS(gpsSolutionData_t *gpsSolData)
 {
     *gpsSolData = gpsVirtualData;
+}
+
+uint32_t getVirtualGPSUpdateCount(void)
+{
+    return updateCount;
 }
 #endif

--- a/src/main/io/gps_virtual.c
+++ b/src/main/io/gps_virtual.c
@@ -33,10 +33,10 @@ static uint32_t updateCount = 0;
 
 void setVirtualGPS(double latitude, double longitude, double altiutude, double speed, double speed3D, double course, double velNorth, double velEast, double velDown)
 {
-    // May be called from a feeder thread (SITL UDP receive); the counter is a
-    // single word so the GPS task can detect freshness without a cross-thread
-    // clock read.
-    updateCount++;
+    // May be called from a feeder thread (SITL UDP receive) while the GPS task
+    // reads on the main loop. Populate the struct fully first, then publish by
+    // release-storing the incremented counter: a reader that acquire-loads the
+    // new count is then guaranteed to see the complete data.
     gpsVirtualData.numSat = 12;    // satellites_in_view
     gpsVirtualData.acc.hAcc = 500; // horizontal_pos_accuracy - convert cm to mm
     gpsVirtualData.acc.vAcc = 500; // vertical_pos_accuracy - convert cm to mm
@@ -53,6 +53,9 @@ void setVirtualGPS(double latitude, double longitude, double altiutude, double s
     gpsVirtualData.velned.velN = (int16_t)(velNorth * 100.0); // cm/sec
     gpsVirtualData.velned.velE = (int16_t)(velEast * 100.0);  // cm/sec
     gpsVirtualData.velned.velD = (int16_t)(velDown * 100.0);  // cm/sec
+
+    const uint32_t next = __atomic_load_n(&updateCount, __ATOMIC_RELAXED) + 1;
+    __atomic_store_n(&updateCount, next, __ATOMIC_RELEASE);
 }
 
 void getVirtualGPS(gpsSolutionData_t *gpsSolData)
@@ -62,6 +65,6 @@ void getVirtualGPS(gpsSolutionData_t *gpsSolData)
 
 uint32_t getVirtualGPSUpdateCount(void)
 {
-    return updateCount;
+    return __atomic_load_n(&updateCount, __ATOMIC_ACQUIRE);
 }
 #endif

--- a/src/main/io/gps_virtual.h
+++ b/src/main/io/gps_virtual.h
@@ -24,3 +24,4 @@
 #include "io/gps.h"
 void setVirtualGPS(double latitude, double longitude, double altiutude, double velocity, double velocity3D, double course, double velNorth, double velEast, double velDown);
 void getVirtualGPS(gpsSolutionData_t *gpsSolData);
+uint32_t getVirtualGPSUpdateCount(void);

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -409,6 +409,9 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
         case FP_ABORT_FLYAWAY:
             tfp_sprintf(warningText, "WP FLYAWAY");
             break;
+        case FP_ABORT_HEADING:
+            tfp_sprintf(warningText, "WP HEADING");
+            break;
         default:
             tfp_sprintf(warningText, "WP ABORT");
             break;

--- a/src/main/pg/flight_plan.c
+++ b/src/main/pg/flight_plan.c
@@ -30,7 +30,7 @@
 
 #if ENABLE_FLIGHT_PLAN
 
-PG_REGISTER_WITH_RESET_TEMPLATE(flightPlanConfig_t, flightPlanConfig, PG_FLIGHT_PLAN_CONFIG, 0);
+PG_REGISTER_WITH_RESET_TEMPLATE(flightPlanConfig_t, flightPlanConfig, PG_FLIGHT_PLAN_CONFIG, 1);
 
 PG_RESET_TEMPLATE(flightPlanConfig_t, flightPlanConfig,
     .waypointCount = 0,

--- a/src/main/pg/flight_plan.h
+++ b/src/main/pg/flight_plan.h
@@ -47,8 +47,10 @@ typedef enum {
 } waypointType_e;
 
 typedef enum {
-    WAYPOINT_PATTERN_ORBIT = 0,
-    WAYPOINT_PATTERN_FIGURE8
+    WAYPOINT_PATTERN_NONE = 0,      // station-keep at the hold point
+    WAYPOINT_PATTERN_ORBIT,
+    WAYPOINT_PATTERN_FIGURE8,
+    WAYPOINT_PATTERN_COUNT
 } waypointPattern_e;
 
 typedef struct {

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -146,6 +146,12 @@ void pgResetFn_compassConfig(compassConfig_t *compassConfig)
     compassConfig->mag_i2c_address = MAG_I2C_ADDRESS;
     compassConfig->mag_spi_device = SPI_DEV_TO_CFG(SPIINVALID);
     compassConfig->mag_spi_csn = IO_TAG_NONE;
+#elif defined(USE_VIRTUAL_MAG)
+    compassConfig->mag_busType = BUS_TYPE_NONE;
+    compassConfig->mag_i2c_device = I2C_DEV_TO_CFG(I2CINVALID);
+    compassConfig->mag_i2c_address = 0;
+    compassConfig->mag_spi_device = SPI_DEV_TO_CFG(SPIINVALID);
+    compassConfig->mag_spi_csn = IO_TAG_NONE;
 #else
     compassConfig->mag_hardware = MAG_NONE;
     compassConfig->mag_busType = BUS_TYPE_NONE;
@@ -386,6 +392,14 @@ static bool compassDetect(magDev_t *magDev, uint8_t *alignment)
 #else
 static bool compassDetect(magDev_t *dev, sensor_align_e *alignment)
 {
+#if defined(USE_VIRTUAL_MAG)
+    *alignment = ALIGN_DEFAULT; // virtual mag data is already in the body frame
+    if (compassConfig()->mag_hardware != MAG_NONE && virtualMagDetect(dev)) {
+        detectedSensors[SENSOR_INDEX_MAG] = MAG_DEFAULT;
+        sensorsSet(SENSOR_MAG);
+        return true;
+    }
+#endif
     UNUSED(dev);
     UNUSED(alignment);
 

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -872,6 +872,16 @@ extern struct linker_symbol __fontdata_end;
 #define ENABLE_FLIGHT_PLAN 0
 #endif
 
+// Failsafe GPS rescue flown as a synthesised flight-plan mission instead of
+// the legacy gps_rescue controller. Opt-in; the BOXGPSRESCUE switch keeps
+// flying legacy rescue either way.
+#if !defined(ENABLE_RESCUE_PLAN)
+#define ENABLE_RESCUE_PLAN 0
+#endif
+#if ENABLE_RESCUE_PLAN && !(ENABLE_FLIGHT_PLAN && defined(USE_GPS_RESCUE) && !defined(USE_WING))
+#error "ENABLE_RESCUE_PLAN requires ENABLE_FLIGHT_PLAN, USE_GPS_RESCUE and !USE_WING"
+#endif
+
 #if defined(USE_POSITION_HOLD) && !(defined(USE_GPS) || defined(USE_OPTICALFLOW))
 #error "USE_POSITION_HOLD requires USE_GPS and/or USE_OPTICALFLOW to be defined"
 #endif

--- a/src/main/telemetry/mavlink_mission.c
+++ b/src/main/telemetry/mavlink_mission.c
@@ -40,6 +40,7 @@
 
 #include "io/gps.h"
 
+#include "pg/autopilot.h"
 #include "pg/flight_plan.h"
 
 #include "telemetry/mavlink.h"
@@ -128,14 +129,23 @@ static void sendMissionItem(uint8_t partnerSys, uint8_t partnerComp, uint16_t se
     uint16_t command;
     float param1 = 0.0f;
     float param2 = 0.0f;
+    float param3 = 0.0f;
     int32_t lat = wp->latitude;
     int32_t lon = wp->longitude;
     float zM = wp->altitude * 0.01f;
 
     switch (wp->type) {
     case WAYPOINT_TYPE_HOLD:
-        command = MAV_CMD_NAV_LOITER_TIME;
-        param1 = wp->duration * 0.1f;
+        if (wp->pattern == WAYPOINT_PATTERN_ORBIT) {
+            command = MAV_CMD_NAV_LOITER_TURNS;
+            param1 = (float)wp->duration / (float)flightPlanNavOrbitPeriodDs(wp->speed);
+            param3 = autopilotConfig()->waypointHoldRadius * 0.01f;
+        } else {
+            // FIGURE8 has no MAVLink vocabulary; it downloads as a plain
+            // timed loiter (the pattern survives only in the stored mission).
+            command = MAV_CMD_NAV_LOITER_TIME;
+            param1 = wp->duration * 0.1f;
+        }
         break;
     case WAYPOINT_TYPE_LAND:
         command = MAV_CMD_NAV_LAND;
@@ -172,7 +182,7 @@ static void sendMissionItem(uint8_t partnerSys, uint8_t partnerComp, uint16_t se
 
     mavlink_msg_mission_item_int_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
         partnerSys, partnerComp, seq, MAV_FRAME_GLOBAL_INT, command, current, 1,
-        param1, param2, 0.0f, 0.0f,
+        param1, param2, param3, 0.0f,
         lat, lon, zM,
         MAV_MISSION_TYPE_MISSION);
     mavlinkSendMessage(&txMsg);
@@ -251,7 +261,7 @@ static bool mapMavCmdToWaypoint(const mavlink_mission_item_int_t *it, waypoint_t
     wp->altitude = altCm;
     wp->speed = 0;
     wp->duration = 0;
-    wp->pattern = WAYPOINT_PATTERN_ORBIT;
+    wp->pattern = WAYPOINT_PATTERN_NONE;
 
     switch (it->command) {
     case MAV_CMD_NAV_WAYPOINT:
@@ -272,9 +282,18 @@ static bool mapMavCmdToWaypoint(const mavlink_mission_item_int_t *it, waypoint_t
             wp->duration = (ds >= UINT16_MAX) ? UINT16_MAX : (uint16_t)ds;
         }
         break;
-    case MAV_CMD_NAV_LOITER_TURNS:
+    case MAV_CMD_NAV_LOITER_TURNS: {
+        // param1 = turns, converted to a hold duration at the executor's
+        // orbit rate. param3's radius is ignored: the orbit flies at the
+        // configured ap_waypoint_hold_radius.
         wp->type = WAYPOINT_TYPE_HOLD;
+        wp->pattern = WAYPOINT_PATTERN_ORBIT;
+        if (it->param1 > 0.0f) {
+            const float ds = it->param1 * (float)flightPlanNavOrbitPeriodDs(wp->speed);
+            wp->duration = (ds >= UINT16_MAX) ? UINT16_MAX : (uint16_t)ds;
+        }
         break;
+    }
     case MAV_CMD_NAV_LOITER_UNLIM:
         wp->type = WAYPOINT_TYPE_HOLD;
         wp->duration = UINT16_MAX;

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -51,6 +51,7 @@
 
 #include "drivers/accgyro/accgyro_virtual.h"
 #include "drivers/barometer/barometer_virtual.h"
+#include "drivers/compass/compass_virtual.h"
 #include "flight/imu.h"
 #include "flight/position.h"
 
@@ -320,6 +321,61 @@ static void updateState(const fdm_packet* pkt)
     // Legacy bridges (X-Plane, RealFlight) supply pressure directly in fdm_packet
     virtualBaroSet((int32_t)pkt->pressure, 2500);
 #endif
+    // Reconstruct the body-to-world (NWU) attitude quaternion from the packet.
+    // Consumed by the direct-attitude path and by the virtual mag feed, which
+    // must use the same rotation or mag fusion fights the fed attitude.
+#if ENABLE_GAZEBO_BRIDGE
+    // The Gazebo BetaflightPlugin sends the quaternion conjugated by Rx(π)
+    // (q_plugin = Rx(π) * M * Rx(π), with M the FLU-body to ENU-world
+    // attitude). Undo the conjugation (negate qy/qz), then rotate the world
+    // frame by Rz(π/2) (ENU -> NWU): q = Rz(π/2) * Rx(π) * q_plugin * Rx(π).
+    // FLU body equals Betaflight's internal NWU body, so the result is the
+    // proper body-to-world rotation - the Euler display and every rMat
+    // vector consumer (position estimator, mag fusion) agree at any heading.
+    const float pktQw = pkt->imu_orientation_quat[0];
+    const float pktQx = pkt->imu_orientation_quat[1];
+    const float pktQy = -pkt->imu_orientation_quat[2];
+    const float pktQz = -pkt->imu_orientation_quat[3];
+    static const float k = 0.70710678f; // cos(π/4) = sin(π/4) = √2/2
+    const float attQw = k * (pktQw - pktQz);
+    const float attQx = k * (pktQx - pktQy);
+    const float attQy = k * (pktQy + pktQx);
+    const float attQz = k * (pktQz + pktQw);
+#else
+    // Legacy bridges send the body-to-world quaternion directly
+    const float attQw = pkt->imu_orientation_quat[0];
+    const float attQx = pkt->imu_orientation_quat[1];
+    const float attQy = pkt->imu_orientation_quat[2];
+    const float attQz = pkt->imu_orientation_quat[3];
+#endif
+
+#if defined(USE_VIRTUAL_MAG)
+    {
+        // Synthetic earth field, NWU, 4096 counts: 60° inclination and 2° east
+        // declination so every body component is generically nonzero
+        // (compassEnabledAndCalibrated requires nonzero x, y and z). The 2°
+        // heading bias is negligible against scenario tolerances; the vertical
+        // component is ignored by imuCalcMagErr's horizontal projection.
+        static const float fieldN = 2046.8f;
+        static const float fieldW = -71.5f;
+        static const float fieldU = -3547.2f;
+        // v_body = R(q)^T * v_world
+        const float r00 = 1.0f - 2.0f * (attQy * attQy + attQz * attQz);
+        const float r01 = 2.0f * (attQx * attQy - attQw * attQz);
+        const float r02 = 2.0f * (attQx * attQz + attQw * attQy);
+        const float r10 = 2.0f * (attQx * attQy + attQw * attQz);
+        const float r11 = 1.0f - 2.0f * (attQx * attQx + attQz * attQz);
+        const float r12 = 2.0f * (attQy * attQz - attQw * attQx);
+        const float r20 = 2.0f * (attQx * attQz - attQw * attQy);
+        const float r21 = 2.0f * (attQy * attQz + attQw * attQx);
+        const float r22 = 1.0f - 2.0f * (attQx * attQx + attQy * attQy);
+        const float magX = r00 * fieldN + r10 * fieldW + r20 * fieldU;
+        const float magY = r01 * fieldN + r11 * fieldW + r21 * fieldU;
+        const float magZ = r02 * fieldN + r12 * fieldW + r22 * fieldU;
+        virtualMagSet(lrintf(magX), lrintf(magY), lrintf(magZ));
+    }
+#endif
+
 #if !defined(USE_IMU_CALC)
 #if defined(SET_IMU_FROM_EULER)
     // set from Euler
@@ -347,25 +403,7 @@ static void updateState(const fdm_packet* pkt)
     zf = atan2(t3, t4) * RAD2DEG;
     imuSetAttitudeRPY(xf, -yf, zf); // yes! pitch was inverted!!
 #else
-#if ENABLE_GAZEBO_BRIDGE
-    // The Gazebo BetaflightPlugin sends the quaternion conjugated by Rx(π)
-    // (q_plugin = Rx(π) * M * Rx(π), with M the FLU-body to ENU-world
-    // attitude). Undo the conjugation (negate qy/qz), then rotate the world
-    // frame by Rz(π/2) (ENU -> NWU): q = Rz(π/2) * Rx(π) * q_plugin * Rx(π).
-    // FLU body equals Betaflight's internal NWU body, so the result is the
-    // proper body-to-world rotation - the Euler display and every rMat
-    // vector consumer (position estimator, mag fusion) agree at any heading.
-    const float qw = pkt->imu_orientation_quat[0];
-    const float qx = pkt->imu_orientation_quat[1];
-    const float qy = -pkt->imu_orientation_quat[2];
-    const float qz = -pkt->imu_orientation_quat[3];
-    static const float k = 0.70710678f; // cos(π/4) = sin(π/4) = √2/2
-    imuSetAttitudeQuat(k * (qw - qz), k * (qx - qy), k * (qy + qx), k * (qz + qw));
-#else
-    // Legacy bridges send body-to-world quaternion directly
-    imuSetAttitudeQuat((float)pkt->imu_orientation_quat[0], (float)pkt->imu_orientation_quat[1],
-                       (float)pkt->imu_orientation_quat[2], (float)pkt->imu_orientation_quat[3]);
-#endif
+    imuSetAttitudeQuat(attQw, attQx, attQy, attQz);
 #endif
 #endif
 
@@ -373,6 +411,7 @@ static void updateState(const fdm_packet* pkt)
     const double longitude = pkt->position_xyz[0];
     const double latitude = pkt->position_xyz[1];
     const double altitude = pkt->position_xyz[2];
+
 
 #if ENABLE_GAZEBO_BRIDGE
     // Gazebo Harmonic's SphericalFromLocalPosition inverts horizontal position
@@ -406,8 +445,13 @@ static void updateState(const fdm_packet* pkt)
         course += 360.0;
     }
     // velocity_xyz is ENU: NED velN = [1], velE = [0], velD = -[2]
-    setVirtualGPS(correctedLat, correctedLon, altitude, speed, speed3D, course,
-                  pkt->velocity_xyz[1], pkt->velocity_xyz[0], -pkt->velocity_xyz[2]);
+    // Out-of-range lat/lon is a test-harness sentinel for GPS loss: skip the
+    // update so the virtual GPS goes stale. Kept as a range check because
+    // -ffast-math folds isnan() to false. Real bridges send valid coordinates.
+    if (fabs(latitude) <= 90.0 && fabs(longitude) <= 180.0) {
+        setVirtualGPS(correctedLat, correctedLon, altitude, speed, speed3D, course,
+                      pkt->velocity_xyz[1], pkt->velocity_xyz[0], -pkt->velocity_xyz[2]);
+    }
 
     if (gpxEnabled) {
         static uint64_t lastGpxTimeUs = 0;

--- a/src/platform/SIMULATOR/target/SITL/target.h
+++ b/src/platform/SIMULATOR/target/SITL/target.h
@@ -52,9 +52,12 @@
 #define DMA_DATA
 #define STATIC_DMA_DATA_AUTO
 
-// use simulatior's attitude directly
-// disable this if wants to test AHRS algorithm
+// SITL runs the real attitude estimator (Mahony + mag/COG fusion) against the
+// virtual gyro/acc/mag feeds. Build with -DSITL_ATTITUDE_DIRECT to bypass it
+// and set attitude straight from the FDM quaternion (legacy behaviour).
+#if defined(SITL_ATTITUDE_DIRECT)
 #undef USE_IMU_CALC
+#endif
 
 //#define ENABLE_SIMULATOR_ACC_SYNC 1
 //#define ENABLE_SIMULATOR_GYRO_SYNC 1

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -199,6 +199,18 @@ flight_failsafe_unittest_DEFINES := \
 		USE_GPS_RESCUE= \
 		ENABLE_FLIGHT_PLAN=1
 
+flight_failsafe_rescue_unittest_SRC := \
+		$(USER_DIR)/common/bitarray.c \
+		$(USER_DIR)/fc/rc_modes.c \
+		$(USER_DIR)/fc/runtime_config.c \
+		$(USER_DIR)/flight/failsafe.c \
+		$(USER_DIR)/pg/autopilot.c
+
+flight_failsafe_rescue_unittest_DEFINES := \
+		USE_GPS_RESCUE= \
+		ENABLE_FLIGHT_PLAN=1 \
+		ENABLE_RESCUE_PLAN=1
+
 
 flight_imu_unittest_SRC := \
 		$(USER_DIR)/common/bitarray.c \
@@ -531,6 +543,22 @@ flight_plan_nav_unittest_DEFINES := \
 		USE_GPS_RESCUE= \
 		USE_FLIGHT_PLAN= \
 		ENABLE_FLIGHT_PLAN=1
+
+flight_plan_rescue_unittest_SRC := \
+		$(USER_DIR)/flight/flight_plan_nav.c \
+		$(USER_DIR)/pg/autopilot.c \
+		$(USER_DIR)/pg/flight_plan.c \
+		$(USER_DIR)/pg/gps_rescue_multirotor.c \
+		$(USER_DIR)/common/maths.c \
+		$(USER_DIR)/common/vector.c
+
+flight_plan_rescue_unittest_DEFINES := \
+		USE_GPS= \
+		USE_GPS_RESCUE= \
+		USE_FLIGHT_PLAN= \
+		ENABLE_FLIGHT_PLAN=1 \
+		ENABLE_RESCUE_PLAN=1
+
 rcdevice_unittest_DEFINES := \
 		USE_RCDEVICE=
 

--- a/src/test/sitl/sitl_harness.py
+++ b/src/test/sitl/sitl_harness.py
@@ -600,7 +600,7 @@ def base_config(extra):
         # matches the MotionModel plant: atan(K_DRAG * v / g) over cruise speeds
         "set ap_velocity_drag_coeff = 440",
         # 10 m above home, 5 m/s — low and quick keeps landing scenarios short
-        f"waypoint insert 0 {WP_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyover 0 orbit",
+        f"waypoint insert 0 {WP_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyover 0 none",
     ] + extra
 
 
@@ -775,6 +775,119 @@ def scenario_mission_land(sitl, rc, fdm):
     dist = fdm.distance_to_wp(25.0, 40.0)
     assert dist < 10.0, f"landed {dist:.1f} m from the LAND waypoint"
     log(f"landed {dist:.1f} m from the LAND waypoint")
+
+
+def scenario_mission_takeoff(sitl, rc, fdm):
+    """TAKEOFF waypoint: climb in place to the waypoint altitude (its lat/lon
+    are advisory), then fly the following leg. The climb must not translate."""
+    boot_and_engage(sitl, rc, fdm)
+    t_engage = fdm.now_t()
+
+    wait_for(
+        "climb through 12 m (TAKEOFF target 15 m)",
+        lambda: fdm.model.pos[2] > 12.0,
+        timeout=90,
+        interval=0.5,
+    )
+    t_top = fdm.now_t()
+
+    # Horizontal drift during the climb, relative to where the mission engaged
+    # (TAKEOFF holds the current position, not home).
+    climb = [s for s in fdm.snapshot_history() if t_engage <= s[0] <= t_top]
+    assert climb, "no recorded samples during the climb"
+    e0, n0 = climb[0][1], climb[0][2]
+    drift = max(math.hypot(s[1] - e0, s[2] - n0) for s in climb)
+    assert drift < 8.0, f"translated {drift:.1f} m during the TAKEOFF climb"
+    log(f"climbed to {fdm.model.pos[2]:.1f} m with {drift:.1f} m drift")
+
+    wait_for(
+        "leg to the north waypoint after the climb",
+        lambda: fdm.distance_to_wp(0.0, 40.0) < 10.0,
+        timeout=90,
+        interval=1.0,
+    )
+    assert BOX_ARM in sitl.modes(), "unexpected disarm during the takeoff mission"
+
+
+def hold_window_samples(fdm, centre_e, centre_n, t0, t1):
+    """(distances, azimuth sweep in rad) of history samples in [t0, t1],
+    measured about the hold point. Sweep accumulates wrapped step deltas, so
+    systematic circulation grows it while hover noise cancels out."""
+    pts = [s for s in fdm.snapshot_history() if t0 <= s[0] <= t1]
+    dists = [math.hypot(s[1] - centre_e, s[2] - centre_n) for s in pts]
+    azimuths = [math.atan2(s[2] - centre_n, s[1] - centre_e) for s in pts]
+    sweep = 0.0
+    for a, b in zip(azimuths, azimuths[1:]):
+        sweep += (b - a + math.pi) % (2.0 * math.pi) - math.pi
+    return dists, sweep
+
+
+def scenario_mission_orbit(sitl, rc, fdm):
+    """HOLD with the ORBIT pattern: after arriving at the hold point the
+    vehicle must circulate around it on the hold radius for the duration."""
+    boot_and_engage(sitl, rc, fdm)
+
+    wait_for(
+        "arrival at the hold point",
+        lambda: fdm.distance_to_wp(0.0, 40.0) < 10.0,
+        timeout=90,
+        interval=1.0,
+    )
+    t_arrive = fdm.now_t()
+
+    # Analysis window: skip 12 s (arrival braking + pattern spin-up), observe
+    # 40 s of the 60 s hold. Carrot rate 0.25 rad/s -> ~1.6 laps in the window.
+    wait_for("orbit window elapsed", lambda: fdm.now_t() > t_arrive + 52.0,
+             timeout=70, interval=2.0)
+    dists, sweep = hold_window_samples(fdm, 0.0, 40.0, t_arrive + 12.0, t_arrive + 52.0)
+    assert len(dists) > 250, f"recorder too sparse over the hold window: {len(dists)} samples"
+
+    mean_dist = sum(dists) / len(dists)
+    log(f"orbit mean radius {mean_dist:.1f} m, peak {max(dists):.1f} m, "
+        f"swept {math.degrees(sweep):.0f} deg")
+    # The vehicle rides the ring with pursuit lag (a little inside) plus the
+    # loop phase lag (a little outside); a hover at the hold point would sit
+    # near zero and a runaway pursuit far outside.
+    assert 3.0 < mean_dist < 12.0, f"orbit radius off: mean {mean_dist:.1f} m from the hold point"
+    assert max(dists) < 16.0, f"orbit excursion: {max(dists):.1f} m from the hold point"
+    assert sweep > math.radians(270.0), f"no sustained circulation: swept {math.degrees(sweep):.0f} deg"
+    assert BOX_ARM in sitl.modes(), "unexpected disarm during the orbit"
+
+
+def scenario_mission_figure8(sitl, rc, fdm):
+    """HOLD with the FIGURE8 pattern: bounded excursion about the hold point
+    with repeated passes back through the centre."""
+    boot_and_engage(sitl, rc, fdm)
+
+    wait_for(
+        "arrival at the hold point",
+        lambda: fdm.distance_to_wp(0.0, 40.0) < 10.0,
+        timeout=90,
+        interval=1.0,
+    )
+    t_arrive = fdm.now_t()
+
+    wait_for("figure-8 window elapsed", lambda: fdm.now_t() > t_arrive + 52.0,
+             timeout=70, interval=2.0)
+    dists, _ = hold_window_samples(fdm, 0.0, 40.0, t_arrive + 12.0, t_arrive + 52.0)
+    assert len(dists) > 250, f"recorder too sparse over the hold window: {len(dists)} samples"
+
+    # Lemniscate on an 8 m radius: lobes reach the ring, the path re-crosses
+    # the centre twice per cycle (~25 s), and never leaves the hold radius.
+    log(f"figure-8 peak {max(dists):.1f} m from the hold point")
+    assert max(dists) < 13.0, f"figure-8 excursion: {max(dists):.1f} m from the hold point"
+    assert max(dists) > 4.0, f"no pattern motion: peak {max(dists):.1f} m from the hold point"
+    crossings = 0
+    away = False
+    for d in dists:
+        if d > 5.0:
+            away = True
+        elif away and d < 4.0:
+            crossings += 1
+            away = False
+    assert crossings >= 2, f"path did not re-cross the centre: {crossings} passes"
+    assert BOX_ARM in sitl.modes(), "unexpected disarm during the figure-8"
+    log(f"figure-8 {crossings} centre passes")
 
 
 def scenario_rx_loss(sitl, rc, fdm, policy):
@@ -1110,7 +1223,7 @@ SCENARIOS = {
     "mission_yaw": (
         scenario_mission_yaw,
         # redirect the default waypoint east so the course demands a 90 deg swing
-        [f"waypoint update 0 {HOME_LAT:.7f} {WP_EAST_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyover 0 orbit"],
+        [f"waypoint update 0 {HOME_LAT:.7f} {WP_EAST_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyover 0 none"],
     ),
     "mission_land": (
         scenario_mission_land,
@@ -1118,14 +1231,43 @@ SCENARIOS = {
             "set ap_yaw_mode = FIXED",
             # short north leg, then LAND at an offset so the executor must fly
             # to the landing point before descending
-            f"waypoint update 0 {WP_NORTH40_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyover 0 orbit",
+            f"waypoint update 0 {WP_NORTH40_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyover 0 none",
             # 5 s pre-descent loiter at the LAND waypoint
-            f"waypoint insert 1 {WP_NORTH40_LAT:.7f} {WP_EAST25_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 land 50 orbit",
+            f"waypoint insert 1 {WP_NORTH40_LAT:.7f} {WP_EAST25_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 land 50 none",
             # SITL's 15-20 Hz position loop wanders during braking; a fatter
             # 3D gate keeps arrival deterministic
             "set ap_waypoint_hold_radius = 400",
             "set ap_landing_descent_rate = 200",  # keep the descent short
             "set landing_disarm_threshold = 10",   # jerk-based touchdown disarm
+        ],
+    ),
+    "mission_takeoff": (
+        scenario_mission_takeoff,
+        [
+            "set ap_yaw_mode = FIXED",
+            # TAKEOFF's lat/lon are advisory; the climb happens in place
+            f"waypoint update 0 {HOME_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 15) * 100)} 500 takeoff 0 none",
+            f"waypoint insert 1 {WP_NORTH40_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 15) * 100)} 500 flyover 0 none",
+        ],
+    ),
+    "mission_orbit": (
+        scenario_mission_orbit,
+        [
+            "set ap_yaw_mode = FIXED",
+            # 8 m pattern radius: caps the carrot at 2 m/s (0.25 rad/s), big
+            # enough to be unambiguous against SITL's coarse position loop
+            "set ap_waypoint_hold_radius = 800",
+            f"waypoint update 0 {WP_NORTH40_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyover 0 none",
+            f"waypoint insert 1 {WP_NORTH40_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 hold 600 orbit",
+        ],
+    ),
+    "mission_figure8": (
+        scenario_mission_figure8,
+        [
+            "set ap_yaw_mode = FIXED",
+            "set ap_waypoint_hold_radius = 800",
+            f"waypoint update 0 {WP_NORTH40_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyover 0 none",
+            f"waypoint insert 1 {WP_NORTH40_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 hold 600 figure8",
         ],
     ),
     "rx_disable": (lambda s, r, f: scenario_rx_loss(s, r, f, "DISABLE"), ["set ap_rx_loss_policy = DISABLE"]),

--- a/src/test/sitl/sitl_harness.py
+++ b/src/test/sitl/sitl_harness.py
@@ -883,6 +883,224 @@ def scenario_geofence_rth_rxloss(sitl, rc, fdm):
     log(f"landed {dist:.1f} m from home under failsafe")
 
 
+# --- A/B rescue scenarios -------------------------------------------------
+# Legacy GPS rescue (binary A) vs the ENABLE_RESCUE_PLAN mission rescue
+# (binary B, built with -DENABLE_RESCUE_PLAN=1) must produce the same
+# qualitative outcome: return, land near home, disarm, no flyaway. The two
+# controllers differ by design, so parity is metric bands, never trajectories.
+
+RESCUE_CFG = [
+    "set failsafe_procedure = GPS-RESCUE",
+    # FIXED_ALT: the default MAX mode keys the return altitude to each leg's
+    # own outbound peak, which varies run to run and would dominate the A/B
+    # altitude comparison; MAX synthesis is unit-tested instead
+    "set gps_rescue_alt_mode = FIXED_ALT",
+    "set gps_rescue_return_alt = 15",     # short climb keeps runs quick
+    "set ap_yaw_mode = FIXED",
+    "set ap_waypoint_hold_radius = 400",
+    "set ap_landing_descent_rate = 200",
+    "set landing_disarm_threshold = 10",   # jerk-based touchdown disarm
+    "aux 3 3 3 1700 2100 0 0",   # ALTHOLD on AUX4: pilot-flown hold after the mission leg
+    "aux 4 11 3 1700 2100 0 0",  # POSHOLD on AUX4
+    "feature BLACKBOX",
+    "set blackbox_device = VIRTUAL",       # .BFL artifact in the scenario dir
+]
+
+
+def fly_out_and_park(sitl, rc, fdm, dist_m):
+    """Mission leg out to dist_m, then hand to pilot-held ALTHOLD+POSHOLD."""
+    boot_and_engage(sitl, rc, fdm)
+    wait_for(
+        f"vehicle {dist_m:.0f} m out",
+        lambda: fdm.distance_from_home() > dist_m,
+        timeout=90,
+        interval=1.0,
+    )
+    rc.set(7, RC_HIGH)  # AUX4: ALTHOLD + POSHOLD (pilot hold)
+    rc.set(5, 1000)     # AUX2: AUTOPILOT off
+    wait_for(
+        "pilot hold (AUTOPILOT off, POSHOLD on)",
+        lambda: (lambda m: BOX_AUTOPILOT not in m and BOX_POSHOLD in m)(sitl.modes()),
+        timeout=10,
+    )
+    time.sleep(2.0)
+
+
+def rescue_engagement_asserts(sitl, variant):
+    # Legacy rescue enables GPS_RESCUE_MODE without the FAILSAFE box; the
+    # mission rescue runs under FAILSAFE + AUTOPILOT.
+    if variant == "A":
+        wait_for("legacy GPS rescue engaged", lambda: BOX_GPSRESCUE in sitl.modes(), timeout=20)
+        assert BOX_AUTOPILOT not in sitl.modes(), "mission engaged on the legacy binary"
+    else:
+        wait_for(
+            "rescue mission engaged (FAILSAFE + AUTOPILOT)",
+            lambda: (lambda m: BOX_FAILSAFE in m and BOX_AUTOPILOT in m)(sitl.modes()),
+            timeout=20,
+        )
+        assert BOX_GPSRESCUE not in sitl.modes(), "legacy rescue engaged on the rescue-plan binary"
+
+
+def rescue_metrics(fdm, t0, kill_dist):
+    return {
+        "kill_dist": kill_dist,
+        "max_alt": max((s[3] for s in fdm.snapshot_history() if s[0] >= t0), default=0.0),
+        "max_dist": fdm.max_distance_from_home(after_t=t0),
+        "time_to_home": fdm.time_to_home(radius_m=20.0, after_t=t0),
+        "touchdown": fdm.touchdown(after_t=t0),
+    }
+
+
+def scenario_rescue_ab(sitl, rc, fdm, variant):
+    fly_out_and_park(sitl, rc, fdm, 120.0)
+    kill_dist = fdm.distance_from_home()
+    t0 = fdm.now_t()
+    log(f"[{variant}] killing RC {kill_dist:.0f} m out")
+    rc.stop_stream()
+
+    rescue_engagement_asserts(sitl, variant)
+    wait_for(
+        "returns within 20 m of home",
+        lambda: fdm.distance_from_home() < 20.0,
+        timeout=120,
+        interval=1.0,
+    )
+    wait_for(
+        "touchdown disarms",
+        lambda: fdm.model.on_ground() and BOX_ARM not in sitl.modes(),
+        timeout=120,
+        interval=1.0,
+    )
+    m = rescue_metrics(fdm, t0, kill_dist)
+    td = m["touchdown"]
+    assert td is not None, "no touchdown recorded"
+    td_dist = math.hypot(td[1], td[2])
+    assert td_dist < 15.0, f"landed {td_dist:.1f} m from home"
+    log(f"[{variant}] landed {td_dist:.1f} m from home, peak alt {m['max_alt']:.1f} m")
+    m["td_dist"] = td_dist
+    return m
+
+
+def scenario_rescue_heading(sitl, rc, fdm, variant):
+    """No mag, true heading east while the FC believes north: the rescue must
+    recover heading via GPS course-over-ground (pitch-forward phase) before
+    flying home."""
+    rc.start()
+    fdm.start()
+    wait_for("GPS fix + RX recovery (arming flags clear)", lambda: sitl.status()["arming_flags"] == 0, timeout=40)
+    sitl.acc_calibrate()
+    time.sleep(2.0)
+    wait_for("recalibration complete", lambda: sitl.status()["arming_flags"] == 0, timeout=20)
+
+    rc.set(6, RC_HIGH)  # ANGLE
+    for attempt in range(3):
+        rc.set(4, RC_HIGH)
+        try:
+            wait_for("armed", lambda: BOX_ARM in sitl.modes(), timeout=8)
+            break
+        except AssertionError:
+            if attempt == 2:
+                raise
+            rc.set(4, 1000)
+            time.sleep(1.0)
+    rc.set(2, 1600)
+    rc.set(7, RC_HIGH)  # ALTHOLD + POSHOLD hover (switch must be off at arm time)
+    wait_for("climbed clear of ground", lambda: fdm.model.pos[2] > 6.0, timeout=20)
+    rc.set(2, 1300)
+    time.sleep(2.0)
+
+    kill_dist = fdm.distance_from_home()
+    t0 = fdm.now_t()
+    log(f"[{variant}] killing RC at hover (heading wrong by 90 deg)")
+    rc.stop_stream()
+
+    rescue_engagement_asserts(sitl, variant)
+    # heading recovery needs forward flight: the craft must depart, learn its
+    # heading from GPS course, then come home and land
+    wait_for(
+        "touchdown disarms (heading recovered, rescue completed)",
+        lambda: fdm.model.on_ground() and BOX_ARM not in sitl.modes(),
+        timeout=240,
+        interval=1.0,
+    )
+    m = rescue_metrics(fdm, t0, kill_dist)
+    td = m["touchdown"]
+    assert td is not None, "no touchdown recorded"
+    td_dist = math.hypot(td[1], td[2])
+    assert td_dist < 30.0, f"landed {td_dist:.1f} m from home"
+    log(f"[{variant}] recovered heading and landed {td_dist:.1f} m from home")
+    m["td_dist"] = td_dist
+    return m
+
+
+def scenario_rescue_gps_loss(sitl, rc, fdm, variant):
+    fly_out_and_park(sitl, rc, fdm, 120.0)
+    kill_dist = fdm.distance_from_home()
+    t0 = fdm.now_t()
+    log(f"[{variant}] killing RC {kill_dist:.0f} m out")
+    rc.stop_stream()
+
+    rescue_engagement_asserts(sitl, variant)
+    wait_for(
+        "return underway (30 m closer)",
+        lambda: fdm.distance_from_home() < kill_dist - 30.0,
+        timeout=90,
+        interval=1.0,
+    )
+    loss_dist = fdm.distance_from_home()
+    log(f"[{variant}] GPS dark {loss_dist:.0f} m out")
+    fdm.gps_valid = False
+
+    # A: legacy emergency descent (baro only). B: mission aborts on estimator
+    # loss and failsafe degrades to the baro auto-landing. Both must get down
+    # and disarm without flying away.
+    wait_for(
+        "descends and disarms without GPS",
+        lambda: fdm.model.on_ground() and BOX_ARM not in sitl.modes(),
+        timeout=180,
+        interval=1.0,
+    )
+    m = rescue_metrics(fdm, t0, kill_dist)
+    assert m["max_dist"] < kill_dist + 40.0, f"flew away after GPS loss: {m['max_dist']:.0f} m"
+    log(f"[{variant}] down and disarmed after GPS loss")
+    return m
+
+
+def compare_rescue_ab(mA, mB):
+    alt_delta = abs(mA["max_alt"] - mB["max_alt"])
+    assert alt_delta <= 7.0, f"peak altitude diverged: A {mA['max_alt']:.1f} B {mB['max_alt']:.1f}"
+    for m, tag in ((mA, "A"), (mB, "B")):
+        assert m["max_dist"] <= m["kill_dist"] + 25.0, f"{tag} flyaway: {m['max_dist']:.0f} m"
+    if "td_dist" in mA and "td_dist" in mB:
+        assert abs(mA["td_dist"] - mB["td_dist"]) <= 10.0, \
+            f"touchdown diverged: A {mA['td_dist']:.1f} B {mB['td_dist']:.1f}"
+    if mA.get("time_to_home") and mB.get("time_to_home"):
+        slow = max(mA["time_to_home"], mB["time_to_home"])
+        assert abs(mA["time_to_home"] - mB["time_to_home"]) <= 0.5 * slow, \
+            f"time-to-home diverged: A {mA['time_to_home']:.0f}s B {mB['time_to_home']:.0f}s"
+    log(f"A/B parity: alt Δ{alt_delta:.1f} m")
+
+
+def compare_rescue_heading(mA, mB):
+    # the pitch-forward heading-recovery excursion is legitimate travel from a
+    # hover start; bound it rather than compare to the kill distance. Altitude
+    # during the 35 deg dash differs with dash length and phase ordering, so
+    # the band is wide; the load-bearing asserts are recovery + touchdown.
+    for m, tag in ((mA, "A"), (mB, "B")):
+        assert m["max_dist"] <= 150.0, f"{tag} heading-recovery excursion ran away: {m['max_dist']:.0f} m"
+    alt_delta = abs(mA["max_alt"] - mB["max_alt"])
+    assert alt_delta <= 15.0, f"peak altitude diverged: A {mA['max_alt']:.1f} B {mB['max_alt']:.1f}"
+    log(f"A/B parity: both recovered heading, alt Δ{alt_delta:.1f} m")
+
+
+def compare_rescue_loss(mA, mB):
+    # after GPS loss both descend wherever they are; only the safety
+    # properties compare
+    for m, tag in ((mA, "A"), (mB, "B")):
+        assert m["max_dist"] <= m["kill_dist"] + 40.0, f"{tag} flyaway: {m['max_dist']:.0f} m"
+    log("A/B parity: both descended and disarmed after GPS loss")
+
+
 SCENARIOS = {
     "baseline": (lambda s, r, f: boot_and_engage(s, r, f), []),
     # FIXED yaw: this scenario validates pure translation control; yaw-coupled
@@ -948,44 +1166,90 @@ SCENARIOS = {
             "set landing_disarm_threshold = 10",
         ],
     ),
+    "rescue_ab": (
+        scenario_rescue_ab,
+        RESCUE_CFG,
+        {"ab": True, "compare": compare_rescue_ab},
+    ),
+    "rescue_heading_recovery": (
+        scenario_rescue_heading,
+        RESCUE_CFG + ["set mag_hardware = NONE"],
+        {"ab": True, "compare": compare_rescue_heading, "initial_yaw_deg": 90.0},
+    ),
+    "rescue_gps_loss": (
+        scenario_rescue_gps_loss,
+        RESCUE_CFG,
+        {"ab": True, "compare": compare_rescue_loss},
+    ),
 }
 
 
-def run_scenario(name, binary, workdir):
-    body, extra_cfg = SCENARIOS[name]
-    scenario_dir = os.path.join(workdir, name)
-    shutil.rmtree(scenario_dir, ignore_errors=True)
-    os.makedirs(scenario_dir)
+def decode_blackbox_logs(scenario_dir):
+    """Best-effort: decode .BFL artifacts when blackbox_decode is available.
+    Never gates pass/fail — the trajectory recorder is the authority."""
+    if not shutil.which("blackbox_decode"):
+        return
+    for entry in sorted(os.listdir(scenario_dir)):
+        if entry.upper().endswith(".BFL"):
+            subprocess.run(["blackbox_decode", os.path.join(scenario_dir, entry)],
+                           capture_output=True, check=False)
 
-    log(f"=== scenario: {name}")
-    sitl = Sitl(binary, scenario_dir)
+
+def run_leg(name, variant, body, extra_cfg, opts, binary, leg_dir):
+    os.makedirs(leg_dir)
+    sitl = Sitl(binary, leg_dir)
     rc = motors = fdm = None
     try:
         # feed construction can fail (port 9002 bind); it must fail the
         # scenario, not abort the suite
         rc = RcFeed()
         motors = MotorFeed()
-        fdm = FdmFeed(motors)
+        fdm = FdmFeed(motors, initial_yaw_deg=opts.get("initial_yaw_deg", 0.0))
         sitl.provision(base_config(extra_cfg))
         sitl.start()
         motors.start()
-        body(sitl, rc, fdm)
-        log(f"=== PASS: {name}")
-        return True
-    except (AssertionError, RuntimeError, TimeoutError, OSError) as e:
-        log(f"=== FAIL: {name}: {e}")
-        return False
+        if variant is None:
+            return body(sitl, rc, fdm)
+        return body(sitl, rc, fdm, variant)
     finally:
         for feed in (rc, fdm, motors):
             if feed is not None:
                 feed.shutdown()
         sitl.stop()
+        decode_blackbox_logs(leg_dir)
+
+
+def run_scenario(name, binary, workdir, binary_b=None):
+    spec = SCENARIOS[name]
+    body, extra_cfg = spec[0], spec[1]
+    opts = spec[2] if len(spec) > 2 else {}
+    scenario_dir = os.path.join(workdir, name)
+    shutil.rmtree(scenario_dir, ignore_errors=True)
+    os.makedirs(scenario_dir)
+
+    log(f"=== scenario: {name}")
+    try:
+        if opts.get("ab"):
+            if binary_b is None:
+                log(f"=== SKIP: {name} (A/B scenario, no --binary-b)")
+                return None
+            metrics_a = run_leg(name, "A", body, extra_cfg, opts, binary, os.path.join(scenario_dir, "A"))
+            metrics_b = run_leg(name, "B", body, extra_cfg, opts, binary_b, os.path.join(scenario_dir, "B"))
+            opts["compare"](metrics_a, metrics_b)
+        else:
+            run_leg(name, None, body, extra_cfg, opts, binary, os.path.join(scenario_dir, "run"))
+        log(f"=== PASS: {name}")
+        return True
+    except (AssertionError, RuntimeError, TimeoutError, OSError) as e:
+        log(f"=== FAIL: {name}: {e}")
+        return False
 
 
 def main():
     global VERBOSE
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--binary", required=True, help="path to betaflight_SITL.elf (built with USE_FLIGHT_PLAN)")
+    ap.add_argument("--binary-b", help="rescue-plan binary (-DENABLE_RESCUE_PLAN=1) for A/B scenarios")
     ap.add_argument("--scenario", default="all", choices=["all"] + list(SCENARIOS))
     ap.add_argument("--workdir", default="/tmp/sitl_harness")
     ap.add_argument("-v", "--verbose", action="store_true")
@@ -994,12 +1258,12 @@ def main():
 
     os.makedirs(args.workdir, exist_ok=True)
     names = list(SCENARIOS) if args.scenario == "all" else [args.scenario]
-    results = {name: run_scenario(name, args.binary, args.workdir) for name in names}
+    results = {name: run_scenario(name, args.binary, args.workdir, args.binary_b) for name in names}
 
     log("--- summary")
     for name, ok in results.items():
-        log(f"{'PASS' if ok else 'FAIL'}  {name}")
-    sys.exit(0 if all(results.values()) else 1)
+        log(f"{'PASS' if ok else 'SKIP' if ok is None else 'FAIL'}  {name}")
+    sys.exit(0 if all(ok is not False for ok in results.values()) else 1)
 
 
 if __name__ == "__main__":

--- a/src/test/sitl/sitl_harness.py
+++ b/src/test/sitl/sitl_harness.py
@@ -280,12 +280,17 @@ class FdmFeed(threading.Thread):
     first packet's origin (the FC un-mirrors).
     """
 
-    def __init__(self, motors=None):
+    def __init__(self, motors=None, initial_yaw_deg=0.0):
         super().__init__(daemon=True)
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.model = MotionModel()
+        self.model.yaw = math.radians(initial_yaw_deg)
         self.motors = motors
         self.running = True
+        self.gps_valid = True     # False emits out-of-range lat/lon: the FC's GPS goes dark
+        self.history = []         # (t, east, north, up, ve, vn, vu, heading_deg) at ~10 Hz
+        self._hist_lock = threading.Lock()
+        self._hist_decim = 0
         self.t0 = time.monotonic()
 
     def move_east(self, metres):
@@ -300,6 +305,38 @@ class FdmFeed(threading.Thread):
     def heading_deg(self):
         return math.degrees(self.model.yaw) % 360.0
 
+    def snapshot_history(self):
+        with self._hist_lock:
+            return list(self.history)
+
+    def max_altitude(self):
+        return max((s[3] for s in self.snapshot_history()), default=0.0)
+
+    def time_to_home(self, radius_m=10.0, after_t=0.0):
+        """First recorded time the craft is within radius_m of home, after after_t."""
+        for s in self.snapshot_history():
+            if s[0] > after_t and math.hypot(s[1], s[2]) < radius_m:
+                return s[0]
+        return None
+
+    def touchdown(self, after_t=0.0):
+        """(t, east, north) of the first on-ground sample following airborne flight."""
+        airborne = False
+        for s in self.snapshot_history():
+            if s[0] < after_t:
+                continue
+            if s[3] > 1.0:
+                airborne = True
+            elif airborne and s[3] <= 0.01:
+                return (s[0], s[1], s[2])
+        return None
+
+    def max_distance_from_home(self, after_t=0.0):
+        return max((math.hypot(s[1], s[2]) for s in self.snapshot_history() if s[0] >= after_t), default=0.0)
+
+    def now_t(self):
+        return time.monotonic() - self.t0
+
     def run(self):
         last = time.monotonic()
         while self.running:
@@ -308,6 +345,15 @@ class FdmFeed(threading.Thread):
             last = now
             m = self.motors.motors if self.motors else [0.0] * 4
             self.model.step(dt, m)
+
+            self._hist_decim += 1
+            if self._hist_decim >= 5:  # ~10 Hz of the 50 Hz loop
+                self._hist_decim = 0
+                with self._hist_lock:
+                    self.history.append((now - self.t0,
+                                         self.model.pos[0], self.model.pos[1], self.model.pos[2],
+                                         self.model.vel[0], self.model.vel[1], self.model.vel[2],
+                                         self.heading_deg()))
 
             lat_true = HOME_LAT + self.model.pos[1] / M_PER_DEG
             lon_true = HOME_LON + self.model.pos[0] / (M_PER_DEG * math.cos(math.radians(HOME_LAT)))
@@ -330,6 +376,11 @@ class FdmFeed(threading.Thread):
             )
             f_body = quat_rotate_inv(q_nwu, f_world_nwu)
 
+            # Out-of-range lat/lon = GPS-loss sentinel; the FC skips the
+            # virtual GPS update and its receive timeout trips, while IMU
+            # feeds stay live. (NaN would be folded away by -ffast-math.)
+            lon_pkt = 2.0 * HOME_LON - lon_true if self.gps_valid else 999.0
+            lat_pkt = 2.0 * HOME_LAT - lat_true if self.gps_valid else 999.0
             pkt = struct.pack(
                 "<18d",
                 now - self.t0,
@@ -340,8 +391,8 @@ class FdmFeed(threading.Thread):
                 -f_body[0], -f_body[1], -f_body[2],                              # negated NWU-body specific force
                 q[0], q[1], q[2], q[3],
                 self.model.vel[0], self.model.vel[1], self.model.vel[2],         # ENU m/s
-                2.0 * HOME_LON - lon_true,                                       # mirrored for the bridge
-                2.0 * HOME_LAT - lat_true,
+                lon_pkt,                                                         # mirrored for the bridge
+                lat_pkt,
                 HOME_ALT_M + self.model.pos[2],
                 101325.0,
             )
@@ -544,6 +595,8 @@ def base_config(extra):
         "aux 0 0 0 1700 2100 0 0",   # ARM on AUX1
         "aux 1 56 1 1700 2100 0 0",  # AUTOPILOT on AUX2
         "aux 2 1 2 1700 2100 0 0",   # ANGLE on AUX3 (heading-validation flight)
+        # the estimator needs the truth-fed virtual mag as a heading source
+        "set trust_mag = ON",
         # matches the MotionModel plant: atan(K_DRAG * v / g) over cruise speeds
         "set ap_velocity_drag_coeff = 440",
         # 10 m above home, 5 m/s — low and quick keeps landing scenarios short

--- a/src/test/sitl/sitl_harness.py
+++ b/src/test/sitl/sitl_harness.py
@@ -18,6 +18,7 @@ Usage:
 """
 
 import argparse
+import json
 import math
 import os
 import shutil
@@ -56,6 +57,7 @@ RC_LOW = 1000
 RC_HIGH = 2000
 
 VERBOSE = False
+TELEMETRY_PORT = 9005  # ground-truth JSON fan-out for external visualisers, 0 disables
 
 
 def log(msg):
@@ -280,12 +282,13 @@ class FdmFeed(threading.Thread):
     first packet's origin (the FC un-mirrors).
     """
 
-    def __init__(self, motors=None, initial_yaw_deg=0.0):
+    def __init__(self, motors=None, initial_yaw_deg=0.0, status=None):
         super().__init__(daemon=True)
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.model = MotionModel()
         self.model.yaw = math.radians(initial_yaw_deg)
         self.motors = motors
+        self.status = status
         self.running = True
         self.gps_valid = True     # False emits out-of-range lat/lon: the FC's GPS goes dark
         self.history = []         # (t, east, north, up, ve, vn, vu, heading_deg) at ~10 Hz
@@ -358,6 +361,33 @@ class FdmFeed(threading.Thread):
             lat_true = HOME_LAT + self.model.pos[1] / M_PER_DEG
             lon_true = HOME_LON + self.model.pos[0] / (M_PER_DEG * math.cos(math.radians(HOME_LAT)))
 
+            if TELEMETRY_PORT:
+                try:
+                    # Ground-truth state for external visualisers. The model
+                    # keeps pitch nose-down/yaw-CW positive; emit display
+                    # conventions (pitch nose-up positive) once, here.
+                    self.sock.sendto(json.dumps({
+                        "t": now - self.t0,
+                        "pos": list(self.model.pos),
+                        "vel": list(self.model.vel),
+                        "att": [math.degrees(self.model.roll),
+                                -math.degrees(self.model.pitch),
+                                math.degrees(self.model.yaw) % 360.0],
+                        "rates": [math.degrees(self.model.rates[0]),
+                                  -math.degrees(self.model.rates[1]),
+                                  math.degrees(self.model.rates[2])],
+                        "motors": list(m),
+                        "lat": lat_true,
+                        "lon": lon_true,
+                        "alt": HOME_ALT_M + self.model.pos[2],
+                        "gps": bool(self.gps_valid),
+                        "armed": self.status.armed if self.status else None,
+                        "modes": self.status.modes if self.status else [],
+                        "home": [HOME_LAT, HOME_LON, HOME_ALT_M],
+                    }).encode(), ("127.0.0.1", TELEMETRY_PORT))
+                except OSError:
+                    pass  # fire-and-forget; a visualiser must never affect a scenario
+
             # The FC's bridge computes q = Rz(+90) * Rx(180) * q_packet * Rx(180),
             # so emit the true NWU attitude pre-rotated by Rz(-90) and
             # pre-conjugated: the FC recovers exactly q_nwu.
@@ -409,19 +439,23 @@ class Msp:
     def __init__(self, sock):
         self.sock = sock
         self.buf = b""
+        # serialises request/reply pairs: the status poller thread shares this
+        # connection with scenario bodies
+        self.lock = threading.Lock()
 
     def request(self, cmd, payload=b"", timeout=2.0):
-        frame = struct.pack("<BB", len(payload), cmd) + payload
-        checksum = 0
-        for b in frame:
-            checksum ^= b
-        self.sock.sendall(b"$M<" + frame + bytes([checksum]))
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            reply = self._read_frame(cmd, deadline)
-            if reply is not None:
-                return reply
-        raise TimeoutError(f"no MSP reply for cmd {cmd}")
+        with self.lock:
+            frame = struct.pack("<BB", len(payload), cmd) + payload
+            checksum = 0
+            for b in frame:
+                checksum ^= b
+            self.sock.sendall(b"$M<" + frame + bytes([checksum]))
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                reply = self._read_frame(cmd, deadline)
+                if reply is not None:
+                    return reply
+            raise TimeoutError(f"no MSP reply for cmd {cmd}")
 
     def _read_frame(self, want_cmd, deadline):
         while time.monotonic() < deadline:
@@ -565,6 +599,42 @@ class Sitl:
             except subprocess.TimeoutExpired:
                 self.proc.kill()
             self.proc = None
+
+
+class StatusPoller(threading.Thread):
+    """5 Hz MSP_STATUS poll feeding true arm/mode state into the telemetry
+    fan-out. Read-only observer: errors are swallowed and the last state kept,
+    so it can never fail a scenario."""
+
+    BOX_NAMES = {
+        BOX_ARM: "ARM",
+        BOX_ALTHOLD: "ALTHOLD",
+        BOX_POSHOLD: "POSHOLD",
+        BOX_FAILSAFE: "FAILSAFE",
+        BOX_GPSRESCUE: "GPSRESCUE",
+        BOX_AUTOPILOT: "AUTOPILOT",
+    }
+
+    def __init__(self, sitl):
+        super().__init__(daemon=True)
+        self.sitl = sitl
+        self.running = True
+        self.armed = False
+        self.modes = []
+
+    def run(self):
+        while self.running:
+            try:
+                if self.sitl.msp is not None:
+                    modes = self.sitl.modes()
+                    self.armed = BOX_ARM in modes
+                    self.modes = [self.BOX_NAMES.get(b, f"BOX{b}") for b in sorted(modes) if b != BOX_ARM]
+            except (TimeoutError, RuntimeError, OSError):
+                pass
+            time.sleep(0.2)
+
+    def shutdown(self):
+        self.running = False
 
 
 def wait_for(description, predicate, timeout=20.0, interval=0.2):
@@ -1340,21 +1410,24 @@ def decode_blackbox_logs(scenario_dir):
 def run_leg(name, variant, body, extra_cfg, opts, binary, leg_dir):
     os.makedirs(leg_dir)
     sitl = Sitl(binary, leg_dir)
-    rc = motors = fdm = None
+    rc = motors = fdm = poller = None
     try:
         # feed construction can fail (port 9002 bind); it must fail the
         # scenario, not abort the suite
         rc = RcFeed()
         motors = MotorFeed()
-        fdm = FdmFeed(motors, initial_yaw_deg=opts.get("initial_yaw_deg", 0.0))
+        poller = StatusPoller(sitl) if TELEMETRY_PORT else None
+        fdm = FdmFeed(motors, initial_yaw_deg=opts.get("initial_yaw_deg", 0.0), status=poller)
         sitl.provision(base_config(extra_cfg))
         sitl.start()
         motors.start()
+        if poller:
+            poller.start()
         if variant is None:
             return body(sitl, rc, fdm)
         return body(sitl, rc, fdm, variant)
     finally:
-        for feed in (rc, fdm, motors):
+        for feed in (rc, fdm, motors, poller):
             if feed is not None:
                 feed.shutdown()
         sitl.stop()
@@ -1388,15 +1461,18 @@ def run_scenario(name, binary, workdir, binary_b=None):
 
 
 def main():
-    global VERBOSE
+    global VERBOSE, TELEMETRY_PORT
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--binary", required=True, help="path to betaflight_SITL.elf (built with USE_FLIGHT_PLAN)")
     ap.add_argument("--binary-b", help="rescue-plan binary (-DENABLE_RESCUE_PLAN=1) for A/B scenarios")
     ap.add_argument("--scenario", default="all", choices=["all"] + list(SCENARIOS))
     ap.add_argument("--workdir", default="/tmp/sitl_harness")
+    ap.add_argument("--telemetry-port", type=int, default=TELEMETRY_PORT,
+                    help="UDP port for ground-truth JSON telemetry (0 disables)")
     ap.add_argument("-v", "--verbose", action="store_true")
     args = ap.parse_args()
     VERBOSE = args.verbose
+    TELEMETRY_PORT = args.telemetry_port
 
     os.makedirs(args.workdir, exist_ok=True)
     names = list(SCENARIOS) if args.scenario == "all" else [args.scenario]

--- a/src/test/unit/flight_failsafe_rescue_unittest.cc
+++ b/src/test/unit/flight_failsafe_rescue_unittest.cc
@@ -1,0 +1,335 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Flag-on companion to flight_failsafe_unittest.cc: ENABLE_RESCUE_PLAN=1,
+// exercising the GPS-RESCUE failsafe procedure's rescue-as-mission staging
+// and the FAILSAFE_AUTOPILOT engage-grace/fallback logic it adds.
+// flight_failsafe_unittest.cc stays the flag-off regression guard.
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <limits.h>
+
+extern "C" {
+    #include "platform.h"
+    #include "build/debug.h"
+
+    #include "pg/pg.h"
+    #include "pg/pg_ids.h"
+    #include "pg/rx.h"
+
+    #include "common/axis.h"
+    #include "common/maths.h"
+    #include "common/bitarray.h"
+
+    #include "fc/runtime_config.h"
+    #include "fc/rc_modes.h"
+    #include "fc/rc_controls.h"
+    #include "fc/core.h"
+
+    #include "flight/failsafe.h"
+    #include "flight/flight_plan_nav.h"
+
+    #include "io/beeper.h"
+
+    #include "drivers/io.h"
+    #include "rx/rx.h"
+
+    #include "pg/autopilot.h"
+
+    extern boxBitmask_t rcModeActivationMask;
+    extern uint16_t flightModeFlags;
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+uint32_t testFeatureMask = 0;
+throttleStatus_e throttleStatus = THROTTLE_HIGH;
+
+enum {
+    COUNTER_MW_DISARM = 0,
+};
+#define CALL_COUNT_ITEM_COUNT 1
+
+static int callCounts[CALL_COUNT_ITEM_COUNT];
+
+#define CALL_COUNTER(item) (callCounts[item])
+
+void resetCallCounters(void)
+{
+    memset(&callCounts, 0, sizeof(callCounts));
+}
+
+uint32_t sysTickUptime;
+
+void configureFailsafe(void)
+{
+    rxConfigMutable()->midrc = 1495;
+    rxConfigMutable()->mincheck = 1100;
+
+    failsafeConfigMutable()->failsafe_delay = 10; // 1 second
+    failsafeConfigMutable()->failsafe_landing_time = 1; // 1.0 seconds
+    failsafeConfigMutable()->failsafe_switch_mode = FAILSAFE_SWITCH_MODE_STAGE1;
+    failsafeConfigMutable()->failsafe_throttle = 1200;
+    failsafeConfigMutable()->failsafe_throttle_low_delay = 100; // 10 seconds
+    failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_AUTO_LANDING;
+    sysTickUptime = 0;
+}
+
+//
+// rx-loss policy / GPS-RESCUE-as-mission tests
+//
+
+extern "C" {
+    extern bool testSticksActive;
+    extern bool testFlightPlanActive;
+    extern flightPlanNavState_e testFlightPlanState;
+    extern bool testStageRescuePlanResult;
+    extern int testStageRescuePlanCalls;
+}
+
+class FlightFailsafeRescueTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        resetCallCounters();
+        configureFailsafe();
+        failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_AUTO_LANDING;
+
+        flightModeFlags = 0;
+        testSticksActive = false;
+        testFlightPlanActive = false;
+        testFlightPlanState = FP_NAV_IDLE;
+        testStageRescuePlanResult = true;
+        testStageRescuePlanCalls = 0;
+        throttleStatus = THROTTLE_HIGH;
+
+        failsafeInit();
+        failsafeReset(); // tests in this fixture are self-contained, not sequential
+        ENABLE_ARMING_FLAG(ARMED);
+        failsafeStartMonitoring();
+
+        sysTickUptime = 0;
+        failsafeOnValidDataReceived();
+    }
+
+    void TearDown() override {
+        flightModeFlags = 0;
+        DISABLE_ARMING_FLAG(ARMED);
+        testSticksActive = false;
+        testFlightPlanActive = false;
+    }
+
+    void startMission() {
+        ENABLE_FLIGHT_MODE(AUTOPILOT_MODE);
+        testFlightPlanActive = true;
+        testFlightPlanState = FP_NAV_TARGETING;
+    }
+
+    void loseRxIntoStage2() {
+        sysTickUptime += (failsafeConfig()->failsafe_delay * MILLIS_PER_TENTH_SECOND) + 1;
+        failsafeOnValidDataFailed();
+        failsafeUpdateState();
+        ASSERT_TRUE(failsafeIsActive());
+    }
+
+    void tickLinkStillDown(uint32_t ms) {
+        sysTickUptime += ms;
+        failsafeOnValidDataFailed();
+        failsafeUpdateState();
+    }
+};
+
+TEST_F(FlightFailsafeRescueTest, GpsRescueProcedureStagesAndEntersAutopilotPhase)
+{
+    failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_GPS_RESCUE;
+    testStageRescuePlanResult = true;
+
+    loseRxIntoStage2();
+
+    EXPECT_EQ(FAILSAFE_AUTOPILOT, failsafePhase());
+    EXPECT_TRUE(FLIGHT_MODE(FAILSAFE_MODE));
+    EXPECT_FALSE(FLIGHT_MODE(GPS_RESCUE_MODE));
+    EXPECT_EQ(1, testStageRescuePlanCalls);
+}
+
+TEST_F(FlightFailsafeRescueTest, StageFailureFallsBackToAutoLanding)
+{
+    failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_GPS_RESCUE;
+    testStageRescuePlanResult = false;
+
+    loseRxIntoStage2();
+
+    EXPECT_EQ(FAILSAFE_LANDING, failsafePhase());
+    EXPECT_FALSE(FLIGHT_MODE(GPS_RESCUE_MODE));
+    EXPECT_EQ(1, testStageRescuePlanCalls);
+}
+
+TEST_F(FlightFailsafeRescueTest, EngageGraceHonoured)
+{
+    failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_GPS_RESCUE;
+    testStageRescuePlanResult = true;
+
+    loseRxIntoStage2();
+    ASSERT_EQ(FAILSAFE_AUTOPILOT, failsafePhase());
+
+    // core.c has not engaged AUTOPILOT_MODE yet; within the 1000 ms grace
+    // window the phase must not degrade.
+    tickLinkStillDown(900);
+    EXPECT_EQ(FAILSAFE_AUTOPILOT, failsafePhase());
+
+    // Past the grace deadline: degrade to auto-landing (GPS_RESCUE remapped).
+    tickLinkStillDown(200);
+    EXPECT_EQ(FAILSAFE_LANDING, failsafePhase());
+}
+
+TEST_F(FlightFailsafeRescueTest, AbortFallsBackToAutoLandingNotRescue)
+{
+    failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_GPS_RESCUE;
+    testStageRescuePlanResult = true;
+
+    loseRxIntoStage2();
+    ASSERT_EQ(FAILSAFE_AUTOPILOT, failsafePhase());
+
+    // core.c engaged the staged mission, which then aborted mid-flight.
+    ENABLE_FLIGHT_MODE(AUTOPILOT_MODE);
+    testFlightPlanActive = true;
+    testFlightPlanState = FP_NAV_ABORTED;
+    const int stageCallsBefore = testStageRescuePlanCalls;
+
+    tickLinkStillDown(100);
+
+    EXPECT_EQ(FAILSAFE_LANDING, failsafePhase());
+    EXPECT_FALSE(FLIGHT_MODE(GPS_RESCUE_MODE));
+    // The failed mission must not be re-staged.
+    EXPECT_EQ(stageCallsBefore, testStageRescuePlanCalls);
+}
+
+TEST_F(FlightFailsafeRescueTest, MissionCompleteFallsBackToConfiguredProcedure)
+{
+    autopilotConfigMutable()->rxLossPolicy = AP_RX_LOSS_CONTINUE;
+    failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_AUTO_LANDING;
+    startMission();
+
+    loseRxIntoStage2();
+    ASSERT_EQ(FAILSAFE_AUTOPILOT, failsafePhase());
+
+    testFlightPlanState = FP_NAV_COMPLETE;
+    tickLinkStillDown(100);
+
+    EXPECT_EQ(FAILSAFE_LANDING, failsafePhase());
+    // GPS_RESCUE staging is never involved when the configured procedure isn't GPS_RESCUE.
+    EXPECT_EQ(0, testStageRescuePlanCalls);
+}
+
+// STUBS
+
+extern "C" {
+float rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
+float rcCommand[4];
+int16_t debug[DEBUG16_VALUE_COUNT];
+uint8_t debugMode = 0;
+bool isUsingSticksToArm = true;
+
+PG_REGISTER(rxConfig_t, rxConfig, PG_RX_CONFIG, 0);
+
+// Return system uptime in milliseconds (rollover in 49 days)
+uint32_t millis(void)
+{
+    return sysTickUptime;
+}
+
+uint32_t micros(void)
+{
+    return millis() * 1000;
+}
+
+throttleStatus_e calculateThrottleStatus()
+{
+    return throttleStatus;
+}
+
+void delay(uint32_t) {}
+
+bool featureIsEnabled(uint32_t mask)
+{
+    return (mask & testFeatureMask);
+}
+
+void disarm(flightLogDisarmReason_e)
+{
+    callCounts[COUNTER_MW_DISARM]++;
+}
+
+void beeper(beeperMode_e mode)
+{
+    UNUSED(mode);
+}
+
+bool isUsingSticksForArming(void)
+{
+    return isUsingSticksToArm;
+}
+
+bool testSticksActive = false;
+bool areSticksActive(uint8_t stickPercentLimit)
+{
+    UNUSED(stickPercentLimit);
+    return testSticksActive;
+}
+
+bool testFlightPlanActive = false;
+flightPlanNavState_e testFlightPlanState = FP_NAV_IDLE;
+
+bool flightPlanNavIsActive(void)
+{
+    return testFlightPlanActive;
+}
+
+flightPlanNavState_e flightPlanNavGetState(void)
+{
+    return testFlightPlanState;
+}
+
+bool testStageRescuePlanResult = true;
+int testStageRescuePlanCalls = 0;
+
+bool flightPlanNavStageRescuePlan(void)
+{
+    testStageRescuePlanCalls++;
+    return testStageRescuePlanResult;
+}
+
+void beeperConfirmationBeeps(uint8_t beepCount) { UNUSED(beepCount); }
+
+bool crashRecoveryModeActive(void) { return false; }
+void pinioBoxTaskControl(void) {}
+
+bool usbCableIsInserted(void)
+{
+    return false;
+}
+
+bool mspSerialIsConfiguratorActive(void)
+{
+    return false;
+}
+}

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -907,8 +907,10 @@ TEST_F(FlightPlanNavSafetyTest, GeofenceRthAboveReturnAltReturnsAtCurrentAltitud
     flightPlanNavUpdate(g_stubMicros + 10'000);
 
     ASSERT_TRUE(flightPlanNavIsInjectedPlanActive());
-    // Never descend en route: return at the higher of the two altitudes.
-    EXPECT_NEAR(g_lastTarget.targetEfM.z, 50.0f, 0.1f);
+    // Never descend en route: the plan returns at the current GPS altitude,
+    // which in the estimator's feedback frame is its reading at engage (the
+    // stub reads 0 while GPS says 150 m AMSL — a mid-flight engagement).
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 0.0f, 0.1f);
 }
 
 TEST_F(FlightPlanNavSafetyTest, LandingTouchdownDisarms)

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -15,6 +15,8 @@
  * along with Betaflight. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <float.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
@@ -70,6 +72,7 @@ struct CapturedTarget {
 CapturedTarget g_lastTarget;
 int g_setTargetCalls;
 int g_clearTargetCalls;
+int g_moveTargetCalls;
 
 gpsLocation_t g_stubGpsOrigin;
 bool g_stubGpsOriginSet;
@@ -105,6 +108,15 @@ void positionNavSetTargetEf(
     g_lastTarget.userData = userData;
     g_lastTarget.valid = true;
     g_setTargetCalls++;
+}
+
+void positionNavMoveTargetEf(const vector3_t *targetPosEfM)
+{
+    if (!g_lastTarget.valid) {
+        return;
+    }
+    g_lastTarget.targetEfM = *targetPosEfM;
+    g_moveTargetCalls++;
 }
 
 void positionNavClearTarget(void)
@@ -218,6 +230,7 @@ protected:
         memset(&g_lastTarget, 0, sizeof(g_lastTarget));
         g_setTargetCalls = 0;
         g_clearTargetCalls = 0;
+        g_moveTargetCalls = 0;
         g_stubMicros = 0;
 
         memset(&g_stubEstimate, 0, sizeof(g_stubEstimate));
@@ -276,13 +289,13 @@ protected:
         wp.speed = speed;
         wp.duration = duration;
         wp.type = type;
-        wp.pattern = WAYPOINT_PATTERN_ORBIT;
+        wp.pattern = WAYPOINT_PATTERN_NONE;
         return wp;
     }
 
     void addWaypoint(int32_t lat, int32_t lon, int32_t altCm,
                      uint8_t type, uint16_t speed = 0, uint16_t duration = 0,
-                     uint8_t pattern = WAYPOINT_PATTERN_ORBIT)
+                     uint8_t pattern = WAYPOINT_PATTERN_NONE)
     {
         flightPlanConfig_t *plan = flightPlanConfigMutable();
         waypoint_t *wp = &plan->waypoints[plan->waypointCount++];
@@ -418,6 +431,297 @@ TEST_F(FlightPlanNavTest, HoldWithZeroDurationAdvancesImmediately)
 
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
     EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
+}
+
+TEST_F(FlightPlanNavTest, TakeoffDispatchClimbsInPlace)
+{
+    // Vehicle at (40 E, 30 N) m; TAKEOFF waypoint 100 m away horizontally.
+    g_stubEstimate.position.x = 4000.0f;
+    g_stubEstimate.position.y = 3000.0f;
+    const int32_t unitsFor100m = (int32_t)((100.0f / 111319.49f) * 1.0e7f);
+    addWaypoint(unitsFor100m, unitsFor100m, 15000, WAYPOINT_TYPE_TAKEOFF);
+
+    flightPlanNavEngage();
+
+    // Target is the current position at the waypoint altitude, with the
+    // station-keeping radius and the climb gated on altitude arrival.
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, 40.0f, 0.01f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.y, 30.0f, 0.01f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 50.0f, 0.01f);
+    EXPECT_NEAR(g_lastTarget.acceptanceRadiusM, 2.0f, 0.01f);
+    EXPECT_TRUE(g_altitudeArrivalRequired);
+}
+
+TEST_F(FlightPlanNavTest, TakeoffAdvancesOnArrival)
+{
+    addWaypoint(0, 0, 15000, WAYPOINT_TYPE_TAKEOFF);
+    addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
+
+    flightPlanNavEngage();
+    triggerReached();
+
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
+}
+
+TEST_F(FlightPlanNavTest, TakeoffWithDurationLoitersThenAdvancesWithoutPattern)
+{
+    // A pattern on a TAKEOFF waypoint is meaningless and must not start.
+    addWaypoint(0, 0, 15000, WAYPOINT_TYPE_TAKEOFF, 0, 20 /* 2.0 s */, WAYPOINT_PATTERN_ORBIT);
+    addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
+
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    triggerReached();
+
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_HOLDING);
+    EXPECT_EQ(g_setTargetCalls, 1);   // no carrot command issued
+
+    g_stubMicros += 1'000'000;
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_HOLDING);
+    EXPECT_EQ(g_moveTargetCalls, 0);
+
+    g_stubMicros += 1'500'000;
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
+}
+
+TEST_F(FlightPlanNavTest, HoldPatternNoneKeepsStationTarget)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_HOLD, 0, 100 /* 10 s */);
+
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    const vector3_t holdTarget = g_lastTarget.targetEfM;
+    triggerReached();
+
+    for (int i = 0; i < 5; i++) {
+        g_stubMicros += 1'000'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_HOLDING);
+    EXPECT_EQ(g_setTargetCalls, 1);
+    EXPECT_EQ(g_moveTargetCalls, 0);
+    EXPECT_EQ(memcmp(&g_lastTarget.targetEfM, &holdTarget, sizeof(holdTarget)), 0);
+}
+
+class FlightPlanNavPatternTest : public FlightPlanNavTest {
+protected:
+    // HOLD waypoint at (10 E, 20 N, +50 U) m, leg cruise 3 m/s. With the
+    // default 2 m hold radius the carrot rate cap gives 0.5 m/s path speed,
+    // so the phase advances at 0.25 rad/s.
+    static constexpr float kCentreE = 10.0f;
+    static constexpr float kCentreN = 20.0f;
+    static constexpr float kCentreU = 50.0f;
+    static constexpr float kRadiusM = 2.0f;
+
+    void engageHoldPattern(uint8_t pattern, uint16_t durationDs = 200)
+    {
+        const int32_t lonUnitsFor10m = (int32_t)((10.0f / 111319.49f) * 1.0e7f);
+        const int32_t latUnitsFor20m = (int32_t)((20.0f / 111319.49f) * 1.0e7f);
+        addWaypoint(latUnitsFor20m, lonUnitsFor10m, 15000, WAYPOINT_TYPE_HOLD,
+                    300 /* 3 m/s */, durationDs, pattern);
+        addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
+
+        g_stubMicros = 1'000'000;
+        flightPlanNavEngage();
+    }
+
+    float distanceFromCentre() const
+    {
+        return sqrtf(sq(g_lastTarget.targetEfM.x - kCentreE) + sq(g_lastTarget.targetEfM.y - kCentreN));
+    }
+};
+
+TEST_F(FlightPlanNavPatternTest, OrbitIssuesNonCompletingCarrotCommand)
+{
+    engageHoldPattern(WAYPOINT_PATTERN_ORBIT);
+    // Vehicle slightly east of the centre: carrot starts at azimuth 0.
+    g_stubEstimate.position.x = (kCentreE + 1.5f) * 100.0f;
+    g_stubEstimate.position.y = kCentreN * 100.0f;
+    triggerReached();
+
+    // Arrival alone must not start the pattern; the update loop starts it
+    // once the arrival braking has settled (stub estimate is at rest).
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_HOLDING);
+    EXPECT_EQ(g_setTargetCalls, 1);
+    flightPlanNavUpdate(g_stubMicros);
+    ASSERT_EQ(g_setTargetCalls, 2);
+    // The carrot command must never complete: completion would refire the
+    // arrival callback (restarting the hold) and zero the velocity target.
+    EXPECT_EQ(g_lastTarget.completionSpeedMps, 0.0f);
+    EXPECT_EQ(g_lastTarget.callback, nullptr);
+    EXPECT_NEAR(g_lastTarget.cruiseSpeedMps, 3.0f, 0.01f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, kCentreE + kRadiusM, 0.05f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.y, kCentreN, 0.05f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, kCentreU, 0.01f);
+}
+
+TEST_F(FlightPlanNavPatternTest, OrbitCarrotStartsAtVehicleAzimuth)
+{
+    engageHoldPattern(WAYPOINT_PATTERN_ORBIT);
+    // Vehicle west of the centre: the first carrot must be on the west side
+    // of the ring (no dash across the circle).
+    g_stubEstimate.position.x = (kCentreE - 2.0f) * 100.0f;
+    g_stubEstimate.position.y = kCentreN * 100.0f;
+    triggerReached();
+    flightPlanNavUpdate(g_stubMicros);
+
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, kCentreE - kRadiusM, 0.05f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.y, kCentreN, 0.05f);
+}
+
+TEST_F(FlightPlanNavPatternTest, OrbitStartDeferredUntilArrivalBrakingSettles)
+{
+    engageHoldPattern(WAYPOINT_PATTERN_ORBIT);
+    g_stubEstimate.position.x = (kCentreE + 1.5f) * 100.0f;
+    g_stubEstimate.position.y = kCentreN * 100.0f;
+    g_stubEstimate.velocity.x = 400.0f;  // still carrying 4 m/s of leg momentum
+    triggerReached();
+
+    g_stubMicros += 1'000'000;
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(g_setTargetCalls, 1);      // too fast: no carrot command yet
+
+    g_stubEstimate.velocity.x = 0.0f;    // braking has parked the vehicle
+    g_stubMicros += 1'000'000;
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(g_setTargetCalls, 2);
+    EXPECT_EQ(g_lastTarget.completionSpeedMps, 0.0f);
+}
+
+TEST_F(FlightPlanNavPatternTest, OrbitStartTimeoutOverridesSettleGate)
+{
+    engageHoldPattern(WAYPOINT_PATTERN_ORBIT);
+    g_stubEstimate.position.x = (kCentreE + 1.5f) * 100.0f;
+    g_stubEstimate.position.y = kCentreN * 100.0f;
+    g_stubEstimate.velocity.x = 400.0f;  // never settles (e.g. holding against wind)
+    triggerReached();
+
+    g_stubMicros += 2'000'000;
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(g_setTargetCalls, 1);
+
+    g_stubMicros += 4'000'000;           // 6 s since arrival: past the 5 s timeout
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(g_setTargetCalls, 2);
+}
+
+TEST_F(FlightPlanNavPatternTest, OrbitCarrotTracksCircleAroundHoldPoint)
+{
+    engageHoldPattern(WAYPOINT_PATTERN_ORBIT);
+    g_stubEstimate.position.x = (kCentreE + 1.5f) * 100.0f;
+    g_stubEstimate.position.y = kCentreN * 100.0f;
+    triggerReached();
+    flightPlanNavUpdate(g_stubMicros);   // settled: pattern starts
+
+    // 0.25 rad/s: after 1 s the azimuth is 0.25 rad, after 2 s 0.5 rad.
+    float previousAzimuth = 0.0f;
+    for (int step = 1; step <= 2; step++) {
+        g_stubMicros += 1'000'000;
+        flightPlanNavUpdate(g_stubMicros);
+
+        EXPECT_EQ(g_moveTargetCalls, step);
+        EXPECT_NEAR(distanceFromCentre(), kRadiusM, 0.01f);
+        EXPECT_NEAR(g_lastTarget.targetEfM.z, kCentreU, 0.01f);
+        const float azimuth = atan2f(g_lastTarget.targetEfM.y - kCentreN,
+                                     g_lastTarget.targetEfM.x - kCentreE);
+        EXPECT_NEAR(azimuth, step * 0.25f, 0.05f);
+        EXPECT_GT(azimuth, previousAzimuth);
+        previousAzimuth = azimuth;
+    }
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_HOLDING);
+}
+
+TEST_F(FlightPlanNavPatternTest, Figure8CarrotBoundedAndRecrossesCentre)
+{
+    engageHoldPattern(WAYPOINT_PATTERN_FIGURE8, 400 /* 40 s */);
+    g_stubEstimate.position.x = kCentreE * 100.0f;
+    g_stubEstimate.position.y = kCentreN * 100.0f;
+    triggerReached();
+    flightPlanNavUpdate(g_stubMicros);   // settled: pattern starts
+
+    // The lemniscate starts at the centre, where the vehicle already is.
+    EXPECT_NEAR(distanceFromCentre(), 0.0f, 0.01f);
+
+    // Walk a full cycle (2π at 0.25 rad/s ≈ 25 s) in 1 s steps: the carrot
+    // stays within the hold radius and returns near the centre mid-cycle.
+    float maxDistance = 0.0f;
+    float minDistanceAfterLeaving = FLT_MAX;
+    bool leftCentre = false;
+    for (int step = 0; step < 26; step++) {
+        g_stubMicros += 1'000'000;
+        flightPlanNavUpdate(g_stubMicros);
+
+        const float distance = distanceFromCentre();
+        EXPECT_LT(distance, kRadiusM + 0.01f);
+        maxDistance = fmaxf(maxDistance, distance);
+        if (distance > 1.5f) {
+            leftCentre = true;
+        } else if (leftCentre) {
+            minDistanceAfterLeaving = fminf(minDistanceAfterLeaving, distance);
+        }
+    }
+    EXPECT_GT(maxDistance, 1.9f);
+    EXPECT_LT(minDistanceAfterLeaving, 0.5f);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_HOLDING);
+}
+
+TEST_F(FlightPlanNavPatternTest, PatternCommandReissuedAfterWipedNavCommand)
+{
+    engageHoldPattern(WAYPOINT_PATTERN_ORBIT);
+    g_stubEstimate.position.x = (kCentreE + 1.5f) * 100.0f;
+    g_stubEstimate.position.y = kCentreN * 100.0f;
+    triggerReached();
+    flightPlanNavUpdate(g_stubMicros);   // settled: pattern starts
+    ASSERT_EQ(g_setTargetCalls, 2);
+
+    // A position-control re-init wipes the nav command mid-hold.
+    g_lastTarget.valid = false;
+
+    g_stubMicros += 1'000'000;
+    flightPlanNavUpdate(g_stubMicros);
+
+    EXPECT_EQ(g_setTargetCalls, 3);
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_EQ(g_lastTarget.completionSpeedMps, 0.0f);
+    EXPECT_NEAR(distanceFromCentre(), kRadiusM, 0.01f);
+}
+
+TEST_F(FlightPlanNavPatternTest, PatternClearedOnAdvance)
+{
+    engageHoldPattern(WAYPOINT_PATTERN_ORBIT, 20 /* 2.0 s */);
+    g_stubEstimate.position.x = (kCentreE + 1.5f) * 100.0f;
+    g_stubEstimate.position.y = kCentreN * 100.0f;
+    triggerReached();
+    flightPlanNavUpdate(g_stubMicros);   // settled: pattern starts
+
+    // Expire the hold: the next leg dispatches and the carrot stops.
+    g_stubMicros += 2'500'000;
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
+
+    const vector3_t legTarget = g_lastTarget.targetEfM;
+    const int movesAtAdvance = g_moveTargetCalls;
+    g_stubMicros += 1'000'000;
+    flightPlanNavUpdate(g_stubMicros);
+
+    EXPECT_EQ(g_moveTargetCalls, movesAtAdvance);
+    EXPECT_EQ(memcmp(&g_lastTarget.targetEfM, &legTarget, sizeof(legTarget)), 0);
+}
+
+TEST_F(FlightPlanNavTest, OrbitPeriodMatchesRateCapAndCruiseLimit)
+{
+    // Default 2 m radius: the 0.25 rad/s rate cap dominates -> 2π/0.25 ≈ 25.1 s
+    EXPECT_EQ(flightPlanNavOrbitPeriodDs(0), 251);
+    // 10 m radius, 1 m/s leg: cruise-limited -> 0.1 rad/s -> 2π/0.1 ≈ 62.8 s
+    autopilotConfigMutable()->waypointHoldRadius = 1000;
+    EXPECT_EQ(flightPlanNavOrbitPeriodDs(100), 628);
 }
 
 TEST_F(FlightPlanNavTest, DisengageClearsTargetAndResetsState)

--- a/src/test/unit/flight_plan_rescue_unittest.cc
+++ b/src/test/unit/flight_plan_rescue_unittest.cc
@@ -1,0 +1,591 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Betaflight. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Flag-on companion to flight_plan_nav_unittest.cc: ENABLE_RESCUE_PLAN=1,
+// exercising the failsafe rescue mission synthesised by
+// flightPlanNavStageRescuePlan(). flight_plan_nav_unittest.cc stays the
+// flag-off regression guard and is not touched by this binary.
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+extern "C" {
+    #include "platform.h"
+    #include "build/debug.h"
+
+    #include "common/maths.h"
+    #include "common/vector.h"
+
+    #include "fc/core.h"
+    #include "fc/runtime_config.h"
+
+    #include "flight/flight_plan_nav.h"
+    #include "flight/gps_rescue.h"
+    #include "flight/position_estimator.h"
+    #include "flight/position_nav.h"
+
+    #include "io/gps.h"
+
+    #include "pg/autopilot.h"
+    #include "pg/flight_plan.h"
+    #include "pg/gps_rescue.h"
+    #include "pg/pg.h"
+
+    int16_t debug[DEBUG16_VALUE_COUNT];
+    uint8_t debugMode;
+
+    uint8_t stateFlags;
+    uint16_t GPS_distanceToHome;
+    gpsSolutionData_t gpsSol;
+    gpsLocation_t GPS_home_llh;
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// --- Stubs and test hooks ---
+// Scaffolding mirrors flight_plan_nav_unittest.cc; extended with the
+// rescue-controller/IMU seams ENABLE_RESCUE_PLAN adds (the rescue
+// CONTROLLER flight/gps_rescue_multirotor.c is not linked here, only its
+// config pg/gps_rescue_multirotor.c, so gpsRescueGetMaxAltitudeCm() is
+// stubbed rather than driven by real rescue state).
+
+namespace {
+
+struct CapturedTarget {
+    vector3_t targetEfM;
+    float cruiseSpeedMps;
+    float acceptanceRadiusM;
+    float completionSpeedMps;
+    bool includeAltitude;
+    positionNavReachedCallbackFn callback;
+    void *userData;
+    bool valid;
+};
+
+CapturedTarget g_lastTarget;
+int g_setTargetCalls;
+int g_clearTargetCalls;
+
+gpsLocation_t g_stubGpsOrigin;
+bool g_stubGpsOriginSet;
+
+timeUs_t g_stubMicros;
+
+positionEstimate3d_t g_stubEstimate;
+bool g_stubValidXY;
+bool g_stubBelowLandingAltitude;
+
+int g_disarmCalls;
+flightLogDisarmReason_e g_lastDisarmReason;
+
+bool g_altitudeArrivalRequired;
+float g_yawRateLimitDps;
+
+float g_stubMaxAltitudeCm;
+bool g_stubHeadingValid;
+int g_pitchForwardCalls;
+bool g_lastPitchForward;
+
+} // namespace
+
+extern "C" {
+
+void positionNavSetTargetEf(
+    const vector3_t *targetPosEfM,
+    float cruiseSpeedMps,
+    float acceptanceRadiusM,
+    float completionSpeedMps,
+    bool includeAltitude,
+    positionNavReachedCallbackFn callback,
+    void *userData)
+{
+    g_lastTarget.targetEfM = *targetPosEfM;
+    g_lastTarget.cruiseSpeedMps = cruiseSpeedMps;
+    g_lastTarget.acceptanceRadiusM = acceptanceRadiusM;
+    g_lastTarget.completionSpeedMps = completionSpeedMps;
+    g_lastTarget.includeAltitude = includeAltitude;
+    g_lastTarget.callback = callback;
+    g_lastTarget.userData = userData;
+    g_lastTarget.valid = true;
+    g_setTargetCalls++;
+}
+
+void positionNavClearTarget(void)
+{
+    g_clearTargetCalls++;
+    g_lastTarget.valid = false;
+}
+
+void positionNavSetAutoClearOnReach(bool autoClear)
+{
+    (void)autoClear;
+}
+
+void positionNavSetAccelLimits(float maxAccelMps2, float maxDecelMps2)
+{
+    (void)maxAccelMps2;
+    (void)maxDecelMps2;
+}
+
+void positionNavSetAltitudeArrivalRequired(bool required)
+{
+    g_altitudeArrivalRequired = required;
+}
+
+bool positionEstimatorGetGpsOrigin(gpsLocation_t *out)
+{
+    if (!g_stubGpsOriginSet || out == NULL) {
+        return false;
+    }
+    *out = g_stubGpsOrigin;
+    return true;
+}
+
+float positionEstimatorGetAltitudeCm(void)
+{
+    return 0.0f;
+}
+
+const positionEstimate3d_t *positionEstimatorGetEstimate(void)
+{
+    return &g_stubEstimate;
+}
+
+bool positionEstimatorIsValidXY(void)
+{
+    return g_stubValidXY;
+}
+
+bool positionNavHasActiveTarget(void)
+{
+    return g_lastTarget.valid;
+}
+
+const positionNavCommand_t *positionNavGetActiveCommand(void)
+{
+    static positionNavCommand_t cmd;
+    memset(&cmd, 0, sizeof(cmd));
+    cmd.active = g_lastTarget.valid;
+    cmd.targetPosEfM = g_lastTarget.targetEfM;
+    cmd.includeAltitude = g_lastTarget.includeAltitude;
+    cmd.cruiseSpeedMps = g_lastTarget.cruiseSpeedMps;
+    return &cmd;
+}
+
+void disarm(flightLogDisarmReason_e reason)
+{
+    g_disarmCalls++;
+    g_lastDisarmReason = reason;
+}
+
+bool isBelowLandingAltitude(void)
+{
+    return g_stubBelowLandingAltitude;
+}
+
+void autopilotSetYawRateLimit(float rateLimitDps)
+{
+    g_yawRateLimitDps = rateLimitDps;
+}
+
+void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *distance)
+{
+    // Simplified flat-earth approximation sufficient for unit-test deltas.
+    // Matches the axis convention of the real implementation:
+    //   x = east (lon delta), y = north (lat delta), both in cm.
+    // 1 deg ~= 111319.49 m at the equator; 1e7 lat units per degree.
+    const float metresPerLatUnit = 111319.49f / 1.0e7f;
+    distance->x = (to->lon - from->lon) * metresPerLatUnit * 100.0f;
+    distance->y = (to->lat - from->lat) * metresPerLatUnit * 100.0f;
+}
+
+timeUs_t micros(void)
+{
+    return g_stubMicros;
+}
+
+uint32_t millis(void)
+{
+    return g_stubMicros / 1000;
+}
+
+// --- ENABLE_RESCUE_PLAN-specific seams ---
+// The rescue controller (flight/gps_rescue_multirotor.c) is not linked; only
+// its config (pg/gps_rescue_multirotor.c) is. gpsRescueGetMaxAltitudeCm()
+// normally reads the controller's running max-altitude-since-arming state.
+float gpsRescueGetMaxAltitudeCm(void)
+{
+    return g_stubMaxAltitudeCm;
+}
+
+bool imuIsHeadingValid(void)
+{
+    return g_stubHeadingValid;
+}
+
+void pitchForwardOverride(bool request)
+{
+    g_pitchForwardCalls++;
+    g_lastPitchForward = request;
+}
+
+} // extern "C"
+
+class FlightPlanRescueTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        memset(&g_lastTarget, 0, sizeof(g_lastTarget));
+        g_setTargetCalls = 0;
+        g_clearTargetCalls = 0;
+        g_stubMicros = 0;
+
+        memset(&g_stubEstimate, 0, sizeof(g_stubEstimate));
+        g_stubValidXY = true;
+        g_stubBelowLandingAltitude = true;
+        g_altitudeArrivalRequired = false;
+        g_disarmCalls = 0;
+        g_yawRateLimitDps = -1.0f;
+
+        g_stubMaxAltitudeCm = 0.0f;
+        g_stubHeadingValid = true; // heading trusted unless a test says otherwise
+        g_pitchForwardCalls = 0;
+        g_lastPitchForward = false;
+
+        // Home and GPS origin at the equator/prime meridian, 100 m AMSL;
+        // current position 30 m east of home so the rescue climb waypoint
+        // (current position) and the return leg (home) are distinguishable.
+        stateFlags = GPS_FIX_HOME | GPS_FIX;
+        GPS_distanceToHome = 100; // clear of the close-range branch (minStartDistM = 15)
+
+        g_stubGpsOrigin.lat = 0;
+        g_stubGpsOrigin.lon = 0;
+        g_stubGpsOrigin.altCm = 10000;
+        g_stubGpsOriginSet = true;
+
+        memset(&GPS_home_llh, 0, sizeof(GPS_home_llh));
+        GPS_home_llh.altCm = 10000;
+
+        memset(&gpsSol, 0, sizeof(gpsSol));
+        gpsSol.llh.lon = metresToLonUnits(30.0f);
+        gpsSol.llh.altCm = 10000;
+
+        gpsRescueConfig_t *rescueCfg = gpsRescueConfigMutable();
+        memset(rescueCfg, 0, sizeof(*rescueCfg));
+        rescueCfg->returnAltitudeM = 30;
+        rescueCfg->groundSpeedCmS = 750;
+        rescueCfg->initialClimbM = 10;
+        rescueCfg->minStartDistM = 15;
+        rescueCfg->altitudeMode = GPS_RESCUE_ALT_MODE_MAX;
+
+        flightPlanConfig_t *plan = flightPlanConfigMutable();
+        memset(plan, 0, sizeof(*plan));
+
+        autopilotConfig_t *cfg = autopilotConfigMutable();
+        memset(cfg, 0, sizeof(*cfg));
+        cfg->waypointArrivalRadius = 500;  // 5 m
+        cfg->waypointHoldRadius = 200;     // 2 m
+        cfg->maxVelocity = 1000;           // 10 m/s
+        cfg->landingDescentRate = 50;      // 0.5 m/s
+        cfg->landingDetectionTime = 10;    // 1 s
+        cfg->landingVelocityThreshold = 50; // 0.5 m/s
+
+        flightPlanNavInit();
+    }
+
+    void TearDown() override {
+        flightPlanNavSetReachedListener(nullptr);
+    }
+
+    static int32_t metresToLonUnits(float metres)
+    {
+        return (int32_t)((metres / 111319.49f) * 1.0e7f);
+    }
+
+    void addWaypoint(int32_t lat, int32_t lon, int32_t altCm,
+                     uint8_t type, uint16_t speed = 0, uint16_t duration = 0)
+    {
+        flightPlanConfig_t *plan = flightPlanConfigMutable();
+        waypoint_t *wp = &plan->waypoints[plan->waypointCount++];
+        wp->latitude = lat;
+        wp->longitude = lon;
+        wp->altitude = altCm;
+        wp->type = type;
+        wp->speed = speed;
+        wp->duration = duration;
+        wp->pattern = WAYPOINT_PATTERN_ORBIT;
+    }
+
+    void triggerReached() {
+        ASSERT_NE(g_lastTarget.callback, nullptr);
+        g_lastTarget.callback(g_lastTarget.userData);
+    }
+
+    // Default-config expected rescue return altitude (MAX mode, 0 cm stubbed
+    // max, 10 m climb, home == current == 100 m AMSL): home + 10 m climb.
+    static constexpr float kDefaultReturnAltM = 10.0f;
+};
+
+// --- Staging and dispatch ---
+
+TEST_F(FlightPlanRescueTest, StageThenEngageDispatchesRescuePlan)
+{
+    // A PG waypoint at a wildly different place/altitude: must never be flown.
+    addWaypoint(500000, 500000, 99999, WAYPOINT_TYPE_FLYOVER);
+
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+
+    EXPECT_TRUE(flightPlanNavIsInjectedPlanActive());
+    EXPECT_TRUE(flightPlanNavIsRescuePlanActive());
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+
+    ASSERT_TRUE(g_lastTarget.valid);
+    // Rescue wp0: HOLD at the current GPS position (30 m east of home/origin).
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, 30.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.y, 0.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, kDefaultReturnAltM, 0.1f);
+}
+
+TEST_F(FlightPlanRescueTest, StageFailsWithoutHomeFix)
+{
+    stateFlags &= ~GPS_FIX_HOME;
+    EXPECT_FALSE(flightPlanNavStageRescuePlan());
+}
+
+TEST_F(FlightPlanRescueTest, StageFailsWithoutGpsFix)
+{
+    stateFlags &= ~GPS_FIX;
+    EXPECT_FALSE(flightPlanNavStageRescuePlan());
+}
+
+// --- Return-altitude computation ---
+
+TEST_F(FlightPlanRescueTest, ReturnAltPerMode)
+{
+    // FIXED: home (100 m) + returnAltitudeM (30 m) = 130 m.
+    gpsRescueConfigMutable()->altitudeMode = GPS_RESCUE_ALT_MODE_FIXED;
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f, 0.01f);
+    flightPlanNavDisengage();
+
+    // CURRENT: current + initialClimbM. In the estimator's feedback frame the
+    // target is 10 m above the current reading (the stub reads 0 while GPS
+    // says 110 m AMSL — zBias reconciles the frames at engage).
+    gpsRescueConfigMutable()->altitudeMode = GPS_RESCUE_ALT_MODE_CURRENT;
+    gpsSol.llh.altCm = 11000;
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 10.0f, 0.01f);
+    flightPlanNavDisengage();
+
+    // MAX: home (100 m) + stubbed max (45 m) + initialClimbM (10 m) = 155 m.
+    gpsRescueConfigMutable()->altitudeMode = GPS_RESCUE_ALT_MODE_MAX;
+    gpsSol.llh.altCm = 10000;
+    g_stubMaxAltitudeCm = 4500;
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 55.0f, 0.01f);
+    flightPlanNavDisengage();
+
+    // Floored at current altitude: FIXED computes 130 m but current is 140 m,
+    // so the plan returns at the current altitude — which in the estimator
+    // frame is its own reading at engage (0 here).
+    gpsRescueConfigMutable()->altitudeMode = GPS_RESCUE_ALT_MODE_FIXED;
+    gpsSol.llh.altCm = 14000;
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 0.0f, 0.01f);
+}
+
+TEST_F(FlightPlanRescueTest, CloseRangeReturnAltitudeUsesModestHeadroom)
+{
+    // Close range (< minStartDistM): MAX(home + 7.5 m, current + climb).
+    // A 2 m climb keeps home+750 (7.5 m) the larger term: 107.5 m -> +7.5 m.
+    GPS_distanceToHome = 10;
+    gpsRescueConfigMutable()->initialClimbM = 2;
+
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 7.5f, 0.01f);
+}
+
+// --- Staging while active / already engaged ---
+
+TEST_F(FlightPlanRescueTest, StageWhileActiveInjectsImmediately)
+{
+    addWaypoint(200000, 0, 15000, WAYPOINT_TYPE_FLYOVER); // ~2.2 km PG mission
+    flightPlanNavEngage();
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    ASSERT_FALSE(flightPlanNavIsInjectedPlanActive());
+    const int callsBefore = g_setTargetCalls;
+
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+
+    EXPECT_TRUE(flightPlanNavIsInjectedPlanActive());
+    EXPECT_TRUE(flightPlanNavIsRescuePlanActive());
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_EQ(g_setTargetCalls, callsBefore + 1);
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, 30.0f, 0.1f); // rescue wp0, not the PG leg
+}
+
+// --- Climb-leg altitude gate ---
+
+TEST_F(FlightPlanRescueTest, ClimbLegAltitudeGated)
+{
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_TRUE(g_altitudeArrivalRequired);
+    ASSERT_TRUE(g_lastTarget.valid);
+    // The climb leg targets the current position, not home.
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, 30.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.y, 0.0f, 0.1f);
+}
+
+// --- Heading gate ---
+
+TEST_F(FlightPlanRescueTest, HeadingGateHoldsAndRecovers)
+{
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+    ASSERT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    const int callsAtWp0 = g_setTargetCalls;
+
+    g_stubHeadingValid = false;
+    triggerReached(); // wp0 (climb) reached with heading untrusted
+
+    EXPECT_EQ(g_pitchForwardCalls, 1);
+    EXPECT_TRUE(g_lastPitchForward);
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0); // no advance
+    EXPECT_EQ(g_setTargetCalls, callsAtWp0);      // target unchanged
+
+    g_stubHeadingValid = true;
+    flightPlanNavUpdate(g_stubMicros);
+
+    EXPECT_EQ(g_lastPitchForward, false);
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    ASSERT_TRUE(g_lastTarget.valid);
+    // wp1: FLYOVER home.
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, 0.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.y, 0.0f, 0.1f);
+}
+
+TEST_F(FlightPlanRescueTest, HeadingGateTimesOutToAbort)
+{
+    g_stubMicros = 1'000'000;
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+
+    g_stubHeadingValid = false;
+    triggerReached();
+    ASSERT_EQ(flightPlanNavGetCurrentIndex(), 0);
+
+    g_stubMicros += 15'000'000; // FP_RESCUE_HEADING_TIMEOUT_US
+    flightPlanNavUpdate(g_stubMicros);
+
+    EXPECT_EQ(g_lastPitchForward, false);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_ABORTED);
+    EXPECT_EQ(flightPlanNavGetAbortReason(), FP_ABORT_HEADING);
+}
+
+TEST_F(FlightPlanRescueTest, DisengageDuringHeadingHoldReleasesPitch)
+{
+    addWaypoint(200000, 0, 15000, WAYPOINT_TYPE_FLYOVER); // PG mission for the re-engage check
+
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+
+    g_stubHeadingValid = false;
+    triggerReached();
+    ASSERT_TRUE(g_lastPitchForward);
+
+    flightPlanNavDisengage();
+    EXPECT_EQ(g_lastPitchForward, false);
+    EXPECT_FALSE(flightPlanNavIsActive());
+
+    // No staged rescue survives disengage: re-engage flies the PG mission.
+    flightPlanNavEngage();
+    EXPECT_FALSE(flightPlanNavIsRescuePlanActive());
+    EXPECT_FALSE(flightPlanNavIsInjectedPlanActive());
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+}
+
+// --- Full mission run ---
+
+TEST_F(FlightPlanRescueTest, FullRescueRunToLanding)
+{
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+    ASSERT_EQ(flightPlanNavGetCurrentIndex(), 0);
+
+    // Heading trusted throughout: wp0 (climb) -> wp1 (home) -> wp2 (land).
+    triggerReached();
+    ASSERT_EQ(flightPlanNavGetCurrentIndex(), 1);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+
+    triggerReached();
+    ASSERT_EQ(flightPlanNavGetCurrentIndex(), 2);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+
+    triggerReached(); // LAND waypoint: starts the descent
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    // Descent establishes.
+    g_stubEstimate.velocity.v[ENU_U] = -40.0f; // cm/s
+    g_stubMicros += 1'000'000;
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(g_disarmCalls, 0);
+
+    // Touchdown: quiet timer starts, then expires.
+    g_stubEstimate.velocity.v[ENU_U] = 0.0f;
+    g_stubMicros += 1'000'000;
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_EQ(g_disarmCalls, 0);
+
+    g_stubMicros += 1'100'000; // past landingDetectionTime (1 s)
+    flightPlanNavUpdate(g_stubMicros);
+
+    EXPECT_EQ(g_disarmCalls, 1);
+    EXPECT_EQ(g_lastDisarmReason, DISARM_REASON_LANDING);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_COMPLETE);
+}
+
+// --- No staging ---
+
+TEST_F(FlightPlanRescueTest, EngageWithoutStagedRunsPgMission)
+{
+    addWaypoint(200000, 0, 15000, WAYPOINT_TYPE_FLYOVER); // ~2.2 km PG mission
+
+    flightPlanNavEngage();
+
+    EXPECT_FALSE(flightPlanNavIsRescuePlanActive());
+    EXPECT_FALSE(flightPlanNavIsInjectedPlanActive());
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    ASSERT_TRUE(g_lastTarget.valid);
+    // The PG waypoint's altitude (50 m AMSL) is nowhere near the rescue climb.
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 50.0f, 0.1f);
+}

--- a/src/test/unit/flight_plan_rescue_unittest.cc
+++ b/src/test/unit/flight_plan_rescue_unittest.cc
@@ -126,6 +126,14 @@ void positionNavSetTargetEf(
     g_setTargetCalls++;
 }
 
+void positionNavMoveTargetEf(const vector3_t *targetPosEfM)
+{
+    if (!g_lastTarget.valid) {
+        return;
+    }
+    g_lastTarget.targetEfM = *targetPosEfM;
+}
+
 void positionNavClearTarget(void)
 {
     g_clearTargetCalls++;
@@ -328,7 +336,7 @@ protected:
         wp->type = type;
         wp->speed = speed;
         wp->duration = duration;
-        wp->pattern = WAYPOINT_PATTERN_ORBIT;
+        wp->pattern = WAYPOINT_PATTERN_NONE;
     }
 
     void triggerReached() {

--- a/src/test/unit/position_nav_unittest.cc
+++ b/src/test/unit/position_nav_unittest.cc
@@ -340,6 +340,42 @@ TEST_F(PositionNavTest, AutoClearDeactivatesOnReach)
     EXPECT_FALSE(positionNavHasActiveTarget());
 }
 
+// --- Move target ---
+
+TEST_F(PositionNavTest, MoveTargetPreservesRampAndRedirectsVelocity)
+{
+    const vector3_t target = {{ 10.0f, 0.0f, 0.0f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.5f, false, testCallback, NULL);
+    positionNavSetAccelLimits(1.0f, 0.0f);
+
+    // Build up a ramped velocity toward the first target.
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f);
+    for (int i = 0; i < 100; i++) {
+        positionNavUpdate(0.01f, &est);
+    }
+    const vector3_t velBefore = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(velBefore.x, 100.0f, 5.0f);  // ~1 m/s after 1 s at 1 m/s^2
+
+    // Move the target north: the very next update must not restart the ramp
+    // from zero — the accel limit only bends the existing velocity.
+    const vector3_t moved = {{ 0.0f, 10.0f, 0.0f }};
+    positionNavMoveTargetEf(&moved);
+    EXPECT_TRUE(positionNavHasActiveTarget());
+    EXPECT_NEAR(positionNavGetActiveCommand()->targetPosEfM.y, 10.0f, 0.001f);
+
+    positionNavUpdate(0.01f, &est);
+    const vector3_t velAfter = positionNavGetTargetVelocityCmS();
+    EXPECT_GT(vector3Norm(&velAfter), 90.0f);
+    EXPECT_EQ(callbackCount, 0);
+}
+
+TEST_F(PositionNavTest, MoveTargetWithoutActiveCommandIsNoOp)
+{
+    const vector3_t moved = {{ 5.0f, 5.0f, 0.0f }};
+    positionNavMoveTargetEf(&moved);
+    EXPECT_FALSE(positionNavHasActiveTarget());
+}
+
 // --- Clear target ---
 
 TEST_F(PositionNavTest, ClearTargetDeactivates)


### PR DESCRIPTION
Next tranche of the autopilot programme, four commits.

- SITL fidelity: the harness now exercises the real attitude estimator with a truth-fed virtual mag, adds GPS-loss injection and a trajectory recorder, gains an A/B driver for flying the same scenario on two binaries, and can stream ground-truth JSON telemetry to an external visualiser.
- Failsafe GPS rescue synthesised as a runtime mission behind `ENABLE_RESCUE_PLAN` (default 0, byte-identical when off): staged plan of climb hold, flyover home, land; `FAILSAFE_AUTOPILOT` phase with a short grace; aborts remapped to auto-landing; heading recovery gated by the pitch-forward override. Switch rescue keeps the legacy path. A/B SITL parity covers heading recovery from 90 degrees of initial error and GPS-loss degradation.
- Remaining waypoint types: TAKEOFF climbs in place to the waypoint altitude (lat/lon advisory, matching MAV_CMD_NAV_TAKEOFF) then loiters for its duration. HOLD gains ORBIT and FIGURE8 patterns, a time-parametrised carrot around the hold point at `ap_waypoint_hold_radius`; the pattern starts once arrival braking settles and rotation is capped at 0.25 rad/s. `WAYPOINT_PATTERN_NONE = 0` keeps stored missions station-keeping. MAVLink `LOITER_TURNS` uploads as an ORBIT hold (turns convert to a duration via the orbit period) and round-trips on download; the upload decoder's pattern default is fixed to NONE.

Part of the autopilot programme tracked in #15411.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rescue-plan support for GPS Rescue (staged mission with climb/return/landing), plus heading-hold recovery and grace-window engagement behavior.
  * Added `NONE` waypoint pattern option, including updates to CLI and MAVLink mission encoding/decoding.
  * Enhanced navigation for TAKEOFF and HOLD/orbit/figure-eight patterns, with improved target updates.
  * Improved virtual sensor support (virtual compass, more robust virtual GPS freshness).

* **Bug Fixes**
  * Improved failsafe rescue fallback/grace handling and added clearer “WP HEADING” warning behavior.

* **Tests**
  * Expanded unit and simulator coverage for rescue plans, waypoint patterns, TAKEOFF, and target updates (including A/B rescue parity and optional telemetry output).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->