### PR TITLE
I2C: flag electrically dead buses (stuck low) at init

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5993,18 +5993,24 @@ static void cliI2cRegs(const char *cmdName, char *cmdline)
         }
         any = true;
         cliPrintLinef("I2C%d: clkSrc=%s(%d) busClk=%s PE=%s TIMINGR=0x%08lx "
-            "SCL[mode=%d af=%d] SDA[mode=%d af=%d]",
+            "SCL[mode=%d af=%d now=%s] SDA[mode=%d af=%d now=%s] "
+            "initHealth=0x%02x[SCL=%s SDA=%s]",
             I2C_DEV_TO_CFG(device),
             clkSrc[r.clkSel & 0x3], r.clkSel,
             r.busClockOn ? "on" : "OFF",
             r.peEnabled ? "yes" : "NO",
             (unsigned long)r.timingr,
-            r.sclMode, r.sclAf, r.sdaMode, r.sdaAf);
+            r.sclMode, r.sclAf, r.sclLevel ? "HIGH" : "LOW",
+            r.sdaMode, r.sdaAf, r.sdaLevel ? "HIGH" : "LOW",
+            r.initHealth,
+            (r.initHealth & I2C_HEALTH_SCL_LOW) ? "low@init" : "ok",
+            (r.initHealth & I2C_HEALTH_SDA_LOW) ? "low@init" : "ok");
     }
     if (!any) {
         cliPrintLine("No configured I2C buses.");
     } else {
-        cliPrintLine("(expect: clkSrc=PCLK, busClk=on, PE=yes, TIMINGR!=0, mode=2, af=4)");
+        cliPrintLine("(expect: I2C1/2 clkSrc=PCLK, I2C3/4 clkSrc=HSI; busClk=on, PE=yes, TIMINGR!=0, mode=2, af=4, now=HIGH)");
+        cliPrintLine("(now=LOW while a meter reads high => bus not driven high when i2cInit ran: powered-late rail)");
     }
 }
 #endif

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5968,6 +5968,40 @@ bool cliSetSettingByName(const char *cmdline)
     return true;
 }
 
+#if defined(STM32H5) && defined(USE_I2C)
+// TEMPORARY (Development Instrumentation): dump the post-init registers that
+// decide whether a configured I2C bus can clock, side by side across buses, so
+// a dead bus is localised to clock-mux / peripheral-enable / pin-AF in one flash.
+static void cliI2cRegs(const char *cmdName, char *cmdline)
+{
+    UNUSED(cmdName);
+    UNUSED(cmdline);
+
+    static const char *clkSrc[] = { "PCLK", "PLL3R", "HSI", "CSI" };
+    bool any = false;
+    for (int device = 0; device < I2CDEV_COUNT; device++) {
+        i2cDebugRegs_t r;
+        if (!i2cGetDebugRegs(device, &r)) {
+            continue;
+        }
+        any = true;
+        cliPrintLinef("I2C%d: clkSrc=%s(%d) busClk=%s PE=%s TIMINGR=0x%08lx "
+            "SCL[mode=%d af=%d] SDA[mode=%d af=%d]",
+            I2C_DEV_TO_CFG(device),
+            clkSrc[r.clkSel & 0x3], r.clkSel,
+            r.busClockOn ? "on" : "OFF",
+            r.peEnabled ? "yes" : "NO",
+            (unsigned long)r.timingr,
+            r.sclMode, r.sclAf, r.sdaMode, r.sdaAf);
+    }
+    if (!any) {
+        cliPrintLine("No configured I2C buses.");
+    } else {
+        cliPrintLine("(expect: clkSrc=PCLK, busClk=on, PE=yes, TIMINGR!=0, mode=2, af=4)");
+    }
+}
+#endif
+
 static void cliStatus(const char *cmdName, char *cmdline)
 {
     UNUSED(cmdName);
@@ -8348,6 +8382,9 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("gyroregisters", "dump gyro config registers contents", NULL, cliDumpGyroRegisters),
 #endif
     CLI_COMMAND_DEF("help", "display command help", "[search string]", cliHelp),
+#if defined(STM32H5) && defined(USE_I2C)
+    CLI_COMMAND_DEF("i2c_regs", "dump I2C bus init registers (H5 bring-up aid)", NULL, cliI2cRegs),
+#endif
 #if ENABLE_LCD_CONSOLE
     CLI_COMMAND_DEF("lcd", "show LCD console grid contents (debug aid)", NULL, cliLcd),
 #endif

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5979,10 +5979,45 @@ bool cliSetSettingByName(const char *cmdline)
 // TEMPORARY (Development Instrumentation): dump the post-init registers that
 // decide whether a configured I2C bus can clock, side by side across buses, so
 // a dead bus is localised to clock-mux / peripheral-enable / pin-AF in one flash.
+static const char *i2cFailReasonName(uint8_t reason)
+{
+    static const char *names[] = { "none", "NACK", "BERR", "ARLO", "OVR", "TIMEOUT" };
+    return (reason < ARRAYLEN(names)) ? names[reason] : "?";
+}
+
+// Decode the decisive ISR/CR2 status bits into a compact human string, keeping
+// the raw hex alongside so nothing is lost to interpretation.
+static void cliI2cPrintFailCapture(int cfgId, const i2cDebugRegs_t *r)
+{
+    if (r->failTotal == 0) {
+        cliPrintLinef("I2C%d: fail=none (no failed transaction recorded)", cfgId);
+        return;
+    }
+    const uint32_t isr = r->lastIsr;
+    cliPrintLinef("I2C%d: fails=%u [NACK=%u BERR=%u ARLO=%u OVR=%u TIMEOUT=%u] last=%s "
+        "ISR=0x%08lx[%s%s%s%s%s%s%s%s] CR2=0x%08lx[%sNBYTES=%lu]",
+        cfgId,
+        r->failTotal, r->failNack, r->failBerr, r->failArlo, r->failOvr, r->failTimeout,
+        i2cFailReasonName(r->lastReason),
+        (unsigned long)isr,
+        (isr & I2C_ISR_BUSY)    ? "BUSY "    : "",
+        (isr & I2C_ISR_NACKF)   ? "NACKF "   : "",
+        (isr & I2C_ISR_BERR)    ? "BERR "    : "",
+        (isr & I2C_ISR_ARLO)    ? "ARLO "    : "",
+        (isr & I2C_ISR_OVR)     ? "OVR "     : "",
+        (isr & I2C_ISR_TIMEOUT) ? "TIMEOUT " : "",
+        (isr & I2C_ISR_TC)      ? "TC "      : "",
+        (isr & I2C_ISR_TXIS)    ? "TXIS "    : "",
+        (unsigned long)r->lastCr2,
+        (r->lastCr2 & I2C_CR2_START) ? "START " : "",
+        (unsigned long)((r->lastCr2 & I2C_CR2_NBYTES) >> I2C_CR2_NBYTES_Pos));
+}
+
 static void cliI2cRegs(const char *cmdName, char *cmdline)
 {
     UNUSED(cmdName);
-    UNUSED(cmdline);
+
+    const bool scan = strcasecmp(cmdline, "scan") == 0;
 
     static const char *clkSrc[] = { "PCLK", "PLL3R", "HSI", "CSI" };
     bool any = false;
@@ -5992,10 +6027,11 @@ static void cliI2cRegs(const char *cmdName, char *cmdline)
             continue;
         }
         any = true;
+        const int cfgId = I2C_DEV_TO_CFG(device);
         cliPrintLinef("I2C%d: clkSrc=%s(%d) busClk=%s PE=%s TIMINGR=0x%08lx "
             "SCL[mode=%d af=%d now=%s] SDA[mode=%d af=%d now=%s] "
-            "initHealth=0x%02x[SCL=%s SDA=%s]",
-            I2C_DEV_TO_CFG(device),
+            "initHealth=0x%02x[SCL=%s SDA=%s] HSI=%s/%u",
+            cfgId,
             clkSrc[r.clkSel & 0x3], r.clkSel,
             r.busClockOn ? "on" : "OFF",
             r.peEnabled ? "yes" : "NO",
@@ -6004,13 +6040,51 @@ static void cliI2cRegs(const char *cmdName, char *cmdline)
             r.sdaMode, r.sdaAf, r.sdaLevel ? "HIGH" : "LOW",
             r.initHealth,
             (r.initHealth & I2C_HEALTH_SCL_LOW) ? "low@init" : "ok",
-            (r.initHealth & I2C_HEALTH_SDA_LOW) ? "low@init" : "ok");
+            (r.initHealth & I2C_HEALTH_SDA_LOW) ? "low@init" : "ok",
+            r.hsiReady ? "rdy" : "OFF", (unsigned)(1u << r.hsiDiv));
+
+        if (scan) {
+            // Active address sweep: reset the capture, probe every 7-bit
+            // address, and report which answered. Zero ACKs with every attempt
+            // a TIMEOUT => the peripheral never clocks the bus; zero ACKs with
+            // NACKs => the bus clocks fine and nothing is listening; any ACK =>
+            // addressing works and the target is alive at that address.
+            i2cResetFailDiag(device);
+            int acks = 0;
+            uint8_t ackAddr[8];
+            for (uint8_t addr = 0x08; addr <= 0x77; addr++) {
+                uint8_t b;
+                if (i2cRead(device, addr, 0xFF, 1, &b)) {
+                    if (acks < (int)ARRAYLEN(ackAddr)) {
+                        ackAddr[acks] = addr;
+                    }
+                    acks++;
+                }
+            }
+            if (acks == 0) {
+                cliPrintLinef("I2C%d: scan 0x08-0x77 -> no devices answered", cfgId);
+            } else {
+                cliPrintf("I2C%d: scan 0x08-0x77 -> %d answered:", cfgId, acks);
+                for (int i = 0; i < acks && i < (int)ARRAYLEN(ackAddr); i++) {
+                    cliPrintf(" 0x%02x", ackAddr[i]);
+                }
+                cliPrintLinefeed();
+            }
+            // Refresh the capture from the sweep just performed.
+            i2cGetFailDiag(device, &r);
+        }
+
+        cliI2cPrintFailCapture(cfgId, &r);
     }
     if (!any) {
         cliPrintLine("No configured I2C buses.");
     } else {
-        cliPrintLine("(expect: I2C1/2 clkSrc=PCLK, I2C3/4 clkSrc=HSI; busClk=on, PE=yes, TIMINGR!=0, mode=2, af=4, now=HIGH)");
+        cliPrintLine("(expect: I2C1/2 clkSrc=PCLK, I2C3/4 clkSrc=HSI; busClk=on, PE=yes, TIMINGR!=0, mode=2, af=4, now=HIGH, HSI=rdy)");
         cliPrintLine("(now=LOW while a meter reads high => bus not driven high when i2cInit ran: powered-late rail)");
+        cliPrintLine("(last=NACK => bus clocks, target silent; last=TIMEOUT + BUSY/START stuck => peripheral not clocking)");
+        if (!scan) {
+            cliPrintLine("(run 'i2c_regs scan' to actively probe every address and refresh the failure capture)");
+        }
     }
 }
 #endif
