### PR TITLE
build: resolve configs by board name across a manufacturer-grouped layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -874,7 +874,8 @@ targets-ci-grouped-print:
 		done; \
 		for t in $(CI_TARGETS); do \
 			config_h="$(CONFIG_DIR)/configs/$$t/config.h"; \
-			if [ -f "$$config_h" ]; then \
+			[ -f "$$config_h" ] || config_h=$$(ls $(CONFIG_DIR)/configs/*/$$t/config.h 2>/dev/null | head -1); \
+			if [ -n "$$config_h" ] && [ -f "$$config_h" ]; then \
 				mcu=$$(grep -m1 'FC_TARGET_MCU' "$$config_h" | awk '{print $$NF}'); \
 				echo "CONFIG $$t $$mcu"; \
 			fi; \

--- a/Makefile
+++ b/Makefile
@@ -874,8 +874,15 @@ targets-ci-grouped-print:
 		done; \
 		for t in $(CI_TARGETS); do \
 			config_h="$(CONFIG_DIR)/configs/$$t/config.h"; \
-			[ -f "$$config_h" ] || config_h=$$(ls $(CONFIG_DIR)/configs/*/$$t/config.h 2>/dev/null | head -1); \
-			if [ -n "$$config_h" ] && [ -f "$$config_h" ]; then \
+			if [ ! -f "$$config_h" ]; then \
+				config_h=""; \
+				for c in $(CONFIG_DIR)/configs/*/$$t/config.h; do \
+					[ -f "$$c" ] || continue; \
+					if [ -n "$$config_h" ]; then echo "Ambiguous CI target $$t matches multiple configs" >&2; config_h=""; break; fi; \
+					config_h="$$c"; \
+				done; \
+			fi; \
+			if [ -n "$$config_h" ]; then \
 				mcu=$$(grep -m1 'FC_TARGET_MCU' "$$config_h" | awk '{print $$NF}'); \
 				echo "CONFIG $$t $$mcu"; \
 			fi; \

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -27,12 +27,18 @@ endif
 
 # Locate the board's config directory, accepting a flat (configs/<BOARD>) or a
 # manufacturer-grouped (configs/<MANUFACTURER_ID>/<BOARD>) layout. A flat match
-# wins; otherwise search one level down for the manufacturer directory.
-CONFIG_MATCHES     := $(wildcard $(CONFIG_DIR)/configs/$(CONFIG)/config.h) $(wildcard $(CONFIG_DIR)/configs/*/$(CONFIG)/config.h)
+# wins; otherwise search one manufacturer level down and reject only a grouped
+# name that resolves to more than one manufacturer.
+CONFIG_FLAT_MATCH  := $(wildcard $(CONFIG_DIR)/configs/$(CONFIG)/config.h)
+ifneq ($(CONFIG_FLAT_MATCH),)
+CONFIG_PATH        := $(patsubst %/,%,$(dir $(CONFIG_FLAT_MATCH)))
+else
+CONFIG_MATCHES     := $(wildcard $(CONFIG_DIR)/configs/*/$(CONFIG)/config.h)
 ifneq ($(word 2,$(CONFIG_MATCHES)),)
 $(error Ambiguous CONFIG '$(CONFIG)' matches multiple configs: $(CONFIG_MATCHES))
 endif
 CONFIG_PATH        := $(patsubst %/,%,$(dir $(firstword $(CONFIG_MATCHES))))
+endif
 ifeq ($(CONFIG_PATH),)
 $(error CONFIG '$(CONFIG)' not found under $(CONFIG_DIR)/configs (flat or <manufacturer>/<board>).)
 endif

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -2,7 +2,13 @@
 CONFIGS_REPO_URL ?= https://github.com/betaflight/config
 # handle only this directory as config submodule
 CONFIGS_SUBMODULE_DIR := src/config
-BASE_CONFIGS           = $(sort $(notdir $(patsubst %/,%,$(dir $(wildcard $(CONFIG_DIR)/configs/*/config.h)))))
+# Configs live either flat (configs/<BOARD>/config.h) or grouped by manufacturer
+# (configs/<MANUFACTURER_ID>/<BOARD>/config.h). Both are accepted; the leaf
+# directory name is always the board name. The two globs never overlap because a
+# manufacturer directory holds board directories, not a config.h of its own.
+BASE_CONFIGS           = $(sort $(notdir $(patsubst %/,%,$(dir \
+                             $(wildcard $(CONFIG_DIR)/configs/*/config.h) \
+                             $(wildcard $(CONFIG_DIR)/configs/*/*/config.h)))))
 
 ifneq ($(words $(CONFIG_DIR)),1)
 $(error CONFIG_DIR/BETAFLIGHT_CONFIG path contains whitespace; unsupported by GNU make wildcard.)
