### PR TITLE
Add explicit permissions blocks for read-default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -13,9 +13,6 @@ jobs:
   close-pr:
     runs-on: ubuntu-latest
     steps:
-      - name: Code Checkout
-        uses: actions/checkout@v5
-
       - name: autoclose
         shell: bash
         if: github.head_ref == 'master'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,6 +12,8 @@ jobs:
       release_build: true
 
   release:
+    permissions:
+      contents: write
     name: Release
     needs: ci
     runs-on: ubuntu-latest

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,6 +14,7 @@ jobs:
   release:
     permissions:
       contents: write
+      actions: read
     name: Release
     needs: ci
     runs-on: ubuntu-latest

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: 0 4 * * *
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   no-response:
     runs-on: ubuntu-latest

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   no-response:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: 30 4 * * *
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The org default GITHUB_TOKEN permission is now read. Adds explicit permissions blocks so these keep the write access they rely on: stale.yaml (label/close issues and PRs), no-response.yml (close issues), and build-release.yml (upload release assets, scoped to the release job). Also drops an unused actions/checkout from auto-close.yml, which only runs gh pr close.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automation reliability by adding explicit workflow permissions for release, no-response handling, and stale-item processing.
  * Updated workflow access controls so automated runs have the required rights to write issues and manage pull requests.
  * Streamlined pull request auto-close processing by removing an unnecessary “code checkout” step before closing PRs from the default branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->