### PR TITLE
Autopilot: OSD waypoint elements, CLI mission status, MAVLink SET_CURRENT

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -105,6 +105,7 @@ bool cliMode = false;
 #include "fc/runtime_config.h"
 
 #include "flight/failsafe.h"
+#include "flight/flight_plan_nav.h"
 #include "flight/imu.h"
 #include "flight/mixer.h"
 #include "flight/pid.h"
@@ -2859,9 +2860,33 @@ static void cliWaypoint(const char *cmdName, char *cmdline)
             }
         }
 
-        // TODO: Add runtime status when Phase 3 (waypoint tracker) is complete
-        // This will show: current waypoint, state, distance, bearing, etc.
-        cliPrintLine("\nRuntime status: Not yet implemented (requires Phase 3)");
+        cliPrintLine("\nRuntime status:");
+        if (!flightPlanNavIsActive()) {
+            cliPrintLine("  inactive");
+            return;
+        }
+
+        static const char * const stateNames[] = {
+            "IDLE", "TARGETING", "HOLDING", "COMPLETE", "LANDING", "ABORTED",
+        };
+        const flightPlanNavState_e state = flightPlanNavGetState();
+        cliPrintLinef("  state: %s", (state < ARRAYLEN(stateNames)) ? stateNames[state] : "UNKNOWN");
+        cliPrintLinef("  current waypoint: %u/%u", flightPlanNavGetCurrentIndex() + 1, config->waypointCount);
+
+        const float distanceM = flightPlanNavGetDistanceToWaypointM();
+        if (distanceM >= 0.0f) {
+            const int32_t bearingDeg = flightPlanNavGetBearingToWaypointDeciDeg() / 10;
+            cliPrintLinef("  distance: %d.%02um  bearing: %ld deg  eta: %us",
+                (int)distanceM, (unsigned)(lrintf(distanceM * 100.0f) % 100), (long)bearingDeg, flightPlanNavGetEtaSeconds());
+        }
+
+        if (state == FP_NAV_ABORTED) {
+            static const char * const abortNames[] = {
+                "NONE", "GPS LOST", "STALLED", "FLYAWAY", "HEADING",
+            };
+            const flightPlanAbortReason_e reason = flightPlanNavGetAbortReason();
+            cliPrintLinef("  abort reason: %s", (reason < ARRAYLEN(abortNames)) ? abortNames[reason] : "UNKNOWN");
+        }
         return;
     }
 

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2871,13 +2871,15 @@ static void cliWaypoint(const char *cmdName, char *cmdline)
         };
         const flightPlanNavState_e state = flightPlanNavGetState();
         cliPrintLinef("  state: %s", (state < ARRAYLEN(stateNames)) ? stateNames[state] : "UNKNOWN");
-        cliPrintLinef("  current waypoint: %u/%u", flightPlanNavGetCurrentIndex() + 1, config->waypointCount);
+        const uint8_t currentDisplay = (config->waypointCount == 0) ? 0 : flightPlanNavGetCurrentIndex() + 1;
+        cliPrintLinef("  current waypoint: %u/%u", currentDisplay, config->waypointCount);
 
         const float distanceM = flightPlanNavGetDistanceToWaypointM();
         if (distanceM >= 0.0f) {
+            const uint32_t distanceCm = lrintf(distanceM * 100.0f);
             const int32_t bearingDeg = flightPlanNavGetBearingToWaypointDeciDeg() / 10;
-            cliPrintLinef("  distance: %d.%02um  bearing: %ld deg  eta: %us",
-                (int)distanceM, (unsigned)(lrintf(distanceM * 100.0f) % 100), (long)bearingDeg, flightPlanNavGetEtaSeconds());
+            cliPrintLinef("  distance: %u.%02um  bearing: %ld deg  eta: %us",
+                distanceCm / 100, distanceCm % 100, (long)bearingDeg, flightPlanNavGetEtaSeconds());
         }
 
         if (state == FP_NAV_ABORTED) {

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -123,6 +123,16 @@ const OSD_Entry menuOsdActiveElemsEntries[] =
     {"HOME DIR",           OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_HOME_DIR]},
     {"HOME DIST",          OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_HOME_DIST]},
     {"FLIGHT DIST",        OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_FLIGHT_DIST]},
+#if ENABLE_FLIGHT_PLAN
+    {"WP NUMBER",          OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_WP_NUMBER]},
+    {"WP LAT",             OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_WP_CURRENT_LAT]},
+    {"WP LON",             OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_WP_CURRENT_LON]},
+    {"WP ALT",             OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_WP_CURRENT_ALT]},
+    {"WP DIST",            OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_WP_DISTANCE]},
+    {"WP DIR",             OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_WP_DIRECTION]},
+    {"WP NEXT",            OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_WP_NEXT_NUMBER]},
+    {"WP ETA",             OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_WP_ETA]},
+#endif
 #endif // GPS
     {"COMPASS BAR",        OME_VISIBLE | DYNAMIC, NULL, &osdConfig_item_pos[OSD_COMPASS_BAR]},
 #ifdef USE_ESC_SENSOR

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -1081,7 +1081,12 @@ uint16_t flightPlanNavGetEtaSeconds(void)
     if (speedMps < 0.5f) {
         return 0;
     }
-    const float etaS = distanceToNavTargetM(est) / speedMps;
+    // Horizontal groundspeed only reaches the waypoint's horizontal offset, so
+    // divide by the 2D distance; the 3D slant would overstate ETA on climbs.
+    vector3_t deltaM;
+    navTargetDeltaEnuM(est, &deltaM);
+    const float distance2dM = sqrtf(sq(deltaM.v[ENU_E]) + sq(deltaM.v[ENU_N]));
+    const float etaS = distance2dM / speedMps;
     return (etaS >= (float)UINT16_MAX) ? UINT16_MAX : (uint16_t)lrintf(etaS);
 }
 

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -120,6 +120,7 @@
 static struct {
     flightPlanNavState_e state;
     uint8_t currentIndex;
+    uint8_t pendingStartIndex;  // MISSION_SET_CURRENT while idle; consumed by engage
     timeUs_t holdStartUs;
     uint16_t holdDurationDs;
     bool active;
@@ -355,14 +356,18 @@ static void abortMission(flightPlanAbortReason_e reason)
     positionNavClearTarget();
 }
 
