### PR TITLE
Autopilot: position-hold stick feedforward split from damping, braking state machine

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1742,6 +1742,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_AP_POSITION_I, "%d",         autopilotConfig()->positionI);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_AP_POSITION_D, "%d",         autopilotConfig()->positionD);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_AP_POSITION_A, "%d",         autopilotConfig()->positionA);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_AP_POSITION_F, "%d",         autopilotConfig()->positionF);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_AP_POSITION_CUTOFF, "%d",    autopilotConfig()->positionCutoff);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_AP_STOP_THRESHOLD, "%d",     autopilotConfig()->stopThreshold);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_AP_MAX_ANGLE, "%d",          autopilotConfig()->maxAngle);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -2005,6 +2005,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_AP_POSITION_I,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, positionI) },
     { PARAM_NAME_AP_POSITION_D,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, positionD) },
     { PARAM_NAME_AP_POSITION_A,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, positionA) },
+    { PARAM_NAME_AP_POSITION_F,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, positionF) },
     { PARAM_NAME_AP_POSITION_CUTOFF,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 10, 250 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, positionCutoff) },
     { PARAM_NAME_AP_STOP_THRESHOLD,      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, stopThreshold) },
     { PARAM_NAME_AP_MAX_ANGLE,           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 10, 70 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, maxAngle) },

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -172,6 +172,7 @@
 #define PARAM_NAME_AP_POSITION_I "ap_position_i"
 #define PARAM_NAME_AP_POSITION_D "ap_position_d"
 #define PARAM_NAME_AP_POSITION_A "ap_position_a"
+#define PARAM_NAME_AP_POSITION_F "ap_position_f"
 #define PARAM_NAME_AP_POSITION_CUTOFF "ap_position_cutoff"
 #define PARAM_NAME_AP_STOP_THRESHOLD "ap_stop_threshold"
 #define PARAM_NAME_AP_MAX_ANGLE "ap_max_angle"

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -97,6 +97,8 @@
 #define POSITION_I_SCALE       0.00015f
 #define POSITION_D_SCALE       0.0017f
 #define POSITION_A_SCALE       0.0003f
+#define POSITION_F_SCALE       0.0017f
+#define POSHOLD_STALL_CHECK_SPEED_CMS  45.0f // below this speed a deceleration reversal means braking has stalled to a stop
 #define SANITY_CHECK_DISTANCE 2000.0f //20m, increased when stopping from speeds above 10m/s
 #define ERROR_DISTANCE_LIMIT  2000.0f // TO DO: test set to a useful value, this is 20m
 #define POSITION_I_LIMIT      2000.0f // TO DO: test and set to a useful value, this is 20m
@@ -142,10 +144,7 @@ static vector2_t targetVelocity;
 static vector2_t posHoldStartPosition;
 static vector2_t distanceError;          // deviation from intended position
 static vector2_t distanceErrorIntegral;  // integral of position error
-static vector2_t initialVelocity;        // to detect stopping
 static vector2_t previousVelocity;       // for acceleration
-static vector2_t dTermRamp;              // to smooth D when starting position hold
-static bool isPosHoldStarting[EF_AXIS_COUNT] = { false, false }; 
 
 static pt2Filter_t posAccelLpf[EF_AXIS_COUNT];
 static pt2Filter_t posDtermLpf[EF_AXIS_COUNT];
@@ -171,6 +170,11 @@ typedef struct autopilotState_s {
     bool wasSticksActive;
     bool navActive;
     float maxAngle;
+    float speedXY;              // horizontal ground speed this loop, cm/s
+    float speedXYOneLoopAgo;
+    float speedTwoLoopsAgo;
+    float prevDeltaSpeedXY;     // speed delta one loop ago, for the stall inflection test
+    bool isPosHoldBraking;      // decelerating toward a captured hold point
     unsigned debugAxis;
 } autopilotState_t;
 
@@ -209,6 +213,7 @@ void autopilotInit(void)
     positionPidCoeffs.Kp  = cfg->positionP  * POSITION_P_SCALE;
     positionPidCoeffs.Ki  = cfg->positionI  * POSITION_I_SCALE;
     positionPidCoeffs.Kd  = cfg->positionD  * POSITION_D_SCALE;
+    positionPidCoeffs.Kf  = cfg->positionF  * POSITION_F_SCALE;
     positionPidCoeffs.Ka  = cfg->positionA  * POSITION_A_SCALE;
 
     velocityKp      = cfg->velocityP * VELOCITY_P_SCALE;
@@ -217,6 +222,11 @@ void autopilotInit(void)
     velocityDragKff = cfg->velocityDragCoeff * VELOCITY_DRAG_SCALE;
     ap.sticksActive = false;
     ap.wasSticksActive = false;
