### PR TITLE
DroneCAN: decode full Fix2 and add GNSS Auxiliary DOP

### DIFF
--- a/src/main/io/dronecan/dronecan.c
+++ b/src/main/io/dronecan/dronecan.c
@@ -259,7 +259,9 @@ void dronecanInit(void)
     dronecanNodeInit();
     // Install the GNSS Fix2 subscriber so a DroneCAN GPS module's broadcasts
     // land in our cache as soon as the transport is live.
+#ifdef USE_GPS
     dronecanGnssInit();
+#endif
 
     canRegisterRxCallback(dronecanDevice, dronecanCanRxAdapter);
 

--- a/src/main/io/dronecan/dronecan_gnss.c
+++ b/src/main/io/dronecan/dronecan_gnss.c
@@ -21,7 +21,7 @@
 
 #include "platform.h"
 
-#if ENABLE_DRONECAN
+#if ENABLE_DRONECAN && defined(USE_GPS)
 
 #include <math.h>
 #include <stdbool.h>
@@ -316,4 +316,4 @@ timeUs_t dronecanGnssLastUpdateUs(void)
     return t;
 }
 
-#endif // ENABLE_DRONECAN
+#endif // ENABLE_DRONECAN && USE_GPS

--- a/src/main/io/dronecan/dronecan_gnss.c
+++ b/src/main/io/dronecan/dronecan_gnss.c
@@ -68,6 +68,13 @@ static volatile uint32_t latestSeq = 0;
 static volatile bool received = false;
 static volatile timeUs_t lastUpdateUs = 0;
 