@@ -8396,7 +8470,7 @@ const clicmd_t cmdTable[] = {
 #endif
     CLI_COMMAND_DEF("help", "display command help", "[search string]", cliHelp),
 #if defined(STM32H5) && defined(USE_I2C)
-    CLI_COMMAND_DEF("i2c_regs", "dump I2C bus init registers (H5 bring-up aid)", NULL, cliI2cRegs),
+    CLI_COMMAND_DEF("i2c_regs", "dump I2C bus regs + failure capture (H5 bring-up aid)", "[scan]", cliI2cRegs),
 #endif
 #if ENABLE_LCD_CONSOLE
     CLI_COMMAND_DEF("lcd", "show LCD console grid contents (debug aid)", NULL, cliLcd),

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6027,18 +6027,27 @@ static void cliStatus(const char *cmdName, char *cmdline)
     cliPrintLinefeed();
 
 #if defined(USE_I2C)
-    // Flag any configured bus that could not be released to idle at init.
-    // Stuck-low lines are almost always a hardware fault (missing external
-    // pull-ups, or a device holding the bus) rather than a firmware issue.
-    const uint16_t i2cStuckBusMask = i2cGetStuckBusMask();
-    if (i2cStuckBusMask) {
-        cliPrint("I2C BUS STUCK LOW AT INIT (check pull-ups/wiring):");
-        for (int device = 0; device < I2CDEV_COUNT; device++) {
-            if (i2cStuckBusMask & (1U << device)) {
-                cliPrintf(" I2C%d", I2C_DEV_TO_CFG(device));
-            }
+    // Report any configured bus that was not healthy at init. Showing the
+    // per-line levels distinguishes an electrical fault (line LOW → pull-ups/
+    // wiring/short) from lines HIGH yet unusable (peripheral/pin-mapping fault).
+    for (int device = 0; device < I2CDEV_COUNT; device++) {
+        const uint8_t health = i2cGetBusHealth(device);
+        if (!(health & I2C_HEALTH_CHECKED)) {
+            continue;  // bus not configured / not checked
         }
-        cliPrintLinefeed();
+        if (health & (I2C_HEALTH_SCL_LOW | I2C_HEALTH_SDA_LOW | I2C_HEALTH_NOT_IDLE)) {
+            cliPrintf("I2C%d NOT HEALTHY AT INIT: SCL=%s SDA=%s idle=%s",
+                I2C_DEV_TO_CFG(device),
+                (health & I2C_HEALTH_SCL_LOW) ? "LOW" : "high",
+                (health & I2C_HEALTH_SDA_LOW) ? "LOW" : "high",
+                (health & I2C_HEALTH_NOT_IDLE) ? "NO" : "yes");
+            if (health & (I2C_HEALTH_SCL_LOW | I2C_HEALTH_SDA_LOW)) {
+                cliPrint(" (line low: check pull-ups/wiring/short)");
+            } else {
+                cliPrint(" (lines high: suspect peripheral/pin-mapping, not pull-ups)");
+            }
+            cliPrintLinefeed();
+        }
     }
 #endif
 

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6026,6 +6026,22 @@ static void cliStatus(const char *cmdName, char *cmdline)
 #endif
     cliPrintLinefeed();
 
+#if defined(USE_I2C)
+    // Flag any configured bus that could not be released to idle at init.
+    // Stuck-low lines are almost always a hardware fault (missing external
+    // pull-ups, or a device holding the bus) rather than a firmware issue.
+    const uint16_t i2cStuckBusMask = i2cGetStuckBusMask();
+    if (i2cStuckBusMask) {
+        cliPrint("I2C BUS STUCK LOW AT INIT (check pull-ups/wiring):");
+        for (int device = 0; device < I2CDEV_COUNT; device++) {
+            if (i2cStuckBusMask & (1U << device)) {
+                cliPrintf(" I2C%d", I2C_DEV_TO_CFG(device));
+            }
+        }
+        cliPrintLinefeed();
+    }
+#endif
+
     // Sensors
 #if defined(USE_SENSOR_NAMES)
     cliPrintf("%s: ", sensorTypeDisplayNames[SENSOR_INDEX_GYRO]);

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6039,8 +6039,8 @@ static void cliStatus(const char *cmdName, char *cmdline)
         if (health & (I2C_HEALTH_SCL_LOW | I2C_HEALTH_SDA_LOW)) {
             cliPrintf("I2C%d UNUSABLE AT INIT: SCL=%s SDA=%s (line held low: short / stuck device / non-functional pin)",
                 I2C_DEV_TO_CFG(device),
-                (health & I2C_HEALTH_SCL_LOW) ? "LOW" : "ok",
-                (health & I2C_HEALTH_SDA_LOW) ? "LOW" : "ok");
+                (health & I2C_HEALTH_SCL_LOW) ? "LOW" : "HIGH",
+                (health & I2C_HEALTH_SDA_LOW) ? "LOW" : "HIGH");
             cliPrintLinefeed();
         }
         if (health & (I2C_HEALTH_SCL_NOPULL | I2C_HEALTH_SDA_NOPULL)) {

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6027,25 +6027,28 @@ static void cliStatus(const char *cmdName, char *cmdline)
     cliPrintLinefeed();
 
 #if defined(USE_I2C)
-    // Report any configured bus that was not healthy at init. Showing the
-    // per-line levels distinguishes an electrical fault (line LOW → pull-ups/
-    // wiring/short) from lines HIGH yet unusable (peripheral/pin-mapping fault).
+    // Report per-bus init health. Two independent lines: an unusable bus (a line
+    // held low despite the internal pull-up — short/stuck/non-functional pin),
+    // and, separately, a missing external pull-up (informational — a bus using
+    // the internal pull-up is never flagged here).
     for (int device = 0; device < I2CDEV_COUNT; device++) {
         const uint8_t health = i2cGetBusHealth(device);
         if (!(health & I2C_HEALTH_CHECKED)) {
             continue;  // bus not configured / not checked
         }
-        if (health & (I2C_HEALTH_SCL_LOW | I2C_HEALTH_SDA_LOW | I2C_HEALTH_NOT_IDLE)) {
-            cliPrintf("I2C%d NOT HEALTHY AT INIT: SCL=%s SDA=%s idle=%s",
+        if (health & (I2C_HEALTH_SCL_LOW | I2C_HEALTH_SDA_LOW)) {
+            cliPrintf("I2C%d UNUSABLE AT INIT: SCL=%s SDA=%s (line held low: short / stuck device / non-functional pin)",
                 I2C_DEV_TO_CFG(device),
-                (health & I2C_HEALTH_SCL_LOW) ? "LOW" : "high",
-                (health & I2C_HEALTH_SDA_LOW) ? "LOW" : "high",
-                (health & I2C_HEALTH_NOT_IDLE) ? "NO" : "yes");
-            if (health & (I2C_HEALTH_SCL_LOW | I2C_HEALTH_SDA_LOW)) {
-                cliPrint(" (line low: check pull-ups/wiring/short)");
-            } else {
-                cliPrint(" (lines high: suspect peripheral/pin-mapping, not pull-ups)");
-            }
+                (health & I2C_HEALTH_SCL_LOW) ? "LOW" : "ok",
+                (health & I2C_HEALTH_SDA_LOW) ? "LOW" : "ok");
+            cliPrintLinefeed();
+        }
+        if (health & (I2C_HEALTH_SCL_NOPULL | I2C_HEALTH_SDA_NOPULL)) {
+            cliPrintf("I2C%d: no external pull-up detected (%s%s%s) - fit pull-ups or enable the pull-up option",
+                I2C_DEV_TO_CFG(device),
+                (health & I2C_HEALTH_SCL_NOPULL) ? "SCL" : "",
+                ((health & I2C_HEALTH_SCL_NOPULL) && (health & I2C_HEALTH_SDA_NOPULL)) ? "+" : "",
+                (health & I2C_HEALTH_SDA_NOPULL) ? "SDA" : "");
             cliPrintLinefeed();
         }
     }

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6018,6 +6018,7 @@ static void cliI2cRegs(const char *cmdName, char *cmdline)
     UNUSED(cmdName);
 
     const bool scan = strcasecmp(cmdline, "scan") == 0;
+    const bool padtest = strcasecmp(cmdline, "padtest") == 0;
 
     static const char *clkSrc[] = { "PCLK", "PLL3R", "HSI", "CSI" };
     bool any = false;
@@ -6074,16 +6075,28 @@ static void cliI2cRegs(const char *cmdName, char *cmdline)
             i2cGetFailDiag(device, &r);
         }
 
+        if (padtest) {
+            // Drive the pins as plain GPIO and scope them: a clean square wave
+            // on a bus the peripheral can't clock isolates the fault to the
+            // I2C peripheral / AF path (not the pin, pull-up or wiring).
+            cliPrintLinef("I2C%d: pad toggle - scope SCL then SDA (~50 kHz, ~0.3 s each); reboot to restore", cfgId);
+            cliI2cPrintFailCapture(cfgId, &r);
+            i2cPadToggleTest(device);
+            continue;
+        }
+
         cliI2cPrintFailCapture(cfgId, &r);
     }
     if (!any) {
         cliPrintLine("No configured I2C buses.");
+    } else if (padtest) {
+        cliPrintLine("(pad toggle done - reboot to restore I2C)");
     } else {
         cliPrintLine("(expect: I2C1/2 clkSrc=PCLK, I2C3/4 clkSrc=HSI; busClk=on, PE=yes, TIMINGR!=0, mode=2, af=4, now=HIGH, HSI=rdy)");
         cliPrintLine("(now=LOW while a meter reads high => bus not driven high when i2cInit ran: powered-late rail)");
         cliPrintLine("(last=NACK => bus clocks, target silent; last=TIMEOUT + BUSY/START stuck => peripheral not clocking)");
         if (!scan) {
-            cliPrintLine("(run 'i2c_regs scan' to actively probe every address and refresh the failure capture)");
+            cliPrintLine("(run 'i2c_regs scan' to probe every address, or 'i2c_regs padtest' to scope the pads as GPIO)");
         }
     }
 }
@@ -8470,7 +8483,7 @@ const clicmd_t cmdTable[] = {
 #endif
     CLI_COMMAND_DEF("help", "display command help", "[search string]", cliHelp),
 #if defined(STM32H5) && defined(USE_I2C)
-    CLI_COMMAND_DEF("i2c_regs", "dump I2C bus regs + failure capture (H5 bring-up aid)", "[scan]", cliI2cRegs),
+    CLI_COMMAND_DEF("i2c_regs", "dump I2C bus regs + failure capture (H5 bring-up aid)", "[scan|padtest]", cliI2cRegs),
 #endif
 #if ENABLE_LCD_CONSOLE
     CLI_COMMAND_DEF("lcd", "show LCD console grid contents (debug aid)", NULL, cliLcd),

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -91,6 +91,26 @@ uint8_t i2cGetRegisteredDeviceCount(void);
 void i2cReportBusHealth(i2cDevice_e device, uint8_t health);
 uint8_t i2cGetBusHealth(i2cDevice_e device);
 
+// Classification of the last failed transaction, recorded by the transaction
+// path so a dead bus can be told apart from a silent (but healthy) bus:
+//   NACK    - address/data byte not acknowledged; the peripheral clocked the
+//             bus correctly, the target simply did not answer (wiring/address/
+//             sensor-rail issue, NOT the peripheral).
+//   BERR    - misplaced START/STOP: bus contention / protocol violation.
+//   ARLO    - arbitration lost: another master or a line stuck low mid-frame.
+//   OVR     - over/under-run (slave mode; unexpected here).
+//   TIMEOUT - the foreground state machine gave up with no completion IRQ; the
+//             peripheral never advanced (e.g. START never issued, BUSY stuck,
+//             no kernel clock reaching the bus).
+typedef enum {
+    I2C_FAIL_NONE = 0,
+    I2C_FAIL_NACK,
+    I2C_FAIL_BERR,
+    I2C_FAIL_ARLO,
+    I2C_FAIL_OVR,
+    I2C_FAIL_TIMEOUT,
+} i2cFailReason_e;
+
 #if defined(STM32H5)
 // TEMPORARY (Development Instrumentation): live register snapshot for an I2C bus,
 // to localise a dead-bus fault to clock-mux vs peripheral-enable vs pin/AF in a
@@ -107,6 +127,30 @@ typedef struct i2cDebugRegs_s {
     bool sclLevel;       // live SCL line level from IDR now (input buffer stays live in AF-OD; 1 = idle high)
     bool sdaLevel;       // live SDA line level from IDR now (1 = idle high)
     uint8_t initHealth;  // bus-health bitmask recorded at i2cInit() (I2C_HEALTH_* bits)
+    // Kernel-clock health — closes the "is HSI actually the running I2C3/4
+    // kernel source?" question on the record (I2C1/2 stay on PCLK, so these are
+    // only meaningful for the HSI-sourced buses).
+    bool hsiReady;       // RCC_CR HSIRDY (kernel oscillator locked)
+    uint8_t hsiDiv;      // RCC_CR HSIDIV (0=>/1 .. 3=>/8); kernel = 64 MHz >> hsiDiv
+    // Last-failure capture (from the transaction path). lastIsr/lastCr2 are the
+    // raw I2Cx->ISR / I2Cx->CR2 sampled at the moment of failure, so no bit is
+    // lost to interpretation; the per-reason counters summarise the boot-time
+    // device-detection sweep.
+    uint32_t lastIsr;
+    uint32_t lastCr2;
+    uint8_t  lastReason; // i2cFailReason_e
+    uint16_t failTotal;
+    uint16_t failNack;
+    uint16_t failBerr;
+    uint16_t failArlo;
+    uint16_t failOvr;
+    uint16_t failTimeout;
 } i2cDebugRegs_t;
 bool i2cGetDebugRegs(i2cDevice_e device, i2cDebugRegs_t *regs);
+// Copy the transaction-path failure capture for a bus into regs (lives in the
+// LL transaction unit, separate from the init unit that fills the rest).
+void i2cGetFailDiag(i2cDevice_e device, i2cDebugRegs_t *regs);
+// Zero a bus's failure capture — used by "i2c_regs scan" so the live sweep's
+// result is not confused with the boot-time counts.
+void i2cResetFailDiag(i2cDevice_e device);
 #endif

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -69,3 +69,11 @@ bool i2cBusy(i2cDevice_e device, bool *error);
 
 uint16_t i2cGetErrorCounter(void);
 uint8_t i2cGetRegisteredDeviceCount(void);
+
+// Startup bus-health diagnostic. A configured bus whose SCL/SDA cannot be
+// released to a valid idle-high at init (stuck low) is almost always a
+// hardware problem — missing external pull-ups or a device holding the bus.
+// i2cInit reports the result here so it can be surfaced (e.g. in CLI status)
+// instead of failing silently. Bit position is the i2cDevice_e value.
+void i2cSetBusStuck(i2cDevice_e device, bool stuck);
+uint16_t i2cGetStuckBusMask(void);

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -70,10 +70,16 @@ bool i2cBusy(i2cDevice_e device, bool *error);
 uint16_t i2cGetErrorCounter(void);
 uint8_t i2cGetRegisteredDeviceCount(void);
 
-// Startup bus-health diagnostic. A configured bus whose SCL/SDA cannot be
-// released to a valid idle-high at init (stuck low) is almost always a
-// hardware problem — missing external pull-ups or a device holding the bus.
-// i2cInit reports the result here so it can be surfaced (e.g. in CLI status)
-// instead of failing silently. Bit position is the i2cDevice_e value.
-void i2cSetBusStuck(i2cDevice_e device, bool stuck);
-uint16_t i2cGetStuckBusMask(void);
+// Startup bus-health diagnostic. i2cInit samples the idle line levels (with the
+// internal pull-down engaged, so a healthy external pull-up reads HIGH and a
+// missing/weak one reads LOW) and whether the bus could be driven to idle, then
+// records it here so a dead bus is visible in CLI status instead of failing
+// silently. Reporting the actual per-line levels distinguishes an electrical
+// fault (line stuck LOW → pull-ups/wiring/short) from lines that are HIGH yet
+// the peripheral still can't talk (firmware/pin-mapping/AF fault).
+#define I2C_HEALTH_CHECKED  (1 << 0)  // bus was configured and checked at init
+#define I2C_HEALTH_SCL_LOW  (1 << 1)  // SCL read low under internal pull-down
+#define I2C_HEALTH_SDA_LOW  (1 << 2)  // SDA read low under internal pull-down
+#define I2C_HEALTH_NOT_IDLE (1 << 3)  // bus could not be released to idle-high
+void i2cReportBusHealth(i2cDevice_e device, uint8_t health);
+uint8_t i2cGetBusHealth(i2cDevice_e device);

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -70,16 +70,23 @@ bool i2cBusy(i2cDevice_e device, bool *error);
 uint16_t i2cGetErrorCounter(void);
 uint8_t i2cGetRegisteredDeviceCount(void);
 
-// Startup bus-health diagnostic. i2cInit samples the idle line levels (with the
-// internal pull-down engaged, so a healthy external pull-up reads HIGH and a
-// missing/weak one reads LOW) and whether the bus could be driven to idle, then
-// records it here so a dead bus is visible in CLI status instead of failing
-// silently. Reporting the actual per-line levels distinguishes an electrical
-// fault (line stuck LOW → pull-ups/wiring/short) from lines that are HIGH yet
-// the peripheral still can't talk (firmware/pin-mapping/AF fault).
-#define I2C_HEALTH_CHECKED  (1 << 0)  // bus was configured and checked at init
-#define I2C_HEALTH_SCL_LOW  (1 << 1)  // SCL read low under internal pull-down
-#define I2C_HEALTH_SDA_LOW  (1 << 2)  // SDA read low under internal pull-down
-#define I2C_HEALTH_NOT_IDLE (1 << 3)  // bus could not be released to idle-high
+// Startup bus-health diagnostic recorded by i2cInit() and surfaced in CLI
+// status so a dead bus is visible instead of failing silently. Two independent
+// checks, kept separate so a board that legitimately relies on the MCU internal
+// pull-up is never mis-reported as faulty:
+//
+//   1. Usability (pull-strategy agnostic): engage the internal pull-UP and read.
+//      An unloaded, functional line reaches HIGH; if it stays LOW something is
+//      holding it down — a short, a stuck device, or a non-functional pin. This
+//      is the actual "bus unusable" signal (*_LOW bits).
+//   2. External pull-up presence: only when the board is NOT using the internal
+//      pull-up. Engage the internal pull-DOWN — a real external pull-up (few
+//      kOhm) overrides it and reads HIGH, its absence reads LOW. Purely
+//      informational (a wiring note), NOT an unusable-bus condition (*_NOPULL).
+#define I2C_HEALTH_CHECKED     (1 << 0)  // bus was configured and checked at init
+#define I2C_HEALTH_SCL_LOW     (1 << 1)  // SCL held low despite internal pull-up (unusable)
+#define I2C_HEALTH_SDA_LOW     (1 << 2)  // SDA held low despite internal pull-up (unusable)
+#define I2C_HEALTH_SCL_NOPULL  (1 << 3)  // no external SCL pull-up detected (info only)
+#define I2C_HEALTH_SDA_NOPULL  (1 << 4)  // no external SDA pull-up detected (info only)
 void i2cReportBusHealth(i2cDevice_e device, uint8_t health);
 uint8_t i2cGetBusHealth(i2cDevice_e device);

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -104,6 +104,9 @@ typedef struct i2cDebugRegs_s {
     uint8_t sclAf;       // SCL pin AF selection (expect 4 for I2C)
     uint8_t sdaMode;     // SDA pin MODER
     uint8_t sdaAf;       // SDA pin AF selection
+    bool sclLevel;       // live SCL line level from IDR now (input buffer stays live in AF-OD; 1 = idle high)
+    bool sdaLevel;       // live SDA line level from IDR now (1 = idle high)
+    uint8_t initHealth;  // bus-health bitmask recorded at i2cInit() (I2C_HEALTH_* bits)
 } i2cDebugRegs_t;
 bool i2cGetDebugRegs(i2cDevice_e device, i2cDebugRegs_t *regs);
 #endif

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -90,3 +90,20 @@ uint8_t i2cGetRegisteredDeviceCount(void);
 #define I2C_HEALTH_SDA_NOPULL  (1 << 4)  // no external SDA pull-up detected (info only)
 void i2cReportBusHealth(i2cDevice_e device, uint8_t health);
 uint8_t i2cGetBusHealth(i2cDevice_e device);
+
+#if defined(STM32H5)
+// TEMPORARY (Development Instrumentation): live register snapshot for an I2C bus,
+// to localise a dead-bus fault to clock-mux vs peripheral-enable vs pin/AF in a
+// single flash. Remove once the H5 I2C3 bring-up issue is resolved.
+typedef struct i2cDebugRegs_s {
+    uint8_t clkSel;      // RCC_CCIPR4 I2CxSEL field (0 = PCLKx, the expected default)
+    bool busClockOn;     // RCC APBxENR I2CxEN
+    bool peEnabled;      // I2Cx->CR1 PE
+    uint32_t timingr;    // I2Cx->TIMINGR (0 = uninitialised)
+    uint8_t sclMode;     // SCL pin MODER (2 = alternate function)
+    uint8_t sclAf;       // SCL pin AF selection (expect 4 for I2C)
+    uint8_t sdaMode;     // SDA pin MODER
+    uint8_t sdaAf;       // SDA pin AF selection
+} i2cDebugRegs_t;
+bool i2cGetDebugRegs(i2cDevice_e device, i2cDebugRegs_t *regs);
+#endif

--- a/src/main/drivers/bus_i2c.h
+++ b/src/main/drivers/bus_i2c.h
@@ -153,4 +153,9 @@ void i2cGetFailDiag(i2cDevice_e device, i2cDebugRegs_t *regs);
 // Zero a bus's failure capture — used by "i2c_regs scan" so the live sweep's
 // result is not confused with the boot-time counts.
 void i2cResetFailDiag(i2cDevice_e device);
+// Drive SCL then SDA as plain open-drain GPIO so the pads can be scoped
+// independently of the I2C peripheral. A clean square wave here on a bus the
+// peripheral cannot clock isolates the fault to the peripheral/AF path rather
+// than the pin, pull-up or wiring. Leaves the pins as GPIO — reboot to restore.
+void i2cPadToggleTest(i2cDevice_e device);
 #endif

--- a/src/main/drivers/bus_i2c_busdev.c
+++ b/src/main/drivers/bus_i2c_busdev.c
@@ -32,6 +32,11 @@
 
 static uint8_t i2cRegisteredDeviceCount = 0;
 
+// Bitmask of configured buses that could not be released to idle at init.
+// Set/cleared by i2cInit() via i2cSetBusStuck(); platforms that never call
+// the setter simply leave the mask at 0.
+static uint16_t i2cStuckBusMask = 0;
+
 bool i2cBusWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data)
 {
     return i2cWrite(dev->bus->busType_u.i2c.device, dev->busType_u.i2c.address, reg, data);
@@ -99,5 +104,23 @@ void i2cBusDeviceRegister(const extDevice_t *dev)
 uint8_t i2cGetRegisteredDeviceCount(void)
 {
     return i2cRegisteredDeviceCount;
+}
+
+void i2cSetBusStuck(i2cDevice_e device, bool stuck)
+{
+    if (device < 0 || device >= I2CDEV_COUNT) {
+        return;
+    }
+
+    if (stuck) {
+        i2cStuckBusMask |= (1U << device);
+    } else {
+        i2cStuckBusMask &= ~(1U << device);
+    }
+}
+
+uint16_t i2cGetStuckBusMask(void)
+{
+    return i2cStuckBusMask;
 }
 #endif

--- a/src/main/drivers/bus_i2c_busdev.c
+++ b/src/main/drivers/bus_i2c_busdev.c
@@ -32,10 +32,10 @@
 
 static uint8_t i2cRegisteredDeviceCount = 0;
 
-// Bitmask of configured buses that could not be released to idle at init.
-// Set/cleared by i2cInit() via i2cSetBusStuck(); platforms that never call
-// the setter simply leave the mask at 0.
-static uint16_t i2cStuckBusMask = 0;
+// Per-bus health sampled at init (I2C_HEALTH_* bits). Populated by i2cInit()
+// via i2cReportBusHealth(); platforms that never call it leave entries at 0
+// (I2C_HEALTH_CHECKED clear → not reported).
+static uint8_t i2cBusHealth[I2CDEV_COUNT];
 
 bool i2cBusWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data)
 {
@@ -106,21 +106,21 @@ uint8_t i2cGetRegisteredDeviceCount(void)
     return i2cRegisteredDeviceCount;
 }
 
-void i2cSetBusStuck(i2cDevice_e device, bool stuck)
+void i2cReportBusHealth(i2cDevice_e device, uint8_t health)
 {
     if (device < 0 || device >= I2CDEV_COUNT) {
         return;
     }
 
-    if (stuck) {
-        i2cStuckBusMask |= (1U << device);
-    } else {
-        i2cStuckBusMask &= ~(1U << device);
-    }
+    i2cBusHealth[device] = health;
 }
 
-uint16_t i2cGetStuckBusMask(void)
+uint8_t i2cGetBusHealth(i2cDevice_e device)
 {
-    return i2cStuckBusMask;
+    if (device < 0 || device >= I2CDEV_COUNT) {
+        return 0;
+    }
+
+    return i2cBusHealth[device];
 }
 #endif

--- a/src/platform/STM32/bus_i2c_ll.c
+++ b/src/platform/STM32/bus_i2c_ll.c
@@ -38,6 +38,85 @@
 
 static volatile uint16_t i2cErrorCount = 0;
 
+#if defined(STM32H5)
+// TEMPORARY (Development Instrumentation) — see bus_i2c.h. Per-bus capture of
+// the most recent failed transaction plus per-reason counters, so the CLI can
+// tell a NACK ("bus clocks, target silent") apart from a TIMEOUT ("peripheral
+// never advanced") without another flash. Remove with the rest of the H5 I2C3
+// bring-up instrumentation.
+typedef struct {
+    uint32_t lastIsr;    // I2Cx->ISR sampled at the failure (raw, nothing lost)
+    uint32_t lastCr2;    // I2Cx->CR2 sampled at the failure
+    uint16_t total;
+    uint16_t nack;
+    uint16_t berr;
+    uint16_t arlo;
+    uint16_t ovr;
+    uint16_t timeout;
+    uint8_t  lastReason; // i2cFailReason_e
+} i2cFailDiag_t;
+static i2cFailDiag_t i2cFailDiag[I2CDEV_COUNT];
+#endif
+
+// Record a failed transaction. reason is authoritative (the flag that triggered
+// the failure may already be cleared by the caller); lastIsr/lastCr2 preserve
+// the surrounding peripheral state (BUSY, START pending, byte counters).
+static void i2cCaptureFail(i2cDevice_e device, i2cFailReason_e reason)
+{
+#if defined(STM32H5)
+    if (device < 0 || device >= I2CDEV_COUNT) {
+        return;
+    }
+    I2C_TypeDef *I2Cx = (I2C_TypeDef *)i2cDevice[device].reg;
+    if (!I2Cx) {
+        return;
+    }
+    i2cFailDiag_t *d = &i2cFailDiag[device];
+    d->lastIsr = I2Cx->ISR;
+    d->lastCr2 = I2Cx->CR2;
+    d->lastReason = reason;
+    d->total++;
+    switch (reason) {
+    case I2C_FAIL_NACK:    d->nack++;    break;
+    case I2C_FAIL_BERR:    d->berr++;    break;
+    case I2C_FAIL_ARLO:    d->arlo++;    break;
+    case I2C_FAIL_OVR:     d->ovr++;     break;
+    case I2C_FAIL_TIMEOUT: d->timeout++; break;
+    default: break;
+    }
+#else
+    (void)device;
+    (void)reason;
+#endif
+}
+
+#if defined(STM32H5)
+void i2cGetFailDiag(i2cDevice_e device, i2cDebugRegs_t *regs)
+{
+    if (device < 0 || device >= I2CDEV_COUNT || !regs) {
+        return;
+    }
+    const i2cFailDiag_t *d = &i2cFailDiag[device];
+    regs->lastIsr = d->lastIsr;
+    regs->lastCr2 = d->lastCr2;
+    regs->lastReason = d->lastReason;
+    regs->failTotal = d->total;
+    regs->failNack = d->nack;
+    regs->failBerr = d->berr;
+    regs->failArlo = d->arlo;
+    regs->failOvr = d->ovr;
+    regs->failTimeout = d->timeout;
+}
+
+void i2cResetFailDiag(i2cDevice_e device)
+{
+    if (device < 0 || device >= I2CDEV_COUNT) {
+        return;
+    }
+    memset(&i2cFailDiag[device], 0, sizeof(i2cFailDiag[device]));
+}
+#endif
+
 static void i2cRecoverFromISRError(I2C_TypeDef *I2Cx, i2cState_t *state)
 {
     // Disable all transfer interrupts
@@ -85,6 +164,7 @@ static void i2cEVIRQHandler(i2cDevice_e device)
 
     // NACK received
     if (LL_I2C_IsEnabledIT_NACK(I2Cx) && LL_I2C_IsActiveFlag_NACK(I2Cx)) {
+        i2cCaptureFail(device, I2C_FAIL_NACK);  // capture before clearing NACKF
         LL_I2C_ClearFlag_NACK(I2Cx);
         i2cRecoverFromISRError(I2Cx, state);
         return;
@@ -169,16 +249,19 @@ static void i2cERIRQHandler(i2cDevice_e device)
     }
 
     if (LL_I2C_IsActiveFlag_BERR(I2Cx)) {
+        i2cCaptureFail(device, I2C_FAIL_BERR);  // capture before clearing the flag
         LL_I2C_ClearFlag_BERR(I2Cx);
         state->error = true;
     }
 
     if (LL_I2C_IsActiveFlag_ARLO(I2Cx)) {
+        i2cCaptureFail(device, I2C_FAIL_ARLO);
         LL_I2C_ClearFlag_ARLO(I2Cx);
         state->error = true;
     }
 
     if (LL_I2C_IsActiveFlag_OVR(I2Cx)) {
+        i2cCaptureFail(device, I2C_FAIL_OVR);
         LL_I2C_ClearFlag_OVR(I2Cx);
         state->error = true;
     }
@@ -236,10 +319,11 @@ void I2C4_EV_IRQHandler(void)
 }
 #endif
 
-static bool i2cHandleHardwareFailure(i2cDevice_e device)
+static bool i2cHandleHardwareFailure(i2cDevice_e device, i2cFailReason_e reason)
 {
     I2C_TypeDef *I2Cx = (I2C_TypeDef *)i2cDevice[device].reg;
     i2cState_t *state = &i2cDevice[device].state;
+    i2cCaptureFail(device, reason);
     i2cRecoverFromISRError(I2Cx, state);
     return false;
 }
@@ -284,10 +368,10 @@ bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
                 LL_I2C_ClearFlag_NACK(I2Cx);
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
             }
         }
         LL_I2C_TransmitData8(I2Cx, data);