+    ap.speedXY = 0.0f;
+    ap.speedXYOneLoopAgo = 0.0f;
+    ap.speedTwoLoopsAgo = 0.0f;
+    ap.prevDeltaSpeedXY = 0.0f;
+    ap.isPosHoldBraking = false;
     abortNavRequested = false;
     forcePitchForward = false;
     disableYawControl();
@@ -370,10 +380,9 @@ void initPositionHold(void)
 {
     updatePositionHoldTarget();
     resetDistanceError();
-    isPosHoldStarting[EF_EAST]  = true;
-    isPosHoldStarting[EF_NORTH] = true;
     targetVelocity.v[EF_EAST]  = 0.0f;
     targetVelocity.v[EF_NORTH] = 0.0f;
+    ap.isPosHoldBraking = true; // arrest any entry speed before capturing the hold point
     // nb: we do not reset the distanceError integral, to hold its opposition to wind between quick stick inputs
 }
 
@@ -383,8 +392,7 @@ static void initNavMode(void)
     resetDistanceError();
     resetDistanceErrorIntegral();
     resetVelocityIntegral();
-    isPosHoldStarting[EF_EAST]  = false;
-    isPosHoldStarting[EF_NORTH] = false;
+    ap.isPosHoldBraking = false;
 }
 
 void resetPositionControl(unsigned taskRateHz)
@@ -582,44 +590,73 @@ bool positionControl(void)
     vector2_t pidI               = { { 0 } };
     vector2_t pidD               = { { 0 } };
     vector2_t pidA               = { { 0 } };
+    vector2_t pidF               = { { 0 } };
     // Update navigation status
     positionNavUpdate(dt, est);
     ap.navActive = positionNavHasActiveTarget() && !positionNavTargetReached();
