### PR TITLE
Add DroneCAN magnetometer support

### DIFF
--- a/mk/dronecan.mk
+++ b/mk/dronecan.mk
@@ -16,6 +16,7 @@ ifneq ($(filter $(DRONECAN_LIB_DIR),$(LIB_SUBMODULES)),)
 MCU_COMMON_SRC += \
             io/dronecan/dronecan.c \
             io/dronecan/dronecan_gnss.c \
+            io/dronecan/dronecan_mag.c \
             io/dronecan/dronecan_node.c \
             dronecan/libcanard/canard.c
 

--- a/src/main/io/dronecan/dronecan.c
+++ b/src/main/io/dronecan/dronecan.c
@@ -44,6 +44,9 @@
 void dronecanNodeInit(void);
 void dronecanNodeUpdate(timeUs_t currentTimeUs);
 void dronecanGnssInit(void);
+#ifdef USE_MAG
+void dronecanMagInit(void);
+#endif
 
 //-----------------------------------------------------------------------------
 // Memory pool
@@ -261,6 +264,11 @@ void dronecanInit(void)
     // land in our cache as soon as the transport is live.
 #ifdef USE_GPS
     dronecanGnssInit();
+#endif
+#ifdef USE_MAG
+    // Install the field-strength subscribers so a DroneCAN compass module's
+    // broadcasts land in our cache as soon as the transport is live.
+    dronecanMagInit();
 #endif
 
     canRegisterRxCallback(dronecanDevice, dronecanCanRxAdapter);