@@ -301,10 +385,10 @@ bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
                 LL_I2C_ClearFlag_NACK(I2Cx);
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
             }
         }
         LL_I2C_TransmitData8(I2Cx, reg_);
@@ -313,10 +397,10 @@ bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
                 LL_I2C_ClearFlag_NACK(I2Cx);
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
             }
         }
         LL_I2C_TransmitData8(I2Cx, data);
@@ -326,10 +410,10 @@ bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
     while (!LL_I2C_IsActiveFlag_STOP(I2Cx)) {
         if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
             LL_I2C_ClearFlag_NACK(I2Cx);
-            return i2cHandleHardwareFailure(device);
+            return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
         }
         if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-            return i2cHandleHardwareFailure(device);
+            return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
         }
     }
     LL_I2C_ClearFlag_STOP(I2Cx);
@@ -387,10 +471,10 @@ bool i2cWriteBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
                 LL_I2C_ClearFlag_NACK(I2Cx);
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
             }
         }
         LL_I2C_TransmitData8(I2Cx, reg_);
@@ -451,10 +535,10 @@ bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
                 LL_I2C_ClearFlag_NACK(I2Cx);
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
             }
         }
         LL_I2C_TransmitData8(I2Cx, reg_);
@@ -463,10 +547,10 @@ bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8
         while (!LL_I2C_IsActiveFlag_TC(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
                 LL_I2C_ClearFlag_NACK(I2Cx);
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
             }
         }
 
