### PR TITLE
Fix H7 FDCAN bring-up: kernel clock query and transceiver silent pin

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6667,6 +6667,7 @@ const cliResourceValue_t resourceTable[] = {
 #if ENABLE_CAN
     DEFW( OWNER_CAN_TX,        PG_CAN_PIN_CONFIG, canPinConfig_t, ioTagTx, CANDEV_COUNT ),
     DEFW( OWNER_CAN_RX,        PG_CAN_PIN_CONFIG, canPinConfig_t, ioTagRx, CANDEV_COUNT ),
+    DEFW( OWNER_CAN_SILENT,    PG_CAN_PIN_CONFIG, canPinConfig_t, ioTagSilent, CANDEV_COUNT ),
 #endif
 #ifdef USE_ESCSERIAL
     DEFS( OWNER_ESCSERIAL,     PG_ESCSERIAL_CONFIG, escSerialConfig_t, ioTag ),

--- a/src/main/drivers/can/can_impl.h
+++ b/src/main/drivers/can/can_impl.h
@@ -61,6 +61,7 @@ typedef struct canDevice_s {
     canResource_t *reg;
     ioTag_t tx;
     ioTag_t rx;
+    ioTag_t silent;
     uint8_t txAF;
     uint8_t rxAF;
 #if PLATFORM_TRAIT_RCC

--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -123,6 +123,7 @@ static const char * const ownerNames[] = {
     [OWNER_PIOUART_RX] = "PIOUART_RX",
     [OWNER_CAN_TX] = "CAN_TX",
     [OWNER_CAN_RX] = "CAN_RX",
+    [OWNER_CAN_SILENT] = "CAN_SILENT",
     // Keep in sync with resourceOwner_e.
 };
 

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -119,6 +119,7 @@ typedef enum {
     OWNER_PIOUART_RX,
     OWNER_CAN_TX,                // TX must be just before RX
     OWNER_CAN_RX,
+    OWNER_CAN_SILENT,
     OWNER_TOTAL_COUNT
 } resourceOwner_e;
 

--- a/src/main/pg/can.c
+++ b/src/main/pg/can.c
@@ -37,12 +37,18 @@
 #ifndef CAN1_RX_PIN
 #define CAN1_RX_PIN NONE
 #endif
+#ifndef CAN1_SILENT_PIN
+#define CAN1_SILENT_PIN NONE
+#endif
 
 #ifndef CAN2_TX_PIN
 #define CAN2_TX_PIN NONE
 #endif
 #ifndef CAN2_RX_PIN
 #define CAN2_RX_PIN NONE
+#endif
+#ifndef CAN2_SILENT_PIN
+#define CAN2_SILENT_PIN NONE
 #endif
 
 #ifndef CAN3_TX_PIN
@@ -51,12 +57,18 @@
 #ifndef CAN3_RX_PIN
 #define CAN3_RX_PIN NONE
 #endif
+#ifndef CAN3_SILENT_PIN
+#define CAN3_SILENT_PIN NONE
+#endif
 
 #ifndef CAN4_TX_PIN
 #define CAN4_TX_PIN NONE
 #endif
 #ifndef CAN4_RX_PIN
 #define CAN4_RX_PIN NONE
+#endif
+#ifndef CAN4_SILENT_PIN
+#define CAN4_SILENT_PIN NONE
 #endif
 
 #ifndef CAN5_TX_PIN
@@ -65,12 +77,18 @@
 #ifndef CAN5_RX_PIN
 #define CAN5_RX_PIN NONE
 #endif
+#ifndef CAN5_SILENT_PIN
+#define CAN5_SILENT_PIN NONE
+#endif
 
 #ifndef CAN6_TX_PIN
 #define CAN6_TX_PIN NONE
 #endif
 #ifndef CAN6_RX_PIN
 #define CAN6_RX_PIN NONE
+#endif
+#ifndef CAN6_SILENT_PIN
+#define CAN6_SILENT_PIN NONE
 #endif
 
 #ifndef CAN7_TX_PIN
@@ -79,6 +97,9 @@
 #ifndef CAN7_RX_PIN
 #define CAN7_RX_PIN NONE
 #endif
+#ifndef CAN7_SILENT_PIN
+#define CAN7_SILENT_PIN NONE
+#endif
 
 #ifndef CAN8_TX_PIN
 #define CAN8_TX_PIN NONE
@@ -86,35 +107,39 @@
 #ifndef CAN8_RX_PIN
 #define CAN8_RX_PIN NONE
 #endif
+#ifndef CAN8_SILENT_PIN
+#define CAN8_SILENT_PIN NONE
+#endif
 
 typedef struct canDefaultConfig_s {
     canDevice_e device;
     ioTag_t tx;
     ioTag_t rx;
+    ioTag_t silent;
 } canDefaultConfig_t;
 
 static const canDefaultConfig_t canDefaultConfig[] = {
-    { CANDEV_1, IO_TAG(CAN1_TX_PIN), IO_TAG(CAN1_RX_PIN) },
-    { CANDEV_2, IO_TAG(CAN2_TX_PIN), IO_TAG(CAN2_RX_PIN) },
-    { CANDEV_3, IO_TAG(CAN3_TX_PIN), IO_TAG(CAN3_RX_PIN) },
+    { CANDEV_1, IO_TAG(CAN1_TX_PIN), IO_TAG(CAN1_RX_PIN), IO_TAG(CAN1_SILENT_PIN) },
+    { CANDEV_2, IO_TAG(CAN2_TX_PIN), IO_TAG(CAN2_RX_PIN), IO_TAG(CAN2_SILENT_PIN) },
+    { CANDEV_3, IO_TAG(CAN3_TX_PIN), IO_TAG(CAN3_RX_PIN), IO_TAG(CAN3_SILENT_PIN) },
 #if CANDEV_COUNT > 3
-    { CANDEV_4, IO_TAG(CAN4_TX_PIN), IO_TAG(CAN4_RX_PIN) },
+    { CANDEV_4, IO_TAG(CAN4_TX_PIN), IO_TAG(CAN4_RX_PIN), IO_TAG(CAN4_SILENT_PIN) },
 #endif
 #if CANDEV_COUNT > 4
-    { CANDEV_5, IO_TAG(CAN5_TX_PIN), IO_TAG(CAN5_RX_PIN) },
+    { CANDEV_5, IO_TAG(CAN5_TX_PIN), IO_TAG(CAN5_RX_PIN), IO_TAG(CAN5_SILENT_PIN) },
 #endif
 #if CANDEV_COUNT > 5
-    { CANDEV_6, IO_TAG(CAN6_TX_PIN), IO_TAG(CAN6_RX_PIN) },
+    { CANDEV_6, IO_TAG(CAN6_TX_PIN), IO_TAG(CAN6_RX_PIN), IO_TAG(CAN6_SILENT_PIN) },
 #endif
 #if CANDEV_COUNT > 6
-    { CANDEV_7, IO_TAG(CAN7_TX_PIN), IO_TAG(CAN7_RX_PIN) },
+    { CANDEV_7, IO_TAG(CAN7_TX_PIN), IO_TAG(CAN7_RX_PIN), IO_TAG(CAN7_SILENT_PIN) },
 #endif
 #if CANDEV_COUNT > 7
-    { CANDEV_8, IO_TAG(CAN8_TX_PIN), IO_TAG(CAN8_RX_PIN) },
+    { CANDEV_8, IO_TAG(CAN8_TX_PIN), IO_TAG(CAN8_RX_PIN), IO_TAG(CAN8_SILENT_PIN) },
 #endif
 };
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(canPinConfig_t, CANDEV_COUNT, canPinConfig, PG_CAN_PIN_CONFIG, 0);
+PG_REGISTER_ARRAY_WITH_RESET_FN(canPinConfig_t, CANDEV_COUNT, canPinConfig, PG_CAN_PIN_CONFIG, 1);
 
 void pgResetFn_canPinConfig(canPinConfig_t *config)
 {
@@ -122,6 +147,7 @@ void pgResetFn_canPinConfig(canPinConfig_t *config)
         const canDefaultConfig_t *defconf = &canDefaultConfig[i];
         config[defconf->device].ioTagTx = defconf->tx;
         config[defconf->device].ioTagRx = defconf->rx;
+        config[defconf->device].ioTagSilent = defconf->silent;
     }
 }
 

--- a/src/main/pg/can.h
+++ b/src/main/pg/can.h
@@ -29,6 +29,7 @@
 typedef struct canPinConfig_s {
     ioTag_t ioTagTx;
     ioTag_t ioTagRx;
+    ioTag_t ioTagSilent;
 } canPinConfig_t;
 
 PG_DECLARE_ARRAY(canPinConfig_t, CANDEV_COUNT, canPinConfig);

--- a/src/platform/common/stm32/can_hw.c
+++ b/src/platform/common/stm32/can_hw.c
@@ -227,7 +227,28 @@ static uint32_t canPackNominalBitTiming(uint32_t nbrp, uint32_t ntseg1,
 // matches the HAL2 reset default for FDCAN.
 static uint32_t canGetKernelClockHz(void)
 {
-#if defined(STM32G4) || defined(STM32H7)
+#if defined(STM32H7)
+    // H7's HAL_RCCEx_GetPeriphCLKFreq() has no FDCAN branch and returns 0
+    // for it, which left CAN stuck in init on every H7 target. Read the
+    // kernel-clock mux directly. HSE_VALUE is compile-time, but it must
+    // match the crystal for the system clocks to have come up at all.
+    switch (__HAL_RCC_GET_FDCAN_SOURCE()) {
+    case RCC_FDCANCLKSOURCE_HSE:
+        return HSE_VALUE;
+    case RCC_FDCANCLKSOURCE_PLL: {
+        PLL1_ClocksTypeDef clocks;
+        HAL_RCCEx_GetPLL1ClockFreq(&clocks);
+        return clocks.PLL1_Q_Frequency;
+    }
+    case RCC_FDCANCLKSOURCE_PLL2: {
+        PLL2_ClocksTypeDef clocks;
+        HAL_RCCEx_GetPLL2ClockFreq(&clocks);
+        return clocks.PLL2_Q_Frequency;
+    }
+    default:
+        return 0;
+    }
+#elif defined(STM32G4)
     return HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_FDCAN);
 #else
     return HAL_RCC_GetPCLK1Freq();
@@ -460,6 +481,16 @@ void canInitDevice(canDevice_e device, uint32_t bitrate)
     // readings during initialisation).
     IOConfigGPIOAF(txIO, IOCFG_AF_PP, pDev->txAF);
     IOConfigGPIOAF(rxIO, IOCFG_AF_PP_UP, pDev->rxAF);
+
+    // Some boards route the transceiver's silent/standby input to a GPIO
+    // (often pulled to silent in hardware); drive it low for normal
+    // operation or the node bus-offs on its first transmission.
+    if (pDev->silent) {
+        IO_t silentIO = IOGetByTag(pDev->silent);
+        IOInit(silentIO, OWNER_CAN_SILENT, RESOURCE_INDEX(device));
+        IOConfigGPIO(silentIO, IOCFG_OUT_PP);
+        IOLo(silentIO);
+    }
 
     if (!canEnterConfigMode(regs)) {
         // Peripheral did not latch INIT; nothing more we can do safely.

--- a/src/platform/common/stm32/can_pinconfig.c
+++ b/src/platform/common/stm32/can_pinconfig.c
@@ -58,6 +58,9 @@ void canPinConfigure(const canPinConfig_t *pConfig)
             }
         }
 
+        // The silent/standby line is a plain GPIO, so any pin is valid.
+        pDev->silent = pConfig[device].ioTagSilent;
+
         if (pDev->tx && pDev->rx) {
             pDev->reg = hw->reg;
 #if PLATFORM_TRAIT_RCC


### PR DESCRIPTION
Two fixes that CAN on H7 needs to actually come up, found on hardware (Matek H743 WLITE with a DroneCAN compass):

- H7's `HAL_RCCEx_GetPeriphCLKFreq()` has no FDCAN branch and returns 0, so bit-timing synthesis failed and every H7 target left CAN stuck in INIT. Read the `D2CCIP1R` kernel-clock mux directly (HSE / PLL1Q / PLL2Q).
- The Matek H743 family gates the CAN transceiver's silent/standby input with a GPIO (PD3) that floats to silent, so the node bus-offs on its first transmission with Bit0 errors. Adds a per-device `CAN_SILENT` resource driven low at init (canPinConfig PG bumped to v1).

This is the remaining layer of #15390 on H7 hardware: with #15425 and these two, a MATEKH743 with `resource CAN_TX 1 D01`, `resource CAN_RX 1 D00`, `resource CAN_SILENT 1 D03` and a node id delivers DroneCAN data end to end (verified live). Overlaps #15350 textually in `can_impl.h`/`can_hw.c`; trivial rebase either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring an optional silent/standby control pin for each CAN device.
  - Silent pins are initialized and reserved automatically when configured.
  - CAN resource listings now identify silent-pin assignments correctly.

- **Bug Fixes**
  - Improved STM32H7 FDCAN clock detection by reading the configured clock source directly.
  - CAN devices without a silent pin retain their existing initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->