### PR TITLE
Optimize timer-based bidirectional DShot on F4 MCUs to reduce scheduler jitter

### DIFF
--- a/src/platform/STM32/pwm_output_dshot.c
+++ b/src/platform/STM32/pwm_output_dshot.c
@@ -117,14 +117,22 @@ static void pwmDshotSetDirectionInput(
     motorDmaOutput_t * const motor
 )
 {
+#if !defined(STM32F4)
     DMA_InitTypeDef* pDmaInit = &motor->dmaInitStruct;
+#endif
 
     const timerHardware_t * const timerHardware = motor->timerHardware;
     TIM_TypeDef *timer = (TIM_TypeDef *)timerHardware->tim;
 
     dmaResource_t *dmaRef = motor->dmaRef;
 
+#if defined(STM32F4)
+    // Output and input share the channel, addresses, widths and increment modes.
+    // Switch direction and disable the output TC interrupt without rebuilding the stream.
+    CLEAR_BIT(((DMA_Stream_TypeDef *)dmaRef)->CR, DMA_SxCR_DIR | DMA_SxCR_TCIE);
+#else
     xDMA_DeInit(dmaRef);
+#endif
 
     motor->isInput = true;
     if (!inputStampUs) {
@@ -135,11 +143,10 @@ static void pwmDshotSetDirectionInput(
 
     TIM_ICInit(timer, &motor->icInitStruct);
 
-#if defined(STM32F4)
+#if !defined(STM32F4)
     motor->dmaInitStruct.DMA_DIR = DMA_DIR_PeripheralToMemory;
-#endif
-
     xDMA_Init(dmaRef, pDmaInit);
+#endif
 }
 #endif
 

--- a/src/platform/STM32/pwm_output_dshot.c
+++ b/src/platform/STM32/pwm_output_dshot.c
@@ -128,7 +128,8 @@ static void pwmDshotSetDirectionInput(
 
 #if defined(STM32F4)
     // Output and input share the channel, addresses, widths and increment modes.
-    // Switch direction and disable the output TC interrupt without rebuilding the stream.
+    // The stream is disabled and its flags are cleared by the IRQ handler before
+    // changing direction, as required before enabling a new DMA transfer.
     CLEAR_BIT(((DMA_Stream_TypeDef *)dmaRef)->CR, DMA_SxCR_DIR | DMA_SxCR_TCIE);
 #else
     xDMA_DeInit(dmaRef);
@@ -144,7 +145,6 @@ static void pwmDshotSetDirectionInput(
     TIM_ICInit(timer, &motor->icInitStruct);
 
 #if !defined(STM32F4)
-    motor->dmaInitStruct.DMA_DIR = DMA_DIR_PeripheralToMemory;
     xDMA_Init(dmaRef, pDmaInit);
 #endif
 }
@@ -197,6 +197,14 @@ FAST_CODE static void motor_DMA_IRQHandler(dmaChannelDescriptor_t *descriptor)
             TIM_DMACmd((TIM_TypeDef *)motor->timerHardware->tim, motor->timerDmaSource, DISABLE);
         }
 
+#if defined(STM32F4)
+        DMA_Stream_TypeDef *stream = (DMA_Stream_TypeDef *)motor->dmaRef;
+        while (stream->CR & DMA_SxCR_EN) {
+            // Configuration registers are write-protected until EN reads zero.
+        }
+        DMA_CLEAR_FLAG(descriptor, DMA_IT_FEIF | DMA_IT_DMEIF | DMA_IT_TEIF | DMA_IT_HTIF | DMA_IT_TCIF);
+#endif
+
 #ifdef USE_DSHOT_TELEMETRY
         if (useDshotTelemetry) {
             pwmDshotSetDirectionInput(motor);
@@ -206,7 +214,9 @@ FAST_CODE static void motor_DMA_IRQHandler(dmaChannelDescriptor_t *descriptor)
             dshotDMAHandlerCycleCounters.changeDirectionCompletedAt = getCycleCounter();
         }
 #endif
+#if !defined(STM32F4)
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
+#endif
     }
 }
 


### PR DESCRIPTION
Experimental PR to try to optimize timer-based bidirectional DShot on the F405 to reduce scheduler jitter. 

When using timer-based bidirectional  DShot, Betaflight changes each motor timer from output mode to telemetry input mode after transmitting a frame. Currently, Betaflight completely erases and rebuilds the motors DMA configuration during every direction change. Four motors can complete at nearly the same time, producing four back-to-back interrupts and delaying the main scheduler.

This PR reuses the DMA configuration that is already valid and modifies only the fields that differ for telemetry input. It should reduce interrupt latency and scheduler jitter without changing the DShot waveform or telemetry format. This change is guarded on and only affects F4-based FCs, which mostly use timer-based DShot due to the DMA errata that precludes bitbanged DShot use. 

Approach:
Instead of calling `DMA_DeInit()`/`DMA_Init()`, the optimized path:
* Clears `DMA_SxCR_DIR`, selecting peripheral-to-memory mode.
* Clears `DMA_SxCR_TCIE`, because the output completion interrupt is not required during telemetry capture.
* Leaves the remaining stream configuration intact.
* Retains the existing timer input-capture initialization.
* Relies on the existing handler code to program `GCR_TELEMETRY_INPUT_LEN` before enabling the stream.
* The normal output path still performs its existing initialization when returning to DShot output mode.

Using `dshot_telemetry_info` in the CLI reports for a F405 the direction change takes about 421 CPU cycles per motor. At 168MHz, this is approximately 421/168 = 2.51 µs. Or for four motors, 2.51 * 4 = 10.04 µs (plus overhead). This is approximately equal to the +/-10 µs of jitter observed in the gyro task interval around the expected 125 µs period (for 8kHz ODR). 
```
# dshot_telemetry_info
...
Dshot directionChange cycles: 421, micros: 2
```

After this PR, `dshot_telemetry_info` reports the direction change takes about 222 CPU cycles per motor, or 222/168 = 1.32 µs. Or for four motors, 1.32 * 4 = 5.28 µs. 

```
# dshot_telemetry_info
...
Dshot directionChange cycles: 222, micros: 1
```


On a F411, the existing config takes about 328 cycles or 328/108 = 3.03 µs.
```
# dshot_telemetry_info
...
Dshot directionChange cycles: 328, micros: 3
```

And after this PR, it takes about 192 cycles, or 192/108 = 1.78 µs.
```
# dshot_telemetry_info
...
Dshot directionChange cycles: 192, micros: 1
```



Further, after this PR, the observed jitter in the gyro task interval is significantly reduced. 

** Not flight tested yet. Needs testing **




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DSHOT telemetry direction switching behavior across STM32 platforms, improving stability during runtime transitions.
  * Enhanced DMA completion/interrupt handling to reduce spurious interruptions and improve overall reliability during high-frequency telemetry updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->