+
+    // Speed history for the braking stop/stall detector, kept in ap so it
+    // resets cleanly on re-engage rather than persisting in a function static.
+    ap.speedXY = vector2Norm(&velocity);
+    const float currentDeltaXY = ap.speedXY - ap.speedXYOneLoopAgo;
+    ap.prevDeltaSpeedXY = ap.speedXYOneLoopAgo - ap.speedTwoLoopsAgo;
+    ap.speedTwoLoopsAgo = ap.speedXYOneLoopAgo;
+    ap.speedXYOneLoopAgo = ap.speedXY;
+
     if (ap.navActive) {
         isPositionHeld = false;
-        if (ap.navActive) {
-            if (!wasNavActive) {
-                initNavMode();
-            }
-            const vector3_t tgtVel = positionNavGetTargetVelocityCmS();
-            targetVelocity = *(const vector2_t *)&tgtVel.v;
+        if (!wasNavActive) {
+            initNavMode();
         }
+        const vector3_t tgtVel = positionNavGetTargetVelocityCmS();
+        targetVelocity = *(const vector2_t *)&tgtVel.v;
+        ap.isPosHoldBraking = false; // nav sequences its own speed
     } else {
         // Control mode should be position hold
         if (!isPositionHeld) {
-            // not in positionHold, but should be
             initPositionHold();
             ap.sanityCheckDistance = calculateSanityCheckDistance();
             isPositionHeld = true;
-            initialVelocity = velocity;
-        } else {
-            // In posHold
-            if (ap.sticksActive) {
-                if (!ap.wasSticksActive) {
-                    initPositionHold(); // resets hold point and enables strong braking mode
-                    initialVelocity = velocity; // Captures current speed for the deceleration math
-                }
-                sticksMoveTarget();
+        }
+        if (ap.sticksActive) {
+            if (!ap.wasSticksActive) {
+                updatePositionHoldTarget();
+                ap.sanityCheckDistance = calculateSanityCheckDistance();
+                ap.isPosHoldBraking = false; // pilot is commanding, don't brake
             }
-            vector2_t deltaPosV;
-            vector2Sub(&deltaPosV, &posHoldStartPosition, &currentPosition);
-            const float sanityDistanceCm = vector2Norm(&deltaPosV);
-            if (sanityDistanceCm > ap.sanityCheckDistance) {
-                disableYawControl();
-                autopilotAngle[AI_ROLL]  = 0.0f; // Level out
-                autopilotAngle[AI_PITCH] = 0.0f;
-                handlepositionControlFailure();
-                return false; // Return failure, allow angle mode control,  and show pos hold fail message in OSD
+            sticksMoveTarget();
+        } else {
+            if (ap.wasSticksActive) {
+                // Sticks just released: capture the current point, drop the
+                // feedforward push to zero so it can't fight deceleration, and
+                // begin the braking phase.
+                updatePositionHoldTarget();
+                targetVelocity.v[EF_EAST]  = 0.0f;
+                targetVelocity.v[EF_NORTH] = 0.0f;
+                ap.sanityCheckDistance = calculateSanityCheckDistance();
+                ap.isPosHoldBraking = true;
+            }
+            if (ap.isPosHoldBraking) {
+                // Stop when decelerating below the stop threshold, or when a
+                // deceleration reversal at low speed shows the brake has stalled.
+                const float inflectionProduct = currentDeltaXY * ap.prevDeltaSpeedXY;
+                const bool stopped = (currentDeltaXY <= 0.0f) && (ap.speedXY < (float)autopilotConfig()->stopThreshold);
+                const bool stalled = (ap.speedXY < POSHOLD_STALL_CHECK_SPEED_CMS) && (inflectionProduct < 0.0f);
+                if (stopped || stalled) {
+                    updatePositionHoldTarget(); // capture the stopped point as the hold target
+                    ap.isPosHoldBraking = false;
+                }
+            } else {
+                // Settled hold: guard against a position-estimate flyaway.
+                vector2_t deltaPosV;
+                vector2Sub(&deltaPosV, &posHoldStartPosition, &currentPosition);
+                if (vector2Norm(&deltaPosV) > ap.sanityCheckDistance) {
+                    disableYawControl();
+                    autopilotAngle[AI_ROLL]  = 0.0f; // Level out
+                    autopilotAngle[AI_PITCH] = 0.0f;
+                    handlepositionControlFailure();
+                    return false; // Return failure, allow angle mode control, and show pos hold fail message in OSD
+                }
             }
         }
     }
@@ -634,49 +671,15 @@ bool positionControl(void)
     vector2_t velocityFilteredV = { { 0 } };
 
     for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
-        if (isPositionHeld) {
-            if (isPosHoldStarting[axis]) {
-                dTermRamp.v[axis] += (1.6f - dTermRamp.v[axis]) * 0.1f;
-                if (dTermRamp.v[axis] > 1.58f) {
-                    dTermRamp.v[axis] = 1.6f;
-                }
-
-                float slowingDownFactor = 0.0f;
-                if (fabsf(initialVelocity.v[axis]) > 0.01f) {
-                    slowingDownFactor = 1.0f - (fabsf(velocity.v[axis]) / fabsf(initialVelocity.v[axis]));
-                    slowingDownFactor = constrainf(slowingDownFactor, 0.0f, 1.0f);
-                } else {
-                    slowingDownFactor = 1.0f; // reduce abrupt P and iTerm windup by not abruptly jumping to a new target point at speed
-                }
-
-                const float tempTargetPosition = targetPosition.v[axis] + (currentPosition.v[axis] - targetPosition.v[axis]) * slowingDownFactor;
-                distanceError.v[axis] = tempTargetPosition - currentPosition.v[axis];
-                
-                if (((initialVelocity.v[axis] * velocity.v[axis]) < 0.0f) || (fabsf(velocity.v[axis]) < 20.0f)) {
-                    isPosHoldStarting[axis] = false; 
-                    dTermRamp.v[axis] = 1.0f; 
-                    targetPosition.v[axis] = currentPosition.v[axis];
-                }
-            } else {
-                dTermRamp.v[axis] += (1.0f - dTermRamp.v[axis]) * 0.1f;
-                if (fabsf(dTermRamp.v[axis] - 1.0f) < 0.01f) {
-                    dTermRamp.v[axis] = 1.0f;
-                }
-                distanceError.v[axis] = targetPosition.v[axis] - currentPosition.v[axis]; 
-            }
-        }
-
         const float velocityFiltered = pt2FilterApply(&posDtermLpf[axis], velocity.v[axis]);
         velocityFilteredV.v[axis] = velocityFiltered;
         velocityError.v[axis] = targetVelocity.v[axis] - velocityFiltered;
         const float accelerationRaw = (previousVelocity.v[axis] - velocityFiltered) * POSHOLD_TASK_RATE_HZ;
         previousVelocity.v[axis] = velocityFiltered;
+        const float acceleration = pt2FilterApply(&posAccelLpf[axis], accelerationRaw);
 
         if (velocityMode) {
-            // Track the nav velocity target directly; dTermRamp is pos-hold
-            // start-up state and holds a stale value during nav, so the raw
-            // error and acceleration are used here.
-            const float acceleration = pt2FilterApply(&posAccelLpf[axis], accelerationRaw);
+            // Nav velocity loop: track the commanded ground velocity directly.
             if (fabsf(velocityError.v[axis]) < VELOCITY_I_RELAX_CMS
                 && (!wasAngleSaturated || (velocityError.v[axis] * velocityIntegral.v[axis]) < 0.0f)) {
                 velocityIntegral.v[axis] += velocityError.v[axis] * velocityKi * dt;
@@ -686,35 +689,40 @@ bool positionControl(void)
             pidI.v[axis] = velocityIntegral.v[axis];
             pidD.v[axis] = acceleration * velocityKd;
             pidA.v[axis] = targetVelocity.v[axis] * velocityDragKff; // drag feedforward carries the cruise tilt
-        } else {
-            velocityError.v[axis] *= dTermRamp.v[axis];
-            const float acceleration = pt2FilterApply(&posAccelLpf[axis], accelerationRaw * dTermRamp.v[axis]);
-
-            if (ap.navActive) {
-                // Anti-windup: while the angle output is saturated (accelerating
-                // toward cruise), only integrate toward unwinding, or metres of
-                // pseudo distance error accumulate that can only be shed by
-                // flying well past the commanded speed.
-                if (!wasAngleSaturated || (velocityError.v[axis] * distanceError.v[axis]) < 0.0f) {
-                    distanceError.v[axis] += velocityError.v[axis] * dt;
-                }
-            } else if (!isPositionHeld) {
-                // sticks active
-                distanceErrorIntegral.v[axis] *= 0.99f;
-                distanceError.v[axis] = 0.0f;
+        } else if (ap.navActive) {
+            // Legacy nav path (velocity mode disabled): integrate velocity error
+            // into a pseudo-distance error and run the position PID against it.
+            if (!wasAngleSaturated || (velocityError.v[axis] * distanceError.v[axis]) < 0.0f) {
+                distanceError.v[axis] += velocityError.v[axis] * dt;
             }
-
             distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
-            distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt * (isPosHoldStarting[axis] ? 0.0f : 1.0f);
+            distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt;
             distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
-
             pidP.v[axis] = distanceError.v[axis] * positionPidCoeffs.Kp;
             pidI.v[axis] = distanceErrorIntegral.v[axis] * positionPidCoeffs.Ki;
-            pidD.v[axis] = velocityError.v[axis] * positionPidCoeffs.Kd * dTermRamp.v[axis];
+            pidD.v[axis] = velocityError.v[axis] * positionPidCoeffs.Kd;
             pidA.v[axis] = acceleration * positionPidCoeffs.Ka;
+        } else {
+            // Position hold: F carries the stick push, D is pure damping on the
+            // measured velocity, so tuning D no longer changes stick response.
+            if (ap.isPosHoldBraking) {
+                // Move the target with the craft while slowing, so P doesn't snap
+                // to a large value the instant the craft stops.
+                targetPosition.v[axis] += velocity.v[axis] * dt;
+            }
+            distanceError.v[axis] = targetPosition.v[axis] - currentPosition.v[axis];
+            distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
+            const bool holdITerm = !(ap.isPosHoldBraking || ap.sticksActive);
+            distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt * (holdITerm ? 1.0f : 0.0f);
+            distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
+            pidP.v[axis] = distanceError.v[axis] * positionPidCoeffs.Kp;
+            pidI.v[axis] = distanceErrorIntegral.v[axis] * positionPidCoeffs.Ki;
+            pidD.v[axis] = -velocityFiltered * positionPidCoeffs.Kd;      // damping only
+            pidA.v[axis] = acceleration * positionPidCoeffs.Ka;
+            pidF.v[axis] = targetVelocity.v[axis] * positionPidCoeffs.Kf; // stick push, tunable apart from D
         }
 
-        pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis];
+        pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis] + pidF.v[axis];
     } // End for loop
 
     bool buildupClamped = false;
@@ -730,7 +738,7 @@ bool positionControl(void)
             const float scale = (pMag > 0.001f) ? buildupMaxDeg / pMag : 0.0f;
             vector2Scale(&pidP, &pidP, scale);
             for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
-                pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis];
+                pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis] + pidF.v[axis];
             }
         }
     }
