### PR TITLE
STM32H5/N6: drive WS2811 LED strip correctly on GPDMA

### DIFF
--- a/src/platform/STM32/light_ws2811strip_hal.c
+++ b/src/platform/STM32/light_ws2811strip_hal.c
@@ -48,7 +48,16 @@ static uint16_t timerChannel = 0;
 static FAST_IRQ_HANDLER void WS2811_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor)
 {
     HAL_DMA_IRQHandler(TimHandle.hdma[descriptor->userParam]);
+#if defined(STM32H5) || defined(STM32N6)
+    // DMA request is the update event (UDE) on GPDMA — see ws2811LedStripHardwareInit().
+    __HAL_TIM_DISABLE_DMA(&TimHandle, TIM_DMA_UPDATE);
+    // On the other platforms TIM_DMACmd() returns the handle to READY; without
+    // this reset DMA_SetCurrDataCounter() returns HAL_BUSY from the second
+    // frame on and the strip freezes on the first frame.
+    TimHandle.State = HAL_TIM_STATE_READY;
+#else
     TIM_DMACmd(&TimHandle, timerChannel, DISABLE);
+#endif
     ws2811LedDataTransferInProgress = false;
 }
 
@@ -123,8 +132,20 @@ bool ws2811LedStripHardwareInit(void)
 
     /* Set the parameters to be configured */
 #if defined(STM32H5) || defined(STM32N6)
-    // N6 uses HPDMA/GPDMA with a different HAL DMA init structure
-    hdma_tim.Init.Request = dmaChannel;
+    // N6/H5 use HPDMA/GPDMA with a different HAL DMA init structure.
+    //
+    // Drive the channel from the timer UPDATE request (UDE), not the
+    // per-channel compare request (CCxDE). Empirically, a CCxDE-driven GPDMA
+    // channel re-fires continuously and races through the whole WS2811 bit
+    // buffer in microseconds, so no valid waveform reaches the pin — even
+    // though plain PWM (no DMA) on the same pin works. RM0481 documents no
+    // semantic difference between the CC and UP DMA requests; UP is the
+    // configuration proven to work, gives one CCRx write per timer period,
+    // and mirrors the DShot GPDMA path (see pwm_output_dshot_hal.c).
+    // timerHardware->dmaTimUPChannel is the per-timer GPDMA request id
+    // (e.g. LL_GPDMA1_REQUEST_TIM1_UP).
+    hdma_tim.Init.Request = timerHardware->dmaTimUPChannel;
+    UNUSED(dmaChannel);
     hdma_tim.Init.Direction = DMA_MEMORY_TO_PERIPH;
     hdma_tim.Init.SrcInc = DMA_SINC_INCREMENTED;
     hdma_tim.Init.DestInc = DMA_DINC_FIXED;
@@ -135,7 +156,12 @@ bool ws2811LedStripHardwareInit(void)
     hdma_tim.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
     hdma_tim.Init.SrcBurstLength = 1;
     hdma_tim.Init.DestBurstLength = 1;
-    hdma_tim.Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0;
+    // On H5 both GPDMA master ports reach all memories and peripherals
+    // (RM0481 fig. 1); splitting the transfer across ports picks each port's
+    // zero-latency fast path: PORT1 for the source buffer in SRAM, PORT0 for
+    // the APB bridge to the timer CCRx. On N6 the split is mandatory: PORT1
+    // is the AXI port and the only one that reaches AXISRAM.
+    hdma_tim.Init.TransferAllocatedPort = DMA_SRC_ALLOCATED_PORT1 | DMA_DEST_ALLOCATED_PORT0;
     hdma_tim.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
 #elif defined(STM32H7) || defined(STM32G4)
     hdma_tim.Init.Request = dmaChannel;
@@ -219,14 +245,32 @@ void ws2811LedStripStartTransfer(void)
     SCB_CleanDCache_by_Addr(ledStripDMABuffer, WS2811_DMA_BUF_CACHE_ALIGN_BYTES);
 #endif
 