--- a/src/main/io/dronecan/dronecan_mag.c
+++ b/src/main/io/dronecan/dronecan_mag.c
@@ -1,0 +1,189 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if ENABLE_DRONECAN && defined(USE_MAG)
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "canard.h"
+
+#include "common/axis.h"
+#include "common/maths.h"
+#include "common/time.h"
+#include "common/utils.h"
+
+#include "drivers/time.h"
+
+#include "io/dronecan/dronecan.h"
+#include "io/dronecan/dronecan_mag.h"
+#include "io/dronecan/dronecan_msg.h"
+
+// Bit offsets into the MagneticFieldStrength2 payload. sensor_id then the
+// fixed-length float16[3] field vector; the trailing float16[<=9] covariance
+// is a TAO tail we don't decode. bit_length values that cross byte boundaries
+// are why we lean on canardDecodeScalar() rather than a packed struct cast.
+// The legacy MagneticFieldStrength carries the same float16[3] vector with
+// no sensor_id, so its fields sit 8 bits earlier.
+#define MAG2_OFFSET_SENSOR_ID   0U    //  8 bits unsigned
+#define MAG2_OFFSET_FIELD_X     8U    // 16 bits float16
+#define MAG2_OFFSET_FIELD_Y     24U   // 16 bits float16
+#define MAG2_OFFSET_FIELD_Z     40U   // 16 bits float16
+#define MAG_OFFSET_FIELD_X      0U    // 16 bits float16
+
+#define GAUSS_TO_MILLIGAUSS     1000.0f
+
+// Seqlock-style publication so a reader on the compass task can never observe a
+// partially-written vector. Same discipline as dronecan_gnss.c: writer bumps
+// the sequence odd before the copy and even after, reader retries on an odd or
+// mismatched count.
+static int16_t latest[XYZ_AXIS_COUNT];
+static volatile uint32_t latestSeq = 0;
+static volatile bool received = false;
+static volatile timeUs_t lastUpdateUs = 0;
+
+// First-seen sensor_id is latched so a multi-mag node's other sensors are
+// ignored. Only touched from the handler (single task context), so it needs no
+// seqlock.
+static bool sensorIdLatched = false;
+static uint8_t latchedSensorId = 0;
+
+static void publishField(const CanardRxTransfer *t, uint32_t fieldBitOffset)
+{
+    uint16_t fieldX_f16 = 0;
+    uint16_t fieldY_f16 = 0;
+    uint16_t fieldZ_f16 = 0;
+
+    canardDecodeScalar(t, fieldBitOffset,       16, false, &fieldX_f16);
+    canardDecodeScalar(t, fieldBitOffset + 16U, 16, false, &fieldY_f16);
+    canardDecodeScalar(t, fieldBitOffset + 32U, 16, false, &fieldZ_f16);
+
+    const float fieldX = canardConvertFloat16ToNativeFloat(fieldX_f16);
+    const float fieldY = canardConvertFloat16ToNativeFloat(fieldY_f16);
+    const float fieldZ = canardConvertFloat16ToNativeFloat(fieldZ_f16);
+
+    latestSeq++;
+    __asm volatile ("" ::: "memory");
+
+    latest[X] = (int16_t)constrainf(fieldX * GAUSS_TO_MILLIGAUSS, INT16_MIN, INT16_MAX);
+    latest[Y] = (int16_t)constrainf(fieldY * GAUSS_TO_MILLIGAUSS, INT16_MIN, INT16_MAX);
+    latest[Z] = (int16_t)constrainf(fieldZ * GAUSS_TO_MILLIGAUSS, INT16_MIN, INT16_MAX);
+
+    lastUpdateUs = micros();
+    received = true;
+
+    __asm volatile ("" ::: "memory");
+    latestSeq++;
+}
+
+static void handleMag2(CanardInstance *ins, CanardRxTransfer *t)
+{
+    UNUSED(ins);
+
+    uint8_t sensorId = 0;
+    canardDecodeScalar(t, MAG2_OFFSET_SENSOR_ID, 8, false, &sensorId);
+
+    if (!sensorIdLatched) {
+        latchedSensorId = sensorId;
+        sensorIdLatched = true;
+    } else if (sensorId != latchedSensorId) {
+        return;
+    }
+
+    publishField(t, MAG2_OFFSET_FIELD_X);
+}
+
+static void handleMagLegacy(CanardInstance *ins, CanardRxTransfer *t)
+{
+    UNUSED(ins);
+
+    publishField(t, MAG_OFFSET_FIELD_X);
+}
+
+void dronecanMagInit(void)
+{
+    memset(latest, 0, sizeof(latest));
+    received = false;
+    lastUpdateUs = 0;
+    sensorIdLatched = false;
+    latchedSensorId = 0;
+
+    const dronecanSubscriber_t mag2Sub = {
+        .signature    = UAVCAN_MAG2_SIGNATURE,
+        .dataTypeId   = UAVCAN_MAG2_ID,
+        .transferType = CanardTransferTypeBroadcast,
+        .handler      = handleMag2,
+    };
+    (void)dronecanRegisterSubscriber(&mag2Sub);
+
+    const dronecanSubscriber_t magLegacySub = {
+        .signature    = UAVCAN_MAG_SIGNATURE,
+        .dataTypeId   = UAVCAN_MAG_ID,
+        .transferType = CanardTransferTypeBroadcast,
+        .handler      = handleMagLegacy,
+    };
+    (void)dronecanRegisterSubscriber(&magLegacySub);
+}
+
+bool dronecanMagGetLatest(int16_t mag[XYZ_AXIS_COUNT])
+{
+    if (!received || mag == NULL) {
+        return false;
+    }
+
+    uint32_t s1;
+    uint32_t s2;
+    do {
+        do {
+            s1 = latestSeq;
+        } while (s1 & 1U);
+        __asm volatile ("" ::: "memory");
+        mag[X] = latest[X];
+        mag[Y] = latest[Y];
+        mag[Z] = latest[Z];
+        __asm volatile ("" ::: "memory");
+        s2 = latestSeq;
+    } while (s1 != s2);
+
+    return true;
+}
+
+timeUs_t dronecanMagLastUpdateUs(void)
+{
+    uint32_t s1;
+    uint32_t s2;
+    timeUs_t t;
+    do {
+        do {
+            s1 = latestSeq;
+        } while (s1 & 1U);
+        __asm volatile ("" ::: "memory");
+        t = lastUpdateUs;
+        __asm volatile ("" ::: "memory");
+        s2 = latestSeq;
+    } while (s1 != s2);
+    return t;
+}
+
+#endif // ENABLE_DRONECAN && USE_MAG