@@ -481,10 +565,10 @@ bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8
         while (!LL_I2C_IsActiveFlag_RXNE(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
                 LL_I2C_ClearFlag_NACK(I2Cx);
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
             }
         }
         buf[i] = LL_I2C_ReceiveData8(I2Cx);
@@ -494,10 +578,10 @@ bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8
     while (!LL_I2C_IsActiveFlag_STOP(I2Cx)) {
         if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
             LL_I2C_ClearFlag_NACK(I2Cx);
-            return i2cHandleHardwareFailure(device);
+            return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
         }
         if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-            return i2cHandleHardwareFailure(device);
+            return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
         }
     }
     LL_I2C_ClearFlag_STOP(I2Cx);
@@ -557,10 +641,10 @@ bool i2cReadBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len,
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
                 LL_I2C_ClearFlag_NACK(I2Cx);
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device);
+                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
             }
         }
         LL_I2C_TransmitData8(I2Cx, reg_);
@@ -603,7 +687,7 @@ bool i2cBusy(i2cDevice_e device, bool *error)
             HAL_NVIC_DisableIRQ(hardware->er_irq);
         }
 
-        i2cHandleHardwareFailure(device);
+        i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
 
         if (hardware) {
             HAL_NVIC_EnableIRQ(hardware->ev_irq);

--- a/src/platform/STM32/bus_i2c_ll.c
+++ b/src/platform/STM32/bus_i2c_ll.c
@@ -96,16 +96,21 @@ void i2cGetFailDiag(i2cDevice_e device, i2cDebugRegs_t *regs)
     if (device < 0 || device >= I2CDEV_COUNT || !regs) {
         return;
     }
-    const i2cFailDiag_t *d = &i2cFailDiag[device];
-    regs->lastIsr = d->lastIsr;
-    regs->lastCr2 = d->lastCr2;
-    regs->lastReason = d->lastReason;
-    regs->failTotal = d->total;
-    regs->failNack = d->nack;
-    regs->failBerr = d->berr;
-    regs->failArlo = d->arlo;
-    regs->failOvr = d->ovr;
-    regs->failTimeout = d->timeout;
+    // i2cCaptureFail() also writes this struct from the EV/ER IRQs, so copy it
+    // atomically — otherwise the snapshot can mix fields from two failures.
+    const uint32_t primask = __get_PRIMASK();
+    __disable_irq();
+    const i2cFailDiag_t d = i2cFailDiag[device];
+    __set_PRIMASK(primask);
+    regs->lastIsr = d.lastIsr;
+    regs->lastCr2 = d.lastCr2;
+    regs->lastReason = d.lastReason;
+    regs->failTotal = d.total;
+    regs->failNack = d.nack;
+    regs->failBerr = d.berr;
+    regs->failArlo = d.arlo;
+    regs->failOvr = d.ovr;
+    regs->failTimeout = d.timeout;
 }
 
 void i2cResetFailDiag(i2cDevice_e device)