@@ -768,7 +776,7 @@ bool positionControl(void)
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 4, lrintf(pidD.v[ap.debugAxis] * 10));
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 5, lrintf(pidA.v[ap.debugAxis] * 10));
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 6, lrintf(pidSumVectorEF.v[ap.debugAxis] * 10));
-    DEBUG_SET(DEBUG_AUTOPILOT_PID, 7, statusValue + (isPosHoldStarting[ap.debugAxis] ? 1 : 0));
+    DEBUG_SET(DEBUG_AUTOPILOT_PID, 7, statusValue + (ap.isPosHoldBraking ? 1 : 0));
 
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 0, lrintf(velocityError.v[EF_EAST]));
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 1, lrintf(velocityError.v[EF_NORTH]));
@@ -776,8 +784,8 @@ bool positionControl(void)
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 3, lrintf(pidSumVectorEF.v[EF_NORTH] * 10));
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 4, lrintf(autopilotAngle[AI_ROLL] * 10));
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 5, lrintf(autopilotAngle[AI_PITCH] * 10));
-    DEBUG_SET(DEBUG_AUTOPILOT_STOP, 6, statusValue + (isPosHoldStarting[EF_EAST] ? 1 : 0));
-    DEBUG_SET(DEBUG_AUTOPILOT_STOP, 7, statusValue + (isPosHoldStarting[EF_NORTH] ? 1 : 0));
+    DEBUG_SET(DEBUG_AUTOPILOT_STOP, 6, lrintf(pidF.v[EF_EAST] * 10));
+    DEBUG_SET(DEBUG_AUTOPILOT_STOP, 7, lrintf(pidF.v[EF_NORTH] * 10));
 
     DEBUG_SET(DEBUG_POSITION_NAV, 0, lrintf(targetVelocity.v[ap.debugAxis]));
     DEBUG_SET(DEBUG_POSITION_NAV, 1, lrintf(velocityFilteredV.v[ap.debugAxis]));

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -626,13 +626,16 @@ bool positionControl(void)
             }
             sticksMoveTarget();
         } else {
+            // No stick input: there is no commanded velocity, so force it to
+            // zero every loop. sticksMoveTarget() latches the last value written
+            // as the stick eased back through the deadband, which is a small
+            // nonzero velocity; left in place it keeps driving the F feedforward
+            // (and fights braking) until the stop capture clears it.
+            targetVelocity.v[EF_EAST]  = 0.0f;
+            targetVelocity.v[EF_NORTH] = 0.0f;
             if (ap.wasSticksActive) {
-                // Sticks just released: capture the current point, drop the
-                // feedforward push to zero so it can't fight deceleration, and
-                // begin the braking phase.
+                // Sticks just released: capture the current point and begin braking.
                 updatePositionHoldTarget();
-                targetVelocity.v[EF_EAST]  = 0.0f;
-                targetVelocity.v[EF_NORTH] = 0.0f;
                 ap.sanityCheckDistance = calculateSanityCheckDistance();
                 ap.isPosHoldBraking = true;
             }

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -689,37 +689,40 @@ bool positionControl(void)
             pidI.v[axis] = velocityIntegral.v[axis];
             pidD.v[axis] = acceleration * velocityKd;
             pidA.v[axis] = targetVelocity.v[axis] * velocityDragKff; // drag feedforward carries the cruise tilt
-        } else if (ap.navActive) {
-            // Legacy nav path (velocity mode disabled): integrate velocity error
-            // into a pseudo-distance error and run the position PID against it.
-            if (!wasAngleSaturated || (velocityError.v[axis] * distanceError.v[axis]) < 0.0f) {
-                distanceError.v[axis] += velocityError.v[axis] * dt;
-            }
-            distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
-            distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt;
-            distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
-            pidP.v[axis] = distanceError.v[axis] * positionPidCoeffs.Kp;
-            pidI.v[axis] = distanceErrorIntegral.v[axis] * positionPidCoeffs.Ki;
-            pidD.v[axis] = velocityError.v[axis] * positionPidCoeffs.Kd;
-            pidA.v[axis] = acceleration * positionPidCoeffs.Ka;
         } else {
-            // Position hold: F carries the stick push, D is pure damping on the
-            // measured velocity, so tuning D no longer changes stick response.
-            if (ap.isPosHoldBraking) {
-                // Move the target with the craft while slowing, so P doesn't snap
-                // to a large value the instant the craft stops.
-                targetPosition.v[axis] += velocity.v[axis] * dt;
+            // Position law shared by position hold and the legacy nav path
+            // (velocity mode disabled). The two differ only in how the distance
+            // error is sourced; the PID sum is identical.
+            //
+            // D is pure damping on measured velocity and F is the target-velocity
+            // feedforward. Kf * target - Kd * velocity equals the old
+            // (target - velocity) * Kd velocity-error D term when the two gains
+            // are equal (they share a scale and default), so this reproduces the
+            // legacy response while letting the push be tuned apart from damping.
+            if (ap.navActive) {
+                // Implied distance error: integrate the velocity error, with
+                // anti-windup so a saturated output only unwinds it.
+                if (!wasAngleSaturated || (velocityError.v[axis] * distanceError.v[axis]) < 0.0f) {
+                    distanceError.v[axis] += velocityError.v[axis] * dt;
+                }
+            } else {
+                if (ap.isPosHoldBraking) {
+                    // Move the target with the craft while slowing, so P doesn't
+                    // snap to a large value the instant the craft stops.
+                    targetPosition.v[axis] += velocity.v[axis] * dt;
+                }
+                distanceError.v[axis] = targetPosition.v[axis] - currentPosition.v[axis];
             }
-            distanceError.v[axis] = targetPosition.v[axis] - currentPosition.v[axis];
             distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
-            const bool holdITerm = !(ap.isPosHoldBraking || ap.sticksActive);
-            distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt * (holdITerm ? 1.0f : 0.0f);
+            // Nav integrates continuously; pos hold freezes the integral while braking or under stick input.
+            const bool accumulateITerm = ap.navActive || !(ap.isPosHoldBraking || ap.sticksActive);
+            distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt * (accumulateITerm ? 1.0f : 0.0f);
             distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
             pidP.v[axis] = distanceError.v[axis] * positionPidCoeffs.Kp;
             pidI.v[axis] = distanceErrorIntegral.v[axis] * positionPidCoeffs.Ki;
-            pidD.v[axis] = -velocityFiltered * positionPidCoeffs.Kd;      // damping only
+            pidD.v[axis] = -velocityFiltered * positionPidCoeffs.Kd;      // damping on measured velocity
             pidA.v[axis] = acceleration * positionPidCoeffs.Ka;
-            pidF.v[axis] = targetVelocity.v[axis] * positionPidCoeffs.Kf; // stick push, tunable apart from D
+            pidF.v[axis] = targetVelocity.v[axis] * positionPidCoeffs.Kf; // target-velocity feedforward
         }
 
         pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis] + pidF.v[axis];

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -53,12 +53,12 @@
 // 1 - DistanceError cm
 // 2 - P term * 10 // based on distance from intended position
 // 3 - I term * 10 // integral of distance error over time
