### PR TITLE
PICO: Allow non-inverted BEC enable on GPIOs, add missing dma include

### DIFF
--- a/src/platform/PICO/bus_spi_pico.c
+++ b/src/platform/PICO/bus_spi_pico.c
@@ -170,8 +170,12 @@ void spiPinConfigure(const struct spiPinConfig_s *pConfig)
 static void spiSetClockFromSpeed(spi_inst_t *spi, uint16_t speed)
 {
     uint32_t freq = spiCalculateClock(speed);
-    bprintf("spiSetClockFromSpeed %p %d -> %d",spi, speed, freq);
-    spi_set_baudrate(spi, freq);
+    uint32_t baudrate = spi_set_baudrate(spi, freq);
+#ifdef PICO_TRACE
+    bprintf("spiSetClockFromSpeed %p %d -> %d, achieved %d",spi, speed, freq, baudrate);
+#else
+    UNUSED(baudrate);
+#endif
 }
 
 /*
@@ -318,6 +322,7 @@ void spiInitBusDMA(void)
         dmaSetHandler(DMA_CHANNEL_TO_IDENTIFIER(bus->dmaRx->channel), spiRxIrqHandler, NVIC_PRIO_SPI_DMA, 0);
 
         // We got the required resources, so we can use DMA on this bus
+        bprintf("PICO SPI init bus DMA true for device %d", device);
         bus->useDMA = true;
     }
 }

--- a/src/platform/PICO/io_pico.c
+++ b/src/platform/PICO/io_pico.c
@@ -58,8 +58,13 @@ void IOInitGlobal(void)
     const int pin5 = IO_PINBYTAG(IO_TAG(PICO_BEC_5V_ENABLE_PIN));
     gpio_init(pin5);
     gpio_set_dir(pin5, 1);
+#if PICO_BEC_ENABLE_NONINVERTED
+    gpio_put(pin5, 1);
+    bprintf("5V enable pin: %d set high", pin5);
+#else
     gpio_put(pin5, 0);
     bprintf("5V enable pin: %d set low", pin5);
+#endif
     ioRecs[pin5].owner = OWNER_SYSTEM;
 #endif
 
@@ -67,8 +72,13 @@ void IOInitGlobal(void)
     const int pin9 = IO_PINBYTAG(IO_TAG(PICO_BEC_9V_ENABLE_PIN));
     gpio_init(pin9);
     gpio_set_dir(pin9, 1);
+#if PICO_BEC_ENABLE_NONINVERTED
+    gpio_put(pin9, 1);
+    bprintf("9V enable pin: %d set high", pin9);
+#else
     gpio_put(pin9, 0);
     bprintf("9V enable pin: %d set low", pin9);
+#endif
     ioRecs[pin9].owner = OWNER_SYSTEM;
 #endif
 }

--- a/src/platform/PICO/osd/osd_pico.c
+++ b/src/platform/PICO/osd/osd_pico.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <math.h>
 
+#include "platform/dma.h"
 #include "common/maths.h"
 #include "drivers/dma.h"
 #include "drivers/io.h"


### PR DESCRIPTION
PICO: Allow non-inverted BEC enable on GPIOs, add missing dma include, update trace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected PICO BEC 5V and 9V enable-pin behavior for configurations using non-inverted controls.
  - Ensured the requested SPI clock speed is applied and accurately reported when diagnostic tracing is enabled.

- **Diagnostics**
  - Added clearer startup messages for successful SPI DMA initialization and BEC power-control states.

- **Compatibility**
  - Improved framebuffer OSD build support on PICO platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->