@@ -113,7 +118,11 @@ void i2cResetFailDiag(i2cDevice_e device)
     if (device < 0 || device >= I2CDEV_COUNT) {
         return;
     }
+    // Guard against an IRQ-context i2cCaptureFail() landing mid-clear.
+    const uint32_t primask = __get_PRIMASK();
+    __disable_irq();
     memset(&i2cFailDiag[device], 0, sizeof(i2cFailDiag[device]));
+    __set_PRIMASK(primask);
 }
 #endif
 
@@ -323,7 +332,12 @@ static bool i2cHandleHardwareFailure(i2cDevice_e device, i2cFailReason_e reason)
 {
     I2C_TypeDef *I2Cx = (I2C_TypeDef *)i2cDevice[device].reg;
     i2cState_t *state = &i2cDevice[device].state;
+    // Snapshot before clearing so the raw ISR still shows NACKF for a NACK
+    // failure; the foreground poll loops deliberately leave the flag set for us.
     i2cCaptureFail(device, reason);
+    if (reason == I2C_FAIL_NACK) {
+        LL_I2C_ClearFlag_NACK(I2Cx);
+    }
     i2cRecoverFromISRError(I2Cx, state);
     return false;
 }
@@ -367,7 +381,6 @@ bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
         // Wait for TXIS
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                LL_I2C_ClearFlag_NACK(I2Cx);
                 return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
@@ -384,7 +397,6 @@ bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
         // Wait for TXIS then send register address
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                LL_I2C_ClearFlag_NACK(I2Cx);
                 return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
@@ -396,7 +408,6 @@ bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
         // Wait for TXIS then send data byte
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                LL_I2C_ClearFlag_NACK(I2Cx);
                 return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
@@ -409,7 +420,6 @@ bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
     // Wait for STOP flag (AUTOEND generates stop automatically)
     while (!LL_I2C_IsActiveFlag_STOP(I2Cx)) {
         if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-            LL_I2C_ClearFlag_NACK(I2Cx);
             return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
         }
         if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
@@ -470,7 +480,6 @@ bool i2cWriteBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len
         timeUs_t timeoutStartUs = microsISR();
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                LL_I2C_ClearFlag_NACK(I2Cx);
                 return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
@@ -534,7 +543,6 @@ bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8
         // Wait for TXIS then send register address
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                LL_I2C_ClearFlag_NACK(I2Cx);
                 return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
@@ -546,7 +554,6 @@ bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8
         // Wait for Transfer Complete (TC) - SOFTEND means no auto-stop
         while (!LL_I2C_IsActiveFlag_TC(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                LL_I2C_ClearFlag_NACK(I2Cx);
                 return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
@@ -564,7 +571,6 @@ bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8
     for (uint8_t i = 0; i < len; i++) {
         while (!LL_I2C_IsActiveFlag_RXNE(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                LL_I2C_ClearFlag_NACK(I2Cx);
                 return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
@@ -577,7 +583,6 @@ bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8
     // Wait for STOP flag (AUTOEND generates stop automatically)
     while (!LL_I2C_IsActiveFlag_STOP(I2Cx)) {
         if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-            LL_I2C_ClearFlag_NACK(I2Cx);
             return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
         }
         if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
@@ -640,7 +645,6 @@ bool i2cReadBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len,
         timeUs_t timeoutStartUs = microsISR();
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
             if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                LL_I2C_ClearFlag_NACK(I2Cx);
                 return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
             }
             if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {

--- a/src/platform/STM32/bus_i2c_ll.c
+++ b/src/platform/STM32/bus_i2c_ll.c
@@ -332,11 +332,15 @@ static bool i2cHandleHardwareFailure(i2cDevice_e device, i2cFailReason_e reason)
 {
     I2C_TypeDef *I2Cx = (I2C_TypeDef *)i2cDevice[device].reg;
     i2cState_t *state = &i2cDevice[device].state;
-    // Snapshot before clearing so the raw ISR still shows NACKF for a NACK
-    // failure; the foreground poll loops deliberately leave the flag set for us.
+    // Snapshot before clearing so the raw ISR still shows the error bit that
+    // triggered the failure; the foreground poll loops deliberately leave the
+    // flag set for us.
     i2cCaptureFail(device, reason);
-    if (reason == I2C_FAIL_NACK) {
-        LL_I2C_ClearFlag_NACK(I2Cx);
+    switch (reason) {
+    case I2C_FAIL_NACK: LL_I2C_ClearFlag_NACK(I2Cx); break;
+    case I2C_FAIL_ARLO: LL_I2C_ClearFlag_ARLO(I2Cx); break;
+    case I2C_FAIL_BERR: LL_I2C_ClearFlag_BERR(I2Cx); break;
+    default: break;
     }
     i2cRecoverFromISRError(I2Cx, state);
     return false;
@@ -345,6 +349,29 @@ static bool i2cHandleHardwareFailure(i2cDevice_e device, i2cFailReason_e reason)
 uint16_t i2cGetErrorCounter(void)
 {
     return i2cErrorCount;
+}
+
+// Poll for a terminating condition inside a blocking transfer loop. Returns the
+// failure reason, or I2C_FAIL_NONE to keep waiting. ARLO/BERR are checked
+// alongside NACK so a bus fault (e.g. an SDA that cannot be driven high) is
+// reported and counted for what it is, instead of only surfacing as the 10 ms
+// timeout it would otherwise decay into. The flag is left set for
+// i2cHandleHardwareFailure() to snapshot before clearing.
+static i2cFailReason_e i2cPollFailure(I2C_TypeDef *I2Cx, timeUs_t timeoutStartUs)
+{
+    if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
+        return I2C_FAIL_NACK;
+    }
+    if (LL_I2C_IsActiveFlag_ARLO(I2Cx)) {
+        return I2C_FAIL_ARLO;
+    }
+    if (LL_I2C_IsActiveFlag_BERR(I2Cx)) {
+        return I2C_FAIL_BERR;
+    }
+    if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
+        return I2C_FAIL_TIMEOUT;
+    }
+    return I2C_FAIL_NONE;
 }
 
 // Blocking write
@@ -380,11 +407,9 @@ bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
 
         // Wait for TXIS
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
-            if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
-            }
-            if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
+            const i2cFailReason_e fail = i2cPollFailure(I2Cx, timeoutStartUs);
+            if (fail != I2C_FAIL_NONE) {
+                return i2cHandleHardwareFailure(device, fail);
             }
         }
         LL_I2C_TransmitData8(I2Cx, data);
@@ -396,22 +421,18 @@ bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
 
         // Wait for TXIS then send register address
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
-            if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
-            }
-            if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
+            const i2cFailReason_e fail = i2cPollFailure(I2Cx, timeoutStartUs);
+            if (fail != I2C_FAIL_NONE) {
+                return i2cHandleHardwareFailure(device, fail);
             }
         }
         LL_I2C_TransmitData8(I2Cx, reg_);
 
         // Wait for TXIS then send data byte
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
-            if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
-            }
-            if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
+            const i2cFailReason_e fail = i2cPollFailure(I2Cx, timeoutStartUs);
+            if (fail != I2C_FAIL_NONE) {
+                return i2cHandleHardwareFailure(device, fail);
             }
         }
         LL_I2C_TransmitData8(I2Cx, data);
@@ -419,11 +440,9 @@ bool i2cWrite(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t data)
 
     // Wait for STOP flag (AUTOEND generates stop automatically)
     while (!LL_I2C_IsActiveFlag_STOP(I2Cx)) {
-        if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-            return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
-        }
-        if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-            return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
+        const i2cFailReason_e fail = i2cPollFailure(I2Cx, timeoutStartUs);
+        if (fail != I2C_FAIL_NONE) {
+            return i2cHandleHardwareFailure(device, fail);
         }
     }
     LL_I2C_ClearFlag_STOP(I2Cx);
@@ -479,11 +498,9 @@ bool i2cWriteBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len
         // so the ISR only deals with data bytes
         timeUs_t timeoutStartUs = microsISR();
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
-            if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
-            }
-            if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
+            const i2cFailReason_e fail = i2cPollFailure(I2Cx, timeoutStartUs);
+            if (fail != I2C_FAIL_NONE) {
+                return i2cHandleHardwareFailure(device, fail);
             }
         }
         LL_I2C_TransmitData8(I2Cx, reg_);
@@ -542,22 +559,18 @@ bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8
 
         // Wait for TXIS then send register address
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
-            if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
-            }
-            if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
+            const i2cFailReason_e fail = i2cPollFailure(I2Cx, timeoutStartUs);
+            if (fail != I2C_FAIL_NONE) {
+                return i2cHandleHardwareFailure(device, fail);
             }
         }
         LL_I2C_TransmitData8(I2Cx, reg_);
 
         // Wait for Transfer Complete (TC) - SOFTEND means no auto-stop
         while (!LL_I2C_IsActiveFlag_TC(I2Cx)) {
-            if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
-            }
-            if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
+            const i2cFailReason_e fail = i2cPollFailure(I2Cx, timeoutStartUs);
+            if (fail != I2C_FAIL_NONE) {
+                return i2cHandleHardwareFailure(device, fail);
             }
         }
 
