### PR TITLE
Autopilot: leg-line carrot tracking, turn-angle cornering, heading-fault park

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -2886,7 +2886,7 @@ static void cliWaypoint(const char *cmdName, char *cmdline)
 
         if (state == FP_NAV_ABORTED) {
             static const char * const abortNames[] = {
-                "NONE", "GPS LOST", "STALLED", "FLYAWAY", "HEADING",
+                "NONE", "GPS LOST", "STALLED", "FLYAWAY", "HEADING", "MAG FAULT",
             };
             const flightPlanAbortReason_e reason = flightPlanNavGetAbortReason();
             cliPrintLinef("  abort reason: %s", (reason < ARRAYLEN(abortNames)) ? abortNames[reason] : "UNKNOWN");

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -2033,6 +2033,15 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_AP_MAX_YAW_RATE,            VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 10, 360 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, maxYawRate) },
     { PARAM_NAME_AP_MIN_FORWARD_VELOCITY,    VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 10, 500 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, minForwardVelocity) },
 
+    // Leg-line carrot path tracking and turn-angle cornering
+    { PARAM_NAME_AP_NAV_CORNER_SPEED,        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 50, 2000 },   PG_AUTOPILOT, offsetof(autopilotConfig_t, navCornerSpeed) },
+    { PARAM_NAME_AP_NAV_CORNER_DELTA_V,      VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 100, 4000 },  PG_AUTOPILOT, offsetof(autopilotConfig_t, navCornerDeltaV) },
+    { PARAM_NAME_AP_NAV_DECEL,               VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 20, 1000 },   PG_AUTOPILOT, offsetof(autopilotConfig_t, navDecel) },
+    { PARAM_NAME_AP_NAV_ACCEL,               VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 20, 1000 },   PG_AUTOPILOT, offsetof(autopilotConfig_t, navAccel) },
+    { PARAM_NAME_AP_NAV_CARROT_LEAD_TIME,    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 2, 40 },      PG_AUTOPILOT, offsetof(autopilotConfig_t, navCarrotLeadTime) },
+    { PARAM_NAME_AP_NAV_CARROT_LEAD_MAX,     VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 500, 6000 },  PG_AUTOPILOT, offsetof(autopilotConfig_t, navCarrotLeadMax) },
+    { PARAM_NAME_AP_NAV_PRETURN_DIST,        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 500, 5000 },  PG_AUTOPILOT, offsetof(autopilotConfig_t, navPreturnDist) },
+
     // Phase 5: Velocity buildup
     { PARAM_NAME_AP_VELOCITY_BUILDUP_MAX_PITCH, VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 20 },   PG_AUTOPILOT, offsetof(autopilotConfig_t, velocityBuildupMaxPitch) },
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -2039,7 +2039,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_AP_NAV_DECEL,               VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 20, 1000 },   PG_AUTOPILOT, offsetof(autopilotConfig_t, navDecel) },
     { PARAM_NAME_AP_NAV_ACCEL,               VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 20, 1000 },   PG_AUTOPILOT, offsetof(autopilotConfig_t, navAccel) },
     { PARAM_NAME_AP_NAV_CARROT_LEAD_TIME,    VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 2, 40 },      PG_AUTOPILOT, offsetof(autopilotConfig_t, navCarrotLeadTime) },
-    { PARAM_NAME_AP_NAV_CARROT_LEAD_MAX,     VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 500, 6000 },  PG_AUTOPILOT, offsetof(autopilotConfig_t, navCarrotLeadMax) },
+    { PARAM_NAME_AP_NAV_CARROT_LEAD_MAX,     VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 600, 6000 },  PG_AUTOPILOT, offsetof(autopilotConfig_t, navCarrotLeadMax) },
     { PARAM_NAME_AP_NAV_PRETURN_DIST,        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 500, 5000 },  PG_AUTOPILOT, offsetof(autopilotConfig_t, navPreturnDist) },
 
     // Phase 5: Velocity buildup

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -196,6 +196,15 @@
 #define PARAM_NAME_AP_MAX_YAW_RATE "ap_max_yaw_rate"
 #define PARAM_NAME_AP_MIN_FORWARD_VELOCITY "ap_min_forward_velocity"
 
+// Leg-line carrot path tracking and turn-angle cornering
+#define PARAM_NAME_AP_NAV_CORNER_SPEED "ap_nav_corner_speed"
+#define PARAM_NAME_AP_NAV_CORNER_DELTA_V "ap_nav_corner_delta_v"
+#define PARAM_NAME_AP_NAV_DECEL "ap_nav_decel"
+#define PARAM_NAME_AP_NAV_ACCEL "ap_nav_accel"
+#define PARAM_NAME_AP_NAV_CARROT_LEAD_TIME "ap_nav_carrot_lead_time"
+#define PARAM_NAME_AP_NAV_CARROT_LEAD_MAX "ap_nav_carrot_lead_max"
+#define PARAM_NAME_AP_NAV_PRETURN_DIST "ap_nav_preturn_dist"
+
 // Phase 5: Velocity buildup
 #define PARAM_NAME_AP_VELOCITY_BUILDUP_MAX_PITCH "ap_velocity_buildup_max_pitch"
 

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -154,6 +154,7 @@ static bool wasPositionHeld = false;
 static bool wasNavActive = false;
 static bool abortNavRequested = false;
 static bool forcePitchForward = false;
+static bool forceLevelPark = false;
 static bool wasAngleSaturated = false;
 
 static float apYawRateDps = 0.0f;
@@ -161,6 +162,8 @@ static bool apYawActive = false;
 static float apYawAttenuator = 0.0f;
 static float apYawRateLimitDps = 0.0f;
 static bool apYawCourseValid = false;
+static bool apNavHeadingOverrideValid = false;   // mission pre-turn: nose commanded onto the next leg
+static float apNavHeadingOverrideDeg = 0.0f;
 
 static void disableYawControl(void);
 
@@ -229,6 +232,8 @@ void autopilotInit(void)
     ap.isPosHoldBraking = false;
     abortNavRequested = false;
     forcePitchForward = false;
+    forceLevelPark = false;
+    apNavHeadingOverrideValid = false;
     disableYawControl();
     apYawRateLimitDps = 0.0f;
     positionNavInit();
@@ -355,6 +360,17 @@ void pitchForwardOverride(bool request)
     forcePitchForward = request;
 }
 