-static float distanceToNavTargetM(const positionEstimate3d_t *est)
+static void navTargetDeltaEnuM(const positionEstimate3d_t *est, vector3_t *deltaM)
 {
     const positionNavCommand_t *cmd = positionNavGetActiveCommand();
-    vector3_t deltaM = {.v = {
-        [ENU_E] = cmd->targetPosEfM.v[ENU_E] - est->position.v[ENU_E] * 0.01f,
-        [ENU_N] = cmd->targetPosEfM.v[ENU_N] - est->position.v[ENU_N] * 0.01f,
-        [ENU_U] = cmd->includeAltitude ? cmd->targetPosEfM.v[ENU_U] - est->position.v[ENU_U] * 0.01f : 0.0f,
-    }};
+    deltaM->v[ENU_E] = cmd->targetPosEfM.v[ENU_E] - est->position.v[ENU_E] * 0.01f;
+    deltaM->v[ENU_N] = cmd->targetPosEfM.v[ENU_N] - est->position.v[ENU_N] * 0.01f;
+    deltaM->v[ENU_U] = cmd->includeAltitude ? cmd->targetPosEfM.v[ENU_U] - est->position.v[ENU_U] * 0.01f : 0.0f;
+}
+
+static float distanceToNavTargetM(const positionEstimate3d_t *est)
+{
+    vector3_t deltaM;
+    navTargetDeltaEnuM(est, &deltaM);
     return vector3Norm(&deltaM);
 }
 
@@ -801,6 +806,7 @@ void flightPlanNavInit(void)
 {
     fp.state = FP_NAV_IDLE;
     fp.currentIndex = 0;
+    fp.pendingStartIndex = 0;
     fp.active = false;
     fp.zBiasM = 0.0f;
     fp.abortReason = FP_ABORT_NONE;
@@ -867,6 +873,9 @@ void flightPlanNavEngage(void)
         return;
     }
 
+    // A MISSION_SET_CURRENT received while idle chooses the starting leg.
+    fp.currentIndex = (fp.pendingStartIndex < flightPlanConfig()->waypointCount) ? fp.pendingStartIndex : 0;
+    fp.pendingStartIndex = 0;
     fp.active = true;
     // Try to dispatch immediately; if the GPS origin isn't ready yet we stay
     // IDLE and flightPlanNavUpdate() will retry.
@@ -1035,6 +1044,65 @@ uint8_t flightPlanNavGetCurrentIndex(void)
 flightPlanAbortReason_e flightPlanNavGetAbortReason(void)
 {
     return fp.abortReason;
+}
+
+float flightPlanNavGetDistanceToWaypointM(void)
+{
+    if (!fp.active || !positionNavHasActiveTarget()) {
+        return -1.0f;
+    }
+    return distanceToNavTargetM(positionEstimatorGetEstimate());
+}
+
+int32_t flightPlanNavGetBearingToWaypointDeciDeg(void)
+{
+    if (!fp.active || !positionNavHasActiveTarget()) {
+        return -1;
+    }
+    vector3_t deltaM;
+    navTargetDeltaEnuM(positionEstimatorGetEstimate(), &deltaM);
+    // Compass bearing: 0 = north, growing clockwise. ENU east/north maps to
+    // atan2(E, N); wrap into [0, 3600) deci-degrees.
+    int32_t deciDeg = lrintf(atan2_approx(deltaM.v[ENU_E], deltaM.v[ENU_N]) * (1800.0f / M_PIf));
+    deciDeg %= 3600;
+    if (deciDeg < 0) {
+        deciDeg += 3600;
+    }
+    return deciDeg;
+}
+
+uint16_t flightPlanNavGetEtaSeconds(void)
+{
+    if (!fp.active || !positionNavHasActiveTarget()) {
+        return 0;
+    }
+    const positionEstimate3d_t *est = positionEstimatorGetEstimate();
+    const float speedMps = sqrtf(sq(est->velocity.v[ENU_E]) + sq(est->velocity.v[ENU_N])) * 0.01f;
+    if (speedMps < 0.5f) {
+        return 0;
+    }
+    const float etaS = distanceToNavTargetM(est) / speedMps;
+    return (etaS >= (float)UINT16_MAX) ? UINT16_MAX : (uint16_t)lrintf(etaS);
+}
+
+void flightPlanNavSetCurrentIndex(uint8_t index)
+{
+    // SET_CURRENT addresses the uploaded PG mission; an injected runtime plan
+    // (geofence RTH / failsafe rescue) owns its own sequencing.
+    if (fp.injectedCount > 0 || index >= flightPlanConfig()->waypointCount) {
+        return;
+    }
+
+    if (fp.active) {
+        fp.currentIndex = index;
+        fp.patternPending = false;
+        fp.patternActive = false;
+        clearModifierState();
+        fp.state = FP_NAV_TARGETING;
+        dispatchWaypoint();
+    } else {
+        fp.pendingStartIndex = index;
+    }
 }
 
 void flightPlanNavSetReachedListener(flightPlanWaypointReachedFn fn)

--- a/src/main/flight/flight_plan_nav.h
+++ b/src/main/flight/flight_plan_nav.h
@@ -66,6 +66,19 @@ flightPlanNavState_e flightPlanNavGetState(void);
 uint8_t flightPlanNavGetCurrentIndex(void);
 flightPlanAbortReason_e flightPlanNavGetAbortReason(void);
 
+// Live navigation geometry to the active waypoint, for OSD/CLI readouts. All
+// three return a sentinel when the executor is not tracking a target:
+// distance < 0, bearing < 0, ETA == 0.
+float flightPlanNavGetDistanceToWaypointM(void);
+int32_t flightPlanNavGetBearingToWaypointDeciDeg(void);
+uint16_t flightPlanNavGetEtaSeconds(void);
+
+// Set the active waypoint (MAVLink MISSION_SET_CURRENT). While the executor is
+// running the PG mission it re-dispatches to that leg; while idle it becomes
+// the index the next engage starts from. Ignored for out-of-range indices and
+// while an injected plan is active.
+void flightPlanNavSetCurrentIndex(uint8_t index);
+
 // Orbit period (deciseconds) at the configured pattern radius for a leg flown
 // at speedCmS (0 = autopilot max velocity). Converts MAVLink LOITER_TURNS turn
 // counts to and from hold durations.

