### PR TITLE
build(openocd): add STM32H5 target config

### DIFF
--- a/mk/openocd.mk
+++ b/mk/openocd.mk
@@ -12,6 +12,9 @@ OPENOCD_CFG := target/stm32f7x.cfg
 
 else ifeq ($(TARGET_MCU_FAMILY),STM32H7)
 OPENOCD_CFG := target/stm32h7x.cfg
+
+else ifeq ($(TARGET_MCU_FAMILY),STM32H5)
+OPENOCD_CFG := target/stm32h5x.cfg
 endif
 
 ifneq ($(OPENOCD_CFG),)


### PR DESCRIPTION
## Summary

`mk/openocd.mk` had no entry for the STM32H5 family, so `make openocd-gdb` (and any openocd-based on-target debugging/flashing) produced no `OPENOCD_COMMAND` for H5 boards — the recipe silently did nothing.

Map `STM32H5` to `target/stm32h5x.cfg`, matching the existing F4/F7/G4/H7 entries.

## Testing

- `make CONFIG=SPEEDYBEEH5 -p` now resolves `OPENOCD_CFG := target/stm32h5x.cfg`.
- Used in practice to flash/debug a SPEEDYBEEH5 (STM32H563) over an ST-Link V3 (invoke with `OPENOCD_IF=interface/stlink.cfg` for V3 probes).

## Notes

Split out from the STM32H5 GPDMA bug fixes (#15419) as a self-contained build/tooling change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenOCD support for STM32H5 microcontroller targets.
  * STM32H5 builds now automatically use the appropriate target configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->