-// 4 - D term * 10 // velocity factor ( distance error derivative)
+// 4 - D term * 10 // damping on measured velocity
 // 5 - A term * 10 // velocity derivative factor (acceleration in distance terms)
-// 6 - PIDsum * 10
-// 7 - Status - encodes navActive+ 10, velocityMode +20, SticksActive +5, PositionHeld +3, +1 when starting,
+// 6 - F term * 10 // target-velocity feedforward (the stick push / nav target)
+// 7 - Status - encodes navActive+ 10, velocityMode +20, SticksActive +5, PositionHeld +3, +1 when braking,
 // In velocity mode slots 2-5 carry the velocity-loop terms: P/I on velocity error,
-// D damping, A the drag feedforward; slot 1 reads ~0. See also DEBUG_POSITION_NAV.
+// D damping, A the drag feedforward; slot 6 (F) reads ~0. See also DEBUG_POSITION_NAV.
 
 // DEBUG_POSITION_NAV, axis set by gyro_filter_debug_axis
 // 0 - target velocity cm/s
@@ -781,7 +781,7 @@ bool positionControl(void)
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 3, lrintf(pidI.v[ap.debugAxis] * 10));
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 4, lrintf(pidD.v[ap.debugAxis] * 10));
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 5, lrintf(pidA.v[ap.debugAxis] * 10));
-    DEBUG_SET(DEBUG_AUTOPILOT_PID, 6, lrintf(pidSumVectorEF.v[ap.debugAxis] * 10));
+    DEBUG_SET(DEBUG_AUTOPILOT_PID, 6, lrintf(pidF.v[ap.debugAxis] * 10));
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 7, statusValue + (ap.isPosHoldBraking ? 1 : 0));
 
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 0, lrintf(velocityError.v[EF_EAST]));
@@ -790,8 +790,8 @@ bool positionControl(void)
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 3, lrintf(pidSumVectorEF.v[EF_NORTH] * 10));
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 4, lrintf(autopilotAngle[AI_ROLL] * 10));
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 5, lrintf(autopilotAngle[AI_PITCH] * 10));
-    DEBUG_SET(DEBUG_AUTOPILOT_STOP, 6, lrintf(pidF.v[EF_EAST] * 10));
-    DEBUG_SET(DEBUG_AUTOPILOT_STOP, 7, lrintf(pidF.v[EF_NORTH] * 10));
+    DEBUG_SET(DEBUG_AUTOPILOT_STOP, 6, statusValue + (ap.isPosHoldBraking ? 1 : 0));
+    DEBUG_SET(DEBUG_AUTOPILOT_STOP, 7, statusValue + (ap.isPosHoldBraking ? 1 : 0));
 
     DEBUG_SET(DEBUG_POSITION_NAV, 0, lrintf(targetVelocity.v[ap.debugAxis]));
     DEBUG_SET(DEBUG_POSITION_NAV, 1, lrintf(velocityFilteredV.v[ap.debugAxis]));