--- a/src/main/io/dronecan/dronecan_mag.h
+++ b/src/main/io/dronecan/dronecan_mag.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "platform.h"
+
+#if ENABLE_DRONECAN && defined(USE_MAG)
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "common/axis.h"
+#include "common/time.h"
+
+// Install the MagneticFieldStrength2 subscriber. Call once from dronecanInit()
+// after the base subscriber table has been initialised.
+void dronecanMagInit(void);
+
+// Copy the last-received field vector (milligauss, body frame) into the
+// caller's buffer. Returns false if no frame has been received yet.
+bool dronecanMagGetLatest(int16_t mag[XYZ_AXIS_COUNT]);
+
+// Microsecond timestamp of the most recent accepted frame (host clock, not the
+// DSDL timestamp). Used by the compass driver to detect staleness.
+timeUs_t dronecanMagLastUpdateUs(void);
+
+#endif // ENABLE_DRONECAN && USE_MAG

--- a/src/main/io/dronecan/dronecan_msg.h
+++ b/src/main/io/dronecan/dronecan_msg.h
@@ -49,6 +49,17 @@
 #define UAVCAN_GNSS_AUXILIARY_ID        1061U
 #define UAVCAN_GNSS_AUXILIARY_SIGNATURE 0x9be8bdc4c3dbbfd2ULL
 
+// uavcan.equipment.ahrs.MagneticFieldStrength2 — broadcast magnetic field
+// vector in Gauss, body frame. Carries a sensor_id so a multi-mag node can be
+// disambiguated.
+#define UAVCAN_MAG2_ID                  1002U
+#define UAVCAN_MAG2_SIGNATURE           0xb6ac0c442430297eULL
+
+// uavcan.equipment.ahrs.MagneticFieldStrength — legacy single-mag variant of
+// the above (no sensor_id); still what many CAN compasses broadcast.
+#define UAVCAN_MAG_ID                   1001U
+#define UAVCAN_MAG_SIGNATURE            0xe2a7d4a9460bc2f2ULL
+
 // Fix2.status enum values.
 #define UAVCAN_GNSS_FIX2_STATUS_NO_FIX      0U
 #define UAVCAN_GNSS_FIX2_STATUS_TIME_ONLY   1U

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -58,6 +58,11 @@
 #include "flight/imu.h"
 #include "io/beeper.h"
 
+#if ENABLE_DRONECAN
+#include "io/dronecan/dronecan.h"
+#include "io/dronecan/dronecan_mag.h"
+#endif
+
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 
@@ -170,6 +175,50 @@ void pgResetFn_compassConfig(compassConfig_t *compassConfig)
 
 static int16_t magADCRaw[XYZ_AXIS_COUNT];
 
