### PR TITLE
fix(build): pin config submodule on hydrate so revision reports correctly

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -52,7 +52,7 @@ endif #config
 .PHONY: configs
 configs:
 ifeq ($(shell realpath $(CONFIG_DIR)),$(shell realpath $(CONFIGS_SUBMODULE_DIR)))
-	git submodule update --init --remote -- $(CONFIGS_SUBMODULE_DIR)
+	git submodule update --init -- $(CONFIGS_SUBMODULE_DIR)
 else
 ifeq ($(wildcard $(CONFIG_DIR)),)
 	@echo "Hydrating clone for configs: $(CONFIG_DIR)"


### PR DESCRIPTION
`make configs` used `git submodule update --init --remote`, which checks out the tip of the config repo's master branch rather than the commit pinned in the gitlink. Once config master advances past the pinned commit (which it now has, relative to the 4.5.5 pin), the superproject sees `src/config` as modified, `git diff --shortstat` is non-empty, and the Makefile REVISION guard falls back to `norevision`. The CLI then reports `(norevision)` for any 4.5.x build done after config master moved on.

Dropping `--remote` checks out the pinned commit, keeping the working tree clean and restoring revision reporting. This matches the behaviour already on master, where `--remote` was removed but never backported here.