--- a/src/main/pg/autopilot.c
+++ b/src/main/pg/autopilot.c
@@ -28,7 +28,7 @@
 
 #include "autopilot.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig, PG_AUTOPILOT, 7);
+PG_REGISTER_WITH_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig, PG_AUTOPILOT, 8);
 
 PG_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig,
     .landingAltitudeM = 4,
@@ -43,6 +43,7 @@ PG_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig,
     .positionI = 30,
     .positionD = 30,
     .positionA = 30,
+    .positionF = 30,
     .positionCutoff = 30,
     .stopThreshold = 10,
     .maxAngle = 50,

--- a/src/main/pg/autopilot.h
+++ b/src/main/pg/autopilot.h
@@ -63,6 +63,7 @@ typedef struct autopilotConfig_s {
     uint8_t positionI;
     uint8_t positionD;
     uint8_t positionA;
+    uint8_t positionF;
     uint8_t positionCutoff;
     uint8_t stopThreshold;       // cm/s, speed below which braking captures a position hold target
     uint8_t maxAngle;

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -435,7 +435,7 @@ TEST_F(PosHoldTest, FeedforwardProducesStickProportionalLean)
 TEST_F(PosHoldTest, FeedforwardZeroWhenSticksInactive)
 {
     initAndSettleAt(0, 0, 0);
-    debugMode = DEBUG_AUTOPILOT_STOP; // slots 6/7 carry pidF East/North * 10
+    debugMode = DEBUG_AUTOPILOT_PID; // slot 6 carries pidF on the debug axis (East here) * 10
 
     // Deflect the roll stick, then centre it and release.
     setSticksActiveStatus(true);
@@ -445,8 +445,7 @@ TEST_F(PosHoldTest, FeedforwardZeroWhenSticksInactive)
     setSticksActiveStatus(false);
     runIterations(SETTLE_ITERATIONS);
 
-    EXPECT_EQ(debug[6], 0); // pidF East
-    EXPECT_EQ(debug[7], 0); // pidF North
+    EXPECT_EQ(debug[6], 0); // pidF, flat with no stick input
     debugMode = DEBUG_NONE;
 }
 

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -429,6 +429,27 @@ TEST_F(PosHoldTest, FeedforwardProducesStickProportionalLean)
     EXPECT_GT(fabsf(leanLarge), fabsf(leanSmall) + 1.0f); // twice the stick, more lean
 }
 