+#if ENABLE_DRONECAN
+// Frames older than this are treated as no data, so a dead bus trips the
+// compass task's read-failure path rather than latching the last vector.
+#define DRONECAN_MAG_TIMEOUT_US (500 * 1000)
+
+static bool dronecanMagDevInit(magDev_t *magDev)
+{
+    UNUSED(magDev);
+    return true;
+}
+
+static bool dronecanMagDevRead(magDev_t *magDev, int16_t *magData)
+{
+    UNUSED(magDev);
+
+    int16_t latest[XYZ_AXIS_COUNT];
+    if (!dronecanMagGetLatest(latest)) {
+        return false;
+    }
+
+    if (cmpTimeUs(micros(), dronecanMagLastUpdateUs()) >= DRONECAN_MAG_TIMEOUT_US) {
+        return false;
+    }
+
+    magData[X] = latest[X];
+    magData[Y] = latest[Y];
+    magData[Z] = latest[Z];
+    return true;
+}
+
+static bool dronecanMagDevDetect(magDev_t *magDev)
+{
+    // A DroneCAN mag can't be probed on a bus. dronecanInit() runs before
+    // compassInit() in fc/init.c, so dronecanIsInitialised() already reflects
+    // the enabled flag, a valid node ID and a valid CAN device.
+    if (!dronecanIsInitialised()) {
+        return false;
+    }
+    magDev->init = dronecanMagDevInit;
+    magDev->read = dronecanMagDevRead;
+    return true;
+}
+#endif // ENABLE_DRONECAN
+
 void compassPreInit(void)
 {
 #ifdef USE_SPI
@@ -185,6 +234,18 @@ static bool compassDetect(magDev_t *magDev, uint8_t *alignment)
     *alignment = MAG_ALIGN;
 
     magSensor_e magHardware = MAG_NONE;
+
+#if ENABLE_DRONECAN
+    // Explicitly-selected only; never part of AUTO probing.
+    if (compassConfig()->mag_hardware == MAG_DRONECAN) {
+        if (dronecanMagDevDetect(magDev)) {
+            detectedSensors[SENSOR_INDEX_MAG] = MAG_DRONECAN;
+            sensorsSet(SENSOR_MAG);
+            return true;
+        }
+        return false;
+    }
+#endif
 
     extDevice_t *dev = &magDev->dev;
     // Associate magnetometer bus with its device

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -53,6 +53,7 @@ typedef enum {
     MAG_IST8310 = 9,
     MAG_MMC560X = 10,
     MAG_QMC5883P = 11,
+    MAG_DRONECAN = 12,
     MAG_HARDWARE_COUNT
 } magSensor_e;
 

--- a/src/main/sensors/sensors.c
+++ b/src/main/sensors/sensors.c
@@ -131,7 +131,10 @@ const char * const lookupTableMagHardware[MAG_HARDWARE_COUNT] = {
     [MAG_MPU925X_AK8963] = "MPU925X_AK8963",
     [MAG_IST8310] = "IST8310",
     [MAG_MMC560X] = "MMC560X",
-    [MAG_QMC5883P] = "QMC5883P"
+    [MAG_QMC5883P] = "QMC5883P",
+#if ENABLE_DRONECAN
+    [MAG_DRONECAN] = "DRONECAN",
+#endif
 };
 
 // sync with rangefinderType_e

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -492,13 +492,11 @@ dronecan_mag_unittest_DEFINES := \
 dronecan_mag_unittest_INCLUDE_DIRS := \
 		$(DRONECAN_LIBCANARD_DIR)
 
-# Hydrate the libcanard submodule on a fresh checkout before the shim (which
-# #includes canard.c) is compiled. Order-only so an already-present tree is
-# never rebuilt.
-$(DRONECAN_LIBCANARD_DIR)/canard.c:
-	$(V1) git -C $(ROOT) submodule update --init -- lib/modules/dronecan/libcanard
-
-$(OBJECT_DIR)/dronecan_mag_unittest/dronecan_mag_canard.c.o: | $(DRONECAN_LIBCANARD_DIR)/canard.c
+# The hydration rule for canard.c lives with the dronecan_gnss test above;
+# order every object of this test after it too.
+$(OBJECT_DIR)/dronecan_mag_unittest/dronecan_mag_canard.c.o \
+$(OBJECT_DIR)/dronecan_mag_unittest/io/dronecan/dronecan_mag.c.o \
+$(OBJECT_DIR)/dronecan_mag_unittest/dronecan_mag_unittest.o: | $(DRONECAN_LIBCANARD_DIR)/canard.c
 
 
 .PHONY: check-pg-ids

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -493,10 +493,10 @@ dronecan_mag_unittest_INCLUDE_DIRS := \
 		$(DRONECAN_LIBCANARD_DIR)
 
 # The hydration rule for canard.c lives with the dronecan_gnss test above;
-# order every object of this test after it too.
+# every object of this test depends on it.
 $(OBJECT_DIR)/dronecan_mag_unittest/dronecan_mag_canard.c.o \
 $(OBJECT_DIR)/dronecan_mag_unittest/io/dronecan/dronecan_mag.c.o \
-$(OBJECT_DIR)/dronecan_mag_unittest/dronecan_mag_unittest.o: | $(DRONECAN_LIBCANARD_DIR)/canard.c
+$(OBJECT_DIR)/dronecan_mag_unittest/dronecan_mag_unittest.o: $(DRONECAN_LIBCANARD_DIR)/canard.c
 
 
 .PHONY: check-pg-ids

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -479,6 +479,27 @@ transponder_ir_unittest_SRC := \
 ws2811_unittest_SRC := \
 		$(USER_DIR)/drivers/light_ws2811strip.c
 
+DRONECAN_LIBCANARD_DIR := $(ROOT)/lib/modules/dronecan/libcanard
+
+dronecan_mag_unittest_SRC := \
+		$(USER_DIR)/io/dronecan/dronecan_mag.c \
+		$(TEST_DIR)/dronecan_mag_canard.c
+
+dronecan_mag_unittest_DEFINES := \
+		ENABLE_DRONECAN=1 \
+		USE_MAG=
+
+dronecan_mag_unittest_INCLUDE_DIRS := \
+		$(DRONECAN_LIBCANARD_DIR)
+
+# Hydrate the libcanard submodule on a fresh checkout before the shim (which
+# #includes canard.c) is compiled. Order-only so an already-present tree is
+# never rebuilt.
+$(DRONECAN_LIBCANARD_DIR)/canard.c:
+	$(V1) git -C $(ROOT) submodule update --init -- lib/modules/dronecan/libcanard
+
+$(OBJECT_DIR)/dronecan_mag_unittest/dronecan_mag_canard.c.o: | $(DRONECAN_LIBCANARD_DIR)/canard.c
+
 
 .PHONY: check-pg-ids
 check-pg-ids:

--- a/src/test/unit/dronecan_mag_canard.c
+++ b/src/test/unit/dronecan_mag_canard.c
@@ -22,4 +22,7 @@
 // Compile libcanard's implementation into the test binary. The submodule path
 // is added to this test's INCLUDE_DIRS so both this shim and the code under
 // test resolve canard.h against the same source.
+#if !__has_include("canard.c")
+#error "libcanard missing; run: git submodule update --init lib/modules/dronecan/libcanard"
+#endif
 #include "canard.c"

--- a/src/test/unit/dronecan_mag_canard.c
+++ b/src/test/unit/dronecan_mag_canard.c
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Compile libcanard's implementation into the test binary. The submodule path
+// is added to this test's INCLUDE_DIRS so both this shim and the code under
+// test resolve canard.h against the same source.
+#include "canard.c"

--- a/src/test/unit/dronecan_mag_unittest.cc
+++ b/src/test/unit/dronecan_mag_unittest.cc
@@ -1,0 +1,208 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdint>
+#include <cstring>
+
+extern "C" {
+    #include "platform.h"
+
+    #include "canard.h"
+
+    #include "common/axis.h"
+
+    #include "io/dronecan/dronecan.h"
+    #include "io/dronecan/dronecan_mag.h"
+    #include "io/dronecan/dronecan_msg.h"
+
+    // dronecanRegisterSubscriber() lives in dronecan.c, which is not linked
+    // into this test. Capture the handlers the module registers, keyed by
+    // data type id, so the tests can feed hand-built transfers directly.
+    static dronecanRxHandler capturedMag2Handler = nullptr;
+    static dronecanRxHandler capturedLegacyHandler = nullptr;
+
+    bool dronecanRegisterSubscriber(const dronecanSubscriber_t *subscriber)
+    {
+        if (subscriber->dataTypeId == UAVCAN_MAG2_ID) {
+            capturedMag2Handler = subscriber->handler;
+        } else if (subscriber->dataTypeId == UAVCAN_MAG_ID) {
+            capturedLegacyHandler = subscriber->handler;
+        }
+        return true;
+    }
+
+    // Controllable clock; the module timestamps each accepted frame with it.
+    static timeUs_t mockMicros = 0;
+
+    timeUs_t micros(void)
+    {
+        return mockMicros;
+    }
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// Assemble a MagneticFieldStrength2 payload: uint8 sensor_id followed by the
+// fixed float16[3] field vector. Covariance (the TAO tail) is omitted.
+static uint8_t payloadBuf[7];
+
+static uint16_t buildMag2Payload(uint8_t sensorId, float x, float y, float z)
+{
+    uint16_t fx = canardConvertNativeFloatToFloat16(x);
+    uint16_t fy = canardConvertNativeFloatToFloat16(y);
+    uint16_t fz = canardConvertNativeFloatToFloat16(z);
+
+    memset(payloadBuf, 0, sizeof(payloadBuf));
+    canardEncodeScalar(payloadBuf, 0,  8,  &sensorId);
+    canardEncodeScalar(payloadBuf, 8,  16, &fx);
+    canardEncodeScalar(payloadBuf, 24, 16, &fy);
+    canardEncodeScalar(payloadBuf, 40, 16, &fz);
+    return sizeof(payloadBuf);
+}
+
+static void feedMag2(uint8_t sensorId, float x, float y, float z)
+{
+    CanardRxTransfer transfer;
+    memset(&transfer, 0, sizeof(transfer));
+    transfer.transfer_type = CanardTransferTypeBroadcast;
+    transfer.data_type_id = UAVCAN_MAG2_ID;
+    transfer.payload_head = payloadBuf;
+    transfer.payload_len = buildMag2Payload(sensorId, x, y, z);
+
+    capturedMag2Handler(nullptr, &transfer);
+}
+
+// The legacy MagneticFieldStrength payload is the same vector with no
+// sensor_id in front.
+static void feedMagLegacy(float x, float y, float z)
+{
+    uint16_t fx = canardConvertNativeFloatToFloat16(x);
+    uint16_t fy = canardConvertNativeFloatToFloat16(y);
+    uint16_t fz = canardConvertNativeFloatToFloat16(z);
+
+    memset(payloadBuf, 0, sizeof(payloadBuf));
+    canardEncodeScalar(payloadBuf, 0,  16, &fx);
+    canardEncodeScalar(payloadBuf, 16, 16, &fy);
+    canardEncodeScalar(payloadBuf, 32, 16, &fz);
+
+    CanardRxTransfer transfer;
+    memset(&transfer, 0, sizeof(transfer));
+    transfer.transfer_type = CanardTransferTypeBroadcast;
+    transfer.data_type_id = UAVCAN_MAG_ID;
+    transfer.payload_head = payloadBuf;
+    transfer.payload_len = 6;
+
+    capturedLegacyHandler(nullptr, &transfer);
+}
+
+class DronecanMagTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        mockMicros = 0;
+        capturedMag2Handler = nullptr;
+        capturedLegacyHandler = nullptr;
+        dronecanMagInit();
+        ASSERT_NE(capturedMag2Handler, nullptr);
+        ASSERT_NE(capturedLegacyHandler, nullptr);
+    }
+};
+
+TEST_F(DronecanMagTest, NoFrameYet)
+{
+    int16_t mag[XYZ_AXIS_COUNT] = {1, 2, 3};
+    EXPECT_FALSE(dronecanMagGetLatest(mag));
+}
+
+TEST_F(DronecanMagTest, DecodesFieldToMilligauss)
+{
+    mockMicros = 123456;
+    feedMag2(0, 0.4f, -0.2f, 0.1f);
+
+    int16_t mag[XYZ_AXIS_COUNT] = {0};
+    ASSERT_TRUE(dronecanMagGetLatest(mag));
+
+    // float16 rounding plus the truncating int cast; allow a couple of counts.
+    EXPECT_NEAR(mag[X], 400, 2);
+    EXPECT_NEAR(mag[Y], -200, 2);
+    EXPECT_NEAR(mag[Z], 100, 2);
+
+    EXPECT_EQ(dronecanMagLastUpdateUs(), (timeUs_t)123456);
+}
+
+TEST_F(DronecanMagTest, DecodesLegacyMessage)
+{
+    mockMicros = 5000;
+    feedMagLegacy(0.25f, -0.6f, 0.05f);
+
+    int16_t mag[XYZ_AXIS_COUNT] = {0};
+    ASSERT_TRUE(dronecanMagGetLatest(mag));
+    EXPECT_NEAR(mag[X], 250, 2);
+    EXPECT_NEAR(mag[Y], -600, 2);
+    EXPECT_NEAR(mag[Z], 50, 2);
+    EXPECT_EQ(dronecanMagLastUpdateUs(), (timeUs_t)5000);
+}
+
+TEST_F(DronecanMagTest, LatchesFirstSensorIdAndIgnoresOthers)
+{
+    mockMicros = 1000;
+    feedMag2(2, 0.3f, 0.0f, 0.0f);
+
+    int16_t first[XYZ_AXIS_COUNT] = {0};
+    ASSERT_TRUE(dronecanMagGetLatest(first));
+
+    // A frame from a different sensor_id on the same node must be dropped: the
+    // cache and its timestamp stay put.
+    mockMicros = 2000;
+    feedMag2(5, -0.5f, -0.5f, -0.5f);
+
+    int16_t second[XYZ_AXIS_COUNT] = {0};
+    ASSERT_TRUE(dronecanMagGetLatest(second));
+    EXPECT_EQ(second[X], first[X]);
+    EXPECT_EQ(second[Y], first[Y]);
+    EXPECT_EQ(second[Z], first[Z]);
+    EXPECT_EQ(dronecanMagLastUpdateUs(), (timeUs_t)1000);
+
+    // The originally-latched sensor still updates the cache and timestamp.
+    mockMicros = 3000;
+    feedMag2(2, 0.1f, 0.1f, 0.1f);
+
+    int16_t third[XYZ_AXIS_COUNT] = {0};
+    ASSERT_TRUE(dronecanMagGetLatest(third));
+    EXPECT_NEAR(third[X], 100, 2);
+    EXPECT_EQ(dronecanMagLastUpdateUs(), (timeUs_t)3000);
+}
+
+TEST_F(DronecanMagTest, TimestampTracksAcceptedFrame)
+{
+    // The accessor reports receipt and the host-clock timestamp; the staleness
+    // window itself is applied by the compass read function against these.
+    mockMicros = 5000;
+    feedMag2(0, 0.2f, 0.2f, 0.2f);
+    EXPECT_EQ(dronecanMagLastUpdateUs(), (timeUs_t)5000);
+
+    mockMicros = 5000 + 600000; // 600 ms later
+    int16_t mag[XYZ_AXIS_COUNT] = {0};
+    EXPECT_TRUE(dronecanMagGetLatest(mag));
+    EXPECT_EQ((timeUs_t)(mockMicros - dronecanMagLastUpdateUs()), (timeUs_t)600000);
+}