@@ -570,11 +583,9 @@ bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8
     // Read all bytes
     for (uint8_t i = 0; i < len; i++) {
         while (!LL_I2C_IsActiveFlag_RXNE(I2Cx)) {
-            if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
-            }
-            if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
+            const i2cFailReason_e fail = i2cPollFailure(I2Cx, timeoutStartUs);
+            if (fail != I2C_FAIL_NONE) {
+                return i2cHandleHardwareFailure(device, fail);
             }
         }
         buf[i] = LL_I2C_ReceiveData8(I2Cx);
@@ -582,11 +593,9 @@ bool i2cRead(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len, uint8
 
     // Wait for STOP flag (AUTOEND generates stop automatically)
     while (!LL_I2C_IsActiveFlag_STOP(I2Cx)) {
-        if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-            return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
-        }
-        if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-            return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
+        const i2cFailReason_e fail = i2cPollFailure(I2Cx, timeoutStartUs);
+        if (fail != I2C_FAIL_NONE) {
+            return i2cHandleHardwareFailure(device, fail);
         }
     }
     LL_I2C_ClearFlag_STOP(I2Cx);
@@ -644,11 +653,9 @@ bool i2cReadBuffer(i2cDevice_e device, uint8_t addr_, uint8_t reg_, uint8_t len,
         // Wait for TXIS to send the register address byte synchronously
         timeUs_t timeoutStartUs = microsISR();
         while (!LL_I2C_IsActiveFlag_TXIS(I2Cx)) {
-            if (LL_I2C_IsActiveFlag_NACK(I2Cx)) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_NACK);
-            }
-            if (cmpTimeUs(microsISR(), timeoutStartUs) >= I2C_TIMEOUT_US) {
-                return i2cHandleHardwareFailure(device, I2C_FAIL_TIMEOUT);
+            const i2cFailReason_e fail = i2cPollFailure(I2Cx, timeoutStartUs);
+            if (fail != I2C_FAIL_NONE) {
+                return i2cHandleHardwareFailure(device, fail);
             }
         }
         LL_I2C_TransmitData8(I2Cx, reg_);

--- a/src/platform/STM32/bus_i2c_ll_init.c
+++ b/src/platform/STM32/bus_i2c_ll_init.c
@@ -326,7 +326,13 @@ void i2cInit(i2cDevice_e device)
     // Enable RCC
     RCC_ClockCmd(hardware->rcc, ENABLE);
 
-    i2cUnstick(scl, sda);
+    // Drive the bus idle and confirm both lines actually reach a valid high.
+    // If they cannot (stuck low), the bus is electrically dead — almost always
+    // missing external pull-ups or a device holding a line. Record it so the
+    // failure is visible (CLI status) rather than silent. Init continues; a
+    // dead bus simply times out on every transaction.
+    const bool busIdle = i2cUnstick(scl, sda);
+    i2cSetBusStuck(device, !busIdle);
 
     // Init pins
 #if defined(STM32F7)

--- a/src/platform/STM32/bus_i2c_ll_init.c
+++ b/src/platform/STM32/bus_i2c_ll_init.c
@@ -345,15 +345,17 @@ void i2cInit(i2cDevice_e device)
 
     // External pull-up presence — only meaningful when not relying on the
     // internal pull-up. Internal pull-down engaged: a real external pull-up