--- a/src/main/flight/flight_plan_nav.h
+++ b/src/main/flight/flight_plan_nav.h
@@ -68,7 +68,9 @@ flightPlanAbortReason_e flightPlanNavGetAbortReason(void);
 
 // Live navigation geometry to the active waypoint, for OSD/CLI readouts. All
 // three return a sentinel when the executor is not tracking a target:
-// distance < 0, bearing < 0, ETA == 0.
+// distance < 0, bearing < 0, ETA == 0. ETA also returns 0 when horizontal
+// speed is below 0.5 m/s (no meaningful estimate), so callers must treat 0 as
+// "no ETA" rather than "arrived".
 float flightPlanNavGetDistanceToWaypointM(void);
 int32_t flightPlanNavGetBearingToWaypointDeciDeg(void);
 uint16_t flightPlanNavGetEtaSeconds(void);

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -1325,8 +1325,12 @@ static void osdElementWpNumber(osdElementParms_t *element)
 static void osdElementWpNextNumber(osdElementParms_t *element)
 {
     const uint8_t count = flightPlanConfig()->waypointCount;
+    if (count == 0) {
+        osdPutHyphen(element);
+        return;
+    }
     const uint8_t next = osdWpCurrentIndex(count) + 1;
-    if (count == 0 || next >= count) {
+    if (next >= count) {
         osdPutHyphen(element);
         return;
     }

--- a/src/main/osd/osd_elements.c
+++ b/src/main/osd/osd_elements.c
@@ -154,6 +154,7 @@
 #include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
 
+#include "flight/flight_plan_nav.h"
 #include "flight/gps_rescue.h"
 #include "flight/position.h"
 #include "flight/imu.h"
@@ -170,6 +171,7 @@
 #include "osd/osd_elements.h"
 #include "osd/osd_warnings.h"
 
+#include "pg/flight_plan.h"
 #include "pg/motor.h"
 #include "pg/pilot.h"
 #include "pg/stats.h"
@@ -1295,6 +1297,107 @@ static void osdElementEfficiency(osdElementParms_t *element)
         tfp_sprintf(element->buff, "----%c/%c", SYM_MAH, unitSymbol);
     }
 }
+
+#if ENABLE_FLIGHT_PLAN
+static void osdPutHyphen(osdElementParms_t *element)
+{
+    element->buff[0] = SYM_HYPHEN;
+    element->buff[1] = '\0';
+}
+
+// Current waypoint clamped into the stored plan; valid only when count > 0.
+static uint8_t osdWpCurrentIndex(uint8_t count)
+{
+    const uint8_t index = flightPlanNavGetCurrentIndex();
+    return (index < count) ? index : (uint8_t)(count - 1);
+}
+
+static void osdElementWpNumber(osdElementParms_t *element)
+{
+    const uint8_t count = flightPlanConfig()->waypointCount;
+    if (count == 0) {
+        osdPutHyphen(element);
+        return;
+    }
+    tfp_sprintf(element->buff, "WP%u/%u", osdWpCurrentIndex(count) + 1, count);
+}
+
+static void osdElementWpNextNumber(osdElementParms_t *element)
+{
+    const uint8_t count = flightPlanConfig()->waypointCount;
+    const uint8_t next = osdWpCurrentIndex(count) + 1;
+    if (count == 0 || next >= count) {
+        osdPutHyphen(element);
+        return;
+    }
+    tfp_sprintf(element->buff, "NEXT%u", next + 1);
+}
+
+static void osdFormatWaypointCoordinate(char *buff, int32_t value, char leadingSymbol)
+{
+    *buff++ = leadingSymbol;
+    if (value < 0) {
+        *buff++ = SYM_HYPHEN;
+    }
+    tfp_sprintf(buff, "%u.%07u", abs(value) / GPS_DEGREES_DIVIDER, abs(value) % GPS_DEGREES_DIVIDER);
+}
+
+static void osdElementWpCoordinate(osdElementParms_t *element)
+{
+    const uint8_t count = flightPlanConfig()->waypointCount;
+    if (count == 0) {
+        osdPutHyphen(element);
+        return;
+    }
+    const waypoint_t *wp = &flightPlanConfig()->waypoints[osdWpCurrentIndex(count)];
+    if (element->item == OSD_WP_CURRENT_LON) {
+        osdFormatWaypointCoordinate(element->buff, wp->longitude, SYM_LON);
+    } else {
+        osdFormatWaypointCoordinate(element->buff, wp->latitude, SYM_LAT);
+    }
+}
+
+static void osdElementWpAltitude(osdElementParms_t *element)
+{
+    const uint8_t count = flightPlanConfig()->waypointCount;
+    if (count == 0) {
+        osdPutHyphen(element);
+        return;
+    }
+    osdFormatAltitudeString(element->buff, flightPlanConfig()->waypoints[osdWpCurrentIndex(count)].altitude, element->type);
+}
+
+static void osdElementWpDistance(osdElementParms_t *element)
+{
+    const float distanceM = flightPlanNavGetDistanceToWaypointM();
+    if (distanceM < 0.0f) {
+        osdPutHyphen(element);
+        return;
+    }
+    osdFormatDistanceString(element->buff, lrintf(distanceM), SYM_NONE);
+}
+
+static void osdElementWpDirection(osdElementParms_t *element)
+{
+    const int32_t bearingDeci = flightPlanNavGetBearingToWaypointDeciDeg();
+    if (bearingDeci < 0) {
+        osdPutHyphen(element);
+        return;
+    }
+    element->buff[0] = osdGetDirectionSymbolFromHeading(DECIDEGREES_TO_DEGREES(bearingDeci - attitude.values.yaw));
+    element->buff[1] = 0;
+}
+
+static void osdElementWpEta(osdElementParms_t *element)
+{
+    const uint16_t etaSeconds = flightPlanNavGetEtaSeconds();
+    if (etaSeconds == 0) {
+        osdPutHyphen(element);
+        return;
+    }
+    tfp_sprintf(element->buff, "%02u:%02u", etaSeconds / 60, etaSeconds % 60);
+}
+#endif // ENABLE_FLIGHT_PLAN
 #endif // USE_GPS
 
 #ifdef USE_GPS_LAP_TIMER