-    if (DMA_SetCurrDataCounter(&TimHandle, timerChannel, ledStripDMABuffer, WS2811_DMA_BUFFER_SIZE) != HAL_OK) {
+#if defined(STM32H5) || defined(STM32N6)
+    // GPDMA sizes the transfer in BYTES (CBR1.BNDT), not in transfer items:
+    // HAL_DMA_Start_IT() writes the length straight into BNDT. Each item is a
+    // 32-bit word (one CCRx write per WS2811 bit), so the byte count is the
+    // word count times 4. Passing the word count would program only a quarter
+    // of the buffer, clocking out ~1/4 of the bitstream (and cutting the reset
+    // latch) so the strip shows nothing/garbage. Classic DMA (F4/F7/H7/G4)
+    // counts transfer items, so it keeps the word count.
+    const uint16_t ws2811DmaLength = WS2811_DMA_BUFFER_SIZE * sizeof(uint32_t);
+#else
+    const uint16_t ws2811DmaLength = WS2811_DMA_BUFFER_SIZE;
+#endif
+
+    if (DMA_SetCurrDataCounter(&TimHandle, timerChannel, ledStripDMABuffer, ws2811DmaLength) != HAL_OK) {
         /* DMA set error */
         ws2811LedDataTransferInProgress = false;
         return;
     }
     /* Reset timer counter */
     __HAL_TIM_SET_COUNTER(&TimHandle,0);
-    /* Enable channel DMA requests */
+    /* Enable DMA requests */
+#if defined(STM32H5) || defined(STM32N6)
+    // Edge-triggered update event on GPDMA — see ws2811LedStripHardwareInit().
+    __HAL_TIM_ENABLE_DMA(&TimHandle, TIM_DMA_UPDATE);
+#else
     TIM_DMACmd(&TimHandle,timerChannel,ENABLE);
+#endif
 }
 #endif


### PR DESCRIPTION
Split out of #15419 (which now carries only the hardware-verified ADC fix) so the LED strip change can be retested independently.

The WS2811 LED-strip DMA needed three GPDMA-specific corrections on the shared H5/N6 path; without them the strip shows nothing even though plain PWM on the same pin works.

1. **Request source** — drive the channel from the timer UPDATE request (UDE via `timerHardware->dmaTimUPChannel`) instead of the per-channel compare request (CCxDE). Empirically a CCxDE-driven GPDMA channel re-fires continuously and races through the whole bit buffer in microseconds; RM0481 documents no semantic difference between the CC and UP requests, but UP gives exactly one CCRx write per timer period and matches the proven DShot GPDMA path (`pwm_output_dshot_hal.c`).

2. **Transfer length** — `HAL_DMA_Start_IT()` programs CBR1.BNDT, which on GPDMA is the block size in **bytes** (RM0481 §16.8.12), not transfer items. Each item is a 32-bit word (one CCRx write per bit), so pass `WS2811_DMA_BUFFER_SIZE * 4`; the word count alone clocks out only a quarter of the frame and cuts the reset latch. Worst case (`USE_LED_STRIP_64`) is 8360 bytes, well within the 16-bit BNDT field. Classic DMA (F4/F7/H7/G4) counts items and is unchanged.

3. **Completion** — `TIM_DMACmd()` was the only place `TimHandle.State` returned to `HAL_TIM_STATE_READY`, and the UDE path no longer calls it, so the handle state is now reset in the DMA IRQ handler. Without this, `DMA_SetCurrDataCounter()` returns `HAL_BUSY` from the second frame on and the strip freezes on the first frame — a static colour looks fine, but nothing ever updates.

The transfer is also split across GPDMA master ports (source buffer in SRAM on PORT1, timer CCRx on PORT0). On H5 both ports reach everything and the split just picks each port's zero-latency fast bus multiplexer path (RM0481 §2.1.5/§2.1.7, fig. 1); on N6 PORT1 (AXI) is genuinely required to reach AXISRAM.

The functional behaviour was checked against RM0481: with OCx preload enabled the DMA-written CCR values latch at the next update event, so the waveform shifts one bit period, which the 42-word trailing zero padding absorbs; the line idles low after the frame, keeping the >50 µs reset latch intact.

`make STM32H563` builds clean with zero warnings.

**Testing**: needs an on-hardware retest with an animated pattern (e.g. larson scanner) — a static colour cannot distinguish a working strip from one frozen on frame 1, which is exactly what the pre-fix code did.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WS2811 LED strip DMA handling on STM32H5/N6 devices.
  * Corrected LED strip transfer sizing and triggering for more reliable output.
  * Reduced the risk of LED update freezes during DMA operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->