### PR TITLE
build: track the 4.5-config submodule branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "config"]
 	path = src/config
 	url = https://github.com/betaflight/config.git
-	branch = master
+	branch = 4.5-config
 	ignore = dirty


### PR DESCRIPTION
Point the config submodule at the `4.5-config` branch instead of `master`. The config repo's `master` is being restructured into a manufacturer-grouped layout (`configs/<MANUFACTURER_ID>/<BOARD>/`) that the 4.5 build does not understand. The new `4.5-config` branch holds the flat layout this line builds against, so `git submodule update --remote` and the cloud build server stay on a config that 4.5 can consume. Only `.gitmodules` changes; the pinned commit is unchanged.