@@ -2053,6 +2156,16 @@ const osdElementDrawFn osdElementDrawFunction[OSD_ITEM_COUNT] = {
 #ifdef USE_GPS
     [OSD_GPS_LON]                 = osdElementGpsCoordinate,
     [OSD_GPS_LAT]                 = osdElementGpsCoordinate,
+#if ENABLE_FLIGHT_PLAN
+    [OSD_WP_NUMBER]               = osdElementWpNumber,
+    [OSD_WP_CURRENT_LAT]          = osdElementWpCoordinate,
+    [OSD_WP_CURRENT_LON]          = osdElementWpCoordinate,
+    [OSD_WP_CURRENT_ALT]          = osdElementWpAltitude,
+    [OSD_WP_DISTANCE]             = osdElementWpDistance,
+    [OSD_WP_DIRECTION]            = osdElementWpDirection,
+    [OSD_WP_NEXT_NUMBER]          = osdElementWpNextNumber,
+    [OSD_WP_ETA]                  = osdElementWpEta,
+#endif
 #endif
     [OSD_DEBUG]                   = osdElementDebug,
     [OSD_DEBUG2]                  = osdElementDebug2,
@@ -2211,6 +2324,16 @@ void osdAddActiveElements(void)
         osdAddActiveElement(OSD_HOME_DIR);
         osdAddActiveElement(OSD_FLIGHT_DIST);
         osdAddActiveElement(OSD_EFFICIENCY);
+#if ENABLE_FLIGHT_PLAN
+        osdAddActiveElement(OSD_WP_NUMBER);
+        osdAddActiveElement(OSD_WP_CURRENT_LAT);
+        osdAddActiveElement(OSD_WP_CURRENT_LON);
+        osdAddActiveElement(OSD_WP_CURRENT_ALT);
+        osdAddActiveElement(OSD_WP_DISTANCE);
+        osdAddActiveElement(OSD_WP_DIRECTION);
+        osdAddActiveElement(OSD_WP_NEXT_NUMBER);
+        osdAddActiveElement(OSD_WP_ETA);
+#endif
     }
 #endif // GPS
 

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -420,6 +420,23 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
         *blinking = true;
         return;
     }
+
+    // Mission progress cues, below every critical warning above. The mode
+    // itself is shown by the flight-mode indicator; these surface the two
+    // states that are otherwise invisible: the terminal descent and arrival.
+    if (FLIGHT_MODE(AUTOPILOT_MODE)) {
+        if (flightPlanNavGetState() == FP_NAV_LANDING) {
+            tfp_sprintf(warningText, "WP LANDING");
+            *displayAttr = DISPLAYPORT_SEVERITY_INFO;
+            return;
+        }
+        if (flightPlanNavGetState() == FP_NAV_COMPLETE) {
+            tfp_sprintf(warningText, "WP COMPLETE");
+            *displayAttr = DISPLAYPORT_SEVERITY_INFO;
+            *blinking = true;
+            return;
+        }
+    }
 #endif
 
     // Show warning if in HEADFREE flight mode

--- a/src/main/telemetry/mavlink_mission.c
+++ b/src/main/telemetry/mavlink_mission.c
@@ -590,6 +590,30 @@ void mavMissionInit(void)
     flightPlanNavSetReachedListener(onWaypointReached);
 }
 
+// Pack and send MISSION_CURRENT from live executor state. Driven at 1 Hz by
+// mavMissionUpdate() and once immediately in response to MISSION_SET_CURRENT.
+static void sendMissionCurrent(void)
+{
+    const uint16_t total = flightPlanConfig()->waypointCount;
+    const bool active = flightPlanNavIsActive();
+    const uint16_t seq = (total && active && !flightPlanNavIsInjectedPlanActive())
+        ? flightPlanNavGetCurrentIndex() : 0;
+    const uint8_t missionMode = active ? 1 : 2;
+    uint8_t missionState;
+    if (total == 0) {
+        missionState = MISSION_STATE_NO_MISSION;
+    } else if (!active) {
+        missionState = MISSION_STATE_NOT_STARTED;
+    } else if (flightPlanNavGetState() == FP_NAV_COMPLETE) {
+        missionState = MISSION_STATE_COMPLETE;
+    } else {
+        missionState = MISSION_STATE_ACTIVE;
+    }
+    mavlink_msg_mission_current_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
+        seq, total, missionState, missionMode, 0, 0, 0);
+    mavlinkSendMessage(&txMsg);
+}
+
 bool mavMissionHandleMessage(const mavlink_message_t *msg)
 {
     // Each handler decodes the typed payload and applies its own target filter
@@ -621,6 +645,18 @@ bool mavMissionHandleMessage(const mavlink_message_t *msg)
     case MAVLINK_MSG_ID_MISSION_CLEAR_ALL:
         handleClearAll(msg);
         return true;
+    case MAVLINK_MSG_ID_MISSION_SET_CURRENT: {
+        mavlink_mission_set_current_t sc;
+        mavlink_msg_mission_set_current_decode(msg, &sc);
+        if (!targetIsUs(sc.target_system, sc.target_component)) {
+            return true;
+        }
+        // Out-of-range seq is a no-op on the cursor; the executor guards the
+        // range too. Either way the partner gets the current cursor back.
+        flightPlanNavSetCurrentIndex((uint8_t)sc.seq);
+        sendMissionCurrent();
+        return true;
+    }
     case MAVLINK_MSG_ID_MISSION_ACK:
         handleMissionAck(msg);
         return true;
@@ -658,24 +694,7 @@ void mavMissionUpdate(timeMs_t nowMs)
     // MISSION_CURRENT @ 1 Hz — lets QGC display the live cursor whether or not
     // the mission is being executed.
     if ((nowMs - m.lastCurrentTxMs) >= MISSION_CURRENT_PERIOD_MS) {
-        const uint16_t total = flightPlanConfig()->waypointCount;
-        const bool active = flightPlanNavIsActive();
-        const uint16_t seq = (total && active && !flightPlanNavIsInjectedPlanActive())
-            ? flightPlanNavGetCurrentIndex() : 0;
-        const uint8_t missionMode = active ? 1 : 2;
-        uint8_t missionState;
-        if (total == 0) {
-            missionState = MISSION_STATE_NO_MISSION;
-        } else if (!active) {
-            missionState = MISSION_STATE_NOT_STARTED;
-        } else if (flightPlanNavGetState() == FP_NAV_COMPLETE) {
-            missionState = MISSION_STATE_COMPLETE;
-        } else {
-            missionState = MISSION_STATE_ACTIVE;
-        }
-        mavlink_msg_mission_current_pack(MAVLINK_SYSTEM_ID, MAVLINK_COMPONENT_ID, &txMsg,
-            seq, total, missionState, missionMode, 0, 0, 0);
-        mavlinkSendMessage(&txMsg);
+        sendMissionCurrent();
         m.lastCurrentTxMs = nowMs;
     }
 }

