### PR TITLE
feat(devcontainer): bake in SWD debugging tooling for STM32H5/C5

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -243,6 +243,32 @@ You can then build and flash the firmware as usual:
 
 ```
 
+## SWD debugging (OpenOCD + GDB)
+
+`openocd` and `gdb-multiarch` are included in the container. To attach to a running target
+over an ST-Link, build with debug symbols and start the gdb-server:
+
+```bash
+make <CONFIG> DEBUG=GDB                       # symbols; flash the resulting HEX via DFU
+.devcontainer/openocd-stm32h5.sh              # STM32H5/C5 (Cortex-M33) gdb-server on :3334
+gdb-multiarch obj/main/betaflight_<TARGET>.elf \
+    -ex 'target extended-remote localhost:3334' -ex 'monitor halt' -ex bt
+```
+
+`openocd-stm32h5.sh` encapsulates the H5/C5 quirk that OpenOCD 0.12 ships no target cfg for
+these parts and that their CPU core debug is on AP1 (see the comments in the script). For other
+MCUs use the matching `target/stm32*.cfg` directly.
+
+Probe access needs a udev rule on the host alongside the FC rules above (the ST-Link node is
+`root:root`), e.g. for an ST-Link V3 in `/etc/udev/rules.d/99-betaflight.rules`:
+
+```bash
+SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="3753", MODE="0660", TAG+="uaccess"
+```
+
+Note: SWD and the Configurator share the single USB link on most FCs, so attaching disturbs the
+VCP — drive the FC from the Configurator with GDB detached, and use GDB only to halt/inspect.
+
 ## Gazebo SITL Simulation
 
 A separate container is provided for running Betaflight SITL with [Gazebo Harmonic](https://gazebosim.org/) simulation.

--- a/.devcontainer/containerfile
+++ b/.devcontainer/containerfile
@@ -26,6 +26,7 @@ RUN apt-get update && \
     btop \
     xxd \
     openocd \
+    gdb-multiarch \
     && rm -rf /var/lib/apt/lists/*
 
 # Generate en_US.UTF-8 locale

--- a/.devcontainer/openocd-stm32h5.sh
+++ b/.devcontainer/openocd-stm32h5.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Start an OpenOCD SWD gdb-server for STM32H5 / STM32C5 (Cortex-M33) targets.
+#
+# OpenOCD 0.12 (shipped in this container) has no stm32h5x.cfg / stm32c5x.cfg,
+# and on these parts the CPU core debug sits on AP1 (the APB-AP), not AP0. So we
+# reuse the DAP that target/stm32h7x.cfg creates and attach a cortex_m target on
+# AP1. (Using AP0 by mistake shows up as: DPIDR/DBGMCU read fine but
+# "Failed to read memory at 0xe000ed00".)
+#
+# We defer-examine the targets stm32h7x.cfg brings up (they are H7-specific and
+# would fail to examine on an H5/C5), so only h5core is examined at init, and we
+# pin its gdb port explicitly.
+#
+# The gdb-server listens on :3334. Connect with the pre-installed gdb-multiarch:
+#   gdb-multiarch obj/main/betaflight_<TARGET>.elf \
+#       -ex 'target extended-remote localhost:3334' -ex 'monitor halt' -ex bt
+#
+# Requires an ST-Link the container can open (see the udev rule in README.md).
+set -euo pipefail
+
+exec openocd \
+    -f interface/stlink-dap.cfg \
+    -c "transport select dapdirect_swd" \
+    -c "adapter speed 2000" \
+    -f target/stm32h7x.cfg \
+    -c "foreach t [target names] { \$t configure -defer-examine }" \
+    -c "target create h5core cortex_m -dap stm32h7x.dap -ap-num 1 -gdb-port 3334" \
+    -c "init" \
+    -c "targets h5core"


### PR DESCRIPTION
## Summary

Bakes the SWD debugging tooling into the devcontainer instead of documenting manual setup steps.

- **`containerfile`**: install `gdb-multiarch`. The bundled `arm-none-eabi-gdb` fails to start on Debian (`libncursesw.so.5` is absent), so `gdb-multiarch` is the working GDB for attaching to ARM targets.
- **`.devcontainer/openocd-stm32h5.sh`**: a ready-to-run OpenOCD gdb-server for STM32H5/STM32C5 (Cortex-M33). OpenOCD 0.12 ships no `stm32h5x.cfg`/`stm32c5x.cfg`, and on these parts the CPU core debug is on **AP1 (APB-AP)**, not AP0 — so the script reuses the DAP that `target/stm32h7x.cfg` creates and attaches a `cortex_m` target on AP1, serving GDB on `:3334`. (AP0 misuse symptom, noted in the script: `DPIDR`/`DBGMCU` read but `Failed to read memory at 0xe000ed00`.)
- **`README.md`**: short usage section plus the host-side ST-Link udev rule (which can't be containerised) and the single-USB SWD/Configurator caveat.

## Usage

```bash
make <CONFIG> DEBUG=GDB                       # symbols; flash the HEX via DFU
.devcontainer/openocd-stm32h5.sh              # gdb-server on :3334
gdb-multiarch obj/main/betaflight_<TARGET>.elf \
    -ex 'target extended-remote :3334' -ex 'monitor halt' -ex bt
```

No firmware code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `gdb-multiarch` to the development container tooling.
  * Included an OpenOCD SWD GDB-server startup script for STM32H5/STM32C5 (Cortex-M33) debugging.
* **Documentation**
  * Added an “SWD debugging (OpenOCD + GDB)” guide covering how to build with symbols, start the GDB server, and connect from `gdb-multiarch` (including the default port).
  * Documented ST-Link USB access/udev guidance and recommended workflow to minimize conflicts with the Configurator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->