### PR TITLE
Autopilot: don't fail position hold on a single bad GPS fix

### DIFF
--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -192,6 +192,7 @@ typedef struct autopilotState_s {
     float speedTrendCmS;        // ~0.5 s lowpass of speedXY: reference for "is the craft slowing?"
     bool speedSlowing;          // speed is meaningfully below its own trend
     bool isPosHoldBraking;      // decelerating toward a captured hold point
+    bool derivativeStale;       // output was frozen past the fence: re-baseline the A-term on resume
     unsigned debugAxis;
 } autopilotState_t;
 
@@ -429,6 +430,7 @@ void positionControlReanchor(void)
     ap.sanityCheckDistance = calculateSanityCheckDistance();
     ap.sanityViolationS = 0.0f;
     ap.violationFreeS = 0.0f;
+    ap.derivativeStale = false;
 }
 
 static void initNavMode(void)
@@ -786,6 +788,10 @@ bool positionControl(void)
                     if (ap.sanityViolationS > SANITY_VIOLATION_LATCH_S) {
                         return sanityViolationExpired();
                     }
+                    // The A-term history is now stale; mark it so the resume
+                    // loop re-baselines instead of differentiating across the
+                    // frozen window (one spurious spike against old velocity)
+                    ap.derivativeStale = true;
                     return true; // brief excursion: hold the previous command
                 } else {
                     ap.sanityViolationS = 0.0f;
@@ -811,6 +817,11 @@ bool positionControl(void)
         const float velocityFiltered = pt2FilterApply(&posDtermLpf[axis], velocity.v[axis]);
         velocityFilteredV.v[axis] = velocityFiltered;
         velocityError.v[axis] = targetVelocity.v[axis] - velocityFiltered;
+        if (ap.derivativeStale) {
+            // frozen-output fixes were skipped: no delta across the window,
+            // so resumption cannot spike A against second-old velocity
+            previousVelocity.v[axis] = velocityFiltered;
+        }
         const float accelerationRaw = (previousVelocity.v[axis] - velocityFiltered) * POSHOLD_TASK_RATE_HZ;
         previousVelocity.v[axis] = velocityFiltered;
         const float acceleration = pt2FilterApply(&posAccelLpf[axis], accelerationRaw);
@@ -864,6 +875,7 @@ bool positionControl(void)
 
         pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis] + pidF.v[axis];
     } // End for loop
