### PR TITLE
fix(cli): don't dereference NULL sensor hardware names

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -329,7 +329,7 @@ static void cliWriterFlushInternal(bufWriter_t *writer)
 
 static void cliPrintInternal(bufWriter_t *writer, const char *str)
 {
-    if (writer) {
+    if (writer && str) {
         while (*str) {
             bufWriterAppend(writer, *str++);
         }
@@ -5491,11 +5491,18 @@ static void cliSensorHardware(const char *cmdName, char *cmdline)
             const char *typeName = sensorTypeName(i);
             if (names && typeName) {
                 cliPrintf("%s: ", typeName);
+                bool first = true;
                 for (int j = 0; j < count; j++) {
-                    if (j > 0) {
+                    // Name tables can have NULL holes for hardware enum values not
+                    // compiled into this build (e.g. MAG_DRONECAN without ENABLE_DRONECAN).
+                    if (!names[j]) {
+                        continue;
+                    }
+                    if (!first) {
                         cliPrint(",");
                     }
                     cliPrint(names[j]);
+                    first = false;
                 }
                 cliPrintLinefeed();
             }


### PR DESCRIPTION
## Summary

The `sensor` CLI command can hang the flight controller with a NULL-pointer dereference.

`cliSensorHardware()` lists each sensor type's supported hardware by walking the name table up to its full count and printing every entry. Those tables have NULL holes for hardware enum values that exist in the enum but are not compiled into the build. The clearest case: `MAG_DRONECAN` is always part of `magSensor_e` (so `MAG_HARDWARE_COUNT` counts it), but `lookupTableMagHardware[MAG_DRONECAN]` is only populated `#if ENABLE_DRONECAN` — otherwise it stays `NULL`.

`cliPrintInternal()` guarded `writer` but not `str`, so `cliPrint(NULL)` ran `while (*str)` on address `0` → fault → `systemFaultAction()` → hang. With the MCU stuck, MSP then stopped responding entirely.

## Fix

- `cliPrintInternal()`: also guard against a `NULL` string (protects every caller).
- `cliSensorHardware()`: skip `NULL` entries while listing, keeping comma separation correct.

## Root cause confirmation

Confirmed on a SpeedyBee H5 (STM32H563) over SWD. The fault backtrace was `mspSerialProcess → cliProcess → cliSensorHardware → cliPrint → cliPrintInternal(str=0x0)` landing in `systemFaultAction()`, and reading the live firmware showed `lookupTableMagHardware` with 13 entries and the last slot (`MAG_DRONECAN`) `== NULL`. After the fix the `sensor` command no longer crashes and the FC stays running.

## Testing

- STM32H563 (SpeedyBee H5): `sensor` no longer faults; FC keeps running.
- Not H5-specific — affects any build that leaves a `NULL` hole in a sensor-name table (e.g. DRONECAN disabled).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented potential crashes when CLI text is missing by safely handling null input during output rendering.
  * Improved sensor hardware listings by skipping unavailable entries and keeping the list formatting correct (proper comma separation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->