@@ -19,12 +25,24 @@ ifneq ($(TARGET),)
 $(error TARGET or CONFIG should be specified. Not both.)
 endif
 
-CONFIG_HEADER_FILE  = $(CONFIG_DIR)/configs/$(CONFIG)/config.h
-CONFIG_SOURCE_FILE  = $(CONFIG_DIR)/configs/$(CONFIG)/config.c
-INCLUDE_DIRS       += $(CONFIG_DIR)/configs/$(CONFIG)
+# Locate the board's config directory, accepting a flat (configs/<BOARD>) or a
+# manufacturer-grouped (configs/<MANUFACTURER_ID>/<BOARD>) layout. A flat match
+# wins; otherwise search one level down for the manufacturer directory.
+CONFIG_MATCHES     := $(wildcard $(CONFIG_DIR)/configs/$(CONFIG)/config.h) $(wildcard $(CONFIG_DIR)/configs/*/$(CONFIG)/config.h)
+ifneq ($(word 2,$(CONFIG_MATCHES)),)
+$(error Ambiguous CONFIG '$(CONFIG)' matches multiple configs: $(CONFIG_MATCHES))
+endif
+CONFIG_PATH        := $(patsubst %/,%,$(dir $(firstword $(CONFIG_MATCHES))))
+ifeq ($(CONFIG_PATH),)
+$(error CONFIG '$(CONFIG)' not found under $(CONFIG_DIR)/configs (flat or <manufacturer>/<board>).)
+endif
 
-# include $(CONFIG)/config.mk if it exists
--include $(CONFIG_DIR)/configs/$(CONFIG)/config.mk
+CONFIG_HEADER_FILE  = $(CONFIG_PATH)/config.h
+CONFIG_SOURCE_FILE  = $(CONFIG_PATH)/config.c
+INCLUDE_DIRS       += $(CONFIG_PATH)
+
+# include the config's config.mk if it exists
+-include $(CONFIG_PATH)/config.mk
 
 # OCTOSPI_FLASH_CHIP selects the flash chip wired to the OCTOSPI/XSPI peripheral.
 # Set in per-config config.mk (e.g. OCTOSPI_FLASH_CHIP := MX66UW1G45G). Emits both


### PR DESCRIPTION
Prep for grouping the config repo by manufacturer (`configs/<MANUFACTURER_ID>/<BOARD>/config.h`) instead of one flat wall of board directories.

The build now accepts either layout: `CONFIG=` stays board-name only, and `mk/config.mk` locates the config directory by preferring a flat `configs/<BOARD>` match then searching one manufacturer level down, erroring on an ambiguous or missing board. `BASE_CONFIGS` and `targets-ci-grouped-print` also learn the nested layout. Supporting both keeps master building through the transition (before its own `src/config` gitlink is bumped) and works for external `BETAFLIGHT_CONFIG` trees in either shape.

Verified by building a target from both a flat tree and a nested fixture (including a target carrying a per-config `config.mk`), and that an unknown `CONFIG=` errors clearly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for both flat and manufacturer-grouped board configuration layouts.
  * Build commands can now locate and use configurations from either supported layout.

* **Bug Fixes**
  * Improved CI configuration reporting for grouped configurations.
  * Added clearer errors when a configuration is missing or when multiple configurations match (ambiguous).
  * Ensures configuration-dependent output is shown only when a resolved configuration is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->