+// Auxiliary hdop/vdop are only carried across Fix2 refreshes while fresh, so
+// a module that stops broadcasting Auxiliary can't pin stale quality figures
+// to live positions. Both handlers run in the dronecan task, so no seqlock.
+#define DRONECAN_GNSS_AUX_FRESH_US 2000000
+static timeUs_t auxUpdateUs = 0;
+static bool auxReceived = false;
+
 static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
 {
     UNUSED(ins);
@@ -115,21 +122,45 @@ static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
         uint8_t covLength = 0;
         canardDecodeScalar(t, bit, 6, false, &covLength); bit += 6;
 
-        // Covariance is a 6x6 position/velocity matrix. Modules send either
-        // the full row-major matrix (36) or just its diagonal (6); any other
-        // length carries no usable per-axis variance.
+        // Covariance is a 6x6 position/velocity matrix; modules send a scalar
+        // (1), the diagonal (6), the upper triangle row-major (21) or the full
+        // row-major matrix (36). Guard the claimed length against the payload
+        // so a truncated or malformed transfer can't be read past its end.
         float diag[6];
         bool haveDiag = false;
-        if (covLength == 6) {
-            for (unsigned i = 0; i < 6; i++) {
-                diag[i] = dronecanDecodeFloat16(t, bit + i * 16U);
+        if (bit + (uint32_t)covLength * 16U <= payloadBits) {
+            // Diagonal element positions within the upper-triangular encoding.
+            static const uint8_t triDiag[6] = { 0, 6, 11, 15, 18, 20 };
+            switch (covLength) {
+            case 1: {
+                const float var = dronecanDecodeFloat16(t, bit);
+                for (unsigned i = 0; i < 6; i++) {
+                    diag[i] = var;
+                }
+                haveDiag = true;
+                break;
             }
-            haveDiag = true;
-        } else if (covLength == 36) {
-            for (unsigned i = 0; i < 6; i++) {
-                diag[i] = dronecanDecodeFloat16(t, bit + (i * 6U + i) * 16U);
+            case 6:
+                for (unsigned i = 0; i < 6; i++) {
+                    diag[i] = dronecanDecodeFloat16(t, bit + i * 16U);
+                }
+                haveDiag = true;
+                break;
+            case 21:
+                for (unsigned i = 0; i < 6; i++) {
+                    diag[i] = dronecanDecodeFloat16(t, bit + triDiag[i] * 16U);
+                }
+                haveDiag = true;
+                break;
+            case 36:
+                for (unsigned i = 0; i < 6; i++) {
+                    diag[i] = dronecanDecodeFloat16(t, bit + (i * 6U + i) * 16U);
+                }
+                haveDiag = true;
+                break;
+            default:
+                break;
             }
-            haveDiag = true;
         }
 
         if (haveDiag) {
@@ -180,10 +211,12 @@ static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
     latestSeq++;
     __asm volatile ("" ::: "memory");
 
-    // hdop/vdop arrive on the Auxiliary message; preserve them across the
-    // reset so a Fix2 update doesn't wipe the last DOP figures.
-    const uint16_t hdop = latest.dop.hdop;
-    const uint16_t vdop = latest.dop.vdop;
+    // hdop/vdop arrive on the Auxiliary message; carry them across the reset
+    // only while Auxiliary is still broadcasting.
+    const bool auxFresh = auxReceived
+            && cmpTimeUs(micros(), auxUpdateUs) < DRONECAN_GNSS_AUX_FRESH_US;
+    const uint16_t hdop = auxFresh ? latest.dop.hdop : 0;
+    const uint16_t vdop = auxFresh ? latest.dop.vdop : 0;
 
     memset(&latest, 0, sizeof(latest));
     latest.llh.lat   = scaleLonLat_1e8to1e7(lat_1e8);
@@ -230,6 +263,9 @@ static void handleAuxiliary(CanardInstance *ins, CanardRxTransfer *t)
     const float hdop = dronecanDecodeFloat16(t, 32);
     const float vdop = dronecanDecodeFloat16(t, 48);
 
+    auxUpdateUs = micros();
+    auxReceived = true;
+
     latestSeq++;
     __asm volatile ("" ::: "memory");
 
@@ -251,6 +287,8 @@ void dronecanGnssInit(void)
     memset(&latest, 0, sizeof(latest));
     received = false;
     lastUpdateUs = 0;
+    auxUpdateUs = 0;
+    auxReceived = false;
 
     const dronecanSubscriber_t fix2Sub = {
         .signature    = UAVCAN_GNSS_FIX2_SIGNATURE,

--- a/src/main/io/dronecan/dronecan_gnss.c
+++ b/src/main/io/dronecan/dronecan_gnss.c
@@ -40,21 +40,14 @@
 #include "io/dronecan/dronecan_gnss.h"
 #include "io/dronecan/dronecan_msg.h"
 
-// Bit offsets into the Fix2 payload (from the DSDL definition). The header
-// fields up to sub_mode are fixed — everything past that (covariance, pdop,
-// ecef) is variable-length with TAO rules, so we stop at sub_mode until we
-// need those fields. bit_length values that cross byte boundaries are why
-// we lean on canardDecodeScalar() rather than a packed struct cast.
-#define FIX2_OFFSET_LONGITUDE_1E8   136U   // 37 bits signed
-#define FIX2_OFFSET_LATITUDE_1E8    173U   // 37 bits signed
-#define FIX2_OFFSET_HEIGHT_MSL_MM   237U   // 27 bits signed
-#define FIX2_OFFSET_VEL_N_F32       264U   // 32 bits float32
-#define FIX2_OFFSET_VEL_E_F32       296U   // 32 bits float32
-#define FIX2_OFFSET_VEL_D_F32       328U   // 32 bits float32
-#define FIX2_OFFSET_SATS_USED       360U   //  6 bits unsigned
-#define FIX2_OFFSET_STATUS          366U   //  2 bits unsigned
-
 #define CM_PER_METRE                100
+
+static float dronecanDecodeFloat16(const CanardRxTransfer *t, uint32_t bitOffset)
+{
+    uint16_t raw = 0;
+    canardDecodeScalar(t, bitOffset, 16, false, &raw);
+    return canardConvertFloat16ToNativeFloat(raw);
+}
 
 // Scale 1e8 degrees down to the betaflight 1e7 convention. Divide before
 // the int32 cast so we don't overflow on high-latitude values.
@@ -79,23 +72,100 @@ static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
 {
     UNUSED(ins);
 
+    uint64_t gnssTimeUsec = 0;
+    uint8_t timeStandard = 0;
     int64_t lon_1e8 = 0;
     int64_t lat_1e8 = 0;
-    int32_t height_msl_mm = 0;
+    int32_t heightMslMm = 0;
     float velN = 0.0f;
     float velE = 0.0f;
     float velD = 0.0f;
     uint8_t satsUsed = 0;
     uint8_t status = 0;
 
-    canardDecodeScalar(t, FIX2_OFFSET_LONGITUDE_1E8,  37, true,  &lon_1e8);
-    canardDecodeScalar(t, FIX2_OFFSET_LATITUDE_1E8,   37, true,  &lat_1e8);
-    canardDecodeScalar(t, FIX2_OFFSET_HEIGHT_MSL_MM,  27, true,  &height_msl_mm);
-    canardDecodeScalar(t, FIX2_OFFSET_VEL_N_F32,      32, false, &velN);
-    canardDecodeScalar(t, FIX2_OFFSET_VEL_E_F32,      32, false, &velE);
-    canardDecodeScalar(t, FIX2_OFFSET_VEL_D_F32,      32, false, &velD);
-    canardDecodeScalar(t, FIX2_OFFSET_SATS_USED,       6, false, &satsUsed);
-    canardDecodeScalar(t, FIX2_OFFSET_STATUS,          2, false, &status);
+    // Walk the payload as a running bit offset: the covariance/pdop tail is
+    // variable-length, so it can't be reached with absolute offsets. Note
+    // ned_velocity is float32[3] (96 bits) — a narrower read would misalign
+    // every field that follows it.
+    uint32_t bit = 0;
+    bit += 56;                                                       // timestamp
+    canardDecodeScalar(t, bit, 56, false, &gnssTimeUsec); bit += 56; // gnss_timestamp
+    canardDecodeScalar(t, bit,  3, false, &timeStandard); bit += 3;
+    bit += 13;                                                       // void13
+    bit += 8;                                                        // num_leap_seconds
+    canardDecodeScalar(t, bit, 37, true,  &lon_1e8);      bit += 37;
+    canardDecodeScalar(t, bit, 37, true,  &lat_1e8);      bit += 37;
+    bit += 27;                                                       // height_ellipsoid_mm
+    canardDecodeScalar(t, bit, 27, true,  &heightMslMm);  bit += 27;
+    canardDecodeScalar(t, bit, 32, false, &velN);         bit += 32;
+    canardDecodeScalar(t, bit, 32, false, &velE);         bit += 32;
+    canardDecodeScalar(t, bit, 32, false, &velD);         bit += 32;
+    canardDecodeScalar(t, bit,  6, false, &satsUsed);     bit += 6;
+    canardDecodeScalar(t, bit,  2, false, &status);       bit += 2;
+    bit += 4;                                                        // mode
+    bit += 6;                                                        // sub_mode
+
+    uint32_t hAccMm = 0;
+    uint32_t vAccMm = 0;
+    uint32_t sAccMmS = 0;
+    uint16_t pdop100 = 0;
+
+    const uint32_t payloadBits = (uint32_t)t->payload_len * 8U;
+    if (bit + 6U <= payloadBits) {
+        uint8_t covLength = 0;
+        canardDecodeScalar(t, bit, 6, false, &covLength); bit += 6;
+
+        // Covariance is a 6x6 position/velocity matrix. Modules send either
+        // the full row-major matrix (36) or just its diagonal (6); any other
+        // length carries no usable per-axis variance.
+        float diag[6];
+        bool haveDiag = false;
+        if (covLength == 6) {
+            for (unsigned i = 0; i < 6; i++) {
+                diag[i] = dronecanDecodeFloat16(t, bit + i * 16U);
+            }
+            haveDiag = true;
+        } else if (covLength == 36) {
+            for (unsigned i = 0; i < 6; i++) {
+                diag[i] = dronecanDecodeFloat16(t, bit + (i * 6U + i) * 16U);
+            }
+            haveDiag = true;
+        }
+
+        if (haveDiag) {
+            const float hVar = 0.5f * (diag[0] + diag[1]);
+            const float vVar = diag[2];
+            const float sVar = (diag[3] + diag[4] + diag[5]) / 3.0f;
+            if (hVar > 0.0f) {
+                hAccMm = (uint32_t)(sqrtf(hVar) * 1000.0f);
+            }
+            if (vVar > 0.0f) {
+                vAccMm = (uint32_t)(sqrtf(vVar) * 1000.0f);
+            }
+            if (sVar > 0.0f) {
+                sAccMmS = (uint32_t)(sqrtf(sVar) * 1000.0f);
+            }
+        }
+
+        bit += (uint32_t)covLength * 16U;
+        if (bit + 16U <= payloadBits) {
+            const float pdop = dronecanDecodeFloat16(t, bit);
+            if (!isnan(pdop) && pdop > 0.0f) {
+                pdop100 = (uint16_t)constrainf(pdop * 100.0f, 0, UINT16_MAX);
+            }
+        }
+    }
+
+    gpsDateTime_t dateTime;
+    memset(&dateTime, 0, sizeof(dateTime));
+    // GPS/TAI stamps need leap-second bookkeeping to become a wall clock, so
+    // only UTC is converted; other standards leave the calendar untouched.
+    if (timeStandard == UAVCAN_GNSS_TIME_STANDARD_UTC && gnssTimeUsec != 0) {
+        gpsUnixSecondsToDateTime(&dateTime,
+                                 (int64_t)(gnssTimeUsec / 1000000ULL),
+                                 (uint16_t)((gnssTimeUsec / 1000ULL) % 1000ULL));
+        dateTime.valid = true;
+    }
 
     const float speed2d = sqrtf(velN * velN + velE * velE);
     const float speed3d = sqrtf(velN * velN + velE * velE + velD * velD);
@@ -110,10 +180,15 @@ static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
     latestSeq++;
     __asm volatile ("" ::: "memory");
 
+    // hdop/vdop arrive on the Auxiliary message; preserve them across the
+    // reset so a Fix2 update doesn't wipe the last DOP figures.
+    const uint16_t hdop = latest.dop.hdop;
+    const uint16_t vdop = latest.dop.vdop;
+
     memset(&latest, 0, sizeof(latest));
     latest.llh.lat   = scaleLonLat_1e8to1e7(lat_1e8);
     latest.llh.lon   = scaleLonLat_1e8to1e7(lon_1e8);
-    latest.llh.altCm = height_msl_mm / 10; // mm -> cm
+    latest.llh.altCm = heightMslMm / 10; // mm -> cm
     // Fix2 reports NED and gpsVelned_t is NED, so forward N/E/D unchanged
     // (velD is Down, positive downward).
     latest.velned.velN = (int16_t)constrainf(velN * CM_PER_METRE, INT16_MIN, INT16_MAX);
@@ -123,6 +198,13 @@ static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
     latest.speed3d     = (uint16_t)constrainf(speed3d * CM_PER_METRE, 0, UINT16_MAX);
     latest.groundCourse = (uint16_t)constrainf(courseDeg * 10.0f, 0, UINT16_MAX);
     latest.numSat      = satsUsed;
+    latest.acc.hAcc    = hAccMm;
+    latest.acc.vAcc    = vAccMm;
+    latest.acc.sAcc    = sAccMmS;
+    latest.dop.pdop    = pdop100;
+    latest.dop.hdop    = hdop;
+    latest.dop.vdop    = vdop;
+    latest.dateTime    = dateTime;
 
     // Signal a loss of fix explicitly so the downstream state can react
     // rather than stay armed on the last position.
@@ -138,6 +220,30 @@ static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
     latestSeq++;
 }
 
+static void handleAuxiliary(CanardInstance *ins, CanardRxTransfer *t)
+{
+    UNUSED(ins);
+
+    // Field order is gdop, pdop, hdop, vdop, ...; only hdop/vdop are taken —
+    // pdop stays sourced from Fix2 so both providers scale it identically.
+    // Unknown DOP values are transmitted as NaN.
+    const float hdop = dronecanDecodeFloat16(t, 32);
+    const float vdop = dronecanDecodeFloat16(t, 48);
+
+    latestSeq++;
+    __asm volatile ("" ::: "memory");
+
+    if (!isnan(hdop) && hdop > 0.0f) {
+        latest.dop.hdop = (uint16_t)constrainf(hdop * 100.0f, 0, UINT16_MAX);
+    }
+    if (!isnan(vdop) && vdop > 0.0f) {
+        latest.dop.vdop = (uint16_t)constrainf(vdop * 100.0f, 0, UINT16_MAX);
+    }
+
+    __asm volatile ("" ::: "memory");
+    latestSeq++;
+}
+
 void dronecanGnssInit(void)
 {
     // Clear the cache before registering so a frame that lands between
@@ -146,13 +252,21 @@ void dronecanGnssInit(void)
     received = false;
     lastUpdateUs = 0;
 
-    const dronecanSubscriber_t sub = {
+    const dronecanSubscriber_t fix2Sub = {
         .signature    = UAVCAN_GNSS_FIX2_SIGNATURE,
         .dataTypeId   = UAVCAN_GNSS_FIX2_ID,
         .transferType = CanardTransferTypeBroadcast,
         .handler      = handleFix2,
     };
-    (void)dronecanRegisterSubscriber(&sub);
+    (void)dronecanRegisterSubscriber(&fix2Sub);
+
+    const dronecanSubscriber_t auxSub = {
+        .signature    = UAVCAN_GNSS_AUXILIARY_SIGNATURE,
+        .dataTypeId   = UAVCAN_GNSS_AUXILIARY_ID,
+        .transferType = CanardTransferTypeBroadcast,
+        .handler      = handleAuxiliary,
+    };
+    (void)dronecanRegisterSubscriber(&auxSub);
 }
 
 bool dronecanGnssGetLatest(gpsSolutionData_t *out)

--- a/src/main/io/dronecan/dronecan_gnss.h
+++ b/src/main/io/dronecan/dronecan_gnss.h
@@ -31,14 +31,14 @@
 #include "common/time.h"
 #include "io/gps.h"
 
-// Install the Fix2 subscriber. Call once from dronecanInit() after the base
-// subscriber table has been initialised.
+// Install the Fix2 and Auxiliary subscribers. Call once from dronecanInit()
+// after the base subscriber table has been initialised.
 void dronecanGnssInit(void);
 
 // Pull the last-received solution into the caller's buffer. Returns false if
-// no frame has been received yet. Populated fields today: llh, numSat,
-// groundSpeed, groundCourse, speed3d, velned. dop / acc / dateTime are left
-// zero until a follow-up decodes covariance + pdop past the Fix2 TAO fields.
+// no Fix2 frame has been received yet. dop.pdop and acc come from Fix2
+// (covariance + pdop), dop.hdop/vdop from Auxiliary, and dateTime from the
+// Fix2 UTC timestamp when the module reports the UTC time standard.
 bool dronecanGnssGetLatest(gpsSolutionData_t *out);
 
 // Microsecond timestamp of the most recent accepted Fix2 (host clock, not

--- a/src/main/io/dronecan/dronecan_msg.h
+++ b/src/main/io/dronecan/dronecan_msg.h
@@ -44,11 +44,23 @@
 #define UAVCAN_GNSS_FIX2_ID             1063U
 #define UAVCAN_GNSS_FIX2_SIGNATURE      0xca41e7000f37435fULL
 
+// uavcan.equipment.gnss.Auxiliary — low-priority companion to Fix2 carrying
+// the dilution-of-precision figures (gdop/pdop/hdop/vdop/...).
+#define UAVCAN_GNSS_AUXILIARY_ID        1061U
+#define UAVCAN_GNSS_AUXILIARY_SIGNATURE 0x9be8bdc4c3dbbfd2ULL
+
 // Fix2.status enum values.
 #define UAVCAN_GNSS_FIX2_STATUS_NO_FIX      0U
 #define UAVCAN_GNSS_FIX2_STATUS_TIME_ONLY   1U
 #define UAVCAN_GNSS_FIX2_STATUS_2D_FIX      2U
 #define UAVCAN_GNSS_FIX2_STATUS_3D_FIX      3U
+
+// Fix2.gnss_time_standard enum values. Only UTC maps to a wall-clock calendar
+// without external leap-second bookkeeping.
+#define UAVCAN_GNSS_TIME_STANDARD_NONE      0U
+#define UAVCAN_GNSS_TIME_STANDARD_TAI       1U
+#define UAVCAN_GNSS_TIME_STANDARD_UTC       2U
+#define UAVCAN_GNSS_TIME_STANDARD_GPS       3U
 
 // NodeStatus.health
 #define UAVCAN_NODE_HEALTH_OK           0U

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -1346,6 +1346,20 @@ static void updateDronecanGPS(void)
     gpsSol = incoming;
     gpsSol.time = gpsData.now;
 
+#ifdef USE_RTC_TIME
+    if (!rtcHasTime() && gpsSol.dateTime.valid) {
+        dateTime_t dt;
+        dt.year = gpsSol.dateTime.year;
+        dt.month = gpsSol.dateTime.month;
+        dt.day = gpsSol.dateTime.day;
+        dt.hours = gpsSol.dateTime.hour;
+        dt.minutes = gpsSol.dateTime.min;
+        dt.seconds = gpsSol.dateTime.sec;
+        dt.millis = gpsSol.dateTime.millis;
+        rtcSetDateTime(&dt);
+    }
+#endif
+
     gpsData.lastNavMessage = gpsData.now;
     sensorsSet(SENSOR_GPS);
 
@@ -2267,7 +2281,7 @@ static const uint16_t gpsMonthDays[2][12] = {
 };
 
 // Convert Unix seconds and milliseconds to gpsDateTime_t
-static void unixSecondsToDateTime(gpsDateTime_t *dt, int64_t unixSeconds, uint16_t millis)
+void gpsUnixSecondsToDateTime(gpsDateTime_t *dt, int64_t unixSeconds, uint16_t millis)
 {
     dt->sec = unixSeconds % 60;
     unixSeconds /= 60;
@@ -2458,7 +2472,7 @@ static void gpsWeekTimeToDateTime(gpsDateTime_t *dt, int16_t week, uint32_t time
     }
 
     int64_t unixSeconds = gpsSeconds + GPS_EPOCH_OFFSET_SECONDS - GPS_LEAP_SECONDS;
-    unixSecondsToDateTime(dt, unixSeconds, (uint16_t)millis);
+    gpsUnixSecondsToDateTime(dt, unixSeconds, (uint16_t)millis);
 }
 
 static bool UBLOX_parse_gps(void)

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -2042,6 +2042,48 @@ static bool gpsNewFrameNMEA(char c)
 }
 #endif // USE_GPS_NMEA
 
+// Days from start of year for each month (non-leap year first row, leap year second row)
+static const uint16_t gpsMonthDays[2][12] = {
+    { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 }, // Non-leap year
+    { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335 }  // Leap year
+};
+
+// Convert Unix seconds and milliseconds to gpsDateTime_t
+void gpsUnixSecondsToDateTime(gpsDateTime_t *dt, int64_t unixSeconds, uint16_t millis)
+{
+    dt->sec = unixSeconds % 60;
+    unixSeconds /= 60;
+    dt->min = unixSeconds % 60;
+    unixSeconds /= 60;
+    dt->hour = unixSeconds % 24;
+    int32_t days = unixSeconds / 24;
+
+    // Calculate year and day of year from 1970
+    int year = 1970;
+    while (true) {
+        int daysInYear = (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) ? 366 : 365;
+        if (days < daysInYear) {
+            break;
+        }
+        days -= daysInYear;
+        year++;
+    }
+    dt->year = year;
+
+    int isLeap = (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) ? 1 : 0;
+
+    int month;
+    for (month = 11; month > 0; month--) {
+        if (days >= gpsMonthDays[isLeap][month]) {
+            break;
+        }
+    }
+    dt->month = month + 1;
+    dt->day = days - gpsMonthDays[isLeap][month] + 1;
+
+    dt->millis = millis;
+}
+
 #ifdef USE_GPS_UBLOX
 // UBX support
 typedef struct ubxNavPosllh_s {
@@ -2273,48 +2315,6 @@ static uint16_t ubxFrameParsePayloadCounter;
 #define GPS_EPOCH_OFFSET_SECONDS 315964800
 // Current GPS-UTC leap seconds offset (as of 2017, 18 leap seconds)
 #define GPS_LEAP_SECONDS 18
-
-// Days from start of year for each month (non-leap year first row, leap year second row)
-static const uint16_t gpsMonthDays[2][12] = {
-    { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 }, // Non-leap year
-    { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335 }  // Leap year
-};
-
-// Convert Unix seconds and milliseconds to gpsDateTime_t
-void gpsUnixSecondsToDateTime(gpsDateTime_t *dt, int64_t unixSeconds, uint16_t millis)
-{
-    dt->sec = unixSeconds % 60;
-    unixSeconds /= 60;
-    dt->min = unixSeconds % 60;
-    unixSeconds /= 60;
-    dt->hour = unixSeconds % 24;
-    int32_t days = unixSeconds / 24;
-
-    // Calculate year and day of year from 1970
-    int year = 1970;
-    while (true) {
-        int daysInYear = (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) ? 366 : 365;
-        if (days < daysInYear) {
-            break;
-        }
-        days -= daysInYear;
-        year++;
-    }
-    dt->year = year;
-
-    int isLeap = (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) ? 1 : 0;
-
-    int month;
-    for (month = 11; month > 0; month--) {
-        if (days >= gpsMonthDays[isLeap][month]) {
-            break;
-        }
-    }
-    dt->month = month + 1;
-    dt->day = days - gpsMonthDays[isLeap][month] + 1;
-
-    dt->millis = millis;
-}
 
 // Convert date/time to Unix seconds (UTC)
 static int64_t dateTimeToUnixSeconds(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec)

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -427,3 +427,4 @@ float getGpsCosLat(void);
 
 baudRate_e getGpsPortActualBaudRateIndex(void);
 uint32_t gpsDateTimeToEpoch(const gpsDateTime_t *dt);
+void gpsUnixSecondsToDateTime(gpsDateTime_t *dt, int64_t unixSeconds, uint16_t millis);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -242,6 +242,15 @@ dronecan_gnss_unittest_DEFINES := \
 dronecan_gnss_unittest_INCLUDE_DIRS := \
 		$(ROOT)/lib/modules/dronecan/libcanard
 
+# libcanard is a submodule the firmware Makefile hydrates on demand; a test-only
+# checkout (CI's test job) arrives without it.
+$(ROOT)/lib/modules/dronecan/libcanard/canard.c:
+	git -C $(ROOT) submodule update --init -- lib/modules/dronecan/libcanard
+
+$(OBJECT_DIR)/dronecan_gnss_unittest/dronecan_gnss_libcanard.c.o \
+$(OBJECT_DIR)/dronecan_gnss_unittest/dronecan_gnss_unittest.o: \
+		$(ROOT)/lib/modules/dronecan/libcanard/canard.c
+
 
 io_serial_unittest_SRC := \
 		$(USER_DIR)/io/serial.c \

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -233,6 +233,16 @@ gps_conversion_unittest_SRC := \
 		$(USER_DIR)/common/gps_conversion.c
 
 
+dronecan_gnss_unittest_SRC := \
+		$(TEST_DIR)/dronecan_gnss_libcanard.c
+
+dronecan_gnss_unittest_DEFINES := \
+		ENABLE_DRONECAN=1
+
+dronecan_gnss_unittest_INCLUDE_DIRS := \
+		$(ROOT)/lib/modules/dronecan/libcanard
+
+
 io_serial_unittest_SRC := \
 		$(USER_DIR)/io/serial.c \
 		$(USER_DIR)/io/serial_resource.c

--- a/src/test/unit/dronecan_gnss_libcanard.c
+++ b/src/test/unit/dronecan_gnss_libcanard.c
@@ -1,0 +1,4 @@
+// libcanard is external to src/main, so the test Makefile has no rule to
+// compile it directly. Pull the plain-C translation unit in here (as C) so the
+// decoder under test links against the real canardDecodeScalar/Encode helpers.
+#include "canard.c"

--- a/src/test/unit/dronecan_gnss_libcanard.c
+++ b/src/test/unit/dronecan_gnss_libcanard.c
@@ -1,4 +1,7 @@
 // libcanard is external to src/main, so the test Makefile has no rule to
 // compile it directly. Pull the plain-C translation unit in here (as C) so the
 // decoder under test links against the real canardDecodeScalar/Encode helpers.
+#if !__has_include("canard.c")
+#error "libcanard missing; run: git submodule update --init lib/modules/dronecan/libcanard"
+#endif
 #include "canard.c"

--- a/src/test/unit/dronecan_gnss_unittest.cc
+++ b/src/test/unit/dronecan_gnss_unittest.cc
@@ -1,0 +1,293 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+
+extern "C" {
+    #include "platform.h"
+
+    #include "canard.h"
+    #include "io/gps.h"
+    #include "io/dronecan/dronecan.h"
+    #include "io/dronecan/dronecan_gnss.h"
+    #include "io/dronecan/dronecan_msg.h"
+
+    static int64_t stubUnixSeconds;
+    static uint16_t stubMillis;
+    static bool stubDateTimeCalled;
+
+    void gpsUnixSecondsToDateTime(gpsDateTime_t *dt, int64_t unixSeconds, uint16_t millis)
+    {
+        stubUnixSeconds = unixSeconds;
+        stubMillis = millis;
+        stubDateTimeCalled = true;
+        memset(dt, 0, sizeof(*dt));
+        dt->year = 2021;
+        dt->month = 1;
+        dt->day = 1;
+        dt->millis = millis;
+    }
+
+    bool dronecanRegisterSubscriber(const dronecanSubscriber_t *subscriber)
+    {
+        (void)subscriber;
+        return true;
+    }
+
+    timeUs_t micros(void) { return 0; }
+
+    // Pulled in as source so the tests can drive the static frame handlers and
+    // inspect the seqlock-published cache directly.
+    #include "io/dronecan/dronecan_gnss.c"
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+static void encodeF32(uint8_t *buf, uint32_t bit, float value)
+{
+    canardEncodeScalar(buf, bit, 32, &value);
+}
+
+static void encodeF16(uint8_t *buf, uint32_t bit, float value)
+{
+    uint16_t raw = canardConvertNativeFloatToFloat16(value);
+    canardEncodeScalar(buf, bit, 16, &raw);
+}
+
+static void resetCache(void)
+{
+    memset(&latest, 0, sizeof(latest));
+    latestSeq = 0;
+    received = false;
+    lastUpdateUs = 0;
+    stubDateTimeCalled = false;
+    stubUnixSeconds = 0;
+    stubMillis = 0;
+}
+
+// Builds a Fix2 payload carrying a 3D fix, a 6-entry (diagonal) covariance and
+// pdop, with a UTC gnss_timestamp. Returns the payload length in bytes.
+static uint16_t buildFix2(uint8_t *buf)
+{
+    memset(buf, 0, 64);
+
+    const uint64_t gnssUsec = 1609459200123456ULL; // 2021-01-01T00:00:00.123456Z
+    const uint8_t timeStandard = UAVCAN_GNSS_TIME_STANDARD_UTC;
+    const int64_t lon_1e8 = 900000000LL;   //   9.0 deg
+    const int64_t lat_1e8 = 4500000000LL;  //  45.0 deg
+    const int32_t heightMslMm = 100000;    // 100 m
+    const uint8_t satsUsed = 12;
+    const uint8_t status = UAVCAN_GNSS_FIX2_STATUS_3D_FIX;
+
+    canardEncodeScalar(buf, 56, 56, &gnssUsec);
+    canardEncodeScalar(buf, 112, 3, &timeStandard);
+    canardEncodeScalar(buf, 136, 37, &lon_1e8);
+    canardEncodeScalar(buf, 173, 37, &lat_1e8);
+    canardEncodeScalar(buf, 237, 27, &heightMslMm);
+    encodeF32(buf, 264, 5.0f);   // velN
+    encodeF32(buf, 296, 3.0f);   // velE
+    encodeF32(buf, 328, -1.0f);  // velD
+    canardEncodeScalar(buf, 360, 6, &satsUsed);
+    canardEncodeScalar(buf, 366, 2, &status);
+
+    const uint8_t covLength = 6;
+    canardEncodeScalar(buf, 378, 6, &covLength);
+    encodeF16(buf, 384 + 0 * 16, 4.0f);   // xx  (m^2)
+    encodeF16(buf, 384 + 1 * 16, 9.0f);   // yy  (m^2)
+    encodeF16(buf, 384 + 2 * 16, 16.0f);  // zz  (m^2)
+    encodeF16(buf, 384 + 3 * 16, 0.25f);  // vxx ((m/s)^2)
+    encodeF16(buf, 384 + 4 * 16, 0.25f);  // vyy
+    encodeF16(buf, 384 + 5 * 16, 1.0f);   // vzz
+    encodeF16(buf, 480, 1.5f);            // pdop
+
+    return 62; // 496 bits
+}
+
+static uint16_t buildAuxiliary(uint8_t *buf)
+{
+    memset(buf, 0, 32);
+    encodeF16(buf, 32, 0.75f); // hdop
+    encodeF16(buf, 48, 1.5f);  // vdop
+    return 16;
+}
+
+static void feed(void (*handler)(CanardInstance *, CanardRxTransfer *),
+                 const uint8_t *payload, uint16_t len)
+{
+    CanardRxTransfer t;
+    memset(&t, 0, sizeof(t));
+    t.payload_head = payload;
+    t.payload_len = len;
+    t.payload_middle = NULL;
+    t.payload_tail = NULL;
+    handler(NULL, &t);
+}
+
+TEST(DronecanGnssTest, Fix2PositionVelocity)
+{
+    resetCache();
+
+    uint8_t buf[64];
+    const uint16_t len = buildFix2(buf);
+    feed(handleFix2, buf, len);
+
+    gpsSolutionData_t sol;
+    ASSERT_TRUE(dronecanGnssGetLatest(&sol));
+
+    EXPECT_EQ(450000000, sol.llh.lat);
+    EXPECT_EQ(90000000, sol.llh.lon);
+    EXPECT_EQ(10000, sol.llh.altCm);
+    EXPECT_EQ(500, sol.velned.velN);
+    EXPECT_EQ(300, sol.velned.velE);
+    EXPECT_EQ(-100, sol.velned.velD);
+    EXPECT_EQ(583, sol.groundSpeed); // sqrt(34) m/s * 100
+    EXPECT_EQ(591, sol.speed3d);     // sqrt(35) m/s * 100
+    EXPECT_EQ(309, sol.groundCourse);
+    EXPECT_EQ(12, sol.numSat);
+}
+
+TEST(DronecanGnssTest, Fix2CovarianceToAccuracy)
+{
+    resetCache();
+
+    uint8_t buf[64];
+    const uint16_t len = buildFix2(buf);
+    feed(handleFix2, buf, len);
+
+    gpsSolutionData_t sol;
+    ASSERT_TRUE(dronecanGnssGetLatest(&sol));
+
+    // hAcc = sqrt(mean(xx,yy)) = sqrt(6.5) m -> mm
+    EXPECT_EQ((uint32_t)(sqrtf(6.5f) * 1000.0f), sol.acc.hAcc);
+    // vAcc = sqrt(zz) = 4 m -> mm
+    EXPECT_EQ(4000u, sol.acc.vAcc);
+    // sAcc = sqrt(mean(vxx,vyy,vzz)) = sqrt(0.5) m/s -> mm/s
+    EXPECT_EQ((uint32_t)(sqrtf(0.5f) * 1000.0f), sol.acc.sAcc);
+    // pdop 1.5 * 100
+    EXPECT_EQ(150, sol.dop.pdop);
+}
+
+TEST(DronecanGnssTest, Fix2FullCovarianceMatrix)
+{
+    resetCache();
+
+    uint8_t buf[128];
+    memset(buf, 0, sizeof(buf));
+
+    const uint8_t status = UAVCAN_GNSS_FIX2_STATUS_3D_FIX;
+    canardEncodeScalar(buf, 366, 2, &status);
+
+    const uint8_t covLength = 36;
+    canardEncodeScalar(buf, 378, 6, &covLength);
+    // Full 6x6 row-major; only the diagonal is consumed.
+    encodeF16(buf, 384 + 0 * 16, 4.0f);
+    encodeF16(buf, 384 + 7 * 16, 9.0f);
+    encodeF16(buf, 384 + 14 * 16, 16.0f);
+    encodeF16(buf, 384 + 21 * 16, 0.25f);
+    encodeF16(buf, 384 + 28 * 16, 0.25f);
+    encodeF16(buf, 384 + 35 * 16, 1.0f);
+    const uint32_t pdopBit = 384 + 36 * 16;
+    encodeF16(buf, pdopBit, 1.5f);
+    const uint16_t len = (uint16_t)((pdopBit + 16 + 7) / 8);
+
+    feed(handleFix2, buf, len);
+
+    gpsSolutionData_t sol;
+    ASSERT_TRUE(dronecanGnssGetLatest(&sol));
+
+    EXPECT_EQ((uint32_t)(sqrtf(6.5f) * 1000.0f), sol.acc.hAcc);
+    EXPECT_EQ(4000u, sol.acc.vAcc);
+    EXPECT_EQ((uint32_t)(sqrtf(0.5f) * 1000.0f), sol.acc.sAcc);
+    EXPECT_EQ(150, sol.dop.pdop);
+}
+
+TEST(DronecanGnssTest, Fix2UtcTimestamp)
+{
+    resetCache();
+
+    uint8_t buf[64];
+    const uint16_t len = buildFix2(buf);
+    feed(handleFix2, buf, len);
+
+    gpsSolutionData_t sol;
+    ASSERT_TRUE(dronecanGnssGetLatest(&sol));
+
+    EXPECT_TRUE(stubDateTimeCalled);
+    EXPECT_EQ(1609459200, stubUnixSeconds);
+    EXPECT_EQ(123, stubMillis);
+    EXPECT_TRUE(sol.dateTime.valid);
+}
+
+TEST(DronecanGnssTest, AuxiliaryDop)
+{
+    resetCache();
+
+    uint8_t fix2[64];
+    feed(handleFix2, fix2, buildFix2(fix2));
+
+    uint8_t aux[32];
+    feed(handleAuxiliary, aux, buildAuxiliary(aux));
+
+    gpsSolutionData_t sol;
+    ASSERT_TRUE(dronecanGnssGetLatest(&sol));
+
+    EXPECT_EQ(75, sol.dop.hdop);  // 0.75 * 100
+    EXPECT_EQ(150, sol.dop.vdop); // 1.5  * 100
+    EXPECT_EQ(150, sol.dop.pdop); // still from Fix2
+}
+
+TEST(DronecanGnssTest, Fix2PreservesAuxiliaryDop)
+{
+    resetCache();
+
+    uint8_t fix2[64];
+    feed(handleFix2, fix2, buildFix2(fix2));
+
+    uint8_t aux[32];
+    feed(handleAuxiliary, aux, buildAuxiliary(aux));
+
+    // A fresh Fix2 must not wipe the hdop/vdop published by Auxiliary.
+    feed(handleFix2, fix2, buildFix2(fix2));
+
+    gpsSolutionData_t sol;
+    ASSERT_TRUE(dronecanGnssGetLatest(&sol));
+
+    EXPECT_EQ(75, sol.dop.hdop);
+    EXPECT_EQ(150, sol.dop.vdop);
+}
+
+TEST(DronecanGnssTest, Fix2NoFixZeroesSats)
+{
+    resetCache();
+
+    uint8_t buf[64];
+    buildFix2(buf);
+    const uint8_t status = UAVCAN_GNSS_FIX2_STATUS_2D_FIX;
+    canardEncodeScalar(buf, 366, 2, &status);
+    feed(handleFix2, buf, 62);
+
+    gpsSolutionData_t sol;
+    ASSERT_TRUE(dronecanGnssGetLatest(&sol));
+    EXPECT_EQ(0, sol.numSat);
+}

--- a/src/test/unit/dronecan_gnss_unittest.cc
+++ b/src/test/unit/dronecan_gnss_unittest.cc
@@ -54,7 +54,9 @@ extern "C" {
         return true;
     }
 
-    timeUs_t micros(void) { return 0; }
+    static timeUs_t mockMicros = 0;
+
+    timeUs_t micros(void) { return mockMicros; }
 
     // Pulled in as source so the tests can drive the static frame handlers and
     // inspect the seqlock-published cache directly.
@@ -81,6 +83,9 @@ static void resetCache(void)
     latestSeq = 0;
     received = false;
     lastUpdateUs = 0;
+    auxUpdateUs = 0;
+    auxReceived = false;
+    mockMicros = 0;
     stubDateTimeCalled = false;
     stubUnixSeconds = 0;
     stubMillis = 0;
@@ -132,6 +137,8 @@ static uint16_t buildAuxiliary(uint8_t *buf)
     return 16;
 }
 
+static void feedDefaultFix2(void);
+
 static void feed(void (*handler)(CanardInstance *, CanardRxTransfer *),
                  const uint8_t *payload, uint16_t len)
 {
@@ -142,6 +149,12 @@ static void feed(void (*handler)(CanardInstance *, CanardRxTransfer *),
     t.payload_middle = NULL;
     t.payload_tail = NULL;
     handler(NULL, &t);
+}
+
+static void feedDefaultFix2(void)
+{
+    uint8_t buf[64];
+    feed(handleFix2, buf, buildFix2(buf));
 }
 
 TEST(DronecanGnssTest, Fix2PositionVelocity)
@@ -243,8 +256,7 @@ TEST(DronecanGnssTest, AuxiliaryDop)
 {
     resetCache();
 
-    uint8_t fix2[64];
-    feed(handleFix2, fix2, buildFix2(fix2));
+    feedDefaultFix2();
 
     uint8_t aux[32];
     feed(handleAuxiliary, aux, buildAuxiliary(aux));
@@ -261,14 +273,13 @@ TEST(DronecanGnssTest, Fix2PreservesAuxiliaryDop)
 {
     resetCache();
 
-    uint8_t fix2[64];
-    feed(handleFix2, fix2, buildFix2(fix2));
+    feedDefaultFix2();
 
     uint8_t aux[32];
     feed(handleAuxiliary, aux, buildAuxiliary(aux));
 
     // A fresh Fix2 must not wipe the hdop/vdop published by Auxiliary.
-    feed(handleFix2, fix2, buildFix2(fix2));
+    feedDefaultFix2();
 
     gpsSolutionData_t sol;
     ASSERT_TRUE(dronecanGnssGetLatest(&sol));
@@ -277,7 +288,9 @@ TEST(DronecanGnssTest, Fix2PreservesAuxiliaryDop)
     EXPECT_EQ(150, sol.dop.vdop);
 }
 
-TEST(DronecanGnssTest, Fix2NoFixZeroesSats)
+// Anything below a 3D fix is unusable for navigation, so 2D is deliberately
+// reported as no fix.
+TEST(DronecanGnssTest, Fix2TreatsTwoDFixAsNoFix)
 {
     resetCache();
 
@@ -290,4 +303,127 @@ TEST(DronecanGnssTest, Fix2NoFixZeroesSats)
     gpsSolutionData_t sol;
     ASSERT_TRUE(dronecanGnssGetLatest(&sol));
     EXPECT_EQ(0, sol.numSat);
+}
+
+TEST(DronecanGnssTest, Fix2ScalarCovariance)
+{
+    resetCache();
+
+    uint8_t buf[128];
+    memset(buf, 0, sizeof(buf));
+
+    const uint8_t status = UAVCAN_GNSS_FIX2_STATUS_3D_FIX;
+    canardEncodeScalar(buf, 366, 2, &status);
+
+    const uint8_t covLength = 1;
+    canardEncodeScalar(buf, 378, 6, &covLength);
+    encodeF16(buf, 384, 4.0f);
+    const uint32_t pdopBit = 384 + 16;
+    encodeF16(buf, pdopBit, 1.5f);
+    feed(handleFix2, buf, (uint16_t)((pdopBit + 16 + 7) / 8));
+
+    gpsSolutionData_t sol;
+    ASSERT_TRUE(dronecanGnssGetLatest(&sol));
+
+    // A single scalar variance applies to every axis.
+    EXPECT_EQ(2000u, sol.acc.hAcc);
+    EXPECT_EQ(2000u, sol.acc.vAcc);
+    EXPECT_EQ(2000u, sol.acc.sAcc);
+    EXPECT_EQ(150, sol.dop.pdop);
+}
+
+TEST(DronecanGnssTest, Fix2UpperTriangularCovariance)
+{
+    resetCache();
+
+    uint8_t buf[128];
+    memset(buf, 0, sizeof(buf));
+
+    const uint8_t status = UAVCAN_GNSS_FIX2_STATUS_3D_FIX;
+    canardEncodeScalar(buf, 366, 2, &status);
+
+    const uint8_t covLength = 21;
+    canardEncodeScalar(buf, 378, 6, &covLength);
+    // Upper triangle row-major; diagonal entries sit at 0, 6, 11, 15, 18, 20.
+    encodeF16(buf, 384 + 0 * 16, 4.0f);
+    encodeF16(buf, 384 + 6 * 16, 9.0f);
+    encodeF16(buf, 384 + 11 * 16, 16.0f);
+    encodeF16(buf, 384 + 15 * 16, 0.25f);
+    encodeF16(buf, 384 + 18 * 16, 0.25f);
+    encodeF16(buf, 384 + 20 * 16, 1.0f);
+    const uint32_t pdopBit = 384 + 21 * 16;
+    encodeF16(buf, pdopBit, 1.5f);
+    feed(handleFix2, buf, (uint16_t)((pdopBit + 16 + 7) / 8));
+
+    gpsSolutionData_t sol;
+    ASSERT_TRUE(dronecanGnssGetLatest(&sol));
+
+    EXPECT_EQ((uint32_t)(sqrtf(6.5f) * 1000.0f), sol.acc.hAcc);
+    EXPECT_EQ(4000u, sol.acc.vAcc);
+    EXPECT_EQ((uint32_t)(sqrtf(0.5f) * 1000.0f), sol.acc.sAcc);
+    EXPECT_EQ(150, sol.dop.pdop);
+}
+
+TEST(DronecanGnssTest, Fix2TruncatedCovarianceIsIgnored)
+{
+    resetCache();
+
+    uint8_t buf[64];
+    memset(buf, 0, sizeof(buf));
+
+    const uint8_t status = UAVCAN_GNSS_FIX2_STATUS_3D_FIX;
+    canardEncodeScalar(buf, 366, 2, &status);
+
+    // Claim a full matrix but truncate the payload after six entries: the
+    // decoder must not read past the payload, and no accuracy is published.
+    const uint8_t covLength = 36;
+    canardEncodeScalar(buf, 378, 6, &covLength);
+    encodeF16(buf, 384, 4.0f);
+    feed(handleFix2, buf, (uint16_t)((384 + 6 * 16) / 8));
+
+    gpsSolutionData_t sol;
+    ASSERT_TRUE(dronecanGnssGetLatest(&sol));
+
+    EXPECT_EQ(0u, sol.acc.hAcc);
+    EXPECT_EQ(0u, sol.acc.vAcc);
+    EXPECT_EQ(0u, sol.acc.sAcc);
+    EXPECT_EQ(0, sol.dop.pdop);
+}
+
+TEST(DronecanGnssTest, AuxiliaryDopExpires)
+{
+    resetCache();
+
+    feedDefaultFix2();
+
+    uint8_t aux[32];
+    feed(handleAuxiliary, aux, buildAuxiliary(aux));
+
+    // Fix2 keeps the Auxiliary figures only while they're fresh.
+    mockMicros = DRONECAN_GNSS_AUX_FRESH_US + 1;
+    feedDefaultFix2();
+
+    gpsSolutionData_t sol;
+    ASSERT_TRUE(dronecanGnssGetLatest(&sol));
+
+    EXPECT_EQ(0, sol.dop.hdop);
+    EXPECT_EQ(0, sol.dop.vdop);
+    EXPECT_EQ(150, sol.dop.pdop);
+}
+
+TEST(DronecanGnssTest, Fix2NonUtcTimestampSkipsDateTime)
+{
+    resetCache();
+
+    uint8_t buf[64];
+    const uint16_t len = buildFix2(buf);
+    const uint8_t timeStandard = UAVCAN_GNSS_TIME_STANDARD_GPS;
+    canardEncodeScalar(buf, 112, 3, &timeStandard);
+    feed(handleFix2, buf, len);
+
+    gpsSolutionData_t sol;
+    ASSERT_TRUE(dronecanGnssGetLatest(&sol));
+
+    EXPECT_FALSE(stubDateTimeCalled);
+    EXPECT_FALSE(sol.dateTime.valid);
 }


### PR DESCRIPTION
Completes the phase-1 GNSS decode. Walks the Fix2 payload as a running bit offset so the variable-length tail is reachable: the covariance diagonal (6 or 36 form) maps to hAcc/vAcc/sAcc and pdop to dop.pdop with ublox scaling. Subscribes to `uavcan.equipment.gnss.Auxiliary` for hdop/vdop, preserved across Fix2 updates. A UTC `gnss_timestamp` fills `dateTime` and mirrors the ublox RTC-set path. Adds a decoder unit test (7 cases) driving the real libcanard encode/decode.

Rebased on master now that #15425 has merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded DroneCAN GNSS support to decode Fix2 (position, velocity, satellite info, accuracy) and derive speed/course plus PDOP/HDOP/VDOP from covariance when available.
  * Added DroneCAN Auxiliary support to publish updated HDOP/VDOP.
  * GNSS time can initialize RTC when unset, and GNSS decoding is now enabled only when GPS support is compiled in.
* **Bug Fixes**
  * Improved Fix2 parsing for time standard/UTC handling and variable-length covariance tails, including correct behavior for non-3D and truncated covariance payloads.
* **Tests**
  * Added/extended unit tests for Fix2/Auxiliary decoding, cached publication behavior, timestamp conversion, and Auxiliary DOP expiry; wired tests to build with the real libcanard code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->