--- a/src/main/telemetry/mavlink_mission.c
+++ b/src/main/telemetry/mavlink_mission.c
@@ -652,8 +652,11 @@ bool mavMissionHandleMessage(const mavlink_message_t *msg)
             return true;
         }
         // Out-of-range seq is a no-op on the cursor; the executor guards the
-        // range too. Either way the partner gets the current cursor back.
-        flightPlanNavSetCurrentIndex((uint8_t)sc.seq);
+        // range too. Guard the narrowing cast so a seq > 255 can't wrap into a
+        // valid index. Either way the partner gets the current cursor back.
+        if (sc.seq <= UINT8_MAX) {
+            flightPlanNavSetCurrentIndex((uint8_t)sc.seq);
+        }
         sendMissionCurrent();
         return true;
     }

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -453,6 +453,19 @@ telemetry_ibus_unittest_SRC := \
 		$(USER_DIR)/telemetry/ibus_shared.c \
 		$(USER_DIR)/telemetry/ibus.c
 
+telemetry_mavlink_mission_unittest_SRC := \
+		$(USER_DIR)/telemetry/mavlink_mission.c \
+		$(USER_DIR)/pg/flight_plan.c \
+		$(USER_DIR)/pg/autopilot.c
+
+telemetry_mavlink_mission_unittest_DEFINES := \
+		USE_GPS= \
+		USE_FLIGHT_PLAN= \
+		ENABLE_FLIGHT_PLAN=1 \
+		USE_TELEMETRY= \
+		USE_TELEMETRY_MAVLINK= \
+		ENABLE_TELEMETRY_MAVLINK_MISSION=1
+
 transponder_ir_unittest_SRC := \
 		$(USER_DIR)/drivers/transponder_ir_ilap.c \
 		$(USER_DIR)/drivers/transponder_ir_arcitimer.c
@@ -693,6 +706,10 @@ COMMON_FLAGS += -Wno-c99-designator
 
 # no warning expected on clang
 COMMON_FLAGS += -Werror
+
+# The vendored MAVLink headers forward-declare mavlink_message_t and then
+# redefine it identically; harmless, but flagged as a C11 feature under gnu99.
+COMMON_FLAGS += -Wno-typedef-redefinition
 
 ifeq ($(shell expr $(CC_VERSION_MAJOR) \< $(CC_VERSION_CHECK_MIN) \| $(CC_VERSION_MAJOR) \> $(CC_VERSION_CHECK_MAX)),1)
 $(error $(CC) $(CC_VERSION) is not supported. The officially supported version of clang is 'clang-18'. If this is not found, 'clang' is used as a fallback. The version of the compiler must be between $(CC_VERSION_CHECK_MIN) and $(CC_VERSION_CHECK_MAX).)

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -724,6 +724,84 @@ TEST_F(FlightPlanNavTest, OrbitPeriodMatchesRateCapAndCruiseLimit)
     EXPECT_EQ(flightPlanNavOrbitPeriodDs(100), 628);
 }
 
+TEST_F(FlightPlanNavTest, SetCurrentIndexReTargetsWhileActive)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
+    addWaypoint(50, 60, 15000, WAYPOINT_TYPE_FLYOVER);
+
+    flightPlanNavEngage();
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    EXPECT_EQ(g_setTargetCalls, 1);
+
+    flightPlanNavSetCurrentIndex(2);
+
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 2);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_EQ(g_setTargetCalls, 2);
+}
+
+TEST_F(FlightPlanNavTest, SetCurrentIndexStoresStartIndexWhileIdle)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
+
+    // Set before engage: no dispatch happens yet.
+    flightPlanNavSetCurrentIndex(1);
+    EXPECT_EQ(g_setTargetCalls, 0);
+
+    flightPlanNavEngage();
+
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
+    EXPECT_EQ(g_setTargetCalls, 1);
+}
+
+TEST_F(FlightPlanNavTest, SetCurrentIndexIgnoresOutOfRange)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
+
+    flightPlanNavEngage();
+    flightPlanNavSetCurrentIndex(5); // >= count
+
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    EXPECT_EQ(g_setTargetCalls, 1);
+}
+
+TEST_F(FlightPlanNavTest, GeometryAccessorsSentinelWhenIdle)
+{
+    addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
+    // Not engaged -> no active target.
+    EXPECT_LT(flightPlanNavGetDistanceToWaypointM(), 0.0f);
+    EXPECT_LT(flightPlanNavGetBearingToWaypointDeciDeg(), 0);
+    EXPECT_EQ(flightPlanNavGetEtaSeconds(), 0);
+}
+
+TEST_F(FlightPlanNavTest, GeometryAccessorsReflectActiveTarget)
+{
+    // Waypoint 10 m east, 20 m north, altitude matching the vehicle so the
+    // 3D distance is purely horizontal.
+    const int32_t lonUnitsFor10m = (int32_t)((10.0f / 111319.49f) * 1.0e7f);
+    const int32_t latUnitsFor20m = (int32_t)((20.0f / 111319.49f) * 1.0e7f);
+    addWaypoint(latUnitsFor20m, lonUnitsFor10m, 5000, WAYPOINT_TYPE_FLYOVER, 300);
+
+    flightPlanNavEngage();
+    ASSERT_TRUE(g_lastTarget.valid);
+
+    // Vehicle at origin, altitude aligned with the target (-50 m ENU up).
+    g_stubEstimate.position.v[0] = 0.0f;      // east cm
+    g_stubEstimate.position.v[1] = 0.0f;      // north cm
+    g_stubEstimate.position.v[2] = -5000.0f;  // up cm (matches target z)
+    g_stubEstimate.velocity.v[0] = 500.0f;    // 5 m/s east
+    g_stubEstimate.velocity.v[1] = 0.0f;
+
+    EXPECT_NEAR(flightPlanNavGetDistanceToWaypointM(), 22.36f, 0.1f);
+    // atan2(E=10, N=20) = 26.57 deg CW from north -> 266 deci-degrees.
+    EXPECT_NEAR(flightPlanNavGetBearingToWaypointDeciDeg(), 266, 2);
+    // 22.36 m / 5 m/s = 4.47 s -> rounds to 4.
+    EXPECT_EQ(flightPlanNavGetEtaSeconds(), 4);
+}
+
 TEST_F(FlightPlanNavTest, DisengageClearsTargetAndResetsState)
 {
     addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);