+void autopilotForceLevelPark(bool request)
+{
+    forceLevelPark = request;
+}
+
+void autopilotSetNavHeadingOverride(bool valid, float headingDeg)
+{
+    apNavHeadingOverrideValid = valid;
+    apNavHeadingOverrideDeg = headingDeg;
+}
+
 static inline float calculateSanityCheckDistance(void)
 {
     const float speedCmS = vector2Norm((const vector2_t *)&positionEstimatorGetEstimate()->velocity.v);
@@ -400,6 +416,8 @@ void resetPositionControl(unsigned taskRateHz)
     UNUSED(taskRateHz);
     abortNavRequested = false;
     forcePitchForward = false;
+    forceLevelPark = false;
+    apNavHeadingOverrideValid = false;
     ap.sticksActive = false;
     ap.wasSticksActive = false;
     disableYawControl();
@@ -515,19 +533,26 @@ static void updateYawControl(float dt, const positionEstimate3d_t *est)
 
     float desiredHeadingDeg = 0.0f;
     bool haveDesiredHeading = false;
-    switch (cfg->yawMode) {
-    case YAW_MODE_VELOCITY:
-        haveDesiredHeading = courseHeadingDeg(est, &desiredHeadingDeg);
-        break;
-    case YAW_MODE_BEARING:
-        haveDesiredHeading = bearingToTargetDeg(est, &desiredHeadingDeg);
-        break;
-    case YAW_MODE_HYBRID:
-        haveDesiredHeading = courseHeadingDeg(est, &desiredHeadingDeg)
-            || bearingToTargetDeg(est, &desiredHeadingDeg);
-        break;
-    default: // YAW_MODE_FIXED, YAW_MODE_DAMPENER (wing only)
-        break;
+    if (apNavHeadingOverrideValid) {
+        // Mission pre-turn blend: point the nose onto the next leg regardless of
+        // the configured yaw mode, so it is already there as the gate is crossed.
+        desiredHeadingDeg = apNavHeadingOverrideDeg;
+        haveDesiredHeading = true;
+    } else {
+        switch (cfg->yawMode) {
+        case YAW_MODE_VELOCITY:
+            haveDesiredHeading = courseHeadingDeg(est, &desiredHeadingDeg);
+            break;
+        case YAW_MODE_BEARING:
+            haveDesiredHeading = bearingToTargetDeg(est, &desiredHeadingDeg);
+            break;
+        case YAW_MODE_HYBRID:
+            haveDesiredHeading = courseHeadingDeg(est, &desiredHeadingDeg)
+                || bearingToTargetDeg(est, &desiredHeadingDeg);
+            break;
+        default: // YAW_MODE_FIXED, YAW_MODE_DAMPENER (wing only)
+            break;
+        }
     }
 
     if (!haveDesiredHeading) {
@@ -572,6 +597,14 @@ bool positionControl(void)
         disableYawControl();
         handlepositionControlFailure();
         return false; // Return failure and show pos hold fail message in OSD
+    }
+    if (forceLevelPark) {
+        // Heading/mag fault: position hold would lean on the suspect heading and
+        // fly sideways, so drop to angle-mode self-level (altitude hold, a
+        // separate mode, keeps holding height) until a mode-switch cycle clears it.
+        disableYawControl();
+        handlepositionControlFailure();
+        return false;
     }
     if (forcePitchForward) {
         disableYawControl();

--- a/src/main/flight/autopilot_multirotor.h
+++ b/src/main/flight/autopilot_multirotor.h
@@ -38,6 +38,8 @@ bool positionControl(void);
 void altitudeControl(float targetAltitudeCm, float taskIntervalS, float targetAltitudeVelCmS, float velLimitCmS);
 void moveTargetLocation(const vector2_t *stepEF, unsigned taskRateHz, bool forceAbortNav);// for nav modes to update the target position
 void pitchForwardOverride(bool request);
+void autopilotForceLevelPark(bool request); // heading/mag fault: force angle-mode self-level, never position hold
+void autopilotSetNavHeadingOverride(bool valid, float headingDeg); // mission pre-turn: command nose heading directly
 void initPositionHold(void);
 uint16_t autopilotGetEffectiveHoverThrottlePwm(void);
 void autopilotCaptureHoverThrottleForAltHold(void);

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -42,6 +42,7 @@
 
 #include "flight/autopilot.h"
 #include "flight/flight_plan_nav.h"
+#include "flight/imu.h"
 #include "flight/position_estimator.h"
 #include "flight/position_nav.h"
 
@@ -82,6 +83,27 @@
 // acceptance radius. Deliberately gentle: the position controller tracks
 // velocity through an integrator, so the ramp must be slow enough to unwind.
 #define FP_APPROACH_DECEL_MPS2    0.3f
+
+// Heading-fault (magnetometer) detector. While the nose is on command and the
+// craft is moving, a course-over-ground that disagrees with the fused heading
+// past FP_HDG_FAULT_ERR_DEG for FP_HDG_FAULT_TIME_S means the heading estimate
+// is wrong — the sideways-flyaway precursor. A real crab angle this large
+// cannot hold a leg line at this ground speed, so wind cannot trip it. The trip
+// parks the craft wings-level rather than in position hold, which would lean on
+// the same bad heading and fly it away.
+#define FP_HDG_FAULT_ERR_DEG        70.0f
+#define FP_HDG_FAULT_TIME_S         2.0f
+#define FP_HDG_FAULT_MIN_SPEED_CMS  300.0f
+#define FP_HDG_FAULT_ALIGNED_DEG    30.0f
+
+// Leg-line carrot path tracking (en-route pass-through legs). Tunable
+// magnitudes live in autopilotConfig (nav_corner_speed etc.); these are the
+// fixed shape limits. Ported from the field-proven tracker in PR #15442.
+#define FP_PASS_MAX_M            12.0f   // largest pass-through gate radius
+#define FP_CARROT_LEAD_MIN_M     6.0f    // the carrot always leads by at least this
+#define FP_GATE_RADIUS_SCALE     1.5f    // gate radius = corner speed (m/s) * this
+#define FP_OVERSPEED_MARGIN_MPS  1.5f    // measured-speed governor margin over the profile speed
+#define FP_OVERRUN_LAT_M         8.0f    // a fast gate miss still counts within this lateral corridor
 
 // Landing descends toward a target far below the current position so vertical
 // arrival can never trigger; touchdown detection is what ends the descent.
@@ -169,6 +191,26 @@ static struct {
     float bestDistanceToTargetM;
     float flyawayMarginM;
     timeUs_t lastProgressUs;
+
+    // Heading-fault detector integrator, and the timestamp the per-cycle dt is
+    // derived from (flightPlanNavUpdate's cadence is not a fixed rate).
+    float hdgFaultTimeS;
+    timeUs_t lastUpdateUs;
+
+    // Leg-line carrot tracking for en-route (FLYOVER/FLYBY) pass-through legs.
+    // positionNav chases a carrot the executor marches along the leg line; the
+    // executor owns gate detection and advancement. State carries across a
+    // corner so the profile is continuous (only engage/retry re-anchor it).
+    bool      legIsPassGate;    // current leg uses carrot leg-line tracking
+    bool      legValid;         // the leg line is anchored
+    vector3_t legTargetEnuM;    // the point this leg flies to (E,N,U metres)
+    float     legCruiseMps;     // this leg's cruise cap
+    vector2_t legStartEnuM;     // anchor of the leg line (E,N metres)
+    float     legProgressM;     // carrot distance travelled along the leg
+    float     carrotSpeedMps;   // slewed carrot speed
+    vector2_t carrotPrevEnuM;   // last commanded carrot; the next leg anchors here
+    bool      carrotPrevValid;
+    bool      inPreTurn;        // blending the nose onto the next leg (excluded from the heading-fault check)
 
     // Landing state
     timeUs_t landingStartUs;
@@ -328,20 +370,48 @@ static bool dispatchWaypoint(void)
         }
     }
 
+    // En-route FLYOVER/FLYBY waypoints (never the last, never station-keeping)
+    // are pass-through gates flown with leg-line carrot tracking; everything else
+    // keeps the precise point-target arrival + hold.
+    const bool isLastWaypoint = (fp.currentIndex + 1 >= activePlanCount());
+    const bool passGate = !isStationKeeping && !isLastWaypoint;
+
     fp.patternPending = false;
     fp.patternActive = false;
-    positionNavSetTargetEf(&targetEnuM, cruiseMps, arrivalRadiusM,
-                           FP_COMPLETION_ANY_MPS, true, onWaypointReached, NULL);
-    positionNavSetAccelLimits(0.0f, FP_APPROACH_DECEL_MPS2);
-    // En-route waypoints advance on horizontal arrival; a vehicle that cannot
-    // reach the commanded altitude must not orbit forever. HOLD, LAND and
-    // TAKEOFF are station-keeping targets and keep the altitude gate.
-    positionNavSetAltitudeArrivalRequired(isStationKeeping);
+    fp.legIsPassGate = passGate;
+    fp.legValid = false;               // re-anchor the leg line on the next update
+    fp.legTargetEnuM = targetEnuM;
+    fp.legCruiseMps = cruiseMps;
+    fp.inPreTurn = false;
+    if (!passGate) {
+        autopilotSetNavHeadingOverride(false, 0.0f);   // precise legs use the configured yaw mode
+    }
+
+    if (passGate) {
+        // positionNav is a pure velocity generator chasing the marched carrot:
+        // acceptance radius 0 stops it ever self-completing, no callback (the
+        // executor advances), and no internal accel/decel (the carrot's
+        // trapezoid owns the speed profile). carrotSpeed carries across the
+        // corner — only engage/retry reset it.
+        positionNavSetTargetEf(&targetEnuM, cruiseMps, 0.0f,
+                               FP_COMPLETION_ANY_MPS, true, NULL, NULL);
+        positionNavSetAccelLimits(0.0f, 0.0f);
+        positionNavSetAltitudeArrivalRequired(false);
+    } else {
+        positionNavSetTargetEf(&targetEnuM, cruiseMps, arrivalRadiusM,
+                               FP_COMPLETION_ANY_MPS, true, onWaypointReached, NULL);
+        positionNavSetAccelLimits(0.0f, FP_APPROACH_DECEL_MPS2);
+        // En-route waypoints advance on horizontal arrival; a vehicle that cannot
+        // reach the commanded altitude must not orbit forever. HOLD, LAND and
+        // TAKEOFF are station-keeping targets and keep the altitude gate.
+        positionNavSetAltitudeArrivalRequired(isStationKeeping);
+    }
 
     fp.state = FP_NAV_TARGETING;
     fp.holdDurationDs = effective.duration;
     fp.bestDistanceToTargetM = FLT_MAX;
     fp.lastProgressUs = micros();
+    fp.hdgFaultTimeS = 0.0f;
     return true;
 }
 
@@ -351,6 +421,8 @@ static void abortMission(flightPlanAbortReason_e reason)
     fp.abortReason = reason;
     fp.patternPending = false;
     fp.patternActive = false;
+    fp.inPreTurn = false;
+    autopilotSetNavHeadingOverride(false, 0.0f);
     // Dropping the nav target makes positionControl() fall back to holding
     // position at the current location; the pilot exits via the mode switch.
     positionNavClearTarget();
@@ -371,14 +443,24 @@ static float distanceToNavTargetM(const positionEstimate3d_t *est)
     return vector3Norm(&deltaM);
 }
 
