### PR TITLE
build: track the 2025.12-config submodule branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "config"]
 	path = src/config
 	url = https://github.com/betaflight/config.git
-	branch = master
+	branch = 2025.12-config
 	ignore = dirty
 [submodule "lib/main/pico-sdk"]
 	path = lib/main/pico-sdk


### PR DESCRIPTION
Point the config submodule at the `2025.12-config` branch instead of `master`. The config repo's `master` is being restructured into a manufacturer-grouped layout (`configs/<MANUFACTURER_ID>/<BOARD>/`) that the 2025.12 build does not understand. The new `2025.12-config` branch holds the flat layout this line builds against, so `git submodule update --remote` and the cloud build server stay on a config that 2025.12 can consume. Only the config submodule entry in `.gitmodules` changes (pico-sdk untouched); the pinned commit is unchanged.