+    ap.derivativeStale = false;
 
     bool buildupClamped = false;
     if (velocityMode) {

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -100,6 +100,15 @@
 #define POSITION_F_SCALE       0.0017f
 #define POSHOLD_STALL_CHECK_SPEED_CMS  45.0f // below this speed a deceleration reversal means braking has stalled to a stop
 #define SANITY_CHECK_DISTANCE 2000.0f //20m, increased when stopping from speeds above 10m/s
+// The settled-hold flyaway fence is graded, not instant: an excursion must
+// persist this long before it counts as a failure. Field logs show single-fix
+// multipath excursions of 12-51 m while parked in a clean hover; instant
+// tripping turned each one into a POSHOLD FAIL with a level-out step.
+#define SANITY_VIOLATION_LATCH_S 1.0f
+// One automatic re-anchor is allowed per healthy stretch; this much clean
+// settled time earns it back. A genuine flyaway trips again immediately after
+// its retry and stays failed.
+#define SANITY_RETRY_REPLENISH_S 10.0f
 #define ERROR_DISTANCE_LIMIT  2000.0f // TO DO: test set to a useful value, this is 20m
 #define POSITION_I_LIMIT      2000.0f // TO DO: test and set to a useful value, this is 20m
 
@@ -169,6 +178,9 @@ static void disableYawControl(void);
 
 typedef struct autopilotState_s {
     float sanityCheckDistance;
+    float sanityViolationS;     // time the settled hold has spent beyond the fence
+    float violationFreeS;       // clean settled time since the last violation; replenishes the retry
+    bool sanityRetryUsed;       // one automatic re-anchor per healthy stretch
     bool sticksActive;
     bool wasSticksActive;
     bool navActive;
@@ -402,6 +414,19 @@ void initPositionHold(void)
     // nb: we do not reset the distanceError integral, to hold its opposition to wind between quick stick inputs
 }
 
+// Re-anchor the hold at the craft's current position — what a pilot cycling
+// the mode switch achieves, callable from recovery paths (sensor dropout
+// recovery, the one-shot sanity retry). Enters through the normal braking
+// capture so any speed the craft picked up meanwhile is arrested first, and
+// the fence is re-sized to the current ground speed.
+void positionControlReanchor(void)
+{
+    initPositionHold();
+    ap.sanityCheckDistance = calculateSanityCheckDistance();
+    ap.sanityViolationS = 0.0f;
+    ap.violationFreeS = 0.0f;
+}
+
 static void initNavMode(void)
 {
     initPidLpfs();
@@ -428,6 +453,9 @@ void resetPositionControl(unsigned taskRateHz)
     positionNavReset();
     wasNavActive = false; // will be enabled as required
     ap.sanityCheckDistance = calculateSanityCheckDistance(); // Set an initial sanity check distance
+    ap.sanityViolationS = 0.0f;
+    ap.violationFreeS = 0.0f;
+    ap.sanityRetryUsed = false;
     initPositionHold(); // sets target location, resets distance error, enables start mode
     previousVelocity = *(const vector2_t *)&positionEstimatorGetEstimate()->velocity.v; // for smooth A in any mode
     resetDistanceErrorIntegral();
@@ -684,14 +712,39 @@ bool positionControl(void)
                 }
             } else {
                 // Settled hold: guard against a position-estimate flyaway.
+                // Graded, not instant: a single bad fix (multipath excursions
+                // of 12-51 m appear in field logs during a clean hover) must
+                // not fail the hold — fed to the PIDs it would also slam P
+                // into the angle clamp, so the previous output is held while
+                // a brief excursion passes. Only a persistent one fails, and
+                // the first sustained trip earns one automatic re-anchor at
+                // the current spot (what a pilot cycling the switch does):
+                // an isolated mid-flight glitch self-heals, while a genuine
+                // flyaway trips again immediately and stays failed.
                 vector2_t deltaPosV;
                 vector2Sub(&deltaPosV, &posHoldStartPosition, &currentPosition);
                 if (vector2Norm(&deltaPosV) > ap.sanityCheckDistance) {
-                    disableYawControl();
-                    autopilotAngle[AI_ROLL]  = 0.0f; // Level out
-                    autopilotAngle[AI_PITCH] = 0.0f;
-                    handlepositionControlFailure();
-                    return false; // Return failure, allow angle mode control, and show pos hold fail message in OSD
+                    ap.violationFreeS = 0.0f;
+                    ap.sanityViolationS += dt;
+                    if (ap.sanityViolationS > SANITY_VIOLATION_LATCH_S) {
+                        if (!ap.sanityRetryUsed) {
+                            ap.sanityRetryUsed = true;
+                            positionControlReanchor();
+                            return true;
+                        }
+                        disableYawControl();
+                        autopilotAngle[AI_ROLL]  = 0.0f; // Level out
+                        autopilotAngle[AI_PITCH] = 0.0f;
+                        handlepositionControlFailure();
+                        return false; // Return failure, allow angle mode control, and show pos hold fail message in OSD
+                    }
+                    return true; // brief excursion: hold the previous command
+                } else {
+                    ap.sanityViolationS = 0.0f;
+                    ap.violationFreeS += dt;
+                    if (ap.violationFreeS > SANITY_RETRY_REPLENISH_S) {
+                        ap.sanityRetryUsed = false;
+                    }
                 }
             }
         }

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -189,6 +189,8 @@ typedef struct autopilotState_s {
     float speedXYOneLoopAgo;
     float speedTwoLoopsAgo;
     float prevDeltaSpeedXY;     // speed delta one loop ago, for the stall inflection test
+    float speedTrendCmS;        // ~0.5 s lowpass of speedXY: reference for "is the craft slowing?"
+    bool speedSlowing;          // speed is meaningfully below its own trend
     bool isPosHoldBraking;      // decelerating toward a captured hold point
     unsigned debugAxis;
 } autopilotState_t;