-    // overrides it (HIGH), its absence reads LOW. Informational only.
+    // overrides it (HIGH), its absence reads LOW. Informational only. Skip a
+    // line already held low above: it reads low here regardless, so we cannot
+    // conclude anything about its pull-up.
     if (!pDev->pullUp) {
         IOConfigGPIO(scl, IOCFG_IPD);
         IOConfigGPIO(sda, IOCFG_IPD);
         delayMicroseconds(10);
-        if (!IORead(scl)) {
+        if (!(busHealth & I2C_HEALTH_SCL_LOW) && !IORead(scl)) {
             busHealth |= I2C_HEALTH_SCL_NOPULL;
         }
-        if (!IORead(sda)) {
+        if (!(busHealth & I2C_HEALTH_SDA_LOW) && !IORead(sda)) {
             busHealth |= I2C_HEALTH_SDA_NOPULL;
         }
     }

--- a/src/platform/STM32/bus_i2c_ll_init.c
+++ b/src/platform/STM32/bus_i2c_ll_init.c
@@ -28,8 +28,10 @@
 #if defined(USE_I2C) && !defined(USE_SOFT_I2C) && !defined(USE_I3C_AS_I2C)
 
 #include "drivers/io.h"
+#include "drivers/io_impl.h"
 #include "drivers/nvic.h"
 #include "drivers/time.h"
+#include "platform/io_impl.h"
 #include "platform/rcc.h"
 
 #include "drivers/bus_i2c.h"
@@ -405,6 +407,21 @@ void i2cInit(i2cDevice_e device)
     // H5 Clock sources:
     //   I2C12  : PCLK1 (APB1)
     //   I2C34  : PCLK3 (APB3)
+    // Explicitly select the kernel clock source rather than trusting the reset
+    // default (I2CxSEL=0). The APB clock enable (APB1L/APB3ENR) only gates
+    // register access; SCL is generated from the *kernel* clock, so if anything
+    // (bootloader, prior state) left I2CxSEL pointing elsewhere the peripheral's
+    // registers respond but the bus never clocks. Pin these to the source the
+    // TIMINGR below is computed against.
+    if (I2Cx == I2C1) {
+        __HAL_RCC_I2C1_CONFIG(RCC_I2C1CLKSOURCE_PCLK1);
+    } else if (I2Cx == I2C2) {
+        __HAL_RCC_I2C2_CONFIG(RCC_I2C2CLKSOURCE_PCLK1);
+    } else if (I2Cx == I2C3) {
+        __HAL_RCC_I2C3_CONFIG(RCC_I2C3CLKSOURCE_PCLK3);
+    } else if (I2Cx == I2C4) {
+        __HAL_RCC_I2C4_CONFIG(RCC_I2C4CLKSOURCE_PCLK3);
+    }
     i2cPclk = (I2Cx == I2C3 || I2Cx == I2C4) ? HAL_RCC_GetPCLK3Freq() : HAL_RCC_GetPCLK1Freq();
 #elif defined(STM32N6)
     // N6 Clock sources:
@@ -439,5 +456,57 @@ void i2cInit(i2cDevice_e device)
     HAL_NVIC_SetPriority(hardware->ev_irq, NVIC_PRIORITY_BASE(NVIC_PRIO_I2C_EV), NVIC_PRIORITY_SUB(NVIC_PRIO_I2C_EV));
     HAL_NVIC_EnableIRQ(hardware->ev_irq);
 }
+
+#if defined(STM32H5)
+// TEMPORARY (Development Instrumentation) — see bus_i2c.h. Read the live post-init
+// registers that determine whether a configured I2C bus can actually clock.
+bool i2cGetDebugRegs(i2cDevice_e device, i2cDebugRegs_t *regs)
+{
+    if (device < 0 || device >= I2CDEV_COUNT || !regs) {
+        return false;
+    }
+
+    const i2cDevice_t *pDev = &i2cDevice[device];
+    I2C_TypeDef *I2Cx = (I2C_TypeDef *)pDev->reg;
+    if (!I2Cx || !pDev->scl || !pDev->sda) {
+        return false;  // bus not configured
+    }
+
+    uint8_t selPos;
+    bool busClockOn;
+    if (I2Cx == I2C1) {
+        selPos = RCC_CCIPR4_I2C1SEL_Pos;
+        busClockOn = (RCC->APB1LENR & RCC_APB1LENR_I2C1EN) != 0;
+    } else if (I2Cx == I2C2) {
+        selPos = RCC_CCIPR4_I2C2SEL_Pos;
+        busClockOn = (RCC->APB1LENR & RCC_APB1LENR_I2C2EN) != 0;
+    } else if (I2Cx == I2C3) {
+        selPos = RCC_CCIPR4_I2C3SEL_Pos;
+        busClockOn = (RCC->APB3ENR & RCC_APB3ENR_I2C3EN) != 0;
+    } else if (I2Cx == I2C4) {
+        selPos = RCC_CCIPR4_I2C4SEL_Pos;
+        busClockOn = (RCC->APB3ENR & RCC_APB3ENR_I2C4EN) != 0;
+    } else {
+        return false;
+    }
+
+    regs->clkSel = (RCC->CCIPR4 >> selPos) & 0x3;
+    regs->busClockOn = busClockOn;
+    regs->peEnabled = (I2Cx->CR1 & I2C_CR1_PE) != 0;
+    regs->timingr = I2Cx->TIMINGR;
+
+    GPIO_TypeDef *sclGpio = IO_GPIO(pDev->scl);
+    const int sclPin = IO_GPIOPinIdx(pDev->scl);
+    regs->sclMode = (sclGpio->MODER >> (sclPin * 2)) & 0x3;
+    regs->sclAf = (sclGpio->AFR[sclPin >> 3] >> ((sclPin & 7) * 4)) & 0xF;
+
+    GPIO_TypeDef *sdaGpio = IO_GPIO(pDev->sda);
+    const int sdaPin = IO_GPIOPinIdx(pDev->sda);
+    regs->sdaMode = (sdaGpio->MODER >> (sdaPin * 2)) & 0x3;
+    regs->sdaAf = (sdaGpio->AFR[sdaPin >> 3] >> ((sdaPin & 7) * 4)) & 0xF;
+
+    return true;
+}
+#endif
 
 #endif

--- a/src/platform/STM32/bus_i2c_ll_init.c
+++ b/src/platform/STM32/bus_i2c_ll_init.c
@@ -326,27 +326,41 @@ void i2cInit(i2cDevice_e device)
     // Enable RCC
     RCC_ClockCmd(hardware->rcc, ENABLE);
 
-    // Bus-health diagnostic. Sample the idle line levels with the internal
-    // pull-down engaged: a healthy external pull-up (few kOhm) overrides it and
-    // reads HIGH, a missing/weak pull-up or a held line reads LOW. Then confirm
-    // the bus can be driven to idle. Recorded for CLI status so a dead bus is
-    // visible instead of failing silently; reporting the actual levels tells a
-    // line stuck LOW (pull-ups/wiring) apart from lines HIGH yet unusable
-    // (peripheral/pin-mapping fault). Init continues regardless.
-    IOConfigGPIO(scl, IOCFG_IPD);
-    IOConfigGPIO(sda, IOCFG_IPD);
-    delayMicroseconds(10);  // settle against the external pull-up
+    // Bus-health diagnostic (recorded for CLI status; init continues regardless).
     uint8_t busHealth = I2C_HEALTH_CHECKED;
+
+    // Usability: engage the internal pull-up. An unloaded, functional line
+    // reaches HIGH; if it stays LOW it is being held down (short, stuck device,
+    // or a non-functional pin). Pull-strategy agnostic — a board relying on the
+    // internal pull-up passes this, so it is never mis-flagged.
+    IOConfigGPIO(scl, IOCFG_IPU);
+    IOConfigGPIO(sda, IOCFG_IPU);
+    delayMicroseconds(10);
     if (!IORead(scl)) {
         busHealth |= I2C_HEALTH_SCL_LOW;
     }
     if (!IORead(sda)) {
         busHealth |= I2C_HEALTH_SDA_LOW;
     }
-    if (!i2cUnstick(scl, sda)) {
-        busHealth |= I2C_HEALTH_NOT_IDLE;
+
+    // External pull-up presence — only meaningful when not relying on the
+    // internal pull-up. Internal pull-down engaged: a real external pull-up
+    // overrides it (HIGH), its absence reads LOW. Informational only.
+    if (!pDev->pullUp) {
+        IOConfigGPIO(scl, IOCFG_IPD);
+        IOConfigGPIO(sda, IOCFG_IPD);
+        delayMicroseconds(10);
+        if (!IORead(scl)) {
+            busHealth |= I2C_HEALTH_SCL_NOPULL;
+        }
+        if (!IORead(sda)) {
+            busHealth |= I2C_HEALTH_SDA_NOPULL;
+        }
     }
+
     i2cReportBusHealth(device, busHealth);
+
+    i2cUnstick(scl, sda);
 
     // Init pins
 #if defined(STM32F7)

--- a/src/platform/STM32/bus_i2c_ll_init.c
+++ b/src/platform/STM32/bus_i2c_ll_init.c
@@ -326,13 +326,27 @@ void i2cInit(i2cDevice_e device)
     // Enable RCC
     RCC_ClockCmd(hardware->rcc, ENABLE);
 
-    // Drive the bus idle and confirm both lines actually reach a valid high.
-    // If they cannot (stuck low), the bus is electrically dead — almost always
-    // missing external pull-ups or a device holding a line. Record it so the
-    // failure is visible (CLI status) rather than silent. Init continues; a
-    // dead bus simply times out on every transaction.
-    const bool busIdle = i2cUnstick(scl, sda);
-    i2cSetBusStuck(device, !busIdle);
+    // Bus-health diagnostic. Sample the idle line levels with the internal
+    // pull-down engaged: a healthy external pull-up (few kOhm) overrides it and
+    // reads HIGH, a missing/weak pull-up or a held line reads LOW. Then confirm
+    // the bus can be driven to idle. Recorded for CLI status so a dead bus is
+    // visible instead of failing silently; reporting the actual levels tells a
+    // line stuck LOW (pull-ups/wiring) apart from lines HIGH yet unusable
+    // (peripheral/pin-mapping fault). Init continues regardless.
+    IOConfigGPIO(scl, IOCFG_IPD);
+    IOConfigGPIO(sda, IOCFG_IPD);
+    delayMicroseconds(10);  // settle against the external pull-up
+    uint8_t busHealth = I2C_HEALTH_CHECKED;
+    if (!IORead(scl)) {
+        busHealth |= I2C_HEALTH_SCL_LOW;
+    }
+    if (!IORead(sda)) {
+        busHealth |= I2C_HEALTH_SDA_LOW;
+    }
+    if (!i2cUnstick(scl, sda)) {
+        busHealth |= I2C_HEALTH_NOT_IDLE;
+    }
+    i2cReportBusHealth(device, busHealth);
 
     // Init pins
 #if defined(STM32F7)

--- a/src/platform/STM32/bus_i2c_ll_init.c
+++ b/src/platform/STM32/bus_i2c_ll_init.c
@@ -523,6 +523,15 @@ bool i2cGetDebugRegs(i2cDevice_e device, i2cDebugRegs_t *regs)
     // HIGH now => the bus was not driven high when i2cInit() ran.
     regs->initHealth = i2cGetBusHealth(device);
 
+    // Kernel-clock health: is HSI (the I2C3/4 kernel source) actually locked,
+    // and at what division? Closes the question of whether clkSrc=HSI in the
+    // line above is a live 64 MHz clock or a selected-but-dead source.
+    regs->hsiReady = (RCC->CR & RCC_CR_HSIRDY) != 0;
+    regs->hsiDiv = (RCC->CR & RCC_CR_HSIDIV) >> RCC_CR_HSIDIV_Pos;
+
+    // Last-failure capture from the transaction unit (separate translation unit).
+    i2cGetFailDiag(device, regs);
+
     return true;
 }
 #endif

--- a/src/platform/STM32/bus_i2c_ll_init.c
+++ b/src/platform/STM32/bus_i2c_ll_init.c
@@ -404,25 +404,35 @@ void i2cInit(i2cDevice_e device)
     //   I2C4   : D3PCLK1 (rcc_pclk4 for APB4)
     i2cPclk = (I2Cx == I2C4) ? HAL_RCCEx_GetD3PCLK1Freq() : HAL_RCC_GetPCLK1Freq();
 #elif defined(STM32H5)
-    // H5 Clock sources:
-    //   I2C12  : PCLK1 (APB1)
-    //   I2C34  : PCLK3 (APB3)
+    // H5 kernel clock sources:
+    //   I2C1/2 (APB1) : PCLK1
+    //   I2C3/4 (APB3) : HSI (64 MHz), NOT PCLK3
     // Explicitly select the kernel clock source rather than trusting the reset
     // default (I2CxSEL=0). The APB clock enable (APB1L/APB3ENR) only gates
     // register access; SCL is generated from the *kernel* clock, so if anything
     // (bootloader, prior state) left I2CxSEL pointing elsewhere the peripheral's
     // registers respond but the bus never clocks. Pin these to the source the
     // TIMINGR below is computed against.
+    //
+    // I2C3/4 are deliberately taken off PCLK3: at the H5's full clock the APB3
+    // kernel would be 250 MHz, which is the *absolute maximum* fI2C_ker_ck and
+    // only "specified by design, not tested in production" (DS14258 Table 21).
+    // HSI (64 MHz) is well inside the tested envelope, independent of the system
+    // clock, and ample for up to Fast-mode Plus. HSI is kept enabled in
+    // SystemClock_Config(). I2C1/2 stay on PCLK1 (proven working on shipping H5
+    // boards) to keep the blast radius on the untested APB3 path only.
     if (I2Cx == I2C1) {
         __HAL_RCC_I2C1_CONFIG(RCC_I2C1CLKSOURCE_PCLK1);
     } else if (I2Cx == I2C2) {
         __HAL_RCC_I2C2_CONFIG(RCC_I2C2CLKSOURCE_PCLK1);
     } else if (I2Cx == I2C3) {
-        __HAL_RCC_I2C3_CONFIG(RCC_I2C3CLKSOURCE_PCLK3);
+        __HAL_RCC_I2C3_CONFIG(RCC_I2C3CLKSOURCE_HSI);
     } else if (I2Cx == I2C4) {
-        __HAL_RCC_I2C4_CONFIG(RCC_I2C4CLKSOURCE_PCLK3);
+        __HAL_RCC_I2C4_CONFIG(RCC_I2C4CLKSOURCE_HSI);
     }
-    i2cPclk = (I2Cx == I2C3 || I2Cx == I2C4) ? HAL_RCC_GetPCLK3Freq() : HAL_RCC_GetPCLK1Freq();
+    i2cPclk = (I2Cx == I2C3 || I2Cx == I2C4)
+        ? (HSI_VALUE >> ((RCC->CR & RCC_CR_HSIDIV) >> RCC_CR_HSIDIV_Pos))
+        : HAL_RCC_GetPCLK1Freq();
 #elif defined(STM32N6)
     // N6 Clock sources:
     //   I2C123 : PCLK1 (APB1)
@@ -499,11 +509,19 @@ bool i2cGetDebugRegs(i2cDevice_e device, i2cDebugRegs_t *regs)
     const int sclPin = IO_GPIOPinIdx(pDev->scl);
     regs->sclMode = (sclGpio->MODER >> (sclPin * 2)) & 0x3;
     regs->sclAf = (sclGpio->AFR[sclPin >> 3] >> ((sclPin & 7) * 4)) & 0xF;
+    regs->sclLevel = (sclGpio->IDR >> sclPin) & 0x1;
 
     GPIO_TypeDef *sdaGpio = IO_GPIO(pDev->sda);
     const int sdaPin = IO_GPIOPinIdx(pDev->sda);
     regs->sdaMode = (sdaGpio->MODER >> (sdaPin * 2)) & 0x3;
     regs->sdaAf = (sdaGpio->AFR[sdaPin >> 3] >> ((sdaPin & 7) * 4)) & 0xF;
+    regs->sdaLevel = (sdaGpio->IDR >> sdaPin) & 0x1;
+
+    // Init-time bus-health bitmask (what the check in i2cInit() saw at boot).
+    // Compared against the live SCL/SDA levels above, this localises a
+    // boot-time-low / powered-late bus: init health says LOW but the line reads
+    // HIGH now => the bus was not driven high when i2cInit() ran.
+    regs->initHealth = i2cGetBusHealth(device);
 
     return true;
 }

--- a/src/platform/STM32/bus_i2c_ll_init.c
+++ b/src/platform/STM32/bus_i2c_ll_init.c
@@ -534,6 +534,53 @@ bool i2cGetDebugRegs(i2cDevice_e device, i2cDebugRegs_t *regs)
 
     return true;
 }
+
+// TEMPORARY (Development Instrumentation) — see bus_i2c.h. Bit-bang SCL then SDA
+// as open-drain GPIO so each pad can be scoped on its own. Open-drain mirrors
+// the I2C drive (low = actively sunk, high = released to the external pull-up),
+// so a clean square wave here proves the pin, pull-up and wiring are all good
+// and localises a dead bus to the I2C peripheral / AF routing.
+void i2cPadToggleTest(i2cDevice_e device)
+{
+    if (device < 0 || device >= I2CDEV_COUNT) {
+        return;
+    }
+    const i2cDevice_t *pDev = &i2cDevice[device];
+    const IO_t scl = pDev->scl;
+    const IO_t sda = pDev->sda;
+    if (!scl || !sda) {
+        return;
+    }
+
+    // Release the pins from the peripheral before driving them by hand.
+    I2C_TypeDef *I2Cx = (I2C_TypeDef *)pDev->reg;
+    if (I2Cx) {
+        LL_I2C_Disable(I2Cx);
+    }
+
+    IOConfigGPIO(scl, IOCFG_OUT_OD);
+    IOConfigGPIO(sda, IOCFG_OUT_OD);
+    IOHi(scl);
+    IOHi(sda);
+    delayMicroseconds(50);
+
+    // ~50 kHz for ~0.3 s per line — a long, countable burst to scope. SCL first
+    // with SDA parked high, then SDA with SCL parked high, so each pad is
+    // unambiguous on the trace.
+    for (int i = 0; i < 15000; i++) {
+        IOLo(scl);
+        delayMicroseconds(10);
+        IOHi(scl);
+        delayMicroseconds(10);
+    }
+    delayMicroseconds(1000);
+    for (int i = 0; i < 15000; i++) {
+        IOLo(sda);
+        delayMicroseconds(10);
+        IOHi(sda);
+        delayMicroseconds(10);
+    }
+}
 #endif
 
 #endif

