### PR TITLE
fix(build): restore git-worktree detection for REVISION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ include $(TARGET_DIR)/target.mk
 endif
 
 REVISION := norevision
-ifneq ($(wildcard .git/),)
+ifneq ($(wildcard .git),)
 ifeq ($(shell git diff --shortstat),)
 REVISION := $(shell git rev-parse --short=9 HEAD)
 endif


### PR DESCRIPTION
AI Generated pull-request

## Summary

`REVISION` in the top-level `Makefile` falls back to `norevision` whenever the working tree is a git worktree, because the guard `$(wildcard .git/)` only matches a directory — a worktree's `.git` is a plain gitdir-pointer file, not a directory.

This was already fixed once in #15209 (`$(wildcard .git/)` → `$(wildcard .git)`, matching both a directory and a file), but #15214 (STM32N6 platform support) touched the same Makefile region and reverted the trailing-slash removal, silently undoing #15209 five days after it merged. Confirmed via `git blame`: `c925d4f682` (single-parent commit, not a merge) is what changed the line back.

## Fix

Re-applies #15209's diff: `$(wildcard .git)` instead of `$(wildcard .git/)`.

## Test plan

- [x] Built `FOXEERF405` in a git worktree before the fix: `norevision` present in the binary's string table, no commit SHA embedded.
- [x] Applied the fix, clean rebuild: `norevision` no longer present; the actual commit SHA (`d1cc3ba8f`) is embedded and shown in `version`/`status` CLI output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved revision detection in Git worktrees and other setups where Git metadata is represented by a file, ensuring builds can correctly identify the current revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->