-static void checkLegProgress(timeUs_t currentTimeUs, const positionEstimate3d_t *est)
+// Delta to the actual waypoint for OSD/CLI readouts. On a carrot leg the nav
+// target is the leading carrot, so report the leg's true waypoint instead.
+static void navWaypointDeltaEnuM(const positionEstimate3d_t *est, vector3_t *deltaM)
 {
-    if (!positionNavHasActiveTarget()) {
-        return;
+    if (fp.legIsPassGate) {
+        deltaM->v[ENU_E] = fp.legTargetEnuM.v[ENU_E] - est->position.v[ENU_E] * 0.01f;
+        deltaM->v[ENU_N] = fp.legTargetEnuM.v[ENU_N] - est->position.v[ENU_N] * 0.01f;
+        deltaM->v[ENU_U] = fp.legTargetEnuM.v[ENU_U] - est->position.v[ENU_U] * 0.01f;
+    } else {
+        navTargetDeltaEnuM(est, deltaM);
     }
+}
 
-    const float distanceM = distanceToNavTargetM(est);
-
+// Stall/flyaway sanity against a distance-to-goal. The carrot path passes the
+// distance to the waypoint (not the leading carrot, which never converges);
+// the point path passes the distance to the nav target.
+static void updateProgressTracking(float distanceM, timeUs_t currentTimeUs)
+{
     if (fp.bestDistanceToTargetM == FLT_MAX) {
         fp.flyawayMarginM = constrainf(distanceM * FP_FLYAWAY_LEG_FRACTION,
                                        FP_FLYAWAY_MARGIN_MIN_M, FP_FLYAWAY_MARGIN_MAX_M);
@@ -398,6 +480,217 @@ static void checkLegProgress(timeUs_t currentTimeUs, const positionEstimate3d_t 
     if (cmpTimeUs(currentTimeUs, fp.lastProgressUs) >= (timeDelta_t)FP_STALL_TIMEOUT_US) {
         abortMission(FP_ABORT_STALLED);
     }
+}
+
+static void checkLegProgress(timeUs_t currentTimeUs, const positionEstimate3d_t *est)
+{
+    if (!positionNavHasActiveTarget()) {
+        return;
+    }
+    updateProgressTracking(distanceToNavTargetM(est), currentTimeUs);
+}
+
+static float wrapDeg180f(float deg)
+{
+    deg = fmodf(deg + 540.0f, 360.0f);
+    if (deg < 0.0f) {
+        deg += 360.0f;
+    }
+    return deg - 180.0f;
+}
+
+// Integrate the heading-fault detector for one cycle. Returns true when a
+// course-over-ground vs fused-heading disagreement has been sustained long
+// enough to declare the heading estimate faulty. Only judged while the nose is
+// on command and the craft is moving, so wind and manoeuvres cannot trip it.
+static bool checkHeadingFault(float dtS, const positionEstimate3d_t *est)
+{
+    vector3_t deltaM;
+    navTargetDeltaEnuM(est, &deltaM);
+    const float bearingDeg = RADIANS_TO_DEGREES(atan2_approx(deltaM.v[ENU_E], deltaM.v[ENU_N]));
+    const float headingDeg = attitude.values.yaw * 0.1f;
+    const float yawErrDeg = wrapDeg180f(headingDeg - bearingDeg);
+    const float cogVsHeadingDeg = fabsf(wrapDeg180f(headingDeg - gpsSol.groundCourse * 0.1f));
+
+    const bool eligible = gpsSol.groundSpeed > FP_HDG_FAULT_MIN_SPEED_CMS
+                       && fabsf(yawErrDeg) < FP_HDG_FAULT_ALIGNED_DEG
+                       && !fp.inPreTurn;   // the pre-turn deliberately swings the nose off-course
+    fp.hdgFaultTimeS = (eligible && cogVsHeadingDeg > FP_HDG_FAULT_ERR_DEG)
+                     ? fp.hdgFaultTimeS + dtS
+                     : fmaxf(fp.hdgFaultTimeS - 2.0f * dtS, 0.0f);
+    return fp.hdgFaultTimeS > FP_HDG_FAULT_TIME_S;
+}
+
+// One cycle of leg-line carrot tracking for an en-route pass-through leg: march a
+// carrot along the leg line toward the waypoint and hand it to positionNav, carve
+// the corner into the next leg at a turn-angle-scaled speed, and own gate
+// detection/advancement. Ported from the tracker in PR #15442.
+static void updateLegCarrot(float dtS, timeUs_t currentTimeUs, const positionEstimate3d_t *est)
+{
+    const autopilotConfig_t *cfg = autopilotConfig();
+    const float cornerSpeedFloorMps = cfg->navCornerSpeed * 0.01f;
+    const float cornerDeltaVMps     = cfg->navCornerDeltaV * 0.01f;
+    const float decelMps2           = cfg->navDecel * 0.01f;
+    const float accelMps2           = cfg->navAccel * 0.01f;
+    const float leadTimeS           = cfg->navCarrotLeadTime * 0.1f;
+    const float leadMaxM            = cfg->navCarrotLeadMax * 0.01f;
+
+    const vector2_t craft = { .x = est->position.v[ENU_E] * 0.01f, .y = est->position.v[ENU_N] * 0.01f };
+    const vector2_t wp    = { .x = fp.legTargetEnuM.v[ENU_E], .y = fp.legTargetEnuM.v[ENU_N] };
+    const vector2_t toWp  = { .x = wp.x - craft.x, .y = wp.y - craft.y };
+    const float distM = vector2Norm(&toWp);
+
+    // A pass-through leg always has a next waypoint; use it for the corner speed.
+    vector2_t next = wp;
+    bool haveNext = false;
+    const waypoint_t *nextWp = activePlanWaypoint(fp.currentIndex + 1);
+    if (nextWp != NULL) {
+        vector3_t nextEnuM;
+        waypoint_t effNext = *nextWp;
+        if (computeTargetEnuM(&effNext, &nextEnuM)) {
+            next.x = nextEnuM.v[ENU_E];
+            next.y = nextEnuM.v[ENU_N];
+            haveNext = true;
+        }
+    }
+
+    // Corner speed on a constant delta-v budget: the velocity change a corner
+    // demands is 2*v*sin(turn/2), so v = deltaV / (2 sin(turn/2)) sheds the same
+    // delta-v at every gate — a shallow bend at cruise runs no wider than a
+    // hairpin at the floor. The gate radius scales with it for the same reason.
+    float cornerSpeedMps = fp.legCruiseMps;
+    const vector2_t inFrom = fp.legValid ? fp.legStartEnuM : craft;
+    if (haveNext) {
+        const vector2_t inVec  = { .x = wp.x - inFrom.x, .y = wp.y - inFrom.y };
+        const vector2_t outVec = { .x = next.x - wp.x,   .y = next.y - wp.y };
+        const float inLen  = vector2Norm(&inVec);
+        const float outLen = vector2Norm(&outVec);
+        if (inLen > 1.0f && outLen > 1.0f) {
+            const float cosTurn = (inVec.x * outVec.x + inVec.y * outVec.y) / (inLen * outLen);
+            const float shed = sqrtf(fmaxf(2.0f - 2.0f * cosTurn, 0.0f)); // = 2 sin(turn/2)
+            cornerSpeedMps = (shed > 0.05f)
+                ? constrainf(cornerDeltaVMps / shed, cornerSpeedFloorMps, fp.legCruiseMps)
+                : fp.legCruiseMps;   // straight through
+        }
+    }
+    const float arriveM = constrainf(cornerSpeedMps * FP_GATE_RADIUS_SCALE,
+                                     cfg->waypointArrivalRadius * 0.01f, FP_PASS_MAX_M);
+
+    // Overrun fallback: a fast crossing that misses the arrive bubble by a hair
+    // still counts once the craft is past the waypoint along-track inside a sane
+    // lateral corridor — without it the craft overruns the carrot and yaws back.
+    bool overran = false;
+    if (fp.legValid) {
+        const vector2_t inVec = { .x = wp.x - fp.legStartEnuM.x, .y = wp.y - fp.legStartEnuM.y };
+        const float inLen = vector2Norm(&inVec);
+        if (inLen > 1.0f) {
+            const float ux = inVec.x / inLen, uy = inVec.y / inLen;
+            const float along   = (craft.x - fp.legStartEnuM.x) * ux + (craft.y - fp.legStartEnuM.y) * uy;
+            const float lateral = fabsf((craft.y - fp.legStartEnuM.y) * ux - (craft.x - fp.legStartEnuM.x) * uy);
+            overran = along > inLen && lateral < FP_OVERRUN_LAT_M;
+        }
+    }
+
+    // Stall/flyaway sanity is measured against the waypoint, not the leading
+    // carrot (which never converges to zero distance).
+    updateProgressTracking(distM, currentTimeUs);
+    if (fp.state != FP_NAV_TARGETING) {
+        return;   // the sanity check aborted the mission
+    }
+
+    if (distM < arriveM || overran) {
+        // Gate crossed: the next leg anchors on this waypoint so the drawn
+        // wp->wp line and the position target stay continuous through the corner.
+        fp.carrotPrevEnuM = wp;
+        fp.carrotPrevValid = true;
+        onWaypointReached(NULL);   // fires the reached listener and advances/dispatches
+        return;
+    }
+
+    // Anchor the leg line. A fresh leg starts at the last commanded carrot
+    // (normally the waypoint just passed) so the flown line is the drawn wp->wp
+    // line; engage/retry clear carrotPrevValid to anchor on the craft instead.
+    if (!fp.legValid) {
+        fp.legStartEnuM = fp.carrotPrevValid ? fp.carrotPrevEnuM : craft;
+        fp.legProgressM = 0.0f;
+        fp.legValid = true;
+    }
+
+    const vector2_t legVec = { .x = wp.x - fp.legStartEnuM.x, .y = wp.y - fp.legStartEnuM.y };
+    const float legLenM = vector2Norm(&legVec);
+    vector2_t legDir = { .x = 1.0f, .y = 0.0f };
+    if (legLenM > 1.0f) {
+        legDir.x = legVec.x / legLenM;
+        legDir.y = legVec.y / legLenM;
+    }
+    const float craftAlongM = (craft.x - fp.legStartEnuM.x) * legDir.x + (craft.y - fp.legStartEnuM.y) * legDir.y;
+
+    // Trapezoidal profile keyed on the craft's distance to the gate: cruise, then
+    // decelerate to cross at the corner speed. The carrot speed slews (no
+    // full-cruise leap at leg starts) and is deliberately not reset at leg
+    // switches, so speed carries smoothly through corners.
+    const float remainingM = fmaxf(legLenM - craftAlongM - arriveM, 0.0f);
+    float desiredMps = fminf(fp.legCruiseMps, sqrtf(sq(cornerSpeedMps) + 2.0f * decelMps2 * remainingM));
+
+    // Governor on measured speed: a craft carrying more than the profile (tailwind,
+    // catch-up) makes the carrot surrender braking authority; freeze it instead.
+    const float horizSpeedMps = sqrtf(sq(est->velocity.v[ENU_E]) + sq(est->velocity.v[ENU_N])) * 0.01f;
+    if (horizSpeedMps > desiredMps + FP_OVERSPEED_MARGIN_MPS) {
+        desiredMps = 0.0f;
+    }
+
+    // March gating keys on alignment with the leg direction so forward progress
+    // never accumulates while rotating in place at a leg start or a reversal.
+    const float headingDeg = attitude.values.yaw * 0.1f;
+    const float legBearingDeg = RADIANS_TO_DEGREES(atan2_approx(legDir.x, legDir.y));
+    const float legErrDeg = wrapDeg180f(headingDeg - legBearingDeg);
+    if (fabsf(legErrDeg) >= 90.0f) {
+        desiredMps = 0.0f;
+    }
+
+    // Pre-turn: through the approach zone (ending a few metres before the gate,
+    // so the yaw law has closed the lag by the crossing) blend the commanded nose
+    // heading from this leg onto the next. Outside the zone the configured yaw
+    // mode governs (override off). Only the nose is affected — the carrot, and so
+    // the path, is unchanged, and the march gate above ignores the pre-turn swing.
+    fp.inPreTurn = false;
+    if (haveNext) {
+        const float preturnM = cfg->navPreturnDist * 0.01f;
+        const float t = 1.0f - constrainf((remainingM - 5.0f) / fmaxf(preturnM - 5.0f, 1.0f), 0.0f, 1.0f);
+        const vector2_t nextLeg = { .x = next.x - wp.x, .y = next.y - wp.y };
+        if (t > 0.0f && vector2Norm(&nextLeg) > 1.0f) {
+            const float nextBearingDeg = RADIANS_TO_DEGREES(atan2_approx(nextLeg.x, nextLeg.y));
+            const float blendedDeg = legBearingDeg + t * wrapDeg180f(nextBearingDeg - legBearingDeg);
+            autopilotSetNavHeadingOverride(true, blendedDeg);
+            fp.inPreTurn = true;
+        }
+    }
+    if (!fp.inPreTurn) {
+        autopilotSetNavHeadingOverride(false, 0.0f);
+    }
+
+    fp.carrotSpeedMps = constrainf(desiredMps,
+                                   fp.carrotSpeedMps - accelMps2 * dtS,
+                                   fp.carrotSpeedMps + accelMps2 * dtS);
+    fp.legProgressM += fp.carrotSpeedMps * dtS;
+
+    // Pure-pursuit lead, with the carrot allowed a bounded gap behind the craft —
+    // the only thing positionNav brakes for — so an overrun bites firmly.
+    const float alongFloorM = fmaxf(craftAlongM, 0.0f);
+    const float leadM     = constrainf(fp.carrotSpeedMps * leadTimeS, FP_CARROT_LEAD_MIN_M, leadMaxM);
+    const float brakeGapM = 0.25f * fp.carrotSpeedMps + 1.5f;
+    fp.legProgressM = constrainf(fp.legProgressM, alongFloorM - brakeGapM, alongFloorM + leadM);
+    fp.legProgressM = constrainf(fp.legProgressM, 0.0f, legLenM);
+
+    vector3_t carrot = {.v = {
+        [ENU_E] = fp.legStartEnuM.x + legDir.x * fp.legProgressM,
+        [ENU_N] = fp.legStartEnuM.y + legDir.y * fp.legProgressM,
+        [ENU_U] = fp.legTargetEnuM.v[ENU_U],   // altitude tracks the waypoint, as the point path does
+    }};
+    fp.carrotPrevEnuM.x = carrot.v[ENU_E];
+    fp.carrotPrevEnuM.y = carrot.v[ENU_N];
+    fp.carrotPrevValid = true;
+    positionNavMoveTargetEf(&carrot);
 }
 
 static void startLanding(timeUs_t currentTimeUs, float targetEastM, float targetNorthM)
@@ -813,6 +1106,13 @@ void flightPlanNavInit(void)
     fp.injectedCount = 0;
     fp.patternPending = false;
     fp.patternActive = false;
+    fp.hdgFaultTimeS = 0.0f;
+    fp.lastUpdateUs = 0;
+    fp.legIsPassGate = false;
+    fp.legValid = false;
+    fp.carrotSpeedMps = 0.0f;
+    fp.carrotPrevValid = false;
+    fp.inPreTurn = false;
 #if ENABLE_RESCUE_PLAN
     fp.stagedCount = 0;
     fp.isRescuePlan = false;
@@ -831,6 +1131,15 @@ void flightPlanNavEngage(void)
     fp.injectedCount = 0;
     fp.patternPending = false;
     fp.patternActive = false;
+    fp.hdgFaultTimeS = 0.0f;
+    fp.lastUpdateUs = 0;
+    fp.legIsPassGate = false;
+    fp.legValid = false;
+    fp.carrotSpeedMps = 0.0f;
+    fp.carrotPrevValid = false;
+    fp.inPreTurn = false;
+    autopilotForceLevelPark(false);   // a fresh engage clears any latched heading-fault park
+    autopilotSetNavHeadingOverride(false, 0.0f);
     clearModifierState();
 
     // Reconcile the estimator's altitude baseline with the GPS frame waypoint
@@ -889,6 +1198,15 @@ void flightPlanNavDisengage(void)
     fp.injectedCount = 0;
     fp.patternPending = false;
     fp.patternActive = false;
+    fp.hdgFaultTimeS = 0.0f;
+    fp.lastUpdateUs = 0;
+    fp.legIsPassGate = false;
+    fp.legValid = false;
+    fp.carrotSpeedMps = 0.0f;
+    fp.carrotPrevValid = false;
+    fp.inPreTurn = false;
+    autopilotForceLevelPark(false);
+    autopilotSetNavHeadingOverride(false, 0.0f);
 #if ENABLE_RESCUE_PLAN
     fp.stagedCount = 0;
     fp.isRescuePlan = false;
@@ -911,6 +1229,8 @@ bool flightPlanNavInjectPlan(const waypoint_t *waypoints, uint8_t count)
     fp.injectedCount = count;
     fp.currentIndex = 0;
     fp.abortReason = FP_ABORT_NONE;
+    fp.carrotPrevValid = false;   // a fresh plan re-anchors on the craft
+    fp.carrotSpeedMps = 0.0f;
 #if ENABLE_RESCUE_PLAN
     fp.isRescuePlan = false;
 #endif
@@ -931,6 +1251,11 @@ void flightPlanNavUpdate(timeUs_t currentTimeUs)
     if (!fp.active) {
         return;
     }
+
+    const float dtS = (fp.lastUpdateUs != 0)
+        ? constrainf(cmpTimeUs(currentTimeUs, fp.lastUpdateUs) * 1e-6f, 0.0f, 0.25f)
+        : 0.0f;
+    fp.lastUpdateUs = currentTimeUs;
 
 #if ENABLE_RESCUE_PLAN
     if (fp.rescueHeadingHold) {
@@ -960,6 +1285,10 @@ void flightPlanNavUpdate(timeUs_t currentTimeUs)
     // activates POS_HOLD_MODE and its first update calls resetPositionControl().
     // Re-issue the current leg whenever the dispatched target has been lost.
     if (fp.state == FP_NAV_TARGETING && !positionNavHasActiveTarget()) {
+        // Position control re-initialised and wiped the target: re-anchor a
+        // carrot leg on the craft's current position, not a stale carrot.
+        fp.carrotPrevValid = false;
+        fp.carrotSpeedMps = 0.0f;
         dispatchWaypoint();
         return;
     }
@@ -991,7 +1320,18 @@ void flightPlanNavUpdate(timeUs_t currentTimeUs)
     }
 
     if (fp.state == FP_NAV_TARGETING) {
-        checkLegProgress(currentTimeUs, positionEstimatorGetEstimate());
+        const positionEstimate3d_t *est = positionEstimatorGetEstimate();
+        if (fp.legIsPassGate) {
+            updateLegCarrot(dtS, currentTimeUs, est);   // marches the carrot, owns gate advance + sanity
+        } else {
+            checkLegProgress(currentTimeUs, est);
+        }
+        if (fp.state == FP_NAV_TARGETING && positionNavHasActiveTarget()
+            && checkHeadingFault(dtS, est)) {
+            autopilotForceLevelPark(true);
+            abortMission(FP_ABORT_MAG_FAULT);
+            return;
+        }
     }
 
     if (fp.state == FP_NAV_HOLDING) {
@@ -1051,7 +1391,9 @@ float flightPlanNavGetDistanceToWaypointM(void)
     if (!fp.active || !positionNavHasActiveTarget()) {
         return -1.0f;
     }
-    return distanceToNavTargetM(positionEstimatorGetEstimate());
+    vector3_t deltaM;
+    navWaypointDeltaEnuM(positionEstimatorGetEstimate(), &deltaM);
+    return vector3Norm(&deltaM);
 }
 
 int32_t flightPlanNavGetBearingToWaypointDeciDeg(void)
@@ -1060,7 +1402,7 @@ int32_t flightPlanNavGetBearingToWaypointDeciDeg(void)
         return -1;
     }
     vector3_t deltaM;
-    navTargetDeltaEnuM(positionEstimatorGetEstimate(), &deltaM);
+    navWaypointDeltaEnuM(positionEstimatorGetEstimate(), &deltaM);
     // Compass bearing: 0 = north, growing clockwise. ENU east/north maps to
     // atan2(E, N); wrap into [0, 3600) deci-degrees.
     int32_t deciDeg = lrintf(atan2_approx(deltaM.v[ENU_E], deltaM.v[ENU_N]) * (1800.0f / M_PIf));
@@ -1084,7 +1426,7 @@ uint16_t flightPlanNavGetEtaSeconds(void)
     // Horizontal groundspeed only reaches the waypoint's horizontal offset, so
     // divide by the 2D distance; the 3D slant would overstate ETA on climbs.
     vector3_t deltaM;
-    navTargetDeltaEnuM(est, &deltaM);
+    navWaypointDeltaEnuM(est, &deltaM);
     const float distance2dM = sqrtf(sq(deltaM.v[ENU_E]) + sq(deltaM.v[ENU_N]));
     const float etaS = distance2dM / speedMps;
     return (etaS >= (float)UINT16_MAX) ? UINT16_MAX : (uint16_t)lrintf(etaS);

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -602,8 +602,16 @@ static void updateLegCarrot(float dtS, timeUs_t currentTimeUs, const positionEst
     }
     // waypointArrivalRadius can be configured above FP_PASS_MAX_M, which would
     // otherwise invert the constrainf bounds; clamp the floor to the gate max.
-    const float minGateM = fminf(cfg->waypointArrivalRadius * 0.01f, FP_PASS_MAX_M);
-    const float arriveM = constrainf(cornerSpeedMps * FP_GATE_RADIUS_SCALE, minGateM, FP_PASS_MAX_M);
+    const float arriveRadiusM = fminf(cfg->waypointArrivalRadius * 0.01f, FP_PASS_MAX_M);
+    // FLYBY cuts the corner: the gate scales up with the corner speed. FLYOVER
+    // keeps its fly-over-the-point meaning - the carrot tracking and corner-speed
+    // profile still apply, but the gate stays at the arrival radius so the craft
+    // passes tight over the point instead of carving the corner wide.
+    const waypoint_t *thisWp = currentWaypoint();
+    const bool flyby = (thisWp == NULL) || (thisWp->type == WAYPOINT_TYPE_FLYBY);
+    const float arriveM = flyby
+        ? constrainf(cornerSpeedMps * FP_GATE_RADIUS_SCALE, arriveRadiusM, FP_PASS_MAX_M)
+        : arriveRadiusM;
 
     // Overrun fallback: a fast crossing that misses the arrive bubble by a hair
     // still counts once the craft is past the waypoint along-track inside a sane
@@ -668,34 +676,34 @@ static void updateLegCarrot(float dtS, timeUs_t currentTimeUs, const positionEst
         desiredMps = 0.0f;
     }
 
-    // March gating keys on alignment with the leg direction so forward progress
-    // never accumulates while rotating in place at a leg start or a reversal.
     const float headingDeg = attitude.values.yaw * 0.1f;
     const float legBearingDeg = RADIANS_TO_DEGREES(atan2_approx(legDir.x, legDir.y));
     const float legErrDeg = wrapDeg180f(headingDeg - legBearingDeg);
-    if (fabsf(legErrDeg) >= 90.0f) {
-        desiredMps = 0.0f;
-    }
 
-    // Pre-turn: through the approach zone (ending a few metres before the gate,
-    // so the yaw law has closed the lag by the crossing) blend the commanded nose
-    // heading from this leg onto the next. Outside the zone the configured yaw
-    // mode governs (override off). Only the nose is affected — the carrot, and so
-    // the path, is unchanged, and the march gate above ignores the pre-turn swing.
+    // Pre-turn: through the approach zone (ending a few metres before the gate, so
+    // the yaw law has closed the lag by the crossing) blend the commanded nose
+    // heading from this leg onto the next. Computed BEFORE the march gate so the
+    // gate can exempt it: the pre-turn deliberately swings the nose past the leg
+    // on sharp corners, and must not stall forward progress while doing so.
     fp.inPreTurn = false;
+    float noseBearingDeg = legBearingDeg;
     if (haveNext) {
         const float preturnM = cfg->navPreturnDist * 0.01f;
         const float t = 1.0f - constrainf((remainingM - 5.0f) / fmaxf(preturnM - 5.0f, 1.0f), 0.0f, 1.0f);
         const vector2_t nextLeg = { .x = next.x - wp.x, .y = next.y - wp.y };
         if (t > 0.0f && vector2Norm(&nextLeg) > 1.0f) {
             const float nextBearingDeg = RADIANS_TO_DEGREES(atan2_approx(nextLeg.x, nextLeg.y));
-            const float blendedDeg = legBearingDeg + t * wrapDeg180f(nextBearingDeg - legBearingDeg);
-            autopilotSetNavHeadingOverride(true, blendedDeg);
+            noseBearingDeg = legBearingDeg + t * wrapDeg180f(nextBearingDeg - legBearingDeg);
             fp.inPreTurn = true;
         }
     }
-    if (!fp.inPreTurn) {
-        autopilotSetNavHeadingOverride(false, 0.0f);
+
+    // March gating keys on alignment with the leg direction so forward progress
+    // never accumulates while rotating in place at a leg start or a reversal; the
+    // pre-turn swing is exempt so corner speed carries through the gate.
+    const bool aligned = fabsf(legErrDeg) < 90.0f || fp.inPreTurn;
+    if (!aligned) {
+        desiredMps = 0.0f;
     }
 
     fp.carrotSpeedMps = constrainf(desiredMps,
@@ -710,6 +718,22 @@ static void updateLegCarrot(float dtS, timeUs_t currentTimeUs, const positionEst
     const float brakeGapM = 0.25f * fp.carrotSpeedMps + 1.5f;
     fp.legProgressM = constrainf(fp.legProgressM, alongFloorM - brakeGapM, alongFloorM + leadM);
     fp.legProgressM = constrainf(fp.legProgressM, 0.0f, legLenM);
+
+    // Nose command. On a pass-through leg the executor owns yaw, which is what
+    // makes the march gate safe: point the nose along the leg (blending onto the
+    // next leg through the pre-turn) whenever it is not already aligned and
+    // chasing a carrot that is ahead. This rotates the nose onto the leg at an
+    // engage or reversal (so a nose-backwards engage cannot deadlock the frozen
+    // carrot), and never points the nose at a carrot that has dropped behind the
+    // craft while braking (which would command a spin and can false-trip the
+    // heading-fault check). Once aligned with the carrot ahead, the configured
+    // yaw mode takes over.
+    const bool carrotAhead = fp.legProgressM > craftAlongM;
+    if (fp.inPreTurn || !aligned || !carrotAhead) {
+        autopilotSetNavHeadingOverride(true, noseBearingDeg);
+    } else {
+        autopilotSetNavHeadingOverride(false, 0.0f);
+    }
 
     vector3_t carrot = {.v = {
         [ENU_E] = fp.legStartEnuM.x + legDir.x * fp.legProgressM,

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -104,6 +104,7 @@
 #define FP_GATE_RADIUS_SCALE     1.5f    // gate radius = corner speed (m/s) * this
 #define FP_OVERSPEED_MARGIN_MPS  1.5f    // measured-speed governor margin over the profile speed
 #define FP_OVERRUN_LAT_M         8.0f    // a fast gate miss still counts within this lateral corridor
+#define FP_CARROT_NO_ARRIVAL_M   -1.0f   // acceptance radius sentinel: positionNav never self-completes a carrot leg
 
 // Landing descends toward a target far below the current position so vertical
 // arrival can never trigger; touchdown detection is what ends the descent.
@@ -406,11 +407,14 @@ static bool dispatchWaypoint(void)
 
     if (passGate) {
         // positionNav is a pure velocity generator chasing the marched carrot:
-        // acceptance radius 0 stops it ever self-completing, no callback (the
-        // executor advances), and no internal accel/decel (the carrot's
-        // trapezoid owns the speed profile). carrotSpeed carries across the
+        // a negative acceptance radius means it never self-completes (the craft
+        // sitting on a carrot frozen at its own position would otherwise trip
+        // "reached", drop ap.navActive, and kill the yaw rotation on a
+        // gate-closed leg start - a deadlock). The executor owns advancement, so
+        // there is no callback, and no internal accel/decel: the carrot's
+        // trapezoid owns the speed profile. carrotSpeed carries across the
         // corner — only engage/retry reset it.
-        positionNavSetTargetEf(&targetEnuM, cruiseMps, 0.0f,
+        positionNavSetTargetEf(&targetEnuM, cruiseMps, FP_CARROT_NO_ARRIVAL_M,
                                FP_COMPLETION_ANY_MPS, true, NULL, NULL);
         positionNavSetAccelLimits(0.0f, 0.0f);
         positionNavSetAltitudeArrivalRequired(false);

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -241,6 +241,21 @@ static const waypoint_t *currentWaypoint(void)
     return activePlanWaypoint(fp.currentIndex);
 }
 
+// The next positional (non-modifier) waypoint at or after `from`, or NULL if the
+// plan has none left. Modifier records (ALT_CHANGE/DELAY/YAW_RATE) carry no
+// coordinates, so the corner geometry and the pass-through/last-leg decision
+// must look past them without consuming modifier state (drainModifiers does that).
+static const waypoint_t *nextPositionalWaypoint(uint8_t from)
+{
+    for (uint8_t i = from; i < activePlanCount(); i++) {
+        const waypoint_t *wp = activePlanWaypoint(i);
+        if (wp != NULL && wp->type < WAYPOINT_TYPE_ALT_CHANGE) {
+            return wp;
+        }
+    }
+    return NULL;
+}
+
 static bool computeTargetEnuM(const waypoint_t *wp, vector3_t *out)
 {
     gpsLocation_t origin;
@@ -373,7 +388,9 @@ static bool dispatchWaypoint(void)
     // En-route FLYOVER/FLYBY waypoints (never the last, never station-keeping)
     // are pass-through gates flown with leg-line carrot tracking; everything else
     // keeps the precise point-target arrival + hold.
-    const bool isLastWaypoint = (fp.currentIndex + 1 >= activePlanCount());
+    // "Last" means no further positional waypoint (trailing modifiers don't count);
+    // only a leg with a real next waypoint becomes a carved pass-through gate.
+    const bool isLastWaypoint = (nextPositionalWaypoint(fp.currentIndex + 1) == NULL);
     const bool passGate = !isStationKeeping && !isLastWaypoint;
 
     fp.patternPending = false;
@@ -505,6 +522,15 @@ static float wrapDeg180f(float deg)
 // on command and the craft is moving, so wind and manoeuvres cannot trip it.
 static bool checkHeadingFault(float dtS, const positionEstimate3d_t *est)
 {
+    // Only meaningful while the autopilot is actively steering the nose toward a
+    // heading; in FIXED/DAMPENER the nose is uncommanded, so a course-vs-heading
+    // gap is expected and must not be read as a fault.
+    const uint8_t yawMode = autopilotConfig()->yawMode;
+    if (yawMode == YAW_MODE_FIXED || yawMode == YAW_MODE_DAMPENER) {
+        fp.hdgFaultTimeS = 0.0f;
+        return false;
+    }
+
     vector3_t deltaM;
     navTargetDeltaEnuM(est, &deltaM);
     const float bearingDeg = RADIANS_TO_DEGREES(atan2_approx(deltaM.v[ENU_E], deltaM.v[ENU_N]));
@@ -540,10 +566,11 @@ static void updateLegCarrot(float dtS, timeUs_t currentTimeUs, const positionEst
     const vector2_t toWp  = { .x = wp.x - craft.x, .y = wp.y - craft.y };
     const float distM = vector2Norm(&toWp);
 
-    // A pass-through leg always has a next waypoint; use it for the corner speed.
+    // Corner geometry uses the next positional waypoint, skipping any modifier
+    // records between legs (their coordinates would otherwise steer the corner).
     vector2_t next = wp;
     bool haveNext = false;
-    const waypoint_t *nextWp = activePlanWaypoint(fp.currentIndex + 1);
+    const waypoint_t *nextWp = nextPositionalWaypoint(fp.currentIndex + 1);
     if (nextWp != NULL) {
         vector3_t nextEnuM;
         waypoint_t effNext = *nextWp;
@@ -573,8 +600,10 @@ static void updateLegCarrot(float dtS, timeUs_t currentTimeUs, const positionEst
                 : fp.legCruiseMps;   // straight through
         }
     }
-    const float arriveM = constrainf(cornerSpeedMps * FP_GATE_RADIUS_SCALE,
-                                     cfg->waypointArrivalRadius * 0.01f, FP_PASS_MAX_M);
+    // waypointArrivalRadius can be configured above FP_PASS_MAX_M, which would
+    // otherwise invert the constrainf bounds; clamp the floor to the gate max.
+    const float minGateM = fminf(cfg->waypointArrivalRadius * 0.01f, FP_PASS_MAX_M);
+    const float arriveM = constrainf(cornerSpeedMps * FP_GATE_RADIUS_SCALE, minGateM, FP_PASS_MAX_M);
 
     // Overrun fallback: a fast crossing that misses the arrive bubble by a hair
     // still counts once the craft is past the waypoint along-track inside a sane

--- a/src/main/flight/flight_plan_nav.h
+++ b/src/main/flight/flight_plan_nav.h
@@ -43,6 +43,7 @@ typedef enum {
     FP_ABORT_STALLED,       // no progress toward the target within the stall window
     FP_ABORT_FLYAWAY,       // distance to target grew past the flyaway margin
     FP_ABORT_HEADING,       // rescue heading recovery did not converge in time
+    FP_ABORT_MAG_FAULT,     // course-over-ground disagreed with heading at speed: parked wings-level
 } flightPlanAbortReason_e;
 
 void flightPlanNavInit(void);

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -387,7 +387,14 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
 #endif // USE_GPS_RESCUE
 
 #ifdef USE_POSITION_HOLD
-    if (osdWarnGetState(OSD_WARNING_POSHOLD_FAILED) && posHoldFailure()) {
+    // A mission abort (e.g. the heading-fault level park) routes through the
+    // position-hold failure path too; let the specific WP warning below own it
+    // rather than masking it with the generic POSHOLD FAIL.
+    bool missionAbortActive = false;
+#if ENABLE_FLIGHT_PLAN && !defined(USE_WING)
+    missionAbortActive = FLIGHT_MODE(AUTOPILOT_MODE) && flightPlanNavGetAbortReason() != FP_ABORT_NONE;
+#endif
+    if (osdWarnGetState(OSD_WARNING_POSHOLD_FAILED) && posHoldFailure() && !missionAbortActive) {
         tfp_sprintf(warningText, "POSHOLD FAIL");
         *displayAttr = DISPLAYPORT_SEVERITY_WARNING;
         *blinking = true;

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -412,6 +412,9 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
         case FP_ABORT_HEADING:
             tfp_sprintf(warningText, "WP HEADING");
             break;
+        case FP_ABORT_MAG_FAULT:
+            tfp_sprintf(warningText, "WP MAG FAULT");
+            break;
         default:
             tfp_sprintf(warningText, "WP ABORT");
             break;

--- a/src/main/pg/autopilot.c
+++ b/src/main/pg/autopilot.c
@@ -62,6 +62,15 @@ PG_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig,
     .stickDeadband = 50,              // RC units
     .throttleDeadband = 50,           // RC units
 
+    // Leg-line carrot path tracking and turn-angle cornering
+    .navCornerSpeed = 220,            // 2.2 m/s corner-speed floor
+    .navCornerDeltaV = 440,           // 4.4 m/s per-corner delta-v budget
+    .navDecel = 100,                  // 1.0 m/s^2 approach deceleration
+    .navAccel = 250,                  // 2.5 m/s^2 carrot slew
+    .navCarrotLeadTime = 12,          // 1.2 s carrot lead
+    .navCarrotLeadMax = 2500,         // 25 m maximum carrot lead
+    .navPreturnDist = 1500,           // 15 m pre-turn blend zone
+
     // Yaw control parameters
     .yawMode = YAW_MODE_VELOCITY,     // Default: follow velocity
     .yawP = 50,                       // 0.5 P gain

--- a/src/main/pg/autopilot.c
+++ b/src/main/pg/autopilot.c
@@ -28,7 +28,7 @@
 
 #include "autopilot.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig, PG_AUTOPILOT, 8);
+PG_REGISTER_WITH_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig, PG_AUTOPILOT, 9);
 
 PG_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig,
     .landingAltitudeM = 4,

--- a/src/main/pg/autopilot.h
+++ b/src/main/pg/autopilot.h
@@ -82,6 +82,15 @@ typedef struct autopilotConfig_s {
     uint16_t stickDeadband;           // RC units (0-500), deadband for pilot override (default 50)
     uint16_t throttleDeadband;        // RC units (0-500), throttle override deadband (default 50)
 
+    // Leg-line carrot path tracking and turn-angle cornering (en-route FLYOVER/FLYBY legs)
+    uint16_t navCornerSpeed;          // cm/s, minimum speed carried across a waypoint gate (default 220)
+    uint16_t navCornerDeltaV;         // cm/s, constant velocity-change budget per corner (default 440)
+    uint16_t navDecel;                // cm/s^2, approach deceleration for the corner speed profile (default 100)
+    uint16_t navAccel;                // cm/s^2, carrot speed slew rate (default 250)
+    uint8_t  navCarrotLeadTime;       // deciseconds of travel the carrot leads the craft by (default 12 = 1.2s)
+    uint16_t navCarrotLeadMax;        // cm, maximum carrot lead ahead of the craft (default 2500)
+    uint16_t navPreturnDist;          // cm, approach zone over which the nose blends onto the next leg (default 1500)
+
     // Yaw control parameters
     uint8_t yawMode;                  // autopilotYawMode_e (default YAW_MODE_VELOCITY)
     uint16_t yawP;                    // scaled by 100 (e.g., 50 = 0.5, default 50)

--- a/src/test/sitl/sitl_harness.py
+++ b/src/test/sitl/sitl_harness.py
@@ -656,6 +656,13 @@ WP_LAT = HOME_LAT + 300.0 / M_PER_DEG  # default waypoint 300 m north of home
 WP_EAST_LON = HOME_LON + 150.0 / (M_PER_DEG * math.cos(math.radians(HOME_LAT)))  # 150 m east
 WP_NORTH40_LAT = HOME_LAT + 40.0 / M_PER_DEG  # short leg for the landing mission
 WP_EAST25_LON = HOME_LON + 25.0 / (M_PER_DEG * math.cos(math.radians(HOME_LAT)))
+WP_NORTH90_LAT = HOME_LAT + 90.0 / M_PER_DEG  # far leg for the backwards-engage mission
+# ~130 deg corner: a 60 m north leg into wp0, then out to (42 m east, 25 m north),
+# so the outgoing leg bears ~130 deg and the pre-turn swings the nose past 90 deg
+# off the inbound leg
+WP_NORTH60_LAT = HOME_LAT + 60.0 / M_PER_DEG
+WP_CORNER_LAT = HOME_LAT + 25.0 / M_PER_DEG
+WP_CORNER_LON = HOME_LON + 42.0 / (M_PER_DEG * math.cos(math.radians(HOME_LAT)))
 
 
 def base_config(extra):
@@ -812,6 +819,73 @@ def scenario_mission_yaw(sitl, rc, fdm):
     )
     assert BOX_ARM in sitl.modes(), "unexpected disarm during yaw mission"
     log(f"leg flown nose-first, heading {fdm.heading_deg():.0f} deg at arrival")
+
+
+def scenario_mission_engage_backwards(sitl, rc, fdm):
+    """Engage with the nose pointing away from the first leg (initial_yaw_deg=180,
+    leg runs north). In the default VELOCITY yaw mode no course develops while the
+    craft sits still, so the executor must rotate the nose onto the leg and fly it
+    rather than freezing the carrot into a STALL abort."""
+    boot_and_engage(sitl, rc, fdm)
+
+    # Departing at all proves it didn't deadlock: a frozen carrot never moves,
+    # develops no course, and aborts STALLED after 30 s.
+    wait_for(
+        "rotates onto the leg and departs (>15 m from home)",
+        lambda: fdm.distance_from_home() > 15.0,
+        timeout=40,
+    )
+
+    def on_leg():
+        err = (fdm.heading_deg() - 0.0 + 180.0) % 360.0 - 180.0
+        return abs(err) < 30.0
+
+    wait_for("nose swung onto the northbound leg (~000)", on_leg, timeout=25)
+
+    wait_for(
+        "reaches the far waypoint (ground truth)",
+        lambda: fdm.distance_to_wp(0.0, 90.0) < 10.0,
+        timeout=120,
+        interval=1.0,
+    )
+    assert BOX_ARM in sitl.modes(), "unexpected disarm on the backwards-engage mission"
+    log(f"rotated onto the leg from a backwards engage, heading {fdm.heading_deg():.0f} deg")
+
+
+def scenario_mission_corner(sitl, rc, fdm):
+    """A ~130 deg corner. The pre-turn deliberately swings the nose past 90 deg
+    off the inbound leg approaching the gate; the march gate must exempt the
+    pre-turn so the craft carries corner speed through the gate instead of
+    freezing in it (the hairpin-stall bug)."""
+    boot_and_engage(sitl, rc, fdm)
+
+    wait_for(
+        "flies the first leg to the corner waypoint",
+        lambda: fdm.distance_to_wp(0.0, 60.0) < 12.0,
+        timeout=90,
+        interval=1.0,
+    )
+
+    # Sample ground speed while crossing the corner: a stalled gate would drop it
+    # toward zero; a working pre-turn carries it through near the corner speed.
+    corner_samples = []
+
+    def carried_through():
+        if fdm.distance_to_wp(0.0, 60.0) < 20.0:
+            corner_samples.append(math.hypot(fdm.model.vel[0], fdm.model.vel[1]))
+        return fdm.distance_to_wp(42.0, 25.0) < 10.0
+
+    wait_for(
+        "carries through the corner to the second waypoint",
+        carried_through,
+        timeout=120,
+        interval=1.0,
+    )
+    assert corner_samples, "never sampled near the corner"
+    corner_min = min(corner_samples)
+    assert corner_min > 0.8, f"stalled in the corner: min ground speed {corner_min:.2f} m/s"
+    assert BOX_ARM in sitl.modes(), "unexpected disarm during the corner mission"
+    log(f"carried the corner, min ground speed {corner_min:.2f} m/s over {len(corner_samples)} samples")
 
 
 def scenario_mission_land(sitl, rc, fdm):
@@ -1297,6 +1371,24 @@ SCENARIOS = {
         scenario_mission_yaw,
         # redirect the default waypoint east so the course demands a 90 deg swing
         [f"waypoint update 0 {HOME_LAT:.7f} {WP_EAST_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyover 0 none"],
+    ),
+    "mission_engage_backwards": (
+        scenario_mission_engage_backwards,
+        [
+            # two north legs so the first is a pass-through carrot leg; the nose
+            # starts backwards (initial_yaw_deg) in the default VELOCITY yaw mode
+            f"waypoint update 0 {WP_NORTH40_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyby 0 none",
+            f"waypoint insert 1 {WP_NORTH90_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyby 0 none",
+        ],
+        {"initial_yaw_deg": 180.0},
+    ),
+    "mission_corner": (
+        scenario_mission_corner,
+        [
+            # 60 m north into the corner, then out on a ~130 deg turn
+            f"waypoint update 0 {WP_NORTH60_LAT:.7f} {HOME_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyby 0 none",
+            f"waypoint insert 1 {WP_CORNER_LAT:.7f} {WP_CORNER_LON:.7f} {int((HOME_ALT_M + 10) * 100)} 500 flyby 0 none",
+        ],
     ),
     "mission_land": (
         scenario_mission_land,

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -966,6 +966,9 @@ TEST_F(FlightPlanNavTest, InjectedPlanReplacesMissionAndRunsToTermination)
     EXPECT_NEAR(g_lastTarget.targetEfM.z, 20.0f, 0.1f); // 120 m AMSL - 100 m origin
 
     // The injected plan advances past the PG waypoint count (1 positional wp).
+    // The FLYOVER return leg keeps the arrival-radius gate, so the craft has to
+    // reach the waypoint (10 m east) for it to count.
+    g_stubEstimate.position.v[ENU_E] = 10.0f * 100.0f;
     arriveAtWaypoint();
     EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
@@ -1543,33 +1546,84 @@ TEST_F(FlightPlanNavCarrotTest, CarrotTracksLegLineNotCraftCrossTrack)
     EXPECT_NEAR(g_lastTarget.targetEfM.y, 50.0f, 5.0f);
 }
 
-TEST_F(FlightPlanNavCarrotTest, StraightThroughAdvancesAtWideGate)
+TEST_F(FlightPlanNavCarrotTest, StraightThroughFlybyAdvancesAtWideGate)
 {
-    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp0
-    addWaypointMetres(0.0f, 200.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp1: straight on (last)
+    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYBY); // wp0
+    addWaypointMetres(0.0f, 200.0f, 15000, WAYPOINT_TYPE_FLYBY); // wp1: straight on (last)
     setCraftMetres(0.0f, 89.0f);   // 11 m short of wp0
     g_stubMicros = 1'000'000;
     flightPlanNavEngage();
     step();
 
-    // Straight-through: corner speed = cruise, gate radius clamps to 12 m, so an
-    // 11 m approach already crosses the gate and advances.
+    // Straight-through FLYBY: corner speed = cruise, gate radius clamps to 12 m,
+    // so an 11 m approach already crosses the gate and advances.
     EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
 }
 
-TEST_F(FlightPlanNavCarrotTest, SharpTurnAdvancesOnlyCloseIn)
+TEST_F(FlightPlanNavCarrotTest, SharpTurnFlybyAdvancesOnlyCloseIn)
 {
-    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp0
-    addWaypointMetres(0.0f, 50.0f, 15000, WAYPOINT_TYPE_FLYOVER);  // wp1: 180 deg reversal (last)
+    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYBY); // wp0
+    addWaypointMetres(0.0f, 50.0f, 15000, WAYPOINT_TYPE_FLYBY);  // wp1: 180 deg reversal (last)
     setCraftMetres(0.0f, 89.0f);   // 11 m short of wp0
     g_stubMicros = 1'000'000;
     flightPlanNavEngage();
     step();
 
-    // Hairpin: corner speed drops to the floor, gate radius shrinks to 5 m, so an
-    // 11 m approach is not yet a crossing — the leg keeps tracking.
+    // Hairpin FLYBY: corner speed drops to the floor, gate radius shrinks to 5 m,
+    // so an 11 m approach is not yet a crossing — the leg keeps tracking.
     EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+}
+
+TEST_F(FlightPlanNavCarrotTest, FlyoverUsesArrivalRadiusGate)
+{
+    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER); // fly over the point
+    addWaypointMetres(0.0f, 200.0f, 15000, WAYPOINT_TYPE_FLYOVER); // straight on (last)
+    setCraftMetres(0.0f, 92.0f);   // 8 m short: inside a FLYBY 12 m gate, outside FLYOVER's 5 m
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    step();
+
+    // FLYOVER keeps the arrival-radius gate, so an 8 m straight-through approach
+    // has not crossed yet (a FLYBY would have).
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+}
+
+TEST_F(FlightPlanNavCarrotTest, EngageNoseBackwardsRotatesOntoLeg)
+{
+    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYBY); // leg due north
+    addWaypointMetres(0.0f, 200.0f, 15000, WAYPOINT_TYPE_FLYBY); // last
+    setCraftMetres(0.0f, 0.0f);
+    attitude.values.yaw = 1800;   // nose pointing south, 180 deg off the north leg
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    step();
+
+    // Nothing else steers yaw in VELOCITY mode with no course developed, so the
+    // executor must command the nose onto the leg (north) rather than deadlocking
+    // on a frozen carrot.
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_TRUE(g_navHeadingOverrideValid);
+    EXPECT_NEAR(g_navHeadingOverrideDeg, 0.0f, 1.0f);   // leg bearing, north
+}
+
+TEST_F(FlightPlanNavCarrotTest, BrakingCarrotBehindKeepsNoseForward)
+{
+    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYBY);
+    addWaypointMetres(0.0f, 200.0f, 15000, WAYPOINT_TYPE_FLYBY);
+    setCraftMetres(0.0f, 0.0f);
+    attitude.values.yaw = 0;   // nose north, along the leg
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    step();
+    setCraftMetres(0.0f, 60.0f);   // overrun: shoot well past the trailing carrot
+    step();
+
+    // The carrot is now behind the craft (braking); the nose stays pointed forward
+    // along the leg (north), never swung 180 back at the trailing carrot.
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_TRUE(g_navHeadingOverrideValid);
+    EXPECT_NEAR(g_navHeadingOverrideDeg, 0.0f, 5.0f);
 }
 
 TEST_F(FlightPlanNavCarrotTest, OverrunFallbackAdvancesPastWaypoint)
@@ -1596,7 +1650,6 @@ TEST_F(FlightPlanNavCarrotTest, PreTurnBlendsNoseTowardNextLeg)
     g_stubMicros = 1'000'000;
     flightPlanNavEngage();
     step();   // anchor leg0 (origin -> (0,100), heading north)
-    EXPECT_FALSE(g_navHeadingOverrideValid);   // far from the gate: the yaw mode governs
 
     // Approach the gate into the pre-turn zone (7 m of leg left past the gate).
     setCraftMetres(0.0f, 88.0f);

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -1608,3 +1608,22 @@ TEST_F(FlightPlanNavCarrotTest, PreTurnBlendsNoseTowardNextLeg)
     EXPECT_GT(g_navHeadingOverrideDeg, 0.0f);
     EXPECT_LT(g_navHeadingOverrideDeg, 90.0f);
 }
+
+TEST_F(FlightPlanNavCarrotTest, CornerSkipsModifierBetweenLegs)
+{
+    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER);    // wp0: turn here
+    addWaypointMetres(-100.0f, 100.0f, 0, WAYPOINT_TYPE_YAW_RATE);    // modifier: bogus west coords, must be ignored
+    addWaypointMetres(100.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER);  // next positional leg: 90 deg east
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    step();
+    setCraftMetres(0.0f, 88.0f);   // into the pre-turn zone before wp0
+    step();
+
+    ASSERT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    ASSERT_TRUE(g_navHeadingOverrideValid);
+    // The corner blends toward the next positional leg (east, +90), not the
+    // modifier's west coordinates, which would drive the override negative.
+    EXPECT_GT(g_navHeadingOverrideDeg, 0.0f);
+    EXPECT_LT(g_navHeadingOverrideDeg, 90.0f);
+}

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -32,6 +32,7 @@ extern "C" {
     #include "fc/runtime_config.h"
 
     #include "flight/flight_plan_nav.h"
+    #include "flight/imu.h"
     #include "flight/position_estimator.h"
     #include "flight/position_nav.h"
 
@@ -49,6 +50,7 @@ extern "C" {
     uint16_t GPS_distanceToHome;
     gpsSolutionData_t gpsSol;
     gpsLocation_t GPS_home_llh;
+    attitudeEulerAngles_t attitude;
 }
 
 #include "unittest_macros.h"
@@ -70,6 +72,7 @@ struct CapturedTarget {
 };
 
 CapturedTarget g_lastTarget;
+vector3_t g_lastDispatchTargetEfM;   // destination from positionNavSetTargetEf only (carrot moves don't touch it)
 int g_setTargetCalls;
 int g_clearTargetCalls;
 int g_moveTargetCalls;
@@ -100,6 +103,7 @@ void positionNavSetTargetEf(
     void *userData)
 {
     g_lastTarget.targetEfM = *targetPosEfM;
+    g_lastDispatchTargetEfM = *targetPosEfM;
     g_lastTarget.cruiseSpeedMps = cruiseSpeedMps;
     g_lastTarget.acceptanceRadiusM = acceptanceRadiusM;
     g_lastTarget.completionSpeedMps = completionSpeedMps;
@@ -201,6 +205,22 @@ void autopilotSetYawRateLimit(float rateLimitDps)
     g_yawRateLimitDps = rateLimitDps;
 }
 
+static bool g_forceLevelPark;
+
+void autopilotForceLevelPark(bool request)
+{
+    g_forceLevelPark = request;
+}
+
+static bool g_navHeadingOverrideValid;
+static float g_navHeadingOverrideDeg;
+
+void autopilotSetNavHeadingOverride(bool valid, float headingDeg)
+{
+    g_navHeadingOverrideValid = valid;
+    g_navHeadingOverrideDeg = headingDeg;
+}
+
 void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *distance)
 {
     // Simplified flat-earth approximation sufficient for unit-test deltas.
@@ -239,6 +259,12 @@ protected:
         g_altitudeArrivalRequired = false;
         g_disarmCalls = 0;
         g_yawRateLimitDps = -1.0f; // sentinel: no autopilotSetYawRateLimit call yet
+        g_forceLevelPark = false;
+        g_navHeadingOverrideValid = false;
+        g_navHeadingOverrideDeg = 0.0f;
+        memset(&g_lastDispatchTargetEfM, 0, sizeof(g_lastDispatchTargetEfM));
+
+        memset(&attitude, 0, sizeof(attitude));
 
         stateFlags = 0;
         GPS_distanceToHome = 0;
@@ -271,6 +297,14 @@ protected:
         cfg->landingDescentRate = 50;      // 0.5 m/s
         cfg->landingDetectionTime = 10;    // 1 s
         cfg->landingVelocityThreshold = 50; // 0.5 m/s
+        // Leg-line carrot tracking (PG reset template is not applied under test).
+        cfg->navCornerSpeed = 220;         // 2.2 m/s floor
+        cfg->navCornerDeltaV = 440;        // 4.4 m/s per-corner budget
+        cfg->navDecel = 100;               // 1.0 m/s^2
+        cfg->navAccel = 250;               // 2.5 m/s^2
+        cfg->navCarrotLeadTime = 12;       // 1.2 s
+        cfg->navCarrotLeadMax = 2500;      // 25 m
+        cfg->navPreturnDist = 1500;        // 15 m
 
         flightPlanNavInit();
     }
@@ -311,6 +345,20 @@ protected:
     void triggerReached() {
         ASSERT_NE(g_lastTarget.callback, nullptr);
         g_lastTarget.callback(g_lastTarget.userData);
+    }
+
+    // Advance the current leg. Precise point legs (last waypoint, station-keeping,
+    // injected LAND) complete via the positionNav callback; en-route pass-through
+    // legs have no callback and advance through the executor's carrot gate on a
+    // position update. The default test waypoints sit within a metre of the
+    // origin, so a craft parked at the origin is already inside any gate radius.
+    void arriveAtWaypoint() {
+        if (g_lastTarget.callback != nullptr) {
+            g_lastTarget.callback(g_lastTarget.userData);
+        } else {
+            g_stubMicros += 100'000;
+            flightPlanNavUpdate(g_stubMicros);
+        }
     }
 };
 
@@ -378,7 +426,7 @@ TEST_F(FlightPlanNavTest, WaypointReachedAdvancesToNext)
     EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
     EXPECT_EQ(g_setTargetCalls, 1);
 
-    triggerReached();
+    arriveAtWaypoint();
 
     EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
@@ -835,7 +883,7 @@ TEST_F(FlightPlanNavTest, ReEngageRestartsAtFirstWaypoint)
     addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
 
     flightPlanNavEngage();
-    triggerReached();
+    arriveAtWaypoint();
     ASSERT_EQ(flightPlanNavGetCurrentIndex(), 1);
 
     flightPlanNavDisengage();
@@ -866,7 +914,7 @@ TEST_F(FlightPlanNavTest, YawRateModifierCapsAutopilotYawAndPersists)
     EXPECT_FLOAT_EQ(g_yawRateLimitDps, 45.0f);
 
     // The cap applies from the modifier onward, not just the next leg.
-    triggerReached();
+    arriveAtWaypoint();
     ASSERT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
     EXPECT_FLOAT_EQ(g_yawRateLimitDps, 45.0f);
 }
@@ -918,11 +966,11 @@ TEST_F(FlightPlanNavTest, InjectedPlanReplacesMissionAndRunsToTermination)
     EXPECT_NEAR(g_lastTarget.targetEfM.z, 20.0f, 0.1f); // 120 m AMSL - 100 m origin
 
     // The injected plan advances past the PG waypoint count (1 positional wp).
-    triggerReached();
+    arriveAtWaypoint();
     EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
 
-    triggerReached();
+    arriveAtWaypoint();
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
 }
 
@@ -970,7 +1018,7 @@ TEST_F(FlightPlanNavTest, ReachedListenerSuppressedWhileInjected)
     addWaypoint(10, 20, 15000, WAYPOINT_TYPE_FLYOVER);
     addWaypoint(30, 40, 15000, WAYPOINT_TYPE_FLYOVER);
     flightPlanNavEngage();
-    triggerReached();
+    arriveAtWaypoint();
     EXPECT_EQ(g_reachedCalls, 1); // PG mission progress is reported
 
     const waypoint_t plan[] = {
@@ -978,7 +1026,7 @@ TEST_F(FlightPlanNavTest, ReachedListenerSuppressedWhileInjected)
         makeWaypoint(0, 0, 12000, WAYPOINT_TYPE_LAND),
     };
     ASSERT_TRUE(flightPlanNavInjectPlan(plan, 2));
-    triggerReached();
+    arriveAtWaypoint();
     EXPECT_EQ(g_reachedCalls, 1); // injected-plan progress is not
 }
 
@@ -1174,6 +1222,49 @@ TEST_F(FlightPlanNavSafetyTest, MovingAwayPastMarginAbortsAsFlyaway)
     EXPECT_EQ(flightPlanNavGetAbortReason(), FP_ABORT_FLYAWAY);
 }
 
+TEST_F(FlightPlanNavSafetyTest, HeadingFaultParksWingsLevel)
+{
+    engageDistantLeg();
+
+    // Nose on command (target due north, heading north) and moving at 5 m/s, but
+    // course-over-ground is 90 deg off the heading: a magnetometer fault.
+    attitude.values.yaw = 0;    // heading 0 deg (north), on the commanded bearing
+    gpsSol.groundSpeed = 500;   // 5 m/s, above the 3 m/s gate
+    gpsSol.groundCourse = 900;  // 90 deg: disagreement with heading exceeds 70 deg
+
+    // The integrator needs > 2 s of sustained disagreement; per-cycle dt is
+    // capped at 0.25 s, so step well past the threshold.
+    for (int i = 0; i < 12; i++) {
+        g_stubMicros += 250'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_ABORTED);
+    EXPECT_EQ(flightPlanNavGetAbortReason(), FP_ABORT_MAG_FAULT);
+    EXPECT_TRUE(g_forceLevelPark);   // angle-mode self-level, never position hold
+    EXPECT_GE(g_clearTargetCalls, 1);
+}
+
+TEST_F(FlightPlanNavSafetyTest, CourseDisagreementOffCommandDoesNotTrip)
+{
+    engageDistantLeg();
+
+    // The same course-over-ground disagreement, but the nose is 60 deg off the
+    // commanded bearing (a deliberate manoeuvre, not a fault): the detector is
+    // ineligible and must not integrate toward a trip.
+    attitude.values.yaw = 600;   // 60 deg, off the northward commanded bearing
+    gpsSol.groundSpeed = 500;
+    gpsSol.groundCourse = 1500;  // 150 deg: 90 deg from heading, still > 70
+
+    for (int i = 0; i < 12; i++) {
+        g_stubMicros += 250'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_FALSE(g_forceLevelPark);
+}
+
 TEST_F(FlightPlanNavSafetyTest, AbortReasonClearsOnReEngage)
 {
     engageDistantLeg();
@@ -1249,13 +1340,14 @@ TEST_F(FlightPlanNavSafetyTest, GeofenceBreachWithRthActionInjectsReturnPlan)
 
     // The return plan replaces the mission: fly to home at the rescue return
     // altitude (30 m above the 100 m home altitude) at the rescue ground speed.
+    // The return leg is a pass-through leg, so positionNav is fed a carrot
+    // marching toward home — assert the dispatched destination, not the carrot.
     EXPECT_TRUE(flightPlanNavIsInjectedPlanActive());
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
     EXPECT_EQ(g_setTargetCalls, callsBeforeBreach + 1);
-    ASSERT_TRUE(g_lastTarget.valid);
-    EXPECT_NEAR(g_lastTarget.targetEfM.x, 0.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.targetEfM.y, 0.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f, 0.1f);
+    EXPECT_NEAR(g_lastDispatchTargetEfM.x, 0.0f, 0.1f);
+    EXPECT_NEAR(g_lastDispatchTargetEfM.y, 0.0f, 0.1f);
+    EXPECT_NEAR(g_lastDispatchTargetEfM.z, 30.0f, 0.1f);
     EXPECT_NEAR(g_lastTarget.cruiseSpeedMps, 7.5f, 0.01f);
 
     // Still outside the fence on the way home: no re-injection.
@@ -1263,14 +1355,18 @@ TEST_F(FlightPlanNavSafetyTest, GeofenceBreachWithRthActionInjectsReturnPlan)
     flightPlanNavUpdate(g_stubMicros);
     EXPECT_EQ(g_setTargetCalls, callsBeforeBreach + 1);
 
-    // Home arrival dispatches the plan's LAND leg; its arrival descends there.
-    triggerReached();
+    // Reach home: the pass-through leg advances through the carrot gate and
+    // dispatches the plan's LAND leg to home; its arrival descends there.
+    GPS_distanceToHome = 0;
+    g_stubEstimate.position.v[ENU_N] = 0.0f;
+    g_stubMicros += 100'000;
+    flightPlanNavUpdate(g_stubMicros);
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
-    triggerReached();
+    EXPECT_NEAR(g_lastDispatchTargetEfM.x, 0.0f, 0.1f);
+    EXPECT_NEAR(g_lastDispatchTargetEfM.y, 0.0f, 0.1f);
+
+    triggerReached();  // the LAND leg is a precise point target: its callback advances it
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
-    ASSERT_TRUE(g_lastTarget.valid);
-    EXPECT_NEAR(g_lastTarget.targetEfM.x, 0.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.targetEfM.y, 0.0f, 0.1f);
 
     // No resume: the injected plan dies with disengagement.
     flightPlanNavDisengage();
@@ -1403,4 +1499,112 @@ TEST_F(FlightPlanNavSafetyTest, LandingQuietTimerResetsIfDescentResumes)
     g_stubMicros += 500'000;
     flightPlanNavUpdate(g_stubMicros); // 1.1 s — past detection time
     EXPECT_EQ(g_disarmCalls, 1);
+}
+
+// --- Leg-line carrot tracking and turn-angle cornering ---
+
+class FlightPlanNavCarrotTest : public FlightPlanNavTest {
+protected:
+    static constexpr float kUnitsPerMetre = 1.0e7f / 111319.49f;
+
+    void addWaypointMetres(float eastM, float northM, int32_t altCm, uint8_t type) {
+        addWaypoint((int32_t)lrintf(northM * kUnitsPerMetre),
+                    (int32_t)lrintf(eastM * kUnitsPerMetre), altCm, type);
+    }
+    void setCraftMetres(float eastM, float northM) {
+        g_stubEstimate.position.v[ENU_E] = eastM * 100.0f;
+        g_stubEstimate.position.v[ENU_N] = northM * 100.0f;
+    }
+    void step(uint32_t us = 100'000) {
+        g_stubMicros += us;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+};
+
+TEST_F(FlightPlanNavCarrotTest, CarrotTracksLegLineNotCraftCrossTrack)
+{
+    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp0 (pass-through)
+    addWaypointMetres(0.0f, 200.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp1 (last)
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();   // craft at the origin: leg0 is origin -> (0,100), due north
+    step();                  // anchor the leg and march
+
+    // Wind pushes the craft 20 m east of the leg line, halfway along.
+    setCraftMetres(20.0f, 50.0f);
+    step();
+
+    // The carrot rides the leg line (E = 0), not the craft (E = 20), so the
+    // position controller is commanded to pull back onto the drawn line. It sits
+    // near the craft's along-track progress (N ~ 50), not stuck at the origin or
+    // the far waypoint.
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    ASSERT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    EXPECT_NEAR(g_lastTarget.targetEfM.x, 0.0f, 0.5f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.y, 50.0f, 5.0f);
+}
+
+TEST_F(FlightPlanNavCarrotTest, StraightThroughAdvancesAtWideGate)
+{
+    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp0
+    addWaypointMetres(0.0f, 200.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp1: straight on (last)
+    setCraftMetres(0.0f, 89.0f);   // 11 m short of wp0
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    step();
+
+    // Straight-through: corner speed = cruise, gate radius clamps to 12 m, so an
+    // 11 m approach already crosses the gate and advances.
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
+}
+
+TEST_F(FlightPlanNavCarrotTest, SharpTurnAdvancesOnlyCloseIn)
+{
+    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp0
+    addWaypointMetres(0.0f, 50.0f, 15000, WAYPOINT_TYPE_FLYOVER);  // wp1: 180 deg reversal (last)
+    setCraftMetres(0.0f, 89.0f);   // 11 m short of wp0
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    step();
+
+    // Hairpin: corner speed drops to the floor, gate radius shrinks to 5 m, so an
+    // 11 m approach is not yet a crossing — the leg keeps tracking.
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+}
+
+TEST_F(FlightPlanNavCarrotTest, OverrunFallbackAdvancesPastWaypoint)
+{
+    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp0
+    addWaypointMetres(0.0f, 50.0f, 15000, WAYPOINT_TYPE_FLYOVER);  // wp1: hairpin, tight 5 m gate
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();   // craft at origin: anchors leg0 origin -> (0,100)
+    step();
+
+    // The craft shoots past wp0 along-track (to N = 108) inside the lateral
+    // corridor without ever entering the 5 m hairpin bubble: the overrun
+    // fallback still counts the gate.
+    setCraftMetres(0.5f, 108.0f);
+    step();
+
+    EXPECT_EQ(flightPlanNavGetCurrentIndex(), 1);
+}
+
+TEST_F(FlightPlanNavCarrotTest, PreTurnBlendsNoseTowardNextLeg)
+{
+    addWaypointMetres(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER);   // wp0: turn here
+    addWaypointMetres(100.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp1: 90 deg east (last)
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    step();   // anchor leg0 (origin -> (0,100), heading north)
+    EXPECT_FALSE(g_navHeadingOverrideValid);   // far from the gate: the yaw mode governs
+
+    // Approach the gate into the pre-turn zone (7 m of leg left past the gate).
+    setCraftMetres(0.0f, 88.0f);
+    step();
+
+    ASSERT_EQ(flightPlanNavGetCurrentIndex(), 0);
+    EXPECT_TRUE(g_navHeadingOverrideValid);
+    // Nose commanded between this leg (0 deg, north) and the next (90 deg, east).
+    EXPECT_GT(g_navHeadingOverrideDeg, 0.0f);
+    EXPECT_LT(g_navHeadingOverrideDeg, 90.0f);
 }

--- a/src/test/unit/flight_plan_rescue_unittest.cc
+++ b/src/test/unit/flight_plan_rescue_unittest.cc
@@ -36,6 +36,7 @@ extern "C" {
 
     #include "flight/flight_plan_nav.h"
     #include "flight/gps_rescue.h"
+    #include "flight/imu.h"
     #include "flight/position_estimator.h"
     #include "flight/position_nav.h"
 
@@ -53,6 +54,7 @@ extern "C" {
     uint16_t GPS_distanceToHome;
     gpsSolutionData_t gpsSol;
     gpsLocation_t GPS_home_llh;
+    attitudeEulerAngles_t attitude;
 }
 
 #include "unittest_macros.h"
@@ -252,6 +254,9 @@ void pitchForwardOverride(bool request)
     g_pitchForwardCalls++;
     g_lastPitchForward = request;
 }
+
+void autopilotForceLevelPark(bool) {}
+void autopilotSetNavHeadingOverride(bool, float) {}
 
 } // extern "C"
 
@@ -554,7 +559,11 @@ TEST_F(FlightPlanRescueTest, FullRescueRunToLanding)
     ASSERT_EQ(flightPlanNavGetCurrentIndex(), 1);
     ASSERT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
 
-    triggerReached();
+    // wp1 (fly home) is an en-route pass-through leg: it advances through the
+    // executor's carrot gate on a position update, not the positionNav callback.
+    // The estimator places the craft at home (ENU origin), already inside the gate.
+    g_stubMicros += 100'000;
+    flightPlanNavUpdate(g_stubMicros);
     ASSERT_EQ(flightPlanNavGetCurrentIndex(), 2);
     ASSERT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
 


### PR DESCRIPTION
En-route FLYOVER/FLYBY legs now fly a leg-line carrot so cross-track error is corrected (wind no longer bows the path off the drawn track), and corners into the next leg are carved at a turn-angle-scaled speed on a constant delta-v budget, with corner-scaled pass-through gates, an overrun fallback, an overspeed governor, and a pre-turn nose blend. Station-keeping (HOLD/LAND/TAKEOFF) and the final waypoint keep the precise point-target arrival and hold, so stopping behaviour is unchanged.

Adds a course-over-ground vs fused-heading fault detector: a sustained disagreement while the nose is on command and the craft is moving parks the craft wings-level (angle plus altitude hold, never position hold, which would lean on the suspect heading). Surfaced as a WP MAG FAULT warning.

New CLI-tunable PG_AUTOPILOT fields (nav_corner_speed, nav_corner_delta_v, nav_decel, nav_accel, nav_carrot_lead_time, nav_carrot_lead_max, nav_preturn_dist); PG version 7 to 8.

The path-tracking approach is adapted from the field-proven waypoint tracker in #15442 (morrob955).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved waypoint execution with leg-line “carrot” tracking for pass-through legs, including better turn/corner handling and pre-turn blending.
  - Added mission heading override support plus a “level park” request mechanism for heading-fault behavior.
  - Introduced new navigation tuning parameters for cornering and carrot lead/pre-return behavior.

- **Safety Improvements**
  - Added sustained course/heading discrepancy detection that triggers a wings-level “level park” and aborts the mission.
  - Updated OSD/CLI to display the new **“WP MAG FAULT”** reason and reduce misleading position-hold warnings during mission aborts.

- **Tests**
  - Expanded unit coverage and added new SITL scenarios for backwards engagement and cornering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->