@@ -240,6 +242,8 @@ void autopilotInit(void)
     ap.speedXY = 0.0f;
     ap.speedXYOneLoopAgo = 0.0f;
     ap.speedTwoLoopsAgo = 0.0f;
+    ap.speedTrendCmS = 0.0f;
+    ap.speedSlowing = false;
     ap.prevDeltaSpeedXY = 0.0f;
     ap.isPosHoldBraking = false;
     abortNavRequested = false;
@@ -472,6 +476,23 @@ void handlepositionControlFailure(void)
 
 }
 
+// A sanity-fence violation has outlived the persistence window: spend the
+// one-shot retry if it is available (re-anchor and carry on), otherwise level
+// out and fail the hold.
+static bool sanityViolationExpired(void)
+{
+    if (!ap.sanityRetryUsed) {
+        ap.sanityRetryUsed = true;
+        positionControlReanchor();
+        return true;
+    }
+    disableYawControl();
+    autopilotAngle[AI_ROLL]  = 0.0f; // Level out
+    autopilotAngle[AI_PITCH] = 0.0f;
+    handlepositionControlFailure();
+    return false; // Return failure, allow angle mode control, and show pos hold fail message in OSD
+}
+
 void sticksMoveTarget(void)
 {
     float stickPitch = getSetpointRate(PITCH);
@@ -663,6 +684,12 @@ bool positionControl(void)
     ap.prevDeltaSpeedXY = ap.speedXYOneLoopAgo - ap.speedTwoLoopsAgo;
     ap.speedTwoLoopsAgo = ap.speedXYOneLoopAgo;
     ap.speedXYOneLoopAgo = ap.speedXY;
+    // "Is the craft actually slowing?" — speed measured against its own ~0.5 s
+    // average, judged before the average absorbs the new sample. Lets the
+    // braking-phase fence tell brake physics (speed falling, distance growth
+    // is expected) from a flyaway (speed held or rising).
+    ap.speedSlowing = ap.speedXY < ap.speedTrendCmS - 20.0f;
+    ap.speedTrendCmS += (dt / (0.5f + dt)) * (ap.speedXY - ap.speedTrendCmS);
 
     if (ap.navActive) {
         isPositionHeld = false;
@@ -709,6 +736,36 @@ bool positionControl(void)
                 if (stopped || stalled) {
                     updatePositionHoldTarget(); // capture the stopped point as the hold target
                     ap.isPosHoldBraking = false;
+                } else {
+                    // The fence watches the brake too. Braking suppresses the
+                    // settled check below, and a genuine flyaway (a bad-mag
+                    // toilet bowl accelerates, so it never meets the stop or
+                    // stall conditions) would otherwise ride the moving target
+                    // indefinitely — including straight after the one-shot
+                    // retry, which re-enters through this braking capture.
+                    // While the craft is actually slowing, growing distance is
+                    // brake physics and the fence rides just ahead of it (so a
+                    // fast entry whose stopping distance beats 2 s of entry
+                    // speed cannot false-trip); beyond the fence and NOT
+                    // slowing runs the same violation clock as the settled
+                    // hold.
+                    vector2_t brakeDeltaV;
+                    vector2Sub(&brakeDeltaV, &posHoldStartPosition, &currentPosition);
+                    const float brakeDistance = vector2Norm(&brakeDeltaV);
+                    if (brakeDistance > ap.sanityCheckDistance) {
+                        if (ap.speedSlowing) {
+                            ap.sanityCheckDistance = brakeDistance + 2.0f * ap.speedXY;
+                            ap.sanityViolationS = 0.0f;
+                        } else {
+                            ap.violationFreeS = 0.0f;
+                            ap.sanityViolationS += dt;
+                            if (ap.sanityViolationS > SANITY_VIOLATION_LATCH_S) {
+                                return sanityViolationExpired();
+                            }
+                        }
+                    } else {
+                        ap.sanityViolationS = 0.0f;
+                    }
                 }
             } else {
                 // Settled hold: guard against a position-estimate flyaway.
@@ -727,16 +784,7 @@ bool positionControl(void)
                     ap.violationFreeS = 0.0f;
                     ap.sanityViolationS += dt;
                     if (ap.sanityViolationS > SANITY_VIOLATION_LATCH_S) {
-                        if (!ap.sanityRetryUsed) {
-                            ap.sanityRetryUsed = true;
-                            positionControlReanchor();
-                            return true;
-                        }
-                        disableYawControl();
-                        autopilotAngle[AI_ROLL]  = 0.0f; // Level out
-                        autopilotAngle[AI_PITCH] = 0.0f;
-                        handlepositionControlFailure();
-                        return false; // Return failure, allow angle mode control, and show pos hold fail message in OSD
+                        return sanityViolationExpired();
                     }
                     return true; // brief excursion: hold the previous command
                 } else {

--- a/src/main/flight/autopilot_multirotor.h
+++ b/src/main/flight/autopilot_multirotor.h
@@ -41,6 +41,7 @@ void pitchForwardOverride(bool request);
 void autopilotForceLevelPark(bool request); // heading/mag fault: force angle-mode self-level, never position hold
 void autopilotSetNavHeadingOverride(bool valid, float headingDeg); // mission pre-turn: command nose heading directly
 void initPositionHold(void);
+void positionControlReanchor(void);
 uint16_t autopilotGetEffectiveHoverThrottlePwm(void);
 void autopilotCaptureHoverThrottleForAltHold(void);
 void autopilotClearAltHoldHoverThrottle(void);

--- a/src/main/flight/pos_hold_multirotor.c
+++ b/src/main/flight/pos_hold_multirotor.c
@@ -101,8 +101,16 @@ void updatePosHold(timeUs_t currentTimeUs) {
 
     if (posHold.isEnabled) {
         posHoldCheckSticks();
+        const bool sensorsWereOk = posHold.areSensorsOk;
         posHold.areSensorsOk = sensorsOk();
         if (posHold.areSensorsOk) {
+            if (!sensorsWereOk) {
+                // Sensors came back after a dropout: the craft drifted while
+                // blind, so resuming against the pre-dropout target would
+                // lurch toward it — or trip the sanity fence on the spot.
+                // Re-anchor the hold at the current position instead.
+                positionControlReanchor();
+            }
             posHold.isControlOk = positionControl();
         } else {
             for (unsigned i = 0; i < RP_AXIS_COUNT; i++) {

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -214,14 +214,48 @@ TEST_F(PosHoldTest, StationaryAtTargetProducesNearZeroOutput)
 
 // -- Flyaway detection --
 
-TEST_F(PosHoldTest, FlyawayDetectionTriggersAtLargeDistance)
+TEST_F(PosHoldTest, FlyawayDetectionRetriesOnceThenTriggers)
 {
     initAndSettleAt(0, 0, 0);
 
-    // exceed sanity check distance
-    testEstimate.position.x = 3000.0f; 
-    // expect positionControl to be false
-    EXPECT_FALSE(positionControl()); 
+    // Exceed the sanity fence. The check is graded: through the persistence
+    // window the output is held, and the first SUSTAINED trip spends the
+    // one-shot auto-retry (re-anchor at the current spot) instead of failing.
+    testEstimate.position.x = 3000.0f;
+    for (int i = 0; i < 120; i++) {   // 1.2 s at 100 Hz: window + retry
+        EXPECT_TRUE(positionControl());
+    }
+
+    // Settle at the re-anchored spot, then run away again before the retry
+    // replenishes: a genuine progressive flyaway must still fail.
+    runIterations(SETTLE_ITERATIONS);
+    testEstimate.position.x = 6000.0f;
+    bool failed = false;
+    for (int i = 0; i < 150 && !failed; i++) {
+        failed = !positionControl();
+    }
+    EXPECT_TRUE(failed);
+}
+
+TEST_F(PosHoldTest, SingleOutlierFixIsAbsorbedHoldingLastOutput)
+{
+    initAndSettleAt(0, 0, 0);
+    const float rollBefore = autopilotAngle[AI_ROLL];
+    const float pitchBefore = autopilotAngle[AI_PITCH];
+
+    // A single 30 m multipath spike, well beyond the 20 m fence.
+    testEstimate.position.x = 3000.0f;
+    EXPECT_TRUE(positionControl());
+    // The spike is not fed to the PIDs: the previous output is held, no
+    // lunge toward the angle clamp and no POSHOLD FAIL.
+    EXPECT_NEAR(autopilotAngle[AI_ROLL], rollBefore, 0.01f);
+    EXPECT_NEAR(autopilotAngle[AI_PITCH], pitchBefore, 0.01f);
+
+    // The next fixes are normal again: control simply carries on.
+    testEstimate.position.x = 0.0f;
+    for (int i = 0; i < 100; i++) {
+        EXPECT_TRUE(positionControl());
+    }
 }
 
 // -- Displacement response: heading North (yaw = 0) --

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -258,6 +258,36 @@ TEST_F(PosHoldTest, SingleOutlierFixIsAbsorbedHoldingLastOutput)
     }
 }
 
+TEST_F(PosHoldTest, ResumeAfterFrozenExcursionDoesNotSpikeTheOutput)
+{
+    initAndSettleAt(0, 0, 0);
+
+    // real motion first, so the A-term history holds a meaningful velocity
+    testEstimate.velocity.x = 300.0f;
+    for (int i = 0; i < 50; i++) {
+        EXPECT_TRUE(positionControl());
+    }
+
+    // a sub-latch excursion freezes the output; meanwhile the craft stops,
+    // so the frozen A-term history goes badly stale
+    testEstimate.position.x = 3000.0f;
+    testEstimate.velocity.x = 0.0f;
+    for (int i = 0; i < 80; i++) {   // 0.8 s, inside the 1 s latch window
+        EXPECT_TRUE(positionControl());
+    }
+    const float rollFrozen = autopilotAngle[AI_ROLL];
+    const float pitchFrozen = autopilotAngle[AI_PITCH];
+
+    // resumption must not step the output: the D/A filter chain and the
+    // A-term history freeze together (coherently), and the explicit
+    // re-baseline pins that property against future restructuring. Measured
+    // transient in this scenario is < 0.05 deg.
+    testEstimate.position.x = 0.0f;
+    EXPECT_TRUE(positionControl());
+    EXPECT_NEAR(autopilotAngle[AI_ROLL], rollFrozen, 0.25f);
+    EXPECT_NEAR(autopilotAngle[AI_PITCH], pitchFrozen, 0.25f);
+}
+
 // -- Displacement response: heading North (yaw = 0) --
 
 TEST_F(PosHoldTest, EastDisplacementProducesNegativeRollResponse)

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -218,23 +218,23 @@ TEST_F(PosHoldTest, FlyawayDetectionRetriesOnceThenTriggers)
 {
     initAndSettleAt(0, 0, 0);
 
-    // Exceed the sanity fence. The check is graded: through the persistence
-    // window the output is held, and the first SUSTAINED trip spends the
-    // one-shot auto-retry (re-anchor at the current spot) instead of failing.
-    testEstimate.position.x = 3000.0f;
-    for (int i = 0; i < 120; i++) {   // 1.2 s at 100 Hz: window + retry
-        EXPECT_TRUE(positionControl());
-    }
-
-    // Settle at the re-anchored spot, then run away again before the retry
-    // replenishes: a genuine progressive flyaway must still fail.
-    runIterations(SETTLE_ITERATIONS);
-    testEstimate.position.x = 6000.0f;
+    // Progressive runaway at a constant 15 m/s (bad-mag style): the estimate
+    // keeps moving and never meets the braking stop/stall conditions, so the
+    // fence has to catch it in BOTH the settled phase (first sustained trip,
+    // which spends the one-shot retry) and the post-retry braking phase
+    // (second trip, which must fail). No artificial settling in between.
     bool failed = false;
-    for (int i = 0; i < 150 && !failed; i++) {
+    int failedAt = -1;
+    for (int i = 0; i < 800 && !failed; i++) {
+        testEstimate.position.x += 15.0f;      // 15 cm per 10 ms tick
+        testEstimate.velocity.x = 1500.0f;
         failed = !positionControl();
+        failedAt = i;
     }
     EXPECT_TRUE(failed);
+    // The failure must land AFTER the retry re-anchored (first sustained trip
+    // is ~2.3 s in): a single trip alone no longer fails the hold.
+    EXPECT_GT(failedAt, 300);
 }
 
 TEST_F(PosHoldTest, SingleOutlierFixIsAbsorbedHoldingLastOutput)


### PR DESCRIPTION
Hardening of the settled position-hold sanity fence, from blackbox on my 7in rig (the same logs behind #15442). Two things show up repeatedly in the logs:

- single-fix multipath excursions of 12-51 m while parked in a clean hover
- mid-flight GPS dropouts (sats to zero, coords zeroed for a moment, then back)

On current master each of those ends the hold: one fix beyond the fence is an instant POSHOLD FAIL and a step to wings-level, and a dropout recovery resumes against the pre-dropout target - the craft drifted while blind, so it either lurches toward the stale target or trips the fence on the spot.

Three changes, kept inside the existing structure:

**Graded fence.** An excursion has to persist 1 s before it counts. Through that window the previous output is held rather than recomputed, so the bad fix never reaches the PIDs (a 50 m error would slam P into the angle clamp). A fix that comes back inside the fence resets the clock, exactly as before.

**One-shot auto-retry.** The first sustained trip re-anchors the hold at the current position - the same thing a pilot cycling the mode switch does - and 10 s of clean control earns the retry back. An isolated glitch self-heals in place; a genuine flyaway trips again immediately and stays failed, wings-level as before. The re-anchor goes through the normal braking capture, so any speed picked up meanwhile is arrested first and the fence re-sizes to current ground speed.

**Dropout recovery re-anchors.** When sensors come back after a dropout the hold re-anchors at the current position instead of resuming the stale target.

Nav legs are untouched: the fence only ever ran in the settled pilot-hold branch, and the flight plan executor keeps its own stall/flyaway checks.

Tests: a single-outlier absorption check (output held through the spike, no failure) and a progressive flyaway that spends its retry and still fails; the old FlyawayDetectionTriggersAtLargeDistance is folded into the latter. F405 builds clean, althold/poshold/rescue-geometry suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated position-hold flyaway (“sanity fence”) behavior to use timed latch logic instead of failing on a single excursion.
  * Improved braking/settled behavior so brief outliers no longer cause output freezes, attitude spikes, or immediate failures.
  * When position-hold sensors recover, position control re-anchors to the current position to prevent lurching and renewed flyaway detection.
  * Added safer recovery and reset timing so retry eligibility returns after a sustained stable period.
* **Tests**
  * Expanded unit coverage for progressive runaway, single-cycle outliers, and recovery after frozen excursions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->