--- a/src/platform/STM32/bus_i2c_stm32f4xx.c
+++ b/src/platform/STM32/bus_i2c_stm32f4xx.c
@@ -463,7 +463,11 @@ void i2cInit(i2cDevice_e device)
 
     I2C_ITConfig(I2Cx, I2C_IT_EVT | I2C_IT_ERR, DISABLE);
 
-    i2cUnstick(scl, sda);
+    // Confirm the bus can be released to idle-high; a stuck-low line is almost
+    // always missing pull-ups or a device holding the bus. Record it so a dead
+    // bus is visible (CLI status) rather than failing silently.
+    const bool busIdle = i2cUnstick(scl, sda);
+    i2cSetBusStuck(device, !busIdle);
 
     // Init pins
 #ifdef STM32F4

--- a/src/platform/STM32/bus_i2c_stm32f4xx.c
+++ b/src/platform/STM32/bus_i2c_stm32f4xx.c
@@ -463,11 +463,25 @@ void i2cInit(i2cDevice_e device)
 
     I2C_ITConfig(I2Cx, I2C_IT_EVT | I2C_IT_ERR, DISABLE);
 
-    // Confirm the bus can be released to idle-high; a stuck-low line is almost
-    // always missing pull-ups or a device holding the bus. Record it so a dead
-    // bus is visible (CLI status) rather than failing silently.
-    const bool busIdle = i2cUnstick(scl, sda);
-    i2cSetBusStuck(device, !busIdle);
+    // Bus-health diagnostic: sample idle line levels with the internal pull-down
+    // engaged (healthy external pull-up reads HIGH, missing/weak reads LOW), then
+    // confirm the bus can be driven to idle. Recorded for CLI status so a dead
+    // bus is visible instead of failing silently; the per-line levels separate an
+    // electrical fault from lines HIGH yet unusable (peripheral/pin-mapping).
+    IOConfigGPIO(scl, IOCFG_IPD);
+    IOConfigGPIO(sda, IOCFG_IPD);
+    delayMicroseconds(10);  // settle against the external pull-up
+    uint8_t busHealth = I2C_HEALTH_CHECKED;
+    if (!IORead(scl)) {
+        busHealth |= I2C_HEALTH_SCL_LOW;
+    }
+    if (!IORead(sda)) {
+        busHealth |= I2C_HEALTH_SDA_LOW;
+    }
+    if (!i2cUnstick(scl, sda)) {
+        busHealth |= I2C_HEALTH_NOT_IDLE;
+    }
+    i2cReportBusHealth(device, busHealth);
 
     // Init pins
 #ifdef STM32F4

--- a/src/platform/STM32/bus_i2c_stm32f4xx.c
+++ b/src/platform/STM32/bus_i2c_stm32f4xx.c
@@ -479,15 +479,17 @@ void i2cInit(i2cDevice_e device)
         busHealth |= I2C_HEALTH_SDA_LOW;
     }
 
-    // External pull-up presence (informational; skipped when using internal pull-up).
+    // External pull-up presence (informational; skipped when using internal
+    // pull-up). Skip a line already held low: it reads low here regardless, so
+    // its pull-up state is indeterminate.
     if (!pDev->pullUp) {
         IOConfigGPIO(scl, IOCFG_IPD);
         IOConfigGPIO(sda, IOCFG_IPD);
         delayMicroseconds(10);
-        if (!IORead(scl)) {
+        if (!(busHealth & I2C_HEALTH_SCL_LOW) && !IORead(scl)) {
             busHealth |= I2C_HEALTH_SCL_NOPULL;
         }
-        if (!IORead(sda)) {
+        if (!(busHealth & I2C_HEALTH_SDA_LOW) && !IORead(sda)) {
             busHealth |= I2C_HEALTH_SDA_NOPULL;
         }
     }

--- a/src/platform/STM32/bus_i2c_stm32f4xx.c
+++ b/src/platform/STM32/bus_i2c_stm32f4xx.c
@@ -463,25 +463,38 @@ void i2cInit(i2cDevice_e device)
 
     I2C_ITConfig(I2Cx, I2C_IT_EVT | I2C_IT_ERR, DISABLE);
 
-    // Bus-health diagnostic: sample idle line levels with the internal pull-down
-    // engaged (healthy external pull-up reads HIGH, missing/weak reads LOW), then
-    // confirm the bus can be driven to idle. Recorded for CLI status so a dead
-    // bus is visible instead of failing silently; the per-line levels separate an
-    // electrical fault from lines HIGH yet unusable (peripheral/pin-mapping).
-    IOConfigGPIO(scl, IOCFG_IPD);
-    IOConfigGPIO(sda, IOCFG_IPD);
-    delayMicroseconds(10);  // settle against the external pull-up
+    // Bus-health diagnostic (recorded for CLI status; init continues regardless).
+    // Same semantics as the LL path.
     uint8_t busHealth = I2C_HEALTH_CHECKED;
+
+    // Usability: internal pull-up engaged — an unloaded functional line reaches
+    // HIGH; still LOW means held down (short/stuck device/non-functional pin).
+    IOConfigGPIO(scl, IOCFG_IPU);
+    IOConfigGPIO(sda, IOCFG_IPU);
+    delayMicroseconds(10);
     if (!IORead(scl)) {
         busHealth |= I2C_HEALTH_SCL_LOW;
     }
     if (!IORead(sda)) {
         busHealth |= I2C_HEALTH_SDA_LOW;
     }
-    if (!i2cUnstick(scl, sda)) {
-        busHealth |= I2C_HEALTH_NOT_IDLE;
+
+    // External pull-up presence (informational; skipped when using internal pull-up).
+    if (!pDev->pullUp) {
+        IOConfigGPIO(scl, IOCFG_IPD);
+        IOConfigGPIO(sda, IOCFG_IPD);
+        delayMicroseconds(10);
+        if (!IORead(scl)) {
+            busHealth |= I2C_HEALTH_SCL_NOPULL;
+        }
+        if (!IORead(sda)) {
+            busHealth |= I2C_HEALTH_SDA_NOPULL;
+        }
     }
+
     i2cReportBusHealth(device, busHealth);
+
+    i2cUnstick(scl, sda);
 
     // Init pins
 #ifdef STM32F4

--- a/src/platform/STM32/startup/system_stm32h5xx.c
+++ b/src/platform/STM32/startup/system_stm32h5xx.c
@@ -248,8 +248,17 @@ void SystemClock_Config(void)
     MODIFY_REG(FLASH->ACR, FLASH_ACR_WRHIGHFREQ, FLASH_ACR_WRHIGHFREQ_1);
 
     RCC_OscInitTypeDef oscInit = {0};
-    oscInit.OscillatorType   = RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI48;
+    // Keep HSI running alongside HSE/PLL: the I2C3/I2C4 (APB3) kernel clock is
+    // sourced from HSI (see bus_i2c_ll_init.c) so it stays inside the I2C
+    // "production-tested" envelope instead of PCLK's 250 MHz. HSI is on by reset
+    // default, but assert it explicitly so nothing downstream can leave those
+    // buses without a kernel clock. HSI is the SYSCLK at this point, so the HAL
+    // only re-applies the calibration here (HSIDIV/on-state are untouched) —
+    // HSICalibrationValue must therefore be the default, not the {0} above.
+    oscInit.OscillatorType   = RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSI48;
     oscInit.HSEState         = RCC_HSE_ON;
+    oscInit.HSIState         = RCC_HSI_ON;
+    oscInit.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
     oscInit.HSI48State       = RCC_HSI48_ON;
     oscInit.PLL.PLLState     = RCC_PLL_ON;
     oscInit.PLL.PLLSource    = RCC_PLL1_SOURCE_HSE;


### PR DESCRIPTION
## Summary

Turns a **silent** I2C failure into an explicit CLI diagnostic. `i2cInit()` already calls `i2cUnstick()` but **discarded the result**, so a configured bus that comes up dead gave no hint whether the cause was hardware or firmware.

This came out of an STM32H562 bring-up where **I2C1 worked but I2C3 did not**. The firmware path (pins/AF `PA8`/`PC9`, `RCC_APB3` enable, `PCLK3` kernel clock, IRQ vectors) was verified correct against the reference manual and datasheet.

## What it does

At init, for each configured bus, `i2cInit()`:
1. Samples the idle line levels with the **internal pull-down engaged** — a healthy external pull-up (few kΩ) overrides it and reads **HIGH**; a missing/weak pull-up or a held line reads **LOW**. This is a deterministic external-pull-up test.
2. Records whether `i2cUnstick()` could drive the bus to idle.

Results are stored per bus (`i2cReportBusHealth`/`i2cGetBusHealth`) and surfaced in CLI `status`, reporting the **actual per-line levels** so an electrical fault is told apart from a live-but-unusable bus:

```
I2C3 NOT HEALTHY AT INIT: SCL=LOW SDA=LOW idle=NO (line low: check pull-ups/wiring/short)
I2C3 NOT HEALTHY AT INIT: SCL=high SDA=high idle=NO (lines high: suspect peripheral/pin-mapping, not pull-ups)
```

A healthy bus prints nothing. Init always continues — a dead bus times out per transaction as before. Purely additive instrumentation.

## Why per-line levels (updated after hardware testing)

The first revision only reported "stuck low" and blamed pull-ups. On-bench testing of the H562 board disproved that: both lines measured **3.32 V** with valid 10 kΩ pull-ups (even with all devices disconnected), yet the bus still failed. The lines are electrically fine — the peripheral simply can't see them — so the cause is **firmware/pin-mapping, not pull-ups**. Reporting the measured levels makes that distinction instead of misdirecting to hardware.

## Scope

- Wired for the STM32 **LL** driver (H5/H7/F7/G4/N6/C5) and the **F4** driver path.
- Platforms that never call `i2cReportBusHealth` (AT32/APM32/ESP32/PICO) leave entries at 0 (`I2C_HEALTH_CHECKED` clear → not reported).

## Testing

- Builds clean: `SPEEDYBEEH5` (H5 LL path) and `ACCIF405` (F4 path).
- Confirmed on the affected H562 board (via @GEPRC bring-up): the previous revision flagged I2C3; the per-line readout is the follow-up to localise it to the peripheral/pin path.

## Notes

Filed under **Development Instrumentation** (to be removed before a release) — a bring-up aid. If broadly useful it could graduate (e.g. mirrored into the MSP `status`/sensor report for the Configurator).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added I2C bus-health diagnostics at startup to flag stuck-low SCL/SDA and detect missing external pull-ups.
  - Added an `i2c_regs` CLI command (STM32H5 + I2C) to show per-bus debug snapshots, plus `scan` and `padtest` for address probing and pin/pull scoping guidance.
- **Bug Fixes**
  - Improved STM32H5 I2C failure handling by classifying NACK/BERR/ARLO/OVR/timeout and capturing accurate low-level state for more reliable recovery.
  - Refined STM32H5 I2C timing/clock selection and updated system clock config to keep HSI active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->