--- a/src/test/unit/telemetry_mavlink_mission_unittest.cc
+++ b/src/test/unit/telemetry_mavlink_mission_unittest.cc
@@ -1,0 +1,320 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+extern "C" {
+    #include "platform.h"
+
+    #include "fc/runtime_config.h"
+    #include "io/gps.h"
+    #include "pg/autopilot.h"
+    #include "pg/flight_plan.h"
+    #include "flight/flight_plan_nav.h"
+    #include "telemetry/mavlink_mission.h"
+
+    uint16_t flightModeFlags = 0;
+    uint8_t stateFlags = 0;
+    gpsLocation_t GPS_home_llh;
+    gpsSolutionData_t gpsSol;
+
+    // Executor mock state, driven by the tests.
+    static bool s_navActive = false;
+    static bool s_navInjected = false;
+    static flightPlanNavState_e s_navState = FP_NAV_IDLE;
+    static uint8_t s_navIndex = 0;
+    static int s_setCurrentArg = -1;
+    static int s_saveCalls = 0;
+    static uint32_t s_millis = 0;
+    static flightPlanWaypointReachedFn s_reachedListener = nullptr;
+
+    bool flightPlanNavIsActive(void) { return s_navActive; }
+    bool flightPlanNavIsInjectedPlanActive(void) { return s_navInjected; }
+    flightPlanNavState_e flightPlanNavGetState(void) { return s_navState; }
+    uint8_t flightPlanNavGetCurrentIndex(void) { return s_navIndex; }
+    void flightPlanNavSetCurrentIndex(uint8_t index) { s_setCurrentArg = index; }
+    void flightPlanNavSetReachedListener(flightPlanWaypointReachedFn fn) { s_reachedListener = fn; }
+
+    // Fixed orbit period so LOITER_TURNS <-> ORBIT conversion is deterministic.
+    uint16_t flightPlanNavOrbitPeriodDs(uint16_t) { return 250; }
+
+    void saveConfigAndNotify(void) { s_saveCalls++; }
+    uint32_t millis(void) { return s_millis; }
+
+    // Capture every message the module transmits.
+    static std::vector<mavlink_message_t> *s_sent = nullptr;
+    void mavlinkSendMessage(mavlink_message_t *msg) { if (s_sent) { s_sent->push_back(*msg); } }
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// GCS identity for messages fed to the module.
+static const uint8_t GCS_SYS = 255;
+static const uint8_t GCS_COMP = 190;
+
+class MavlinkMissionTest : public ::testing::Test {
+protected:
+    std::vector<mavlink_message_t> sent;
+
+    void SetUp() override {
+        flightModeFlags = 0;
+        stateFlags = 0;
+        memset(&GPS_home_llh, 0, sizeof(GPS_home_llh));
+        GPS_home_llh.altCm = 10000;
+        ENABLE_STATE(GPS_FIX_HOME);
+        memset(&gpsSol, 0, sizeof(gpsSol));
+
+        autopilotConfig_t *cfg = autopilotConfigMutable();
+        memset(cfg, 0, sizeof(*cfg));
+        cfg->waypointHoldRadius = 800; // 8 m
+
+        flightPlanConfig_t *plan = flightPlanConfigMutable();
+        memset(plan, 0, sizeof(*plan));
+
+        s_navActive = false;
+        s_navInjected = false;
+        s_navState = FP_NAV_IDLE;
+        s_navIndex = 0;
+        s_setCurrentArg = -1;
+        s_saveCalls = 0;
+        s_millis = 0;
+        s_reachedListener = nullptr;
+
+        sent.clear();
+        s_sent = &sent;
+
+        mavMissionInit();
+    }
+
+    void feed(const mavlink_message_t &msg) {
+        mavlink_message_t copy = msg;
+        copy.sysid = GCS_SYS;
+        copy.compid = GCS_COMP;
+        mavMissionHandleMessage(&copy);
+    }
+
+    const mavlink_message_t *lastOfType(uint32_t msgid) const {
+        for (auto it = sent.rbegin(); it != sent.rend(); ++it) {
+            if (it->msgid == msgid) {
+                return &(*it);
+            }
+        }
+        return nullptr;
+    }
+
+    int countOfType(uint32_t msgid) const {
+        int n = 0;
+        for (const auto &m : sent) {
+            if (m.msgid == msgid) { n++; }
+        }
+        return n;
+    }
+
+    // Drive one upload item and return the resulting item write.
+    void sendItem(uint16_t seq, uint16_t command, uint16_t total,
+                  float param1 = 0.0f, int32_t lat = 0, int32_t lon = 0, float alt = 0.0f) {
+        mavlink_message_t msg;
+        mavlink_msg_mission_item_int_pack(GCS_SYS, GCS_COMP, &msg,
+            1, 0, seq, MAV_FRAME_GLOBAL_INT, command, /*current*/ 0, /*autocontinue*/ 1,
+            param1, 0.0f, 0.0f, 0.0f, lat, lon, alt, MAV_MISSION_TYPE_MISSION);
+        (void)total;
+        feed(msg);
+    }
+
+    void sendCount(uint16_t count) {
+        mavlink_message_t msg;
+        mavlink_msg_mission_count_pack(GCS_SYS, GCS_COMP, &msg,
+            1, 0, count, MAV_MISSION_TYPE_MISSION, 0);
+        feed(msg);
+    }
+};
+
+TEST_F(MavlinkMissionTest, UploadWritesWaypointsToConfig)
+{
+    sendCount(3);
+    // COUNT is answered with REQUEST_INT(0).
+    const mavlink_message_t *req = lastOfType(MAVLINK_MSG_ID_MISSION_REQUEST_INT);
+    ASSERT_NE(req, nullptr);
+    mavlink_mission_request_int_t r;
+    mavlink_msg_mission_request_int_decode(req, &r);
+    EXPECT_EQ(r.seq, 0);
+
+    sendItem(0, MAV_CMD_NAV_TAKEOFF, 3, 0.0f, 100, 200, 12.0f);
+    sendItem(1, MAV_CMD_NAV_WAYPOINT, 3, 0.0f, 300, 400, 20.0f);
+    sendItem(2, MAV_CMD_NAV_LAND, 3, 0.0f, 500, 600, 0.0f);
+
+    // Final item is acked and the config is persisted.
+    const mavlink_message_t *ack = lastOfType(MAVLINK_MSG_ID_MISSION_ACK);
+    ASSERT_NE(ack, nullptr);
+    mavlink_mission_ack_t a;
+    mavlink_msg_mission_ack_decode(ack, &a);
+    EXPECT_EQ(a.type, MAV_MISSION_ACCEPTED);
+    EXPECT_EQ(s_saveCalls, 1);
+
+    const flightPlanConfig_t *plan = flightPlanConfig();
+    ASSERT_EQ(plan->waypointCount, 3);
+    EXPECT_EQ(plan->waypoints[0].type, WAYPOINT_TYPE_TAKEOFF);
+    EXPECT_EQ(plan->waypoints[1].type, WAYPOINT_TYPE_FLYBY);
+    EXPECT_EQ(plan->waypoints[1].latitude, 300);
+    EXPECT_EQ(plan->waypoints[1].longitude, 400);
+    EXPECT_EQ(plan->waypoints[2].type, WAYPOINT_TYPE_LAND);
+}
+
+TEST_F(MavlinkMissionTest, UploadMapsLoiterTurnsToOrbitHold)
+{
+    sendCount(1);
+    sendItem(0, MAV_CMD_NAV_LOITER_TURNS, 1, /*turns*/ 3.0f, 100, 200, 15.0f);
+
+    const flightPlanConfig_t *plan = flightPlanConfig();
+    ASSERT_EQ(plan->waypointCount, 1);
+    EXPECT_EQ(plan->waypoints[0].type, WAYPOINT_TYPE_HOLD);
+    EXPECT_EQ(plan->waypoints[0].pattern, WAYPOINT_PATTERN_ORBIT);
+    // 3 turns * 250 ds/turn (mocked orbit period) = 750 ds.
+    EXPECT_EQ(plan->waypoints[0].duration, 750);
+}
+
+TEST_F(MavlinkMissionTest, UploadDefaultsPatternToNone)
+{
+    sendCount(1);
+    sendItem(0, MAV_CMD_NAV_LOITER_TIME, 1, /*seconds*/ 5.0f, 100, 200, 15.0f);
+
+    const flightPlanConfig_t *plan = flightPlanConfig();
+    ASSERT_EQ(plan->waypointCount, 1);
+    EXPECT_EQ(plan->waypoints[0].type, WAYPOINT_TYPE_HOLD);
+    EXPECT_EQ(plan->waypoints[0].pattern, WAYPOINT_PATTERN_NONE);
+}
+
+TEST_F(MavlinkMissionTest, UploadRejectedWhileAutopilotActive)
+{
+    flightModeFlags = AUTOPILOT_MODE;
+    sendCount(2);
+
+    const mavlink_message_t *ack = lastOfType(MAVLINK_MSG_ID_MISSION_ACK);
+    ASSERT_NE(ack, nullptr);
+    mavlink_mission_ack_t a;
+    mavlink_msg_mission_ack_decode(ack, &a);
+    EXPECT_EQ(a.type, MAV_MISSION_DENIED);
+    EXPECT_EQ(countOfType(MAVLINK_MSG_ID_MISSION_REQUEST_INT), 0);
+}
+
+TEST_F(MavlinkMissionTest, DownloadEncodesWaypointsRoundTrip)
+{
+    flightPlanConfig_t *plan = flightPlanConfigMutable();
+    plan->waypointCount = 3;
+    plan->waypoints[0] = { 100, 200, 1200, 0, 0, WAYPOINT_TYPE_TAKEOFF, WAYPOINT_PATTERN_NONE };
+    plan->waypoints[1] = { 300, 400, 2000, 0, 300 /* 30 s */, WAYPOINT_TYPE_HOLD, WAYPOINT_PATTERN_ORBIT };
+    plan->waypoints[2] = { 500, 600, 0, 0, 0, WAYPOINT_TYPE_LAND, WAYPOINT_PATTERN_NONE };
+
+    // REQUEST_LIST -> COUNT.
+    mavlink_message_t list;
+    mavlink_msg_mission_request_list_pack(GCS_SYS, GCS_COMP, &list, 1, 0, MAV_MISSION_TYPE_MISSION);
+    feed(list);
+    const mavlink_message_t *cnt = lastOfType(MAVLINK_MSG_ID_MISSION_COUNT);
+    ASSERT_NE(cnt, nullptr);
+    mavlink_mission_count_t mc;
+    mavlink_msg_mission_count_decode(cnt, &mc);
+    EXPECT_EQ(mc.count, 3);
+
+    auto requestItem = [&](uint16_t seq) -> uint16_t {
+        mavlink_message_t req;
+        mavlink_msg_mission_request_int_pack(GCS_SYS, GCS_COMP, &req, 1, 0, seq, MAV_MISSION_TYPE_MISSION);
+        feed(req);
+        const mavlink_message_t *item = lastOfType(MAVLINK_MSG_ID_MISSION_ITEM_INT);
+        EXPECT_NE(item, nullptr);
+        mavlink_mission_item_int_t it;
+        mavlink_msg_mission_item_int_decode(item, &it);
+        EXPECT_EQ(it.seq, seq);
+        return it.command;
+    };
+
+    EXPECT_EQ(requestItem(0), MAV_CMD_NAV_TAKEOFF);
+    EXPECT_EQ(requestItem(1), MAV_CMD_NAV_LOITER_TURNS); // ORBIT hold -> LOITER_TURNS
+    EXPECT_EQ(requestItem(2), MAV_CMD_NAV_LAND);
+}
+
+TEST_F(MavlinkMissionTest, MissionItemReachedEmitted)
+{
+    ASSERT_NE(s_reachedListener, nullptr);
+    s_reachedListener(2);
+
+    mavMissionUpdate(0); // time 0 avoids a coincident MISSION_CURRENT
+    const mavlink_message_t *reached = lastOfType(MAVLINK_MSG_ID_MISSION_ITEM_REACHED);
+    ASSERT_NE(reached, nullptr);
+    mavlink_mission_item_reached_t mr;
+    mavlink_msg_mission_item_reached_decode(reached, &mr);
+    EXPECT_EQ(mr.seq, 2);
+
+    // Latched index is one-shot: a second update does not re-emit.
+    sent.clear();
+    mavMissionUpdate(0);
+    EXPECT_EQ(countOfType(MAVLINK_MSG_ID_MISSION_ITEM_REACHED), 0);
+}
+
+TEST_F(MavlinkMissionTest, MissionCurrentReflectsExecutorState)
+{
+    flightPlanConfigMutable()->waypointCount = 3;
+    s_navActive = true;
+    s_navState = FP_NAV_TARGETING;
+    s_navIndex = 1;
+
+    mavMissionUpdate(1000);
+    const mavlink_message_t *cur = lastOfType(MAVLINK_MSG_ID_MISSION_CURRENT);
+    ASSERT_NE(cur, nullptr);
+    mavlink_mission_current_t mc;
+    mavlink_msg_mission_current_decode(cur, &mc);
+    EXPECT_EQ(mc.seq, 1);
+    EXPECT_EQ(mc.total, 3);
+    EXPECT_EQ(mc.mission_state, MISSION_STATE_ACTIVE);
+}
+
+TEST_F(MavlinkMissionTest, MissionCurrentSuppressedForInjectedPlan)
+{
+    flightPlanConfigMutable()->waypointCount = 3;
+    s_navActive = true;
+    s_navInjected = true;
+    s_navIndex = 2;
+
+    mavMissionUpdate(1000);
+    const mavlink_message_t *cur = lastOfType(MAVLINK_MSG_ID_MISSION_CURRENT);
+    ASSERT_NE(cur, nullptr);
+    mavlink_mission_current_t mc;
+    mavlink_msg_mission_current_decode(cur, &mc);
+    // An injected runtime plan owns its own sequencing; the uploaded-mission
+    // cursor stays at 0 for the tracking GCS.
+    EXPECT_EQ(mc.seq, 0);
+}
+
+TEST_F(MavlinkMissionTest, SetCurrentDispatchesAndEchoesCursor)
+{
+    flightPlanConfigMutable()->waypointCount = 3;
+    s_navActive = true;
+    s_navIndex = 2;
+
+    mavlink_message_t sc;
+    mavlink_msg_mission_set_current_pack(GCS_SYS, GCS_COMP, &sc, 1, 0, 2);
+    feed(sc);
+
+    EXPECT_EQ(s_setCurrentArg, 2);
+    EXPECT_NE(lastOfType(MAVLINK_MSG_ID_MISSION_CURRENT), nullptr);
+}


### PR DESCRIPTION
Pilot surface and MAVLink completion for the flight-plan feature, following #15413.

- OSD: wire the eight OSD_WP_* elements (current/next waypoint number, current waypoint lat/lon/alt, distance, direction arrow, ETA). Their ids and CLI positions shipped earlier without any rendering code. Add flightPlanNavGetDistanceToWaypointM / BearingToWaypointDeciDeg / EtaSeconds over the executor's existing target-distance computation, shared by the elements and the CLI. Add WP LANDING and WP COMPLETE cues to the OSD warnings line, below every critical warning.
- CLI: complete the `waypoint status` runtime section (state, current waypoint, distance, bearing, ETA, abort reason); it was a stub.
- MAVLink: handle MISSION_SET_CURRENT (re-dispatch to the requested leg while flying, set the engage start index while idle), and add a host unit test covering the mission round-trip (upload decode to the stored plan, download encode, MISSION_ITEM_REACHED, MISSION_CURRENT, SET_CURRENT). SITL builds no MAVLink telemetry, so the unit test is the automated coverage for that path; real transport is hardware-in-the-loop.

OSD is not built in SITL, so the elements are verified by the F405 + USE_FLIGHT_PLAN build and the accessor unit tests. User-facing documentation will live on the betaflight.com website rather than in the firmware repo.

Part of the autopilot programme tracked in #15411.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added real-time flight-plan status reporting in the CLI, including navigation state, waypoint progress, distance, bearing, ETA, and abort details.
  - Added new flight-plan waypoint OSD elements for current/next waypoint and live navigation metrics (with placeholders when unavailable).
  - Added MAVLink support for selecting the active mission waypoint and publishing updated mission cursor status.
  - Added “WP LANDING” and “WP COMPLETE” flight-plan alerts on the OSD.

- **Bug Fixes**
  - Improved waypoint selection/engagement behavior and live navigation geometry used for OSD/telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->