### PR TITLE
Correct DroneCAN Fix2 signature and ned_velocity decode

### DIFF
--- a/src/main/io/dronecan/dronecan_gnss.c
+++ b/src/main/io/dronecan/dronecan_gnss.c
@@ -48,11 +48,11 @@
 #define FIX2_OFFSET_LONGITUDE_1E8   136U   // 37 bits signed
 #define FIX2_OFFSET_LATITUDE_1E8    173U   // 37 bits signed
 #define FIX2_OFFSET_HEIGHT_MSL_MM   237U   // 27 bits signed
-#define FIX2_OFFSET_VEL_N_F16       264U   // 16 bits float16
-#define FIX2_OFFSET_VEL_E_F16       280U   // 16 bits float16
-#define FIX2_OFFSET_VEL_D_F16       296U   // 16 bits float16
-#define FIX2_OFFSET_SATS_USED       312U   //  6 bits unsigned
-#define FIX2_OFFSET_STATUS          318U   //  2 bits unsigned
+#define FIX2_OFFSET_VEL_N_F32       264U   // 32 bits float32
+#define FIX2_OFFSET_VEL_E_F32       296U   // 32 bits float32
+#define FIX2_OFFSET_VEL_D_F32       328U   // 32 bits float32
+#define FIX2_OFFSET_SATS_USED       360U   //  6 bits unsigned
+#define FIX2_OFFSET_STATUS          366U   //  2 bits unsigned
 
 #define CM_PER_METRE                100
 
@@ -82,24 +82,20 @@ static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
     int64_t lon_1e8 = 0;
     int64_t lat_1e8 = 0;
     int32_t height_msl_mm = 0;
-    uint16_t velN_f16 = 0;
-    uint16_t velE_f16 = 0;
-    uint16_t velD_f16 = 0;
+    float velN = 0.0f;
+    float velE = 0.0f;
+    float velD = 0.0f;
     uint8_t satsUsed = 0;
     uint8_t status = 0;
 
     canardDecodeScalar(t, FIX2_OFFSET_LONGITUDE_1E8,  37, true,  &lon_1e8);
     canardDecodeScalar(t, FIX2_OFFSET_LATITUDE_1E8,   37, true,  &lat_1e8);
     canardDecodeScalar(t, FIX2_OFFSET_HEIGHT_MSL_MM,  27, true,  &height_msl_mm);
-    canardDecodeScalar(t, FIX2_OFFSET_VEL_N_F16,      16, false, &velN_f16);
-    canardDecodeScalar(t, FIX2_OFFSET_VEL_E_F16,      16, false, &velE_f16);
-    canardDecodeScalar(t, FIX2_OFFSET_VEL_D_F16,      16, false, &velD_f16);
+    canardDecodeScalar(t, FIX2_OFFSET_VEL_N_F32,      32, false, &velN);
+    canardDecodeScalar(t, FIX2_OFFSET_VEL_E_F32,      32, false, &velE);
+    canardDecodeScalar(t, FIX2_OFFSET_VEL_D_F32,      32, false, &velD);
     canardDecodeScalar(t, FIX2_OFFSET_SATS_USED,       6, false, &satsUsed);
     canardDecodeScalar(t, FIX2_OFFSET_STATUS,          2, false, &status);
-
-    const float velN = canardConvertFloat16ToNativeFloat(velN_f16);
-    const float velE = canardConvertFloat16ToNativeFloat(velE_f16);
-    const float velD = canardConvertFloat16ToNativeFloat(velD_f16);
 
     const float speed2d = sqrtf(velN * velN + velE * velE);
     const float speed3d = sqrtf(velN * velN + velE * velE + velD * velD);

--- a/src/main/io/dronecan/dronecan_msg.h
+++ b/src/main/io/dronecan/dronecan_msg.h
@@ -42,7 +42,7 @@
 // fix state). Superset of the legacy Fix message; most CAN GNSS modules
 // publish this variant.
 #define UAVCAN_GNSS_FIX2_ID             1063U
-#define UAVCAN_GNSS_FIX2_SIGNATURE      0xca41e928aebcb2d9ULL
+#define UAVCAN_GNSS_FIX2_SIGNATURE      0xca41e7000f37435fULL
 
 // Fix2.status enum values.
 #define UAVCAN_GNSS_FIX2_STATUS_NO_FIX      0U


### PR DESCRIPTION
The Fix2 data-type signature didn't match the official DSDL, so libcanard rejected every multi-frame Fix2 transfer on its CRC, and `ned_velocity` was read as float16 where the DSDL defines `float32[3]`, misaligning every field after it — DroneCAN GPS couldn't deliver a solution at all. Signature verified against the DSDL compiler output and ecosystem-generated headers (`0xca41e7000f37435f`). Minimal on purpose so it can be cherry-picked to 2026.6.

Fixes #15390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DroneCAN GNSS Fix2 message handling by correctly decoding velocity values, resulting in more accurate north, east, and down velocity data.
  - Updated message compatibility information to align with the current GNSS Fix2 format.
  - Preserved existing position, altitude, satellite count, and status processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->