### PR DESCRIPTION
Subscribes to `uavcan.equipment.ahrs.MagneticFieldStrength2` and the legacy `MagneticFieldStrength` (still what many CAN compasses broadcast) and publishes the field vector through a seqlock cache, mirroring the DroneCAN GNSS path. Adds `MAG_DRONECAN` as an explicitly selected compass hardware type (a CAN mag can't be probed at init, so it never participates in auto detection); the magDev reads the cache with a 500 ms staleness window and milligauss scaling. DSDL signatures verified against the reference compiler and ecosystem-generated headers. Decoder unit tests included.

Cloud builds need the MAG custom define as usual for board-config targets. Hardware verified on a Matek H743 WLITE (with #15429's H7 bring-up fixes) against a DroneCAN compass on a DNA-allocated node, live field data through to MSP consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DroneCAN magnetometer support for both legacy and MAG2 (multi-sensor) message variants, including conversion to milligauss, staleness handling (500 ms), and safe latest-value/timestamp access.
  * Integrated DroneCAN magnetometer as an explicit compass/sensor selection option and updated magnetometer naming to “DRONECAN”.
  * Added DroneCAN MAG2/MAG message ID and signature constants to enable decoding.

* **Tests**
  * Added unit tests validating MAG2 vs legacy decoding, sensor_id filtering behavior, and latest-value/timestamp readiness, with dedicated DroneCAN magnetometer test build setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->