+// With no stick input the commanded target velocity, and therefore the F
+// feedforward, must be zero. sticksMoveTarget() latches its last value as the
+// stick eases back through the deadband; that residue must not stay driving F.
+TEST_F(PosHoldTest, FeedforwardZeroWhenSticksInactive)
+{
+    initAndSettleAt(0, 0, 0);
+    debugMode = DEBUG_AUTOPILOT_STOP; // slots 6/7 carry pidF East/North * 10
+
+    // Deflect the roll stick, then centre it and release.
+    setSticksActiveStatus(true);
+    simulatedStickRoll = 150.0f;
+    runIterations(50);
+    simulatedStickRoll = 0.0f;
+    setSticksActiveStatus(false);
+    runIterations(SETTLE_ITERATIONS);
+
+    EXPECT_EQ(debug[6], 0); // pidF East
+    EXPECT_EQ(debug[7], 0); // pidF North
+    debugMode = DEBUG_NONE;
+}
+
 // Guards the fix: on stick release the stale target velocity is zeroed, so the
 // feedforward can't keep pushing in the direction of travel and fight braking.
 TEST_F(PosHoldTest, ReleaseDropsFeedforwardSoBrakingOpposesMotion)

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -156,6 +156,8 @@ static void initAndSettleAt(float eastCm, float northCm, int16_t yawDecidegrees)
     cfg->positionI  = 30;
     cfg->positionD  = 30;
     cfg->positionA  = 30;
+    cfg->positionF  = 30;
+    cfg->stopThreshold = 10;
     cfg->maxAngle   = 30;
     cfg->hoverThrottle = 1500;
     cfg->throttleMin   = 1000;
@@ -405,31 +407,73 @@ TEST_F(PosHoldTest, VelocityTransitionSimulatesFallbackAndRecovery)
     EXPECT_NEAR(-0.7f, autopilotAngle[AI_ROLL], 0.1f);
 }
 
