### PR TITLE
Autopilot: cross waypoint gates at corner speed - chase-lag braking, carrot measurement filtering, governor hysteresis

### DIFF
--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -105,6 +105,13 @@
 #define FP_OVERSPEED_MARGIN_MPS  1.5f    // measured-speed governor margin over the profile speed
 #define FP_OVERRUN_LAT_M         8.0f    // a fast gate miss still counts within this lateral corridor
 #define FP_CARROT_NO_ARRIVAL_M   -1.0f   // acceptance radius sentinel: positionNav never self-completes a carrot leg
+// The GPS-fed position estimate steps a metre or two on every fix. Shaping the
+// carrot directly from it turns that noise into lean and throttle twitches at
+// cruise, and lets the overspeed governor chatter between cruise and freeze.
+// Filter the measurements that shape the carrot (not the sensors themselves);
+// gate detection and pre-turn timing stay on the raw estimate so a crossing
+// still counts, and the nose still starts swinging, the moment they happen.
+#define FP_MEAS_FILTER_S         0.20f   // PT1 tau on along-track position and ground speed
 
 // Landing descends toward a target far below the current position so vertical
 // arrival can never trigger; touchdown detection is what ends the descent.
@@ -212,6 +219,10 @@ static struct {
     vector2_t carrotPrevEnuM;   // last commanded carrot; the next leg anchors here
     bool      carrotPrevValid;
     bool      inPreTurn;        // blending the nose onto the next leg (excluded from the heading-fault check)
+    float     alongFiltM;       // PT1-filtered along-track position; shapes the carrot floor and trapezoid
+    float     speedFiltMps;     // PT1-filtered horizontal ground speed; feeds the overspeed governor
+    bool      measFiltValid;
+    bool      overspeedHold;    // hysteretic governor: holding the carrot until the craft is back on profile
 
     // Landing state
     timeUs_t landingStartUs;
@@ -655,6 +666,7 @@ static void updateLegCarrot(float dtS, timeUs_t currentTimeUs, const positionEst
         fp.legStartEnuM = fp.carrotPrevValid ? fp.carrotPrevEnuM : craft;
         fp.legProgressM = 0.0f;
         fp.legValid = true;
+        fp.measFiltValid = false;   // new leg, new along-track frame: re-seed the filters
     }
 
     const vector2_t legVec = { .x = wp.x - fp.legStartEnuM.x, .y = wp.y - fp.legStartEnuM.y };
@@ -666,17 +678,48 @@ static void updateLegCarrot(float dtS, timeUs_t currentTimeUs, const positionEst
     }
     const float craftAlongM = (craft.x - fp.legStartEnuM.x) * legDir.x + (craft.y - fp.legStartEnuM.y) * legDir.y;
 
+    const float horizSpeedMps = sqrtf(sq(est->velocity.v[ENU_E]) + sq(est->velocity.v[ENU_N])) * 0.01f;
+    if (!fp.measFiltValid || dtS <= 0.0f) {
+        fp.alongFiltM = craftAlongM;
+        fp.speedFiltMps = horizSpeedMps;
+        fp.measFiltValid = true;
+    } else {
+        const float alpha = dtS / (FP_MEAS_FILTER_S + dtS);
+        fp.alongFiltM += alpha * (craftAlongM - fp.alongFiltM);
+        fp.speedFiltMps += alpha * (horizSpeedMps - fp.speedFiltMps);
+    }
+
     // Trapezoidal profile keyed on the craft's distance to the gate: cruise, then
     // decelerate to cross at the corner speed. The carrot speed slews (no
     // full-cruise leap at leg starts) and is deliberately not reset at leg
     // switches, so speed carries smoothly through corners.
-    const float remainingM = fmaxf(legLenM - craftAlongM - arriveM, 0.0f);
-    float desiredMps = fminf(fp.legCruiseMps, sqrtf(sq(cornerSpeedMps) + 2.0f * decelMps2 * remainingM));
+    // Pre-turn timing keeps the raw along-track (the nose must start swinging on
+    // time); the trapezoid and carrot floor use the filtered copy.
+    const float remainingRawM  = fmaxf(legLenM - craftAlongM - arriveM, 0.0f);
+    const float remainingFiltM = fmaxf(legLenM - fp.alongFiltM - arriveM, 0.0f);
+
+    // Chase-lag compensation: the craft answers the carrot's braking roughly one
+    // pursuit-lead time later (the chase equilibrium sits a lead behind), so a
+    // profile keyed on raw remaining distance is crossed hot by about
+    // lag * decel. Start the brake one lag-distance early and the craft — not
+    // just the carrot — arrives at corner speed, riding the last stretch AT
+    // corner speed instead of still braking through the gate.
+    const float brakeLagM = fp.carrotSpeedMps * leadTimeS;
+    const float remainingBrakeM = fmaxf(remainingFiltM - brakeLagM, 0.0f);
+    float desiredMps = fminf(fp.legCruiseMps, sqrtf(sq(cornerSpeedMps) + 2.0f * decelMps2 * remainingBrakeM));
 
     // Governor on measured speed: a craft carrying more than the profile (tailwind,
-    // catch-up) makes the carrot surrender braking authority; freeze it instead.
-    const float horizSpeedMps = sqrtf(sq(est->velocity.v[ENU_E]) + sq(est->velocity.v[ENU_N])) * 0.01f;
-    if (horizSpeedMps > desiredMps + FP_OVERSPEED_MARGIN_MPS) {
+    // catch-up) makes the carrot surrender braking authority; hold it instead.
+    // Hysteretic on the filtered speed — enter at the full margin, release at half
+    // — because a hard 0/cruise toggle around a single threshold chattered the
+    // position target at fix rate (rhythmic pitch jerks at cruise). The accel
+    // slew below bleeds the carrot speed smoothly rather than stepping it.
+    if (fp.speedFiltMps > desiredMps + FP_OVERSPEED_MARGIN_MPS) {
+        fp.overspeedHold = true;
+    } else if (fp.speedFiltMps < desiredMps + 0.5f * FP_OVERSPEED_MARGIN_MPS) {
+        fp.overspeedHold = false;
+    }
+    if (fp.overspeedHold) {
         desiredMps = 0.0f;
     }
 
@@ -693,7 +736,7 @@ static void updateLegCarrot(float dtS, timeUs_t currentTimeUs, const positionEst
     float noseBearingDeg = legBearingDeg;
     if (haveNext) {
         const float preturnM = cfg->navPreturnDist * 0.01f;
-        const float t = 1.0f - constrainf((remainingM - 5.0f) / fmaxf(preturnM - 5.0f, 1.0f), 0.0f, 1.0f);
+        const float t = 1.0f - constrainf((remainingRawM - 5.0f) / fmaxf(preturnM - 5.0f, 1.0f), 0.0f, 1.0f);
         const vector2_t nextLeg = { .x = next.x - wp.x, .y = next.y - wp.y };
         if (t > 0.0f && vector2Norm(&nextLeg) > 1.0f) {
             const float nextBearingDeg = RADIANS_TO_DEGREES(atan2_approx(nextLeg.x, nextLeg.y));
@@ -717,7 +760,11 @@ static void updateLegCarrot(float dtS, timeUs_t currentTimeUs, const positionEst
 
     // Pure-pursuit lead, with the carrot allowed a bounded gap behind the craft —
     // the only thing positionNav brakes for — so an overrun bites firmly.
-    const float alongFloorM = fmaxf(craftAlongM, 0.0f);
+    // The floor rides the filtered along-track: on the raw estimate, every
+    // metre-scale GPS step dragged the clamp (and with it the position target)
+    // back and forth at fix rate — the main source of lean twitch, and via
+    // tilt-throttle coupling, altitude pumping at cruise.
+    const float alongFloorM = fmaxf(fp.alongFiltM, 0.0f);
     const float leadM     = constrainf(fp.carrotSpeedMps * leadTimeS, FP_CARROT_LEAD_MIN_M, leadMaxM);
     const float brakeGapM = 0.25f * fp.carrotSpeedMps + 1.5f;
     fp.legProgressM = constrainf(fp.legProgressM, alongFloorM - brakeGapM, alongFloorM + leadM);
@@ -1170,6 +1217,8 @@ void flightPlanNavInit(void)
     fp.carrotSpeedMps = 0.0f;
     fp.carrotPrevValid = false;
     fp.inPreTurn = false;
+    fp.measFiltValid = false;
+    fp.overspeedHold = false;
 #if ENABLE_RESCUE_PLAN
     fp.stagedCount = 0;
     fp.isRescuePlan = false;
@@ -1195,6 +1244,8 @@ void flightPlanNavEngage(void)
     fp.carrotSpeedMps = 0.0f;
     fp.carrotPrevValid = false;
     fp.inPreTurn = false;
+    fp.measFiltValid = false;
+    fp.overspeedHold = false;
     autopilotForceLevelPark(false);   // a fresh engage clears any latched heading-fault park
     autopilotSetNavHeadingOverride(false, 0.0f);
     clearModifierState();
@@ -1262,6 +1313,8 @@ void flightPlanNavDisengage(void)
     fp.carrotSpeedMps = 0.0f;
     fp.carrotPrevValid = false;
     fp.inPreTurn = false;
+    fp.measFiltValid = false;
+    fp.overspeedHold = false;
     autopilotForceLevelPark(false);
     autopilotSetNavHeadingOverride(false, 0.0f);
 #if ENABLE_RESCUE_PLAN
@@ -1288,6 +1341,8 @@ bool flightPlanNavInjectPlan(const waypoint_t *waypoints, uint8_t count)
     fp.abortReason = FP_ABORT_NONE;
     fp.carrotPrevValid = false;   // a fresh plan re-anchors on the craft
     fp.carrotSpeedMps = 0.0f;
+    fp.measFiltValid = false;
+    fp.overspeedHold = false;
 #if ENABLE_RESCUE_PLAN
     fp.isRescuePlan = false;
 #endif
@@ -1346,6 +1401,8 @@ void flightPlanNavUpdate(timeUs_t currentTimeUs)
         // carrot leg on the craft's current position, not a stale carrot.
         fp.carrotPrevValid = false;
         fp.carrotSpeedMps = 0.0f;
+        fp.measFiltValid = false;
+        fp.overspeedHold = false;
         dispatchWaypoint();
         return;
     }

--- a/src/main/pg/autopilot.c
+++ b/src/main/pg/autopilot.c
@@ -65,7 +65,11 @@ PG_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig,
     // Leg-line carrot path tracking and turn-angle cornering
     .navCornerSpeed = 220,            // 2.2 m/s corner-speed floor
     .navCornerDeltaV = 440,           // 4.4 m/s per-corner delta-v budget
-    .navDecel = 100,                  // 1.0 m/s^2 approach deceleration
+    .navDecel = 250,                  // 2.5 m/s^2 approach deceleration; with the chase-lag
+                                      // compensated profile this stays trackable through the
+                                      // pursuit dynamics (brake authority grows with the gap
+                                      // and with drag, both rising with speed), and long legs
+                                      // no longer begin braking hundreds of metres out
     .navAccel = 250,                  // 2.5 m/s^2 carrot slew
     .navCarrotLeadTime = 12,          // 1.2 s carrot lead
     .navCarrotLeadMax = 2500,         // 25 m maximum carrot lead

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -300,7 +300,7 @@ protected:
         // Leg-line carrot tracking (PG reset template is not applied under test).
         cfg->navCornerSpeed = 220;         // 2.2 m/s floor
         cfg->navCornerDeltaV = 440;        // 4.4 m/s per-corner budget
-        cfg->navDecel = 100;               // 1.0 m/s^2
+        cfg->navDecel = 250;               // 2.5 m/s^2
         cfg->navAccel = 250;               // 2.5 m/s^2
         cfg->navCarrotLeadTime = 12;       // 1.2 s
         cfg->navCarrotLeadMax = 2500;      // 25 m
@@ -1532,9 +1532,13 @@ TEST_F(FlightPlanNavCarrotTest, CarrotTracksLegLineNotCraftCrossTrack)
     flightPlanNavEngage();   // craft at the origin: leg0 is origin -> (0,100), due north
     step();                  // anchor the leg and march
 
-    // Wind pushes the craft 20 m east of the leg line, halfway along.
+    // Wind pushes the craft 20 m east of the leg line, halfway along. The
+    // along-track measurement is PT1-filtered (0.2 s), so give it a few cycles
+    // to converge on the displaced position.
     setCraftMetres(20.0f, 50.0f);
-    step();
+    for (int i = 0; i < 8; i++) {
+        step();
+    }
 
     // The carrot rides the leg line (E = 0), not the craft (E = 20), so the
     // position controller is commanded to pull back onto the drawn line. It sits
@@ -1679,4 +1683,96 @@ TEST_F(FlightPlanNavCarrotTest, CornerSkipsModifierBetweenLegs)
     // modifier's west coordinates, which would drive the override negative.
     EXPECT_GT(g_navHeadingOverrideDeg, 0.0f);
     EXPECT_LT(g_navHeadingOverrideDeg, 90.0f);
+}
+
+TEST_F(FlightPlanNavCarrotTest, OverspeedGovernorHoldsCarrotWithHysteresis)
+{
+    addWaypointMetres(0.0f, 300.0f, 15000, WAYPOINT_TYPE_FLYOVER);
+    addWaypointMetres(0.0f, 600.0f, 15000, WAYPOINT_TYPE_FLYOVER); // straight on (last)
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    step();   // anchor the leg; craft parked at the origin
+
+    // On profile: the carrot marches away from the parked craft. Keep this
+    // phase short so the hold below happens well inside the minimum 6 m lead
+    // cap — a carrot parked ON the cap would mask a broken governor.
+    for (int i = 0; i < 3; i++) {
+        step();
+    }
+    const float marchingN = g_lastTarget.targetEfM.y;
+    EXPECT_GT(marchingN, 0.05f);
+
+    // Craft carries 15 m/s against the 10 m/s cruise profile (tailwind /
+    // catch-up): the governor holds the carrot so braking authority returns.
+    g_stubEstimate.velocity.v[ENU_N] = 1500.0f;
+    for (int i = 0; i < 20; i++) {
+        step();   // speed filter converges, carrot speed slews to a stop
+    }
+    const float heldN = g_lastTarget.targetEfM.y;
+    EXPECT_LT(heldN, 5.5f);   // held by the governor, not parked on the lead cap
+    for (int i = 0; i < 10; i++) {
+        step();
+    }
+    EXPECT_NEAR(g_lastTarget.targetEfM.y, heldN, 0.01f);
+
+    // Speed drops into the hysteresis band (10.9 m/s: below the 11.5 entry,
+    // above the 10.75 release). A single-threshold governor resumes marching
+    // here and chatters cruise/freeze at fix rate; the hold must stick.
+    g_stubEstimate.velocity.v[ENU_N] = 1090.0f;
+    for (int i = 0; i < 20; i++) {
+        step();
+    }
+    EXPECT_NEAR(g_lastTarget.targetEfM.y, heldN, 0.01f);
+
+    // Fully back on profile (craft moving gently up the leg so the lead window
+    // opens ahead): the carrot marches again.
+    g_stubEstimate.velocity.v[ENU_N] = 200.0f;
+    for (int i = 0; i < 20; i++) {
+        setCraftMetres(0.0f, (i + 1) * 0.2f);
+        step();
+    }
+    EXPECT_GT(g_lastTarget.targetEfM.y, heldN + 0.5f);
+}
+
+TEST_F(FlightPlanNavCarrotTest, ChaseLagCompensationCrossesGateNearCornerSpeed)
+{
+    addWaypointMetres(0.0f, 300.0f, 15000, WAYPOINT_TYPE_FLYBY);   // 90 deg corner here
+    addWaypointMetres(300.0f, 300.0f, 15000, WAYPOINT_TYPE_FLYBY); // east leg (last)
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+    step();
+
+    // First-order pursuit: the craft chases the commanded carrot with the same
+    // time constant as the configured carrot lead (1.2 s) — the chase lag the
+    // brake compensation exists for. Without the compensation the carrot itself
+    // reaches corner speed at the gate but the craft, answering ~1.2 s late,
+    // crosses hot by roughly lag * decel.
+    const float dt = 0.1f;
+    const float tauS = 1.2f;
+    float craftE = 0.0f;
+    float craftN = 0.0f;
+    float crossingSpeedMps = -1.0f;
+    float maxSpeedMps = 0.0f;
+    for (int i = 0; i < 1500 && crossingSpeedMps < 0.0f; i++) {
+        const float velE = (g_lastTarget.targetEfM.x - craftE) / tauS;
+        const float velN = (g_lastTarget.targetEfM.y - craftN) / tauS;
+        craftE += velE * dt;
+        craftN += velN * dt;
+        setCraftMetres(craftE, craftN);
+        g_stubEstimate.velocity.v[ENU_E] = velE * 100.0f;
+        g_stubEstimate.velocity.v[ENU_N] = velN * 100.0f;
+        const float speedMps = sqrtf(velE * velE + velN * velN);
+        maxSpeedMps = fmaxf(maxSpeedMps, speedMps);
+        step();
+        if (flightPlanNavGetCurrentIndex() == 1) {
+            crossingSpeedMps = speedMps;
+        }
+    }
+
+    // The leg actually cruised, and the CRAFT (not just the carrot) crossed the
+    // corner gate near the 90-degree corner speed (4.4 m/s delta-v budget ->
+    // 3.1 m/s), instead of several m/s hot.
+    EXPECT_GT(maxSpeedMps, 8.0f);
+    ASSERT_GE(crossingSpeedMps, 0.0f);
+    EXPECT_LT(crossingSpeedMps, 4.3f);
 }


### PR DESCRIPTION
Follow-up to #15443, from flying the same tracking core on my 7in quad, now at 18 m/s cruise on long legs. Four changes, all flown on my fork before porting here.

**Chase-lag braking compensation.** The craft answers the carrot's braking about one pursuit-lead time late (the chase equilibrium sits a lead behind the carrot). With the profile keyed on raw remaining distance, the carrot crosses the gate at corner speed but the craft crosses 1.5-3 m/s hot. Starting the brake one lead-distance early fixes it: the craft rides the last few metres AT corner speed instead of still braking through the gate.

**ap_nav_decel default 100 -> 250.** With the compensated profile this is trackable: brake authority through the chase (gap collapse plus drag) grows with speed and holds 2.5 m/s^2 across the whole profile. My logs show the rig pulls 9-16 m/s^2 braking manually, so 2.5 is still conservative. At 100, an 18 m/s approach started braking 160 m out and long legs spent most of their time crawling at gates.

**PT1 (0.2 s) filters on the along-track position and ground speed that shape the carrot.** The position estimate steps a metre or two on every GPS fix. Fed raw into the carrot floor and the trapezoid, that noise moves the position target at fix rate - I could see it as lean twitch and, through tilt-throttle coupling, altitude pumping at cruise. Gate detection and pre-turn timing stay on the raw estimate, so crossings count the moment they happen and the nose starts swinging on time.

**Hysteresis on the overspeed governor** (enter at the full 1.5 m/s margin, release at half). The single-threshold version toggles the carrot between cruise and freeze every few fixes around the boundary, which feels like rhythmic pitch jerks.

Flew this exact shaping today in 30+ mph gusts ahead of a thunderstorm: 18 m/s legs, corners carried at the budgeted speed, no hunting, no governor chatter.

Two regressions added: a governor hysteresis check, and a first-order-chase sim asserting the CRAFT, not just the carrot, crosses a 90 deg gate near corner speed - that one fails without the lag compensation. The existing CarrotTracksLegLineNotCraftCrossTrack teleports the craft 50 m in a single step, so it now settles a few filter cycles before asserting.

F405 builds clean, flight plan suites and neighbours all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved flight-plan navigation stability by filtering GPS measurements used for carrot tracking.
  - Reduced carrot overshoot during high-speed flight with improved hysteresis handling.
  - Improved navigation behavior near turns and when transitioning between flight-plan legs.
  - Increased approach deceleration to help the aircraft better follow target speeds, especially on longer legs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->