-TEST_F(PosHoldTest, ReleasingSticksBrakes)
+// -- Feedforward (stick push) is a term of its own, apart from damping --
+
+TEST_F(PosHoldTest, FeedforwardProducesStickProportionalLean)
 {
     initAndSettleAt(0, 0, 0);
 
-    // Pilot is moving with sticks active
+    // Craft stationary at target, so pidP and pidD are both ~0; the lean comes
+    // from the F feedforward driven by the stick-commanded target velocity.
     setSticksActiveStatus(true);
-    testEstimate.velocity.x = 120.0f;
 
-    // Ensure sticks are centered for this baseline cruise test
-    simulatedStickRoll = 0.0f;
+    simulatedStickRoll = 100.0f;
+    runIterations(SETTLE_ITERATIONS);
+    const float leanSmall = autopilotAngle[AI_ROLL];
 
+    simulatedStickRoll = 200.0f;
+    runIterations(SETTLE_ITERATIONS);
+    const float leanLarge = autopilotAngle[AI_ROLL];
+
+    EXPECT_GT(fabsf(leanSmall), 0.5f);                 // a real push, not noise
+    EXPECT_GT(fabsf(leanLarge), fabsf(leanSmall) + 1.0f); // twice the stick, more lean
+}
+
+// Guards the fix: on stick release the stale target velocity is zeroed, so the
+// feedforward can't keep pushing in the direction of travel and fight braking.
+TEST_F(PosHoldTest, ReleaseDropsFeedforwardSoBrakingOpposesMotion)
+{
+    initAndSettleAt(0, 0, 0);
+
+    // Cruise East under a large stick deflection while actually moving East.
+    setSticksActiveStatus(true);
+    simulatedStickRoll = 300.0f;
+    testEstimate.velocity.x = 150.0f;
     runIterations(SETTLE_ITERATIONS);
 
-    // UPDATE: Changed from -3.73f to -9.3767f to match the active tracking math
-    EXPECT_NEAR(autopilotAngle[AI_ROLL], -9.3767f, 0.05f);
-    EXPECT_NEAR(autopilotAngle[AI_PITCH],  0.0f,        0.01f);
-
-    // Stick release should cause a greater angle
+    // Release the stick but the craft is still moving East at the moment of release.
     setSticksActiveStatus(false);
-    runIterations(SETTLE_ITERATIONS);
+    simulatedStickRoll = 0.0f;
+    testEstimate.velocity.x = 150.0f;
+    positionControl(); // first braking loop
 
-    float expectedBrakeAngle = -14.4f;
-    EXPECT_NEAR(autopilotAngle[AI_ROLL], expectedBrakeAngle, 0.1f);
+    // Must lean West (negative roll) to brake. If the feedforward push survived
+    // the release it would dominate and roll would be positive (still pushing East).
+    EXPECT_LT(autopilotAngle[AI_ROLL], 0.0f);
+}
 
+TEST_F(PosHoldTest, ReleasingSticksBrakesThenHolds)
+{
+    initAndSettleAt(0, 0, 0);
+
+    // Cruise East, stick centered, moving at 120 cm/s.
+    setSticksActiveStatus(true);
+    simulatedStickRoll = 0.0f;
+    testEstimate.velocity.x = 120.0f;
     runIterations(SETTLE_ITERATIONS);
+    EXPECT_LT(autopilotAngle[AI_ROLL], 0.0f);          // damping opposes the drift
+    EXPECT_NEAR(autopilotAngle[AI_PITCH], 0.0f, 0.01f);
+
+    // Release: decay velocity toward zero while advancing position, as a real brake would.
+    setSticksActiveStatus(false);
+    for (int i = 0; i < 600; i++) {
+        testEstimate.velocity.x *= 0.96f;
+        testEstimate.position.x += testEstimate.velocity.x * 0.01f;
+        positionControl();
+    }
+
+    // Stop captured: output settles back to level once the craft has stopped.
+    EXPECT_NEAR(autopilotAngle[AI_ROLL],  0.0f, 0.5f);
     EXPECT_NEAR(autopilotAngle[AI_PITCH], 0.0f, 0.1f);
 }
 


### PR DESCRIPTION
Adopts the good parts of @ctzsnooze's pos-hold work onto current master, scoped to the position-hold path so velocity mode (the nav inner loop) is untouched.

Adds `ap_position_f`: the stick push becomes its own feedforward term and D becomes pure damping on measured velocity, so D can be tuned for damping without changing stick response. Replaces the `dTermRamp`/`isPosHoldStarting` start-up smoothing with a stop/stall braking state machine that moves the hold target with the craft while decelerating and captures the point once stopped (wired to the existing `ap_stop_threshold`). The feedforward is zeroed on stick release so it cannot fight the brake.

Nav velocity mode, the legacy nav fallback, and yaw control are unchanged. `PG_AUTOPILOT` bumped to 8 for the new parameter.

Part of the autopilot programme (#15411).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable position-control feedforward gain (**ap_position_f**) with a default value of 30.
  * Exposed the new setting via CLI configuration and system information.
  * Enhanced multirotor position hold with stick feedforward and improved braking behavior on stick release.
* **Bug Fixes**
  * Improved stop/stall detection to reduce unwanted drift before settling into position hold.
* **Tests**
  * Added unit tests covering feedforward response, feedforward drop when sticks are inactive, braking direction after release, and return to stable hover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->