### PR TITLE
Nav pid refactor,  feedforward includes delta target velocity

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -2023,9 +2023,6 @@ const clivalue_t valueTable[] = {
 
     // Velocity-based position control with drag compensation
     { PARAM_NAME_AP_VELOCITY_CONTROL_ENABLE, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_AUTOPILOT, offsetof(autopilotConfig_t, velocityControlEnable) },
-    { PARAM_NAME_AP_VELOCITY_P,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, velocityP) },
-    { PARAM_NAME_AP_VELOCITY_I,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, velocityI) },
-    { PARAM_NAME_AP_VELOCITY_D,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, velocityD) },
     { PARAM_NAME_AP_VELOCITY_DRAG_COEFF, VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, velocityDragCoeff) },
     { PARAM_NAME_AP_MAX_VELOCITY,        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 100, 5000 },  PG_AUTOPILOT, offsetof(autopilotConfig_t, maxVelocity) },
 

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -2017,7 +2017,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_AP_POSITION_D,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, positionD) },
     { PARAM_NAME_AP_POSITION_A,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, positionA) },
     { PARAM_NAME_AP_POSITION_F,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, positionF) },
-    { PARAM_NAME_AP_POSITION_CUTOFF,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 10, 250 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, positionCutoff) },
+    { PARAM_NAME_AP_POSITION_CUTOFF,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 10, 50 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, positionCutoff) },
     { PARAM_NAME_AP_STOP_THRESHOLD,      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, stopThreshold) },
     { PARAM_NAME_AP_MAX_ANGLE,           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 10, 70 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, maxAngle) },
 

--- a/src/main/drivers/rangefinder/rangefinder_lidartf.c
+++ b/src/main/drivers/rangefinder/rangefinder_lidartf.c
@@ -131,6 +131,7 @@ static uint8_t tfReceivePosition;
 static const uint8_t tfConfigCmd[] = { 0x42, 0x57, 0x02, 0x00, 0x00, 0x00, 0x01, 0x06 };
 
 static int lidarTFValue;
+static bool hasLidarTFNewData = false;
 static unsigned lidarTFerrors = 0;
 
 
@@ -165,6 +166,7 @@ static void lidarTFInit(rangefinderDev_t *dev)
 
     tfFrameState = TF_FRAME_STATE_WAIT_START1;
     tfReceivePosition = 0;
+    hasLidarTFNewData = false;
 }
 
 static int tfProcessFrame(const uint8_t* frame, int len)
@@ -250,6 +252,7 @@ static void lidarTFUpdate(rangefinderDev_t *dev)
 
             if (c == cksum) {
                 lidarTFValue = tfProcessFrame(tfFrame, TF_FRAME_LENGTH);
+                hasLidarTFNewData = true;
                 lastFrameReceivedMs = timeNowMs;
             } else {
                 // Checksum error. Simply ignore the current frame.
@@ -272,11 +275,15 @@ static void lidarTFUpdate(rangefinderDev_t *dev)
 }
 
 // Return most recent device output in cm
-// TODO - handle timeout; return value only once (see lidarMT)
 static int32_t lidarTFGetDistance(rangefinderDev_t *dev)
 {
     UNUSED(dev);
 
+    if (!hasLidarTFNewData) {
+        return RANGEFINDER_NO_NEW_DATA;
+    }
+
+    hasLidarTFNewData = false;
     return lidarTFValue;
 }
 

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -179,9 +179,6 @@
 
 // Velocity-based position control with drag compensation
 #define PARAM_NAME_AP_VELOCITY_CONTROL_ENABLE "ap_velocity_control_enable"
-#define PARAM_NAME_AP_VELOCITY_P "ap_velocity_p"
-#define PARAM_NAME_AP_VELOCITY_I "ap_velocity_i"
-#define PARAM_NAME_AP_VELOCITY_D "ap_velocity_d"
 #define PARAM_NAME_AP_VELOCITY_DRAG_COEFF "ap_velocity_drag_coeff"
 #define PARAM_NAME_AP_MAX_VELOCITY "ap_max_velocity"
 

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -862,25 +862,6 @@ distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT,
         pidSumVectorEF.v[axis] = pidI.v[axis] + pidD.v[axis] + noisyPidsFiltered;
     }   // End for loop
 
-    ap.derivativeStale = false;
-
-    bool buildupClamped = false;
-    if (velocityMode) {
-        // velocityBuildupMaxPitch bounds the velocity-proportional drive vector (now pidD)
-        // so the pitch bias while building up to speed is limited.
-        const float buildupMaxDeg = autopilotConfig()->velocityBuildupMaxPitch;
-        const float dMag = vector2Norm(&pidD);
-        if (dMag > buildupMaxDeg) {
-            buildupClamped = true;
-            const float scale = (dMag > 0.001f) ? buildupMaxDeg / dMag : 0.0f;
-            vector2Scale(&pidD, &pidD, scale);
-            // Re-sum the vectors with the scaled D component
-            for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
-                pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis] + pidF.v[axis];
-            }
-        }
-    }
-
     // Rotation from Earth Frame to Body Frame
     const float headingRad = DECIDEGREES_TO_RADIANS(attitude.values.yaw);
     vector2_t headingV;

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -117,6 +117,7 @@
 #define POSITION_I_LIMIT      2000.0f        // TO DO: test and set to a useful value, this is 20m
 #define XY_VELOCITY_I_RELAX_CMS   250.0f     // in Nav mode only, integrate only near the target speed, so the
                                              // integral cannot wind up during the accel phase
+#define BRAKING_MODE_THRESHOLD 100.0f       // enable braking mode if starting position hold above this speed
 static pidCoefficient_t xyPid;
 static float xyKDrag = 0.0f;
 
@@ -178,6 +179,7 @@ typedef struct autopilotState_s {
     float speedTrendCmS;        // ~0.5 s lowpass of speedXY: reference for "is the craft slowing?"
     bool speedSlowing;          // speed is meaningfully below its own trend
     bool isPosHoldBraking;      // decelerating toward a captured hold point
+    unsigned brakingTimer;
     bool derivativeStale;       // output was frozen past the fence: re-baseline the A-term on resume
     unsigned debugAxis;
 } autopilotState_t;
@@ -384,9 +386,21 @@ static void resetDistanceErrorIntegral(void)
     distanceErrorIntegral = (vector2_t){{ 0.0f, 0.0f }};
 }
 
+static void setBrakingMode (void)
+{
+    if (ap.speedXY > BRAKING_MODE_THRESHOLD){ // maybe share POSHOLD_VELOCITY_REVERSAL_THRESHOLD ??
+        ap.isPosHoldBraking = true; // arrest entry speed before capturing the hold point, boost dTerm
+        ap.brakingTimer = 0;
+    } else {
+        ap.isPosHoldBraking = false;
+    }
+
+}
+
 void initPositionHold(void)
 {
     updatePositionHoldTarget();
+    setBrakingMode();
     resetDistanceError();
     targetVelocity.v[EF_EAST]  = 0.0f;
     targetVelocity.v[EF_NORTH] = 0.0f;
@@ -394,7 +408,6 @@ void initPositionHold(void)
     targetAcceleration.v[EF_NORTH] = 0.0f;
     previousTargetVelocity.v[EF_EAST]  = 0.0f;
     previousTargetVelocity.v[EF_NORTH] = 0.0f;
-    ap.isPosHoldBraking = true; // arrest any entry speed before capturing the hold point
     // nb: we do not reset the distanceError integral, to hold its opposition to wind between quick stick inputs
 }
 
@@ -619,7 +632,6 @@ bool positionControl(void)
     const positionEstimate3d_t *est = positionEstimatorGetEstimate();
     const timeDelta_t posholdDtUs = getTaskDeltaTimeUs(TASK_SELF);
     const float dt = (posholdDtUs > 0) ? (posholdDtUs * 1e-6f) : HZ_TO_INTERVAL(POSHOLD_TASK_RATE_HZ);
-    static int brakingTimer = 0;
 
     if (!est->isValidXY) {
         disableYawControl();
@@ -682,7 +694,6 @@ bool positionControl(void)
         // Control mode should be position hold
         if (!isPositionHeld) {
             initPositionHold();
-            brakingTimer = 0;
             ap.sanityCheckDistance = calculateSanityCheckDistance();
             isPositionHeld = true;
         }
@@ -707,26 +718,25 @@ bool positionControl(void)
                 targetPosition = currentPosition; //final update the target location
                 posHoldStartPosition = currentPosition; // in case of a drift after centering the sticks
                 ap.sanityCheckDistance = calculateSanityCheckDistance();
-                ap.isPosHoldBraking = true;
-                brakingTimer = 0;
+                setBrakingMode(); // enter braking mode or not, according to speed
             }
             if (ap.isPosHoldBraking) {
                 targetPosition = currentPosition; // Drag target location every frame while braking to avoid P and I climb
-                brakingTimer += 1; //
-                if (brakingTimer > POSHOLD_TASK_RATE_HZ) { // one second, might be better at 1.5 or 2.0s but this is pretty good
-                    brakingTimer = POSHOLD_TASK_RATE_HZ;
+                ap.brakingTimer += 1; //
+                if (ap.brakingTimer > POSHOLD_TASK_RATE_HZ) { // one second, might be better at 1.5 or 2.0s but this is pretty good
+                    ap.brakingTimer = POSHOLD_TASK_RATE_HZ;
                 }
                 // Braking mode; ends when velocity is below the stop threshold or when the dominant velocity vector reverses sign
                 const float vectorDotProduct = (velocity.v[EF_NORTH] * previousVelocity.v[EF_NORTH]) + 
                                                (velocity.v[EF_EAST]  * previousVelocity.v[EF_EAST]);
                 const bool velocityCrossingZero = vectorDotProduct < -POSHOLD_VELOCITY_REVERSAL_THRESHOLD; // some deadband
                 const bool stopped = (ap.speedXY < (float)autopilotConfig()->stopThreshold);
-                const bool timedOut = brakingTimer >= POSHOLD_TASK_RATE_HZ;
+                const bool timedOut = ap.brakingTimer >= POSHOLD_TASK_RATE_HZ;
                 if (stopped || timedOut || velocityCrossingZero) {
                     targetPosition = currentPosition; //update the final target location
                     posHoldStartPosition = currentPosition; // reset the  start position for sanity checks
-                    brakingTimer = 0;
-                    ap.isPosHoldBraking = false;
+                    ap.isPosHoldBraking = false; // terminate braking mode
+                    ap.brakingTimer = 0;
                 } else {
                     // The fence watches the brake too. Braking suppresses the
                     // settled check below, and a genuine flyaway (a bad-mag

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -801,7 +801,7 @@ bool positionControl(void)
 
     for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
         float dTermBrakingBoost = 1.0f;
-        const float targetVelDelta = (targetVelocity.v[axis] - previousTargetVelocity.v[axis]) * POSHOLD_TASK_RATE_HZ; //cm/s per second
+        float targetVelDelta = (targetVelocity.v[axis] - previousTargetVelocity.v[axis]) * POSHOLD_TASK_RATE_HZ; //cm/s per second
         previousTargetVelocity.v[axis] = targetVelocity.v[axis];
         bool shouldIntegrateDistanceError = true;
         velocityError.v[axis] = targetVelocity.v[axis] - velocity.v[axis];

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -429,6 +429,8 @@ static void initNavMode(void)
     resetDistanceError();
     previousTargetVelocity.v[EF_EAST]  = 0.0f;
     previousTargetVelocity.v[EF_NORTH] = 0.0f;
+    targetAcceleration.v[EF_EAST]  = 0.0f;
+    targetAcceleration.v[EF_NORTH] = 0.0f;
     ap.isPosHoldBraking = false;
 }
 

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -102,7 +102,6 @@
 #define XY_F_SCALE           0.03f / POSHOLD_TASK_RATE_HZ   //  velocity target delta scale factor
 #define XY_DRAG_SCALE        0.0002f  //  velocity based drag correction factor, cancels up to half the D at speed must be less than D scale
 
-
 #define POSHOLD_VELOCITY_REVERSAL_THRESHOLD 50.0f // dotcross reversal greater than this will terminate braking mode
 #define SANITY_CHECK_DISTANCE 2000.0f        // 20m, increased when stopping from speeds above 10m/s
 #define SANITY_RETRY_REPLENISH_S 10.0f
@@ -397,7 +396,6 @@ void initPositionHold(void)
     targetAcceleration.v[EF_NORTH] = 0.0f;
     previousTargetVelocity.v[EF_EAST]  = 0.0f;
     previousTargetVelocity.v[EF_NORTH] = 0.0f;
-
     ap.isPosHoldBraking = true; // arrest any entry speed before capturing the hold point
     // nb: we do not reset the distanceError integral, to hold its opposition to wind between quick stick inputs
 }
@@ -425,7 +423,6 @@ static void initNavMode(void)
     previousTargetVelocity.v[EF_NORTH] = 0.0f;
     targetAcceleration.v[EF_EAST]  = 0.0f;
     targetAcceleration.v[EF_NORTH] = 0.0f;
-
     resetDistanceError();
     ap.isPosHoldBraking = false;
 }
@@ -463,8 +460,8 @@ void handlepositionControlFailure(void)
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 7, 100);
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 6, 100);
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 7, 100);
-
 }
+
 void sticksSetTargetVelocity(void)
 {
     const float stickPitch = getSetpointRate(PITCH) * setpointVelocityGainPitch;
@@ -482,7 +479,6 @@ void sticksSetTargetVelocity(void)
 #endif
 }
 
-
 // A sanity-fence violation has outlived the persistence window: spend the
 // one-shot retry if it is available (re-anchor and carry on), otherwise level
 // out and fail the hold.
@@ -499,6 +495,7 @@ static bool sanityViolationExpired(void)
     handlepositionControlFailure();
     return false; // Return failure, allow angle mode control, and show pos hold fail message in OSD
 }
+
 void autopilotSetYawRateLimit(float rateLimitDps)
 {
     apYawRateLimitDps = rateLimitDps;
@@ -803,60 +800,64 @@ bool positionControl(void)
     wasPositionHeld = isPositionHeld;
     wasNavActive = ap.navActive;
     ap.wasSticksActive = ap.sticksActive; // Main frame-to-frame history update
-
     const bool velocityMode = ap.navActive && autopilotConfig()->velocityControlEnable;
-    vector2_t velocityFilteredV = { { 0 } };
 
     for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
-         float dTermBrakingBoost = 1.0f;
-        const float velocityFiltered = pt2FilterApply(&posDtermLpf[axis], velocity.v[axis]);
-        velocityFilteredV.v[axis] = velocityFiltered;
-        velocityError.v[axis] = targetVelocity.v[axis] - velocityFiltered;
+        float dTermBrakingBoost = 1.0f;
+        const float targetVelDelta = targetVelocity.v[axis] - previousTargetVelocity.v[axis];
+        previousTargetVelocity.v[axis] = targetVelocity.v[axis];
+        bool shouldIntegrateDistanceError = true;
         if (ap.derivativeStale) {
             // frozen-output fixes were skipped: no delta across the window,
             // so resumption cannot spike A against second-old velocity
-            previousVelocity.v[axis] = velocityFiltered;
+            previousVelocity.v[axis] =  velocity.v[axis];
         }
-        const float accelerationRaw = (previousVelocity.v[axis] - velocityFiltered) * POSHOLD_TASK_RATE_HZ;
-        previousVelocity.v[axis] = velocityFiltered;
-        const float acceleration = pt2FilterApply(&posAccelLpf[axis], accelerationRaw);
+        const float acceleration = (previousVelocity.v[axis] -  velocity.v[axis]) * POSHOLD_TASK_RATE_HZ;
         bool shouldIntegrateDistanceError = true;
-        float kF = xyPid.Kf; // normal kF for position hold stick movements
 
         if (velocityMode) {
             // Nav velocity loop: track the commanded ground velocity directly.
-            kF = xyKDrag + xyPid.Kd; // drag feedforward plus normal D gain to emulate D from error
             distanceErrorIntegral.v[axis] = 0.0f; // force distance error integral to zero
             shouldIntegrateDistanceError = false; // do not allow second integral accumulation
             if (fabsf(velocityError.v[axis]) < XY_VELOCITY_I_RELAX_CMS
                 && (!wasAngleSaturated || (velocityError.v[axis] * distanceError.v[axis]) < 0.0f)) {
                 distanceError.v[axis] += velocityError.v[axis] * dt; // make a virtual distance error from integral of velocityError
             }
-        } else if (ap.isPosHoldBraking) {
-            kF = 0.0f; // no drive from velocity target while braking :comment may not be needed as target velocity must be zero while braking
-            // Move the target with the craft while slowing, so P doesn'tsnap from a large value to zero the instant the craft stops.
-            targetPosition.v[axis] += velocity.v[axis] * dt;
-            shouldIntegrateDistanceError = false;
         } else {
-            // not in a special mode
-            distanceError.v[axis] = targetPosition.v[axis] - currentPosition.v[axis]; //normal distanceError calculation from currentPosition
-            shouldIntegrateDistanceError = !ap.sticksActive; // don't add to distance integral while sticks are active
+            // in Position Hold Mode
+#ifdef USE_FEEDFORWARD
+            tgtVelAcceleration = targetAcceleration.v[axis]; // from sticks using setpoint feedforward like in acro
+#endif
+            if (ap.sticksActive) {
+                // position hold with sticks active - velocity target according to setpoint
+                shouldIntegrateDistanceError = false; // avoid iTerm windup, but retain current value
+                distanceError.v[axis] += velocityError.v[axis] * dt; // virtual distance error like velocityMode
+            } else {
+                // position hold but sticks not active
+                distanceError.v[axis] = targetPosition.v[axis] - currentPosition.v[axis];
+                if (ap.isPosHoldBraking) {
+                    dTermBrakingBoost = 1.0f + fabsf(velocity.v[axis]) * 0.0005f; // stronger D when stopping from high velocity, doubled at 20m/s
+                }
+            }
         }
-        // these things happen in all positionControl modes
-        distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
+        //these things happen in all modes
+         distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
         if (shouldIntegrateDistanceError) {
-            distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt;
-            distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
+                distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt;
         }
+        distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
 
             pidP.v[axis] = distanceError.v[axis] * xyPid.Kp; // P factor from distance error, real or virtual
             pidI.v[axis] = distanceErrorIntegral.v[axis] * xyPid.Ki; // integral of distance error, forced to zero when there is no hard position source
             pidD.v[axis] = -velocityFiltered * xyPid.Kd * dTermBrakingBoost; // damping on measured velocity
+            pidD.v[axis] += velocityFiltered *xyKDrag; // drag compensation reduces damping
             pidA.v[axis] = acceleration * xyPid.Ka;
-            pidF.v[axis] = targetVelocity.v[axis] * kF; // velocity feedforward
-
-        pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis] + pidF.v[axis];
-    } // End for loop
+            pidF.v[axis] = (targetVelocity.v[axis] + targetVelDelta) * xyPid.Kf;
+        // in F, we use Kd on the constant target velocity component to balance D when craft is at target velocity; using D on the delta provides tunable acceleration deceleration responsiveness
+        const float noisyPids = pidP.v[axis] + pidA.v[axis] + pidF.v[axis]; // these get double PT2 for integration and smoothing
+        float noisyPidsFiltered = pt3FilterApply(&posNoisyPidsLpf[axis], noisyPids);
+        pidSumVectorEF.v[axis] = pidI.v[axis] + pidD.v[axis] + noisyPidsFiltered;
+    }   // End for loop
     ap.derivativeStale = false;
 
     bool buildupClamped = false;
@@ -909,7 +910,8 @@ bool positionControl(void)
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 4, lrintf(pidD.v[ap.debugAxis] * 10));
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 5, lrintf(pidA.v[ap.debugAxis] * 10));
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 6, lrintf(pidF.v[ap.debugAxis] * 10));
-    DEBUG_SET(DEBUG_AUTOPILOT_PID, 7, statusValue + (ap.isPosHoldBraking ? 1 : 0));
+//    DEBUG_SET(DEBUG_AUTOPILOT_PID, 7, statusValue + (ap.isPosHoldBraking ? 1 : 0));
+    DEBUG_SET(DEBUG_AUTOPILOT_PID, 7, lrintf(pidSumVectorEF.v[ap.debugAxis] * 10));
 
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 0, lrintf(velocityError.v[EF_EAST]));
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 1, lrintf(velocityError.v[EF_NORTH]));

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -95,10 +95,6 @@
 #define AP_YAW_D_SCALE         0.01f
 #define AP_YAW_RAMP_TIME_S     1.0f
 
-#define AP_YAW_P_SCALE         0.01f
-#define AP_YAW_D_SCALE         0.01f
-#define AP_YAW_RAMP_TIME_S     1.0f
-
 #define XY_DISTANCE_SCALE    0.0015f   // distance P / velocity I
 #define XY_DISTANCE_I_SCALE  0.00015f  // distance I
 #define XY_VELOCITY_SCALE    0.003f    // distance D / velocity P (opposes velocity)
@@ -419,12 +415,13 @@ void positionControlReanchor(void)
 static void initNavMode(void)
 {
     initPidLpfs();
+    resetDistanceError();
     resetDistanceErrorIntegral();
     previousTargetVelocity.v[EF_EAST]  = 0.0f;
     previousTargetVelocity.v[EF_NORTH] = 0.0f;
     targetAcceleration.v[EF_EAST]  = 0.0f;
     targetAcceleration.v[EF_NORTH] = 0.0f;
-    resetDistanceError();
+
     ap.isPosHoldBraking = false;
 }
 
@@ -802,9 +799,81 @@ bool positionControl(void)
     ap.wasSticksActive = ap.sticksActive; // Main frame-to-frame history update
     const bool velocityMode = ap.navActive && autopilotConfig()->velocityControlEnable;
 
+    for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
+        float dTermBrakingBoost = 1.0f;
+        const float targetVelDelta = (targetVelocity.v[axis] - previousTargetVelocity.v[axis]) * POSHOLD_TASK_RATE_HZ; //cm/s per second
+        previousTargetVelocity.v[axis] = targetVelocity.v[axis];
+        bool shouldIntegrateDistanceError = true;
+        velocityError.v[axis] = targetVelocity.v[axis] - velocity.v[axis];
+        const float acceleration = (previousVelocity.v[axis] -  velocity.v[axis]) * POSHOLD_TASK_RATE_HZ;
+        if (ap.derivativeStale) {
+            // frozen-output fixes were skipped: no delta across the window,
+            // so resumption cannot spike A against second-old velocity
+        previousVelocity.v[axis] =  velocity.v[axis];
+        }
 
-<<<
-    // Rotation from Earth Frame to Body Frame
+        if (velocityMode) {
+            // Nav velocity loop: track the commanded ground velocity directly.
+            distanceErrorIntegral.v[axis] = 0.0f; // force distance error integral to zero
+            shouldIntegrateDistanceError = false; // do not allow second integral accumulation
+            if (fabsf(velocityError.v[axis]) < XY_VELOCITY_I_RELAX_CMS
+                && (!wasAngleSaturated || (velocityError.v[axis] * distanceError.v[axis]) < 0.0f)) {
+                distanceError.v[axis] += velocityError.v[axis] * dt; // make a virtual distance error from integral of velocityError
+            }
+        } else {
+            // in Position Hold Mode
+#ifdef USE_FEEDFORWARD
+            targetVelDelta = targetAcceleration.v[axis]; // from sticks using setpoint feedforward like in acro
+#endif
+            if (ap.sticksActive) {
+                // position hold with sticks active - velocity target according to setpoint
+                shouldIntegrateDistanceError = false; // avoid iTerm windup, but retain current value
+                distanceError.v[axis] += velocityError.v[axis] * dt; // virtual distance error like velocityMode
+            } else {
+                // position hold but sticks not active
+                distanceError.v[axis] = targetPosition.v[axis] - currentPosition.v[axis];
+                if (ap.isPosHoldBraking) {
+                    dTermBrakingBoost = 1.0f + fabsf(velocity.v[axis]) * 0.0005f; // stronger D when stopping from high velocity, doubled at 20m/s
+                }
+            }
+        }
+distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
+        if (shouldIntegrateDistanceError) {
+                distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt;
+        }
+        distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
+        pidP.v[axis] = distanceError.v[axis] * xyPid.Kp; // P factor from distance error, real or virtual
+        pidI.v[axis] = distanceErrorIntegral.v[axis] * xyPid.Ki; // integral of distance error, forced to zero when there is no hard position source
+        pidD.v[axis] = -velocity.v[axis] * xyPid.Kd * dTermBrakingBoost; // damping on measured velocity
+        pidD.v[axis] += velocity.v[axis] *xyKDrag; // drag compensation reduces damping at higher speed
+        pidA.v[axis] = acceleration * xyPid.Ka;
+        pidF.v[axis] = targetVelocity.v[axis] * xyPid.Kd + targetVelDelta * xyPid.Kf;
+        // in F, we use Kd on the constant target velocity component to balance D when craft is at target velocity; using D on the delta provides tunable acceleration deceleration responsiveness
+        const float noisyPids = pidP.v[axis] + pidA.v[axis] + pidF.v[axis]; // these get double PT2 for integration and smoothing
+        float noisyPidsFiltered = pt3FilterApply(&posNoisyPidsLpf[axis], noisyPids);
+        pidSumVectorEF.v[axis] = pidI.v[axis] + pidD.v[axis] + noisyPidsFiltered;
+    }   // End for loop
+    
+    ap.derivativeStale = false;
+
+    bool buildupClamped = false;
+    if (velocityMode) {
+        // velocityBuildupMaxPitch bounds the velocity-proportional drive vector (now pidD)
+        // so the pitch bias while building up to speed is limited.
+        const float buildupMaxDeg = autopilotConfig()->velocityBuildupMaxPitch;
+        const float dMag = vector2Norm(&pidD);
+        if (dMag > buildupMaxDeg) {
+            buildupClamped = true;
+            const float scale = (dMag > 0.001f) ? buildupMaxDeg / dMag : 0.0f;
+            vector2Scale(&pidD, &pidD, scale);
+            // Re-sum the vectors with the scaled D component
+            for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
+                pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis] + pidF.v[axis];
+            }
+        }
+    }
+
+    // Rotation from Earth Frame to Body Frame    const float headingRad = DECIDEGREES_TO_RADIANS(attitude.values.yaw);
     const float headingRad = DECIDEGREES_TO_RADIANS(attitude.values.yaw);
     vector2_t headingV;
     vector2_t angleV;

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -117,6 +117,7 @@
 #define POSITION_I_LIMIT      2000.0f        // TO DO: test and set to a useful value, this is 20m
 #define XY_VELOCITY_I_RELAX_CMS   250.0f     // in Nav mode only, integrate only near the target speed, so the
                                              // integral cannot wind up during the accel phase
+#define MAX_TARGET_VELOCITY_STEP 100.0f // target velocity for feedforward cannot change by more than this per loop
 
 static pidCoefficient_t xyPid;
 static float xyKDrag = 0.0f;
@@ -424,6 +425,8 @@ static void initNavMode(void)
     targetAcceleration.v[EF_EAST]  = 0.0f;
     targetAcceleration.v[EF_NORTH] = 0.0f;
     resetDistanceError();
+    targetVelocityRamped.v[EF_EAST]  = 0.0f;
+    targetVelocityRamped.v[EF_NORTH] = 0.0f;
     ap.isPosHoldBraking = false;
 }
 
@@ -804,16 +807,16 @@ bool positionControl(void)
 
     for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
         float dTermBrakingBoost = 1.0f;
-        const float targetVelDelta = targetVelocity.v[axis] - previousTargetVelocity.v[axis];
-        previousTargetVelocity.v[axis] = targetVelocity.v[axis];
+        float targetVelDelta = (targetVelocity.v[axis] - previousTargetVelocity.v[axis]) * POSHOLD_TASK_RATE_HZ; //cm/s per second
+        velocityError.v[axis] = targetVelocity.v[axis] - velocity.v[axis];
+        const float acceleration = (previousVelocity.v[axis] -  velocity.v[axis]) * POSHOLD_TASK_RATE_HZ;
+        previousVelocity.v[axis] =  velocity.v[axis];
         bool shouldIntegrateDistanceError = true;
         if (ap.derivativeStale) {
             // frozen-output fixes were skipped: no delta across the window,
             // so resumption cannot spike A against second-old velocity
             previousVelocity.v[axis] =  velocity.v[axis];
         }
-        const float acceleration = (previousVelocity.v[axis] -  velocity.v[axis]) * POSHOLD_TASK_RATE_HZ;
-        bool shouldIntegrateDistanceError = true;
 
         if (velocityMode) {
             // Nav velocity loop: track the commanded ground velocity directly.
@@ -826,7 +829,7 @@ bool positionControl(void)
         } else {
             // in Position Hold Mode
 #ifdef USE_FEEDFORWARD
-            tgtVelAcceleration = targetAcceleration.v[axis]; // from sticks using setpoint feedforward like in acro
+            targetVelDelta = targetAcceleration.v[axis]; // from sticks using setpoint feedforward like in acro
 #endif
             if (ap.sticksActive) {
                 // position hold with sticks active - velocity target according to setpoint
@@ -846,19 +849,18 @@ bool positionControl(void)
                 distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt;
         }
         distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
-
-            pidP.v[axis] = distanceError.v[axis] * xyPid.Kp; // P factor from distance error, real or virtual
-            pidI.v[axis] = distanceErrorIntegral.v[axis] * xyPid.Ki; // integral of distance error, forced to zero when there is no hard position source
-            pidD.v[axis] = -velocityFiltered * xyPid.Kd * dTermBrakingBoost; // damping on measured velocity
-            pidD.v[axis] += velocityFiltered *xyKDrag; // drag compensation reduces damping
-            pidA.v[axis] = acceleration * xyPid.Ka;
-            pidF.v[axis] = (targetVelocity.v[axis] + targetVelDelta) * xyPid.Kf;
+        pidP.v[axis] = distanceError.v[axis] * xyPid.Kp; // P factor from distance error, real or virtual
+        pidI.v[axis] = distanceErrorIntegral.v[axis] * xyPid.Ki; // integral of distance error, forced to zero when there is no hard position source
+        pidD.v[axis] = -velocity.v[axis] * xyPid.Kd * dTermBrakingBoost; // damping on measured velocity
+        pidD.v[axis] += velocity.v[axis] *xyKDrag; // drag compensation reduces damping at higher speed
+        pidA.v[axis] = acceleration * xyPid.Ka;
+        pidF.v[axis] = targetVelocity.v[axis] * xyPid.Kd + targetVelDelta * xyPid.Kf;
         // in F, we use Kd on the constant target velocity component to balance D when craft is at target velocity; using D on the delta provides tunable acceleration deceleration responsiveness
         const float noisyPids = pidP.v[axis] + pidA.v[axis] + pidF.v[axis]; // these get double PT2 for integration and smoothing
         float noisyPidsFiltered = pt3FilterApply(&posNoisyPidsLpf[axis], noisyPids);
         pidSumVectorEF.v[axis] = pidI.v[axis] + pidD.v[axis] + noisyPidsFiltered;
     }   // End for loop
-    ap.derivativeStale = false;
+        ap.derivativeStale = false;
 
     bool buildupClamped = false;
     if (velocityMode) {

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -95,6 +95,10 @@
 #define AP_YAW_D_SCALE         0.01f
 #define AP_YAW_RAMP_TIME_S     1.0f
 
+#define AP_YAW_P_SCALE         0.01f
+#define AP_YAW_D_SCALE         0.01f
+#define AP_YAW_RAMP_TIME_S     1.0f
+
 #define XY_DISTANCE_SCALE    0.0015f   // distance P / velocity I
 #define XY_DISTANCE_I_SCALE  0.00015f  // distance I
 #define XY_VELOCITY_SCALE    0.003f    // distance D / velocity P (opposes velocity)
@@ -117,8 +121,6 @@
 #define POSITION_I_LIMIT      2000.0f        // TO DO: test and set to a useful value, this is 20m
 #define XY_VELOCITY_I_RELAX_CMS   250.0f     // in Nav mode only, integrate only near the target speed, so the
                                              // integral cannot wind up during the accel phase
-#define MAX_TARGET_VELOCITY_STEP 100.0f // target velocity for feedforward cannot change by more than this per loop
-
 static pidCoefficient_t xyPid;
 static float xyKDrag = 0.0f;
 
@@ -425,8 +427,8 @@ static void initNavMode(void)
     targetAcceleration.v[EF_EAST]  = 0.0f;
     targetAcceleration.v[EF_NORTH] = 0.0f;
     resetDistanceError();
-    targetVelocityRamped.v[EF_EAST]  = 0.0f;
-    targetVelocityRamped.v[EF_NORTH] = 0.0f;
+    previousTargetVelocity.v[EF_EAST]  = 0.0f;
+    previousTargetVelocity.v[EF_NORTH] = 0.0f;
     ap.isPosHoldBraking = false;
 }
 
@@ -859,6 +861,9 @@ distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT,
         float noisyPidsFiltered = pt3FilterApply(&posNoisyPidsLpf[axis], noisyPids);
         pidSumVectorEF.v[axis] = pidI.v[axis] + pidD.v[axis] + noisyPidsFiltered;
     }   // End for loop
+
+    ap.derivativeStale = false;
+
     bool buildupClamped = false;
     if (velocityMode) {
         // velocityBuildupMaxPitch bounds the velocity-proportional drive vector (now pidD)

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -91,15 +91,21 @@
 #define ALTITUDE_VEL_CMD_MAX_DEFAULT_CM_S  1500.0f
 #define ALTITUDE_I_LIMIT      150.0f
 
-// Using optical flow PID scales as the unified set
+#define AP_YAW_P_SCALE         0.01f
+#define AP_YAW_D_SCALE         0.01f
+#define AP_YAW_RAMP_TIME_S     1.0f
 
-#define POSITION_P_SCALE       0.0012f
-#define POSITION_I_SCALE       0.00015f
-#define POSITION_D_SCALE       0.0017f
-#define POSITION_A_SCALE       0.0003f
-#define POSITION_F_SCALE       0.0017f
-#define POSHOLD_STALL_CHECK_SPEED_CMS  45.0f // below this speed a deceleration reversal means braking has stalled to a stop
-#define SANITY_CHECK_DISTANCE 2000.0f //20m, increased when stopping from speeds above 10m/s
+#define XY_DISTANCE_SCALE    0.0015f   // distance P / velocity I
+#define XY_DISTANCE_I_SCALE  0.00015f  // distance I
+#define XY_VELOCITY_SCALE    0.003f    // distance D / velocity P (opposes velocity)
+#define XY_ACCEL_SCALE       0.0006f   // distance Acceleration / velocity D
+#define XY_F_SCALE           0.03f / POSHOLD_TASK_RATE_HZ   //  velocity target delta scale factor
+#define XY_DRAG_SCALE        0.0002f  //  velocity based drag correction factor, cancels up to half the D at speed must be less than D scale
+
+
+#define POSHOLD_VELOCITY_REVERSAL_THRESHOLD 50.0f // dotcross reversal greater than this will terminate braking mode
+#define SANITY_CHECK_DISTANCE 2000.0f        // 20m, increased when stopping from speeds above 10m/s
+#define SANITY_RETRY_REPLENISH_S 10.0f
 // The settled-hold flyaway fence is graded, not instant: an excursion must
 // persist this long before it counts as a failure. Field logs show single-fix
 // multipath excursions of 12-51 m while parked in a clean hover; instant
@@ -108,30 +114,13 @@
 // One automatic re-anchor is allowed per healthy stretch; this much clean
 // settled time earns it back. A genuine flyaway trips again immediately after
 // its retry and stays failed.
-#define SANITY_RETRY_REPLENISH_S 10.0f
-#define ERROR_DISTANCE_LIMIT  2000.0f // TO DO: test set to a useful value, this is 20m
-#define POSITION_I_LIMIT      2000.0f // TO DO: test and set to a useful value, this is 20m
+#define ERROR_DISTANCE_LIMIT  2000.0f        // TO DO: test set to a useful value, this is 20m
+#define POSITION_I_LIMIT      2000.0f        // TO DO: test and set to a useful value, this is 20m
+#define XY_VELOCITY_I_RELAX_CMS   250.0f     // in Nav mode only, integrate only near the target speed, so the
+                                             // integral cannot wind up during the accel phase
 
-#define AP_YAW_P_SCALE         0.01f
-#define AP_YAW_D_SCALE         0.01f
-#define AP_YAW_RAMP_TIME_S     1.0f
-
-// Nav velocity loop (cm/s error -> degrees of lean)
-#define VELOCITY_P_SCALE       0.0004f   // default 50 -> 2 deg per m/s of error
-#define VELOCITY_I_SCALE       0.001f
-#define VELOCITY_D_SCALE       0.0004f
-#define VELOCITY_DRAG_SCALE    0.0001f   // default 50 -> 2.5 deg at 5 m/s target
-#define VELOCITY_I_LIMIT_DEG    15.0f
-#define VELOCITY_I_RELAX_CMS   250.0f    // integrate only near the target speed, so the
-                                         // integral cannot wind up during the accel phase
-
-static pidCoefficient_t positionPidCoeffs;
-
-static float velocityKp;
-static float velocityKi;
-static float velocityKd;
-static float velocityDragKff;
-static vector2_t velocityIntegral;       // nav velocity-loop I term, degrees, earth frame
+static pidCoefficient_t xyPid;
+static float xyKDrag = 0.0f;
 
 static float altitudeKp;
 static float altitudeKi;
@@ -150,13 +139,16 @@ static float throttleOut = 0.0f;
 
 static vector2_t targetPosition;
 static vector2_t targetVelocity;
+static vector2_t previousTargetVelocity; // for feedforward when target velocity changes
+static vector2_t targetAcceleration;
 static vector2_t posHoldStartPosition;
 static vector2_t distanceError;          // deviation from intended position
 static vector2_t distanceErrorIntegral;  // integral of position error
 static vector2_t previousVelocity;       // for acceleration
+static float setpointVelocityGainPitch;  // to set max velocity at full stick
+static float setpointVelocityGainRoll;
 
-static pt2Filter_t posAccelLpf[EF_AXIS_COUNT];
-static pt2Filter_t posDtermLpf[EF_AXIS_COUNT];
+static pt3Filter_t posNoisyPidsLpf[EF_AXIS_COUNT];
 
 static bool isPositionHeld;
 static bool wasPositionHeld = false;
@@ -186,9 +178,6 @@ typedef struct autopilotState_s {
     bool navActive;
     float maxAngle;
     float speedXY;              // horizontal ground speed this loop, cm/s
-    float speedXYOneLoopAgo;
-    float speedTwoLoopsAgo;
-    float prevDeltaSpeedXY;     // speed delta one loop ago, for the stall inflection test
     float speedTrendCmS;        // ~0.5 s lowpass of speedXY: reference for "is the craft slowing?"
     bool speedSlowing;          // speed is meaningfully below its own trend
     bool isPosHoldBraking;      // decelerating toward a captured hold point
@@ -208,10 +197,9 @@ static void initPidLpfs(void)
 {
     const autopilotConfig_t *cfg = autopilotConfig();
     const float cutoffHz = fmaxf(cfg->positionCutoff * 0.1f, 0.1f); // default of 30 is 3Hz, range 1 to 25Hz
-    const float k = pt2FilterGain(cutoffHz, HZ_TO_INTERVAL(POSHOLD_TASK_RATE_HZ));
+    const float k = pt3FilterGain(cutoffHz, HZ_TO_INTERVAL(POSHOLD_TASK_RATE_HZ));
     for (unsigned i = 0; i < EF_AXIS_COUNT; i++) {
-        pt2FilterInit(&posAccelLpf[i], k);
-        pt2FilterInit(&posDtermLpf[i], k);
+        pt3FilterInit(&posNoisyPidsLpf[i], k);
     }
 }
 
@@ -219,7 +207,8 @@ void autopilotInit(void)
 {
     const autopilotConfig_t *cfg = autopilotConfig();
     initPidLpfs();
-
+    setpointVelocityGainRoll = cfg->maxVelocity / getMaxRcRate(ROLL);
+    setpointVelocityGainPitch = cfg->maxVelocity / getMaxRcRate(PITCH);
     ap.maxAngle = cfg->maxAngle;
     ap.debugAxis = (gyroConfig()->gyro_filter_debug_axis == FD_PITCH) ? 1 : 0; // 1 for Pitch / North, 0 for Roll / East
 
@@ -228,24 +217,18 @@ void autopilotInit(void)
     altitudeKd = cfg->altitudeD * ALTITUDE_D_SCALE;
     altitudeKf = cfg->altitudeF * ALTITUDE_F_SCALE;
 
-    positionPidCoeffs.Kp  = cfg->positionP  * POSITION_P_SCALE;
-    positionPidCoeffs.Ki  = cfg->positionI  * POSITION_I_SCALE;
-    positionPidCoeffs.Kd  = cfg->positionD  * POSITION_D_SCALE;
-    positionPidCoeffs.Kf  = cfg->positionF  * POSITION_F_SCALE;
-    positionPidCoeffs.Ka  = cfg->positionA  * POSITION_A_SCALE;
+    xyPid.Kp = cfg->positionP  * XY_DISTANCE_SCALE;
+    xyPid.Ki = cfg->positionI  * XY_DISTANCE_I_SCALE;
+    xyPid.Kd = cfg->positionD  * XY_VELOCITY_SCALE;
+    xyPid.Ka = cfg->positionA  * XY_ACCEL_SCALE;
+    xyPid.Kf = cfg->positionF  * XY_F_SCALE;
+    xyKDrag =  cfg->velocityDragCoeff * XY_DRAG_SCALE;
 
-    velocityKp      = cfg->velocityP * VELOCITY_P_SCALE;
-    velocityKi      = cfg->velocityI * VELOCITY_I_SCALE;
-    velocityKd      = cfg->velocityD * VELOCITY_D_SCALE;
-    velocityDragKff = cfg->velocityDragCoeff * VELOCITY_DRAG_SCALE;
     ap.sticksActive = false;
     ap.wasSticksActive = false;
     ap.speedXY = 0.0f;
-    ap.speedXYOneLoopAgo = 0.0f;
-    ap.speedTwoLoopsAgo = 0.0f;
     ap.speedTrendCmS = 0.0f;
     ap.speedSlowing = false;
-    ap.prevDeltaSpeedXY = 0.0f;
     ap.isPosHoldBraking = false;
     abortNavRequested = false;
     forcePitchForward = false;
@@ -404,17 +387,17 @@ static void resetDistanceErrorIntegral(void)
     distanceErrorIntegral = (vector2_t){{ 0.0f, 0.0f }};
 }
 
-static void resetVelocityIntegral(void)
-{
-    velocityIntegral = (vector2_t){{ 0.0f, 0.0f }};
-}
-
 void initPositionHold(void)
 {
     updatePositionHoldTarget();
     resetDistanceError();
     targetVelocity.v[EF_EAST]  = 0.0f;
     targetVelocity.v[EF_NORTH] = 0.0f;
+    targetAcceleration.v[EF_EAST]  = 0.0f;
+    targetAcceleration.v[EF_NORTH] = 0.0f;
+    previousTargetVelocity.v[EF_EAST]  = 0.0f;
+    previousTargetVelocity.v[EF_NORTH] = 0.0f;
+
     ap.isPosHoldBraking = true; // arrest any entry speed before capturing the hold point
     // nb: we do not reset the distanceError integral, to hold its opposition to wind between quick stick inputs
 }
@@ -438,7 +421,12 @@ static void initNavMode(void)
     initPidLpfs();
     resetDistanceError();
     resetDistanceErrorIntegral();
-    resetVelocityIntegral();
+    previousTargetVelocity.v[EF_EAST]  = 0.0f;
+    previousTargetVelocity.v[EF_NORTH] = 0.0f;
+    targetAcceleration.v[EF_EAST]  = 0.0f;
+    targetAcceleration.v[EF_NORTH] = 0.0f;
+
+    resetDistanceError();
     ap.isPosHoldBraking = false;
 }
 
@@ -465,7 +453,7 @@ void resetPositionControl(unsigned taskRateHz)
     initPositionHold(); // sets target location, resets distance error, enables start mode
     previousVelocity = *(const vector2_t *)&positionEstimatorGetEstimate()->velocity.v; // for smooth A in any mode
     resetDistanceErrorIntegral();
-    resetVelocityIntegral();
+    resetDistanceError();
 }
 
 void handlepositionControlFailure(void)
@@ -477,6 +465,23 @@ void handlepositionControlFailure(void)
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 7, 100);
 
 }
+void sticksSetTargetVelocity(void)
+{
+    const float stickPitch = getSetpointRate(PITCH) * setpointVelocityGainPitch;
+    const float stickRoll  = getSetpointRate(ROLL) * setpointVelocityGainRoll;
+    const float headingRad = DECIDEGREES_TO_RADIANS(attitude.values.yaw);
+    const float cosYaw = cosf(headingRad);
+    const float sinYaw = sinf(headingRad);
+    targetVelocity.v[EF_NORTH] = (stickPitch * cosYaw) - (stickRoll * sinYaw);
+    targetVelocity.v[EF_EAST]  = (stickPitch * sinYaw) + (stickRoll * cosYaw);
+#ifdef USE_FEEDFORWARD
+    const float stickFFPitch = getFeedforward(PITCH) * setpointVelocityGainPitch;
+    const float stickFFRoll  = getFeedforward(ROLL) * setpointVelocityGainRoll;
+    targetAcceleration.v[EF_NORTH] = (stickFFPitch * cosYaw) - (stickFFRoll * sinYaw);
+    targetAcceleration.v[EF_EAST]  = (stickFFPitch * sinYaw) + (stickFFRoll * cosYaw);
+#endif
+}
+
 
 // A sanity-fence violation has outlived the persistence window: spend the
 // one-shot retry if it is available (re-anchor and carry on), otherwise level
@@ -494,26 +499,6 @@ static bool sanityViolationExpired(void)
     handlepositionControlFailure();
     return false; // Return failure, allow angle mode control, and show pos hold fail message in OSD
 }
-
-void sticksMoveTarget(void)
-{
-    float stickPitch = getSetpointRate(PITCH);
-    float stickRoll  = getSetpointRate(ROLL);
-
-    const float headingRad = DECIDEGREES_TO_RADIANS(attitude.values.yaw);
-    const float cosYaw = cosf(headingRad);
-    const float sinYaw = sinf(headingRad);
-
-    targetVelocity.v[EF_NORTH] = (stickPitch * cosYaw) - (stickRoll * sinYaw);
-    targetVelocity.v[EF_EAST]  = (stickPitch * sinYaw) + (stickRoll * cosYaw);
-
-    const float dt = HZ_TO_INTERVAL(POSHOLD_TASK_RATE_HZ);
-    targetPosition.v[EF_NORTH] += targetVelocity.v[EF_NORTH] * dt;
-    targetPosition.v[EF_EAST]  += targetVelocity.v[EF_EAST] * dt;
-
-    posHoldStartPosition = targetPosition;
-}
-
 void autopilotSetYawRateLimit(float rateLimitDps)
 {
     apYawRateLimitDps = rateLimitDps;
@@ -639,6 +624,7 @@ bool positionControl(void)
     const positionEstimate3d_t *est = positionEstimatorGetEstimate();
     const timeDelta_t posholdDtUs = getTaskDeltaTimeUs(TASK_SELF);
     const float dt = (posholdDtUs > 0) ? (posholdDtUs * 1e-6f) : HZ_TO_INTERVAL(POSHOLD_TASK_RATE_HZ);
+    static int brakingTimer = 0;
 
     if (!est->isValidXY) {
         disableYawControl();
@@ -670,6 +656,7 @@ bool positionControl(void)
     const vector2_t velocity = *(const vector2_t *)&est->velocity.v;
     vector2_t pidSumVectorEF     = { { 0 } };
     vector2_t velocityError      = { { 0 } };
+    // PIDs are distance based, so D is a Velocity-proportional factor, A is acceleration-proportional, etc
     vector2_t pidP               = { { 0 } };
     vector2_t pidI               = { { 0 } };
     vector2_t pidD               = { { 0 } };
@@ -678,18 +665,13 @@ bool positionControl(void)
     // Update navigation status
     positionNavUpdate(dt, est);
     ap.navActive = positionNavHasActiveTarget() && !positionNavTargetReached();
-
-    // Speed history for the braking stop/stall detector, kept in ap so it
-    // resets cleanly on re-engage rather than persisting in a function static.
     ap.speedXY = vector2Norm(&velocity);
-    const float currentDeltaXY = ap.speedXY - ap.speedXYOneLoopAgo;
-    ap.prevDeltaSpeedXY = ap.speedXYOneLoopAgo - ap.speedTwoLoopsAgo;
-    ap.speedTwoLoopsAgo = ap.speedXYOneLoopAgo;
-    ap.speedXYOneLoopAgo = ap.speedXY;
     // "Is the craft actually slowing?" — speed measured against its own ~0.5 s
     // average, judged before the average absorbs the new sample. Lets the
     // braking-phase fence tell brake physics (speed falling, distance growth
     // is expected) from a flyaway (speed held or rising).
+    // Speed history for the braking stop/stall detector, kept in ap so it
+    // resets cleanly on re-engage rather than persisting in a function static.
     ap.speedSlowing = ap.speedXY < ap.speedTrendCmS - 20.0f;
     ap.speedTrendCmS += (dt / (0.5f + dt)) * (ap.speedXY - ap.speedTrendCmS);
 
@@ -705,38 +687,50 @@ bool positionControl(void)
         // Control mode should be position hold
         if (!isPositionHeld) {
             initPositionHold();
+            brakingTimer = 0;
             ap.sanityCheckDistance = calculateSanityCheckDistance();
             isPositionHeld = true;
         }
         if (ap.sticksActive) {
             if (!ap.wasSticksActive) {
-                updatePositionHoldTarget();
+                // initialise sticksActive
+                resetDistanceError();
                 ap.sanityCheckDistance = calculateSanityCheckDistance();
-                ap.isPosHoldBraking = false; // pilot is commanding, don't brake
+                ap.isPosHoldBraking = false;
             }
-            sticksMoveTarget();
+            sticksSetTargetVelocity(); //generate target velocities from stick position and heading
+            posHoldStartPosition = currentPosition; // in case pilot flies a very long way away
         } else {
-            // No stick input: there is no commanded velocity, so force it to
-            // zero every loop. sticksMoveTarget() latches the last value written
-            // as the stick eased back through the deadband, which is a small
-            // nonzero velocity; left in place it keeps driving the F feedforward
-            // (and fights braking) until the stop capture clears it.
+            // No stick input
             targetVelocity.v[EF_EAST]  = 0.0f;
             targetVelocity.v[EF_NORTH] = 0.0f;
+            targetAcceleration.v[EF_EAST]  = 0.0f;
+            targetAcceleration.v[EF_NORTH] = 0.0f;
+
             if (ap.wasSticksActive) {
-                // Sticks just released: capture the current point and begin braking.
-                updatePositionHoldTarget();
+                // Sticks were active and have just been released: capture the current point and begin braking.
+                targetPosition = currentPosition; //final update the target location
+                posHoldStartPosition = currentPosition; // in case of a drift after centering the sticks
                 ap.sanityCheckDistance = calculateSanityCheckDistance();
                 ap.isPosHoldBraking = true;
+                brakingTimer = 0;
             }
             if (ap.isPosHoldBraking) {
-                // Stop when decelerating below the stop threshold, or when a
-                // deceleration reversal at low speed shows the brake has stalled.
-                const float inflectionProduct = currentDeltaXY * ap.prevDeltaSpeedXY;
-                const bool stopped = (currentDeltaXY <= 0.0f) && (ap.speedXY < (float)autopilotConfig()->stopThreshold);
-                const bool stalled = (ap.speedXY < POSHOLD_STALL_CHECK_SPEED_CMS) && (inflectionProduct < 0.0f);
-                if (stopped || stalled) {
-                    updatePositionHoldTarget(); // capture the stopped point as the hold target
+                targetPosition = currentPosition; // Drag target location every frame while braking to avoid P and I climb
+                brakingTimer += 1; //
+                if (brakingTimer > POSHOLD_TASK_RATE_HZ) { // one second, might be better at 1.5 or 2.0s but this is pretty good
+                    brakingTimer = POSHOLD_TASK_RATE_HZ;
+                }
+                // Braking mode; ends when velocity is below the stop threshold or when the dominant velocity vector reverses sign
+                const float vectorDotProduct = (velocity.v[EF_NORTH] * previousVelocity.v[EF_NORTH]) + 
+                                               (velocity.v[EF_EAST]  * previousVelocity.v[EF_EAST]);
+                const bool velocityCrossingZero = vectorDotProduct < -POSHOLD_VELOCITY_REVERSAL_THRESHOLD; // some deadband
+                const bool stopped = (ap.speedXY < (float)autopilotConfig()->stopThreshold);
+                const bool timedOut = brakingTimer >= POSHOLD_TASK_RATE_HZ;
+                if (stopped || timedOut || velocityCrossingZero) {
+                    targetPosition = currentPosition; //update the final target location
+                    posHoldStartPosition = currentPosition; // reset the  start position for sanity checks
+                    brakingTimer = 0;
                     ap.isPosHoldBraking = false;
                 } else {
                     // The fence watches the brake too. Braking suppresses the
@@ -814,6 +808,7 @@ bool positionControl(void)
     vector2_t velocityFilteredV = { { 0 } };
 
     for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
+         float dTermBrakingBoost = 1.0f;
         const float velocityFiltered = pt2FilterApply(&posDtermLpf[axis], velocity.v[axis]);
         velocityFilteredV.v[axis] = velocityFiltered;
         velocityError.v[axis] = targetVelocity.v[axis] - velocityFiltered;
@@ -825,53 +820,40 @@ bool positionControl(void)
         const float accelerationRaw = (previousVelocity.v[axis] - velocityFiltered) * POSHOLD_TASK_RATE_HZ;
         previousVelocity.v[axis] = velocityFiltered;
         const float acceleration = pt2FilterApply(&posAccelLpf[axis], accelerationRaw);
+        bool shouldIntegrateDistanceError = true;
+        float kF = xyPid.Kf; // normal kF for position hold stick movements
 
         if (velocityMode) {
             // Nav velocity loop: track the commanded ground velocity directly.
-            if (fabsf(velocityError.v[axis]) < VELOCITY_I_RELAX_CMS
-                && (!wasAngleSaturated || (velocityError.v[axis] * velocityIntegral.v[axis]) < 0.0f)) {
-                velocityIntegral.v[axis] += velocityError.v[axis] * velocityKi * dt;
-                velocityIntegral.v[axis] = constrainf(velocityIntegral.v[axis], -VELOCITY_I_LIMIT_DEG, VELOCITY_I_LIMIT_DEG);
+            kF = xyKDrag + xyPid.Kd; // drag feedforward plus normal D gain to emulate D from error
+            distanceErrorIntegral.v[axis] = 0.0f; // force distance error integral to zero
+            shouldIntegrateDistanceError = false; // do not allow second integral accumulation
+            if (fabsf(velocityError.v[axis]) < XY_VELOCITY_I_RELAX_CMS
+                && (!wasAngleSaturated || (velocityError.v[axis] * distanceError.v[axis]) < 0.0f)) {
+                distanceError.v[axis] += velocityError.v[axis] * dt; // make a virtual distance error from integral of velocityError
             }
-            pidP.v[axis] = velocityError.v[axis] * velocityKp;
-            pidI.v[axis] = velocityIntegral.v[axis];
-            pidD.v[axis] = acceleration * velocityKd;
-            pidA.v[axis] = targetVelocity.v[axis] * velocityDragKff; // drag feedforward carries the cruise tilt
+        } else if (ap.isPosHoldBraking) {
+            kF = 0.0f; // no drive from velocity target while braking :comment may not be needed as target velocity must be zero while braking
+            // Move the target with the craft while slowing, so P doesn'tsnap from a large value to zero the instant the craft stops.
+            targetPosition.v[axis] += velocity.v[axis] * dt;
+            shouldIntegrateDistanceError = false;
         } else {
-            // Position law shared by position hold and the legacy nav path
-            // (velocity mode disabled). The two differ only in how the distance
-            // error is sourced; the PID sum is identical.
-            //
-            // D is pure damping on measured velocity and F is the target-velocity
-            // feedforward. Kf * target - Kd * velocity equals the old
-            // (target - velocity) * Kd velocity-error D term when the two gains
-            // are equal (they share a scale and default), so this reproduces the
-            // legacy response while letting the push be tuned apart from damping.
-            if (ap.navActive) {
-                // Implied distance error: integrate the velocity error, with
-                // anti-windup so a saturated output only unwinds it.
-                if (!wasAngleSaturated || (velocityError.v[axis] * distanceError.v[axis]) < 0.0f) {
-                    distanceError.v[axis] += velocityError.v[axis] * dt;
-                }
-            } else {
-                if (ap.isPosHoldBraking) {
-                    // Move the target with the craft while slowing, so P doesn't
-                    // snap to a large value the instant the craft stops.
-                    targetPosition.v[axis] += velocity.v[axis] * dt;
-                }
-                distanceError.v[axis] = targetPosition.v[axis] - currentPosition.v[axis];
-            }
-            distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
-            // Nav integrates continuously; pos hold freezes the integral while braking or under stick input.
-            const bool accumulateITerm = ap.navActive || !(ap.isPosHoldBraking || ap.sticksActive);
-            distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt * (accumulateITerm ? 1.0f : 0.0f);
-            distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
-            pidP.v[axis] = distanceError.v[axis] * positionPidCoeffs.Kp;
-            pidI.v[axis] = distanceErrorIntegral.v[axis] * positionPidCoeffs.Ki;
-            pidD.v[axis] = -velocityFiltered * positionPidCoeffs.Kd;      // damping on measured velocity
-            pidA.v[axis] = acceleration * positionPidCoeffs.Ka;
-            pidF.v[axis] = targetVelocity.v[axis] * positionPidCoeffs.Kf; // target-velocity feedforward
+            // not in a special mode
+            distanceError.v[axis] = targetPosition.v[axis] - currentPosition.v[axis]; //normal distanceError calculation from currentPosition
+            shouldIntegrateDistanceError = !ap.sticksActive; // don't add to distance integral while sticks are active
         }
+        // these things happen in all positionControl modes
+        distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
+        if (shouldIntegrateDistanceError) {
+            distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt;
+            distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
+        }
+
+            pidP.v[axis] = distanceError.v[axis] * xyPid.Kp; // P factor from distance error, real or virtual
+            pidI.v[axis] = distanceErrorIntegral.v[axis] * xyPid.Ki; // integral of distance error, forced to zero when there is no hard position source
+            pidD.v[axis] = -velocityFiltered * xyPid.Kd * dTermBrakingBoost; // damping on measured velocity
+            pidA.v[axis] = acceleration * xyPid.Ka;
+            pidF.v[axis] = targetVelocity.v[axis] * kF; // velocity feedforward
 
         pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis] + pidF.v[axis];
     } // End for loop
@@ -879,16 +861,15 @@ bool positionControl(void)
 
     bool buildupClamped = false;
     if (velocityMode) {
-        // velocityBuildupMaxPitch bounds the P vector, the acceleration-demand
-        // term, so the pitch bias while building up to speed is limited; the
-        // drag feedforward, integral trim and damping ride on top, with the
-        // maxAngle clamp below as the hard limit on the total.
+        // velocityBuildupMaxPitch bounds the velocity-proportional drive vector (now pidD)
+        // so the pitch bias while building up to speed is limited.
         const float buildupMaxDeg = autopilotConfig()->velocityBuildupMaxPitch;
-        const float pMag = vector2Norm(&pidP);
-        if (pMag > buildupMaxDeg) {
+        const float dMag = vector2Norm(&pidD);
+        if (dMag > buildupMaxDeg) {
             buildupClamped = true;
-            const float scale = (pMag > 0.001f) ? buildupMaxDeg / pMag : 0.0f;
-            vector2Scale(&pidP, &pidP, scale);
+            const float scale = (dMag > 0.001f) ? buildupMaxDeg / dMag : 0.0f;
+            vector2Scale(&pidD, &pidD, scale);
+            // Re-sum the vectors with the scaled D component
             for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
                 pidSumVectorEF.v[axis] = pidP.v[axis] + pidI.v[axis] + pidD.v[axis] + pidA.v[axis] + pidF.v[axis];
             }
@@ -921,7 +902,7 @@ bool positionControl(void)
     if (abortNavRequested)  statusValue += 100;
     if (isPositionHeld)     statusValue += 3; // plus 1, ie 4,  if stopping
     if (ap.sticksActive)    statusValue += 5;
-    DEBUG_SET(DEBUG_AUTOPILOT_PID, 0, lrintf(velocityError.v[ap.debugAxis])); // velocity error
+    DEBUG_SET(DEBUG_AUTOPILOT_PID, 0, lrintf(velocity.v[ap.debugAxis])); // velocity error
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 1, lrintf(distanceError.v[ap.debugAxis])); // distance error
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 2, lrintf(pidP.v[ap.debugAxis] * 10));   
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 3, lrintf(pidI.v[ap.debugAxis] * 10));

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -151,7 +151,6 @@ static float setpointVelocityGainPitch;  // to set max velocity at full stick
 static float setpointVelocityGainRoll;
 
 static pt3Filter_t posNoisyPidsLpf[EF_AXIS_COUNT];
-
 static bool isPositionHeld;
 static bool wasPositionHeld = false;
 static bool wasNavActive = false;
@@ -420,17 +419,12 @@ void positionControlReanchor(void)
 static void initNavMode(void)
 {
     initPidLpfs();
-    resetDistanceError();
     resetDistanceErrorIntegral();
     previousTargetVelocity.v[EF_EAST]  = 0.0f;
     previousTargetVelocity.v[EF_NORTH] = 0.0f;
     targetAcceleration.v[EF_EAST]  = 0.0f;
     targetAcceleration.v[EF_NORTH] = 0.0f;
     resetDistanceError();
-    previousTargetVelocity.v[EF_EAST]  = 0.0f;
-    previousTargetVelocity.v[EF_NORTH] = 0.0f;
-    targetAcceleration.v[EF_EAST]  = 0.0f;
-    targetAcceleration.v[EF_NORTH] = 0.0f;
     ap.isPosHoldBraking = false;
 }
 

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -458,6 +458,7 @@ void resetPositionControl(unsigned taskRateHz)
     ap.sanityViolationS = 0.0f;
     ap.violationFreeS = 0.0f;
     ap.sanityRetryUsed = false;
+    ap.derivativeStale = false;
     initPositionHold(); // sets target location, resets distance error, enables start mode
     previousVelocity = *(const vector2_t *)&positionEstimatorGetEstimate()->velocity.v; // for smooth A in any mode
     resetDistanceErrorIntegral();
@@ -787,10 +788,11 @@ bool positionControl(void)
                     if (ap.sanityViolationS > SANITY_VIOLATION_LATCH_S) {
                         return sanityViolationExpired();
                     }
+                    // FIX THIS
                     // The A-term history is now stale; mark it so the resume
                     // loop re-baselines instead of differentiating across the
                     // frozen window (one spurious spike against old velocity)
-                    ap.derivativeStale = true;
+                    ap.derivativeStale = false;
                     return true; // brief excursion: hold the previous command
                 } else {
                     ap.sanityViolationS = 0.0f;
@@ -816,7 +818,7 @@ bool positionControl(void)
         bool shouldIntegrateDistanceError = true;
         velocityError.v[axis] = targetVelocity.v[axis] - velocity.v[axis];
         const float acceleration = (previousVelocity.v[axis] -  velocity.v[axis]) * POSHOLD_TASK_RATE_HZ;
-        if (ap.derivativeStale) {
+        if (!ap.derivativeStale) {
             // frozen-output fixes were skipped: no delta across the window,
             // so resumption cannot spike A against second-old velocity
         previousVelocity.v[axis] =  velocity.v[axis];
@@ -864,7 +866,7 @@ distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT,
         pidSumVectorEF.v[axis] = pidI.v[axis] + pidD.v[axis] + noisyPidsFiltered;
     }   // End for loop
     
-    ap.derivativeStale = false;
+    ap.derivativeStale = false; // FIX THIS
 
     bool buildupClamped = false;
     if (velocityMode) {

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -803,61 +803,7 @@ bool positionControl(void)
     const bool velocityMode = ap.navActive && autopilotConfig()->velocityControlEnable;
 
 
-    for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
-        float dTermBrakingBoost = 1.0f;
-        const float targetVelDelta = (targetVelocity.v[axis] - previousTargetVelocity.v[axis]) * POSHOLD_TASK_RATE_HZ; //cm/s per second
-        previousTargetVelocity.v[axis] = targetVelocity.v[axis];
-        bool shouldIntegrateDistanceError = true;
-        velocityError.v[axis] = targetVelocity.v[axis] - velocity.v[axis];
-        const float acceleration = (previousVelocity.v[axis] -  velocity.v[axis]) * POSHOLD_TASK_RATE_HZ;
-        if (ap.derivativeStale) {
-            // frozen-output fixes were skipped: no delta across the window,
-            // so resumption cannot spike A against second-old velocity
-        previousVelocity.v[axis] =  velocity.v[axis];
-        }
-
-        if (velocityMode) {
-            // Nav velocity loop: track the commanded ground velocity directly.
-            distanceErrorIntegral.v[axis] = 0.0f; // force distance error integral to zero
-            shouldIntegrateDistanceError = false; // do not allow second integral accumulation
-            if (fabsf(velocityError.v[axis]) < XY_VELOCITY_I_RELAX_CMS
-                && (!wasAngleSaturated || (velocityError.v[axis] * distanceError.v[axis]) < 0.0f)) {
-                distanceError.v[axis] += velocityError.v[axis] * dt; // make a virtual distance error from integral of velocityError
-            }
-        } else {
-            // in Position Hold Mode
-#ifdef USE_FEEDFORWARD
-            targetVelDelta = targetAcceleration.v[axis]; // from sticks using setpoint feedforward like in acro
-#endif
-            if (ap.sticksActive) {
-                // position hold with sticks active - velocity target according to setpoint
-                shouldIntegrateDistanceError = false; // avoid iTerm windup, but retain current value
-                distanceError.v[axis] += velocityError.v[axis] * dt; // virtual distance error like velocityMode
-            } else {
-                // position hold but sticks not active
-                distanceError.v[axis] = targetPosition.v[axis] - currentPosition.v[axis];
-                if (ap.isPosHoldBraking) {
-                    dTermBrakingBoost = 1.0f + fabsf(velocity.v[axis]) * 0.0005f; // stronger D when stopping from high velocity, doubled at 20m/s
-                }
-            }
-        }
-distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
-        if (shouldIntegrateDistanceError) {
-                distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt;
-        }
-        distanceErrorIntegral.v[axis] = constrainf(distanceErrorIntegral.v[axis], -POSITION_I_LIMIT, POSITION_I_LIMIT);
-        pidP.v[axis] = distanceError.v[axis] * xyPid.Kp; // P factor from distance error, real or virtual
-        pidI.v[axis] = distanceErrorIntegral.v[axis] * xyPid.Ki; // integral of distance error, forced to zero when there is no hard position source
-        pidD.v[axis] = -velocity.v[axis] * xyPid.Kd * dTermBrakingBoost; // damping on measured velocity
-        pidD.v[axis] += velocity.v[axis] *xyKDrag; // drag compensation reduces damping at higher speed
-        pidA.v[axis] = acceleration * xyPid.Ka;
-        pidF.v[axis] = targetVelocity.v[axis] * xyPid.Kd + targetVelDelta * xyPid.Kf;
-        // in F, we use Kd on the constant target velocity component to balance D when craft is at target velocity; using D on the delta provides tunable acceleration deceleration responsiveness
-        const float noisyPids = pidP.v[axis] + pidA.v[axis] + pidF.v[axis]; // these get double PT2 for integration and smoothing
-        float noisyPidsFiltered = pt3FilterApply(&posNoisyPidsLpf[axis], noisyPids);
-        pidSumVectorEF.v[axis] = pidI.v[axis] + pidD.v[axis] + noisyPidsFiltered;
-    }   // End for loop
-
+<<<
     // Rotation from Earth Frame to Body Frame
     const float headingRad = DECIDEGREES_TO_RADIANS(attitude.values.yaw);
     vector2_t headingV;

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -797,7 +797,6 @@ bool positionControl(void)
             }
         }
     }
-
     updateYawControl(dt, est);
 
     wasPositionHeld = isPositionHeld;
@@ -805,17 +804,18 @@ bool positionControl(void)
     ap.wasSticksActive = ap.sticksActive; // Main frame-to-frame history update
     const bool velocityMode = ap.navActive && autopilotConfig()->velocityControlEnable;
 
+
     for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
         float dTermBrakingBoost = 1.0f;
-        float targetVelDelta = (targetVelocity.v[axis] - previousTargetVelocity.v[axis]) * POSHOLD_TASK_RATE_HZ; //cm/s per second
+        const float targetVelDelta = (targetVelocity.v[axis] - previousTargetVelocity.v[axis]) * POSHOLD_TASK_RATE_HZ; //cm/s per second
+        previousTargetVelocity.v[axis] = targetVelocity.v[axis];
+        bool shouldIntegrateDistanceError = true;
         velocityError.v[axis] = targetVelocity.v[axis] - velocity.v[axis];
         const float acceleration = (previousVelocity.v[axis] -  velocity.v[axis]) * POSHOLD_TASK_RATE_HZ;
-        previousVelocity.v[axis] =  velocity.v[axis];
-        bool shouldIntegrateDistanceError = true;
         if (ap.derivativeStale) {
             // frozen-output fixes were skipped: no delta across the window,
             // so resumption cannot spike A against second-old velocity
-            previousVelocity.v[axis] =  velocity.v[axis];
+        previousVelocity.v[axis] =  velocity.v[axis];
         }
 
         if (velocityMode) {
@@ -843,8 +843,7 @@ bool positionControl(void)
                 }
             }
         }
-        //these things happen in all modes
-         distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
+distanceError.v[axis] = constrainf(distanceError.v[axis], -ERROR_DISTANCE_LIMIT, ERROR_DISTANCE_LIMIT);
         if (shouldIntegrateDistanceError) {
                 distanceErrorIntegral.v[axis] += distanceError.v[axis] * dt;
         }
@@ -860,8 +859,6 @@ bool positionControl(void)
         float noisyPidsFiltered = pt3FilterApply(&posNoisyPidsLpf[axis], noisyPids);
         pidSumVectorEF.v[axis] = pidI.v[axis] + pidD.v[axis] + noisyPidsFiltered;
     }   // End for loop
-        ap.derivativeStale = false;
-
     bool buildupClamped = false;
     if (velocityMode) {
         // velocityBuildupMaxPitch bounds the velocity-proportional drive vector (now pidD)
@@ -905,7 +902,7 @@ bool positionControl(void)
     if (abortNavRequested)  statusValue += 100;
     if (isPositionHeld)     statusValue += 3; // plus 1, ie 4,  if stopping
     if (ap.sticksActive)    statusValue += 5;
-    DEBUG_SET(DEBUG_AUTOPILOT_PID, 0, lrintf(velocity.v[ap.debugAxis])); // velocity error
+    DEBUG_SET(DEBUG_AUTOPILOT_PID, 0, lrintf(velocity.v[ap.debugAxis])); // velocity cm/s
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 1, lrintf(distanceError.v[ap.debugAxis])); // distance error
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 2, lrintf(pidP.v[ap.debugAxis] * 10));   
     DEBUG_SET(DEBUG_AUTOPILOT_PID, 3, lrintf(pidI.v[ap.debugAxis] * 10));
@@ -925,7 +922,7 @@ bool positionControl(void)
     DEBUG_SET(DEBUG_AUTOPILOT_STOP, 7, statusValue + (ap.isPosHoldBraking ? 1 : 0));
 
     DEBUG_SET(DEBUG_POSITION_NAV, 0, lrintf(targetVelocity.v[ap.debugAxis]));
-    DEBUG_SET(DEBUG_POSITION_NAV, 1, lrintf(velocityFilteredV.v[ap.debugAxis]));
+    DEBUG_SET(DEBUG_POSITION_NAV, 1, lrintf(velocity.v[ap.debugAxis]));
     DEBUG_SET(DEBUG_POSITION_NAV, 2, lrintf(velocityError.v[ap.debugAxis]));
     DEBUG_SET(DEBUG_POSITION_NAV, 3, lrintf(pidP.v[ap.debugAxis] * 10));
     DEBUG_SET(DEBUG_POSITION_NAV, 4, lrintf(pidI.v[ap.debugAxis] * 10));

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -619,7 +619,7 @@ STATIC_UNIT_TESTED FAST_CODE_NOINLINE float pidLevel(int axis, const pidProfile_
     pidRuntime.angleTarget[axis] = angleTarget;  // set target for alternate axis to current axis, for use in preceding calculation
 
     // smooth final angle rate output to clean up attitude signal steps (500hz), GPS steps (10 or 100hz), RC steps etc
-    // this filter runs at ATTITUDE_CUTOFF_HZ, currently 50hz, so GPS roll may be a bit steppy
+    // this filter runs at ATTITUDE_CUTOFF_HZ, currently 20hz, so GPS roll may be a bit steppy
     angleRate = pt3FilterApply(&pidRuntime.attitudeFilter[axis], angleRate);
 
     if (FLIGHT_MODE(ANGLE_MODE| GPS_RESCUE_MODE | POS_HOLD_MODE)) {

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -55,7 +55,7 @@
 #define D_MAX_SETPOINT_GAIN_FACTOR 0.00008f // same DMax gain with either rate of change source; not intended preserve legacy behaviour
 #endif
 
-#define ATTITUDE_CUTOFF_HZ 50
+#define ATTITUDE_CUTOFF_HZ 20
 
 static void pidSetTargetLooptime(uint32_t pidLooptime)
 {

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -204,6 +204,10 @@ static bool gpsAltOffsetSet = false;
 static float baroAltOffsetCm = 0.0f;
 static float baroAltAccumulator = 0.0f;
 static bool baroOffsetSet = false;
+static bool baroDataAvailable = false;
+static timeUs_t baroTimestampUs = 0;
+static timeDelta_t baroHoldDurationUs = 0;
+static float baroMeasurementNoiseScale = 1.0f;
 #endif
 
 #ifdef USE_RANGEFINDER
@@ -271,6 +275,10 @@ void positionEstimatorInit(void)
     baroAltOffsetCm = 0.0f;
     baroAltAccumulator = 0.0f;
     baroOffsetSet = false;
+    baroDataAvailable = false;
+    baroTimestampUs = 0;
+    baroHoldDurationUs = 0;
+    baroMeasurementNoiseScale = 1.0f;
 #endif
 #ifdef USE_RANGEFINDER
     rangefinderAltOffsetCm = 0.0f;
@@ -383,6 +391,39 @@ STATIC_UNIT_TESTED bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *nois
     }
 
     *noiseScale = gpsMeasurementNoiseScale;
+    return true;
+}
+#endif
+
+#ifdef USE_BARO
+// A complete pressure-conversion cycle can be slower than the barometer task's
+// scheduler rate. Use timestamps from valid altitude samples so conversion
+// delays and target-specific barometer rates are both accounted for.
+STATIC_UNIT_TESTED bool baroMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale)
+{
+    const timeUs_t sampleTimeUs = getBaroLatestSampleTimeUs();
+    const bool hasNewData = !baroDataAvailable || sampleTimeUs != baroTimestampUs;
+    if (hasNewData) {
+        const timeDelta_t sourceIntervalUs = getBaroSampleIntervalUs();
+
+        baroDataAvailable = true;
+        baroTimestampUs = sampleTimeUs;
+        baroHoldDurationUs = sourceIntervalUs;
+        baroMeasurementNoiseScale = fmaxf(
+            (float)TASK_ALTITUDE_RATE_HZ * sourceIntervalUs * 1e-6f,
+            1.0f);
+    }
+
+    const timeDelta_t sampleAgeUs = cmpTimeUs(nowUs, baroTimestampUs);
+    const bool withinHoldInterval = baroDataAvailable &&
+        baroHoldDurationUs > 0 &&
+        sampleAgeUs >= 0 &&
+        sampleAgeUs < baroHoldDurationUs;
+    if ((!hasNewData || baroHoldDurationUs > 0) && !withinHoldInterval) {
+        return false;
+    }
+
+    *noiseScale = baroMeasurementNoiseScale;
     return true;
 }
 #endif
@@ -556,6 +597,7 @@ static void feedBaroMeasurements(timeUs_t nowUs)
 {
 #ifdef USE_BARO
     if (!sensors(SENSOR_BARO)) {
+        baroDataAvailable = false;
         return;
     }
 
@@ -566,6 +608,11 @@ static void feedBaroMeasurements(timeUs_t nowUs)
     }
 
     const float baroAltCm = getBaroAltitude();
+
+    float noiseScale;
+    if (!baroMeasurementReadyForFusion(nowUs, &noiseScale)) {
+        return;
+    }
 
     if (!baroOffsetSet) {
         // Capture disarmed baseline once; keep live relative altitude while disarmed.
@@ -578,7 +625,7 @@ static void feedBaroMeasurements(timeUs_t nowUs)
     const float baroPreference = constrainf(positionConfig()->altitude_prefer_baro * 0.01f, 0.01f, 1.0f);
     const float baroR = R_BARO_ALT / baroPreference;
 
-    kalmanUpdatePosition(&kfUp, baroAltCm - baroAltOffsetCm, baroR);
+    kalmanUpdatePosition(&kfUp, baroAltCm - baroAltOffsetCm, baroR * noiseScale);
     lastZMeasurementUs = nowUs;
 
     zCal[CAL_Z_BARO].rawReading = baroAltCm;

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -211,6 +211,13 @@ static float rangefinderAltOffsetCm = 0.0f;
 static bool rangefinderOffsetSet = false;
 #endif
 
+#ifdef USE_OPTICALFLOW
+static bool opticalFlowDataAvailable = false;
+static timeUs_t opticalFlowTimestampUs = 0;
+static timeDelta_t opticalFlowHoldDurationUs = 0;
+static float opticalFlowMeasurementNoiseScale = 1.0f;
+#endif
+
 static void initZCalEntries(void)
 {
     for (int i = 0; i < CAL_Z_COUNT; i++) {
@@ -264,6 +271,12 @@ void positionEstimatorInit(void)
 #ifdef USE_RANGEFINDER
     rangefinderAltOffsetCm = 0.0f;
     rangefinderOffsetSet = false;
+#endif
+#ifdef USE_OPTICALFLOW
+    opticalFlowDataAvailable = false;
+    opticalFlowTimestampUs = 0;
+    opticalFlowHoldDurationUs = 0;
+    opticalFlowMeasurementNoiseScale = 1.0f;
 #endif
 
     initZCalEntries();
@@ -380,6 +393,43 @@ static float opticalFlowR(int16_t quality)
     // Scale R inversely with quality: better quality = lower noise
     const float qualityNorm = constrainf((float)(quality - minQuality) / (100.0f - minQuality), 0.01f, 1.0f);
     return R_OPTICALFLOW_VEL / qualityNorm;
+}
+
+// Optical-flow drivers expose the timestamp of the last processed sensor
+// sample. Use its measured cadence after the first sample; delayMs is only the
+// nominal first-sample fallback. This avoids mistaking a driver's faster
+// polling rate (such as the UP-T1 rangefinder's 2x polling) for its data rate.
+STATIC_UNIT_TESTED bool opticalFlowMeasurementReadyForFusion(timeUs_t nowUs, const opticalflow_t *flow, float *noiseScale)
+{
+    const bool hasNewData = !opticalFlowDataAvailable || flow->timeStampUs != opticalFlowTimestampUs;
+    if (hasNewData) {
+        timeDelta_t sourceIntervalUs = (timeDelta_t)flow->dev.delayMs * 1000;
+        if (opticalFlowDataAvailable) {
+            const timeDelta_t measuredIntervalUs = cmpTimeUs(flow->timeStampUs, opticalFlowTimestampUs);
+            if (measuredIntervalUs > 0 && measuredIntervalUs <= OPTICALFLOW_HARDWARE_TIMEOUT_US) {
+                sourceIntervalUs = measuredIntervalUs;
+            }
+        }
+
+        opticalFlowDataAvailable = true;
+        opticalFlowTimestampUs = flow->timeStampUs;
+        opticalFlowHoldDurationUs = sourceIntervalUs;
+        opticalFlowMeasurementNoiseScale = fmaxf(
+            (float)TASK_ALTITUDE_RATE_HZ * sourceIntervalUs * 1e-6f,
+            1.0f);
+    }
+
+    const timeDelta_t sampleAgeUs = cmpTimeUs(nowUs, opticalFlowTimestampUs);
+    const bool withinHoldInterval = opticalFlowDataAvailable &&
+        opticalFlowHoldDurationUs > 0 &&
+        sampleAgeUs >= 0 &&
+        sampleAgeUs < opticalFlowHoldDurationUs;
+    if (!hasNewData && !withinHoldInterval) {
+        return false;
+    }
+
+    *noiseScale = opticalFlowMeasurementNoiseScale;
+    return true;
 }
 #endif
 
@@ -541,6 +591,7 @@ static void feedOpticalFlowMeasurements(timeUs_t nowUs)
     }
 
     if (!sensors(SENSOR_OPTICALFLOW) || !isOpticalflowHealthy()) {
+        opticalFlowDataAvailable = false;
         return;
     }
 
@@ -581,6 +632,11 @@ static void feedOpticalFlowMeasurements(timeUs_t nowUs)
         return;  // quality too low
     }
 
+    float noiseScale;
+    if (!opticalFlowMeasurementReadyForFusion(nowUs, flow, &noiseScale)) {
+        return;
+    }
+
     // Convert flow rates (rad/s) to velocity (cm/s) in body frame, scaled by rangefinder height.
     // Flow sensor X axis measures rightward motion; Y axis measures forward motion.
     const float flowRight   = flow->processedFlowRates.x * altitudeCm;
@@ -599,8 +655,8 @@ static void feedOpticalFlowMeasurements(timeUs_t nowUs)
     const float velEast  =  velForward * sinYaw - velRight * cosYaw;
     const float velNorth =  velForward * cosYaw + velRight * sinYaw;
 
-    kalmanUpdateVelocity(&kfEast, velEast, flowR);
-    kalmanUpdateVelocity(&kfNorth, velNorth, flowR);
+    kalmanUpdateVelocity(&kfEast, velEast, flowR * noiseScale);
+    kalmanUpdateVelocity(&kfNorth, velNorth, flowR * noiseScale);
 
     lastXYMeasurementUs = nowUs;
 #else

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -190,6 +190,10 @@ static sensorCalEntry_t zCal[CAL_Z_COUNT];
 
 #ifdef USE_GPS
 static uint16_t gpsStamp = 0;
+static bool gpsDataAvailable = false;
+static timeUs_t gpsDataReceivedAtUs = 0;
+static timeDelta_t gpsDataHoldDurationUs = 0;
+static float gpsMeasurementNoiseScale = 1.0f;
 static gpsLocation_t armLocationGps;
 static bool gpsArmLocationSet = false;
 static float gpsAltOffsetCm = 0.0f;
@@ -244,6 +248,10 @@ void positionEstimatorInit(void)
 
 #ifdef USE_GPS
     gpsStamp = 0;
+    gpsDataAvailable = false;
+    gpsDataReceivedAtUs = 0;
+    gpsDataHoldDurationUs = 0;
+    gpsMeasurementNoiseScale = 1.0f;
     gpsArmLocationSet = false;
     gpsAltOffsetCm = 0.0f;
     gpsAltOffsetSet = false;
@@ -324,6 +332,38 @@ static uint16_t gpsDopOrFallback(uint16_t preferredDop, uint16_t fallbackDop)
 {
     return (preferredDop >= GPS_DOP_MIN_VALID) ? preferredDop : fallbackDop;
 }
+
+// Hold each GPS sample until the next one is expected so it can be fused at the
+// altitude task rate. Scaling R by the number of repeated updates preserves
+// approximately the same information per second as fusion at the GPS rate.
+STATIC_UNIT_TESTED bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale)
+{
+    const bool hasNewData = gpsHasNewData(&gpsStamp);
+    if (hasNewData) {
+        const float gpsFrequencyHz = getGpsDataFrequencyHz();
+
+        gpsDataAvailable = true;
+        gpsDataReceivedAtUs = nowUs;
+        if (gpsFrequencyHz > 0.0f) {
+            gpsDataHoldDurationUs = (timeDelta_t)lrintf(1000000.0f / gpsFrequencyHz);
+            gpsMeasurementNoiseScale = fmaxf((float)TASK_ALTITUDE_RATE_HZ / gpsFrequencyHz, 1.0f);
+        } else {
+            // An invalid frequency cannot define a safe hold interval.
+            gpsDataHoldDurationUs = 0;
+            gpsMeasurementNoiseScale = 1.0f;
+        }
+    }
+
+    const bool withinHoldInterval = gpsDataAvailable &&
+        gpsDataHoldDurationUs > 0 &&
+        cmpTimeUs(nowUs, gpsDataReceivedAtUs) < gpsDataHoldDurationUs;
+    if (!hasNewData && !withinHoldInterval) {
+        return false;
+    }
+
+    *noiseScale = gpsMeasurementNoiseScale;
+    return true;
+}
 #endif
 
 #ifdef USE_OPTICALFLOW
@@ -347,10 +387,12 @@ static void feedGPSMeasurements(timeUs_t nowUs)
 {
 #ifdef USE_GPS
     if (!sensors(SENSOR_GPS) || !STATE(GPS_FIX)) {
+        gpsDataAvailable = false;
         return;
     }
 
-    if (!gpsHasNewData(&gpsStamp)) {
+    float noiseScale;
+    if (!gpsMeasurementReadyForFusion(nowUs, &noiseScale)) {
         return;
     }
 
@@ -382,12 +424,12 @@ static void feedGPSMeasurements(timeUs_t nowUs)
         // v[EF_EAST] = East (lon), v[EF_NORTH] = North (lat) relative to the arm point.
 
         const uint16_t xyDop = gpsDopOrFallback(gpsSol.dop.hdop, gpsSol.dop.pdop);
-        const float rPos = gpsR(R_GPS_POS_BASE, xyDop);
+        const float rPos = gpsR(R_GPS_POS_BASE, xyDop) * noiseScale;
         kalmanUpdatePosition(&kfEast, gpsDistCm.v[EF_EAST], rPos);
         kalmanUpdatePosition(&kfNorth, gpsDistCm.v[EF_NORTH], rPos);
 
         // GPS velocity (NED from UBX) -> ENU
-        const float rVel = gpsR(R_GPS_VEL_BASE, xyDop);
+        const float rVel = gpsR(R_GPS_VEL_BASE, xyDop) * noiseScale;
         kalmanUpdateVelocity(&kfEast, (float)gpsSol.velned.velE, rVel);
         kalmanUpdateVelocity(&kfNorth, (float)gpsSol.velned.velN, rVel);
 
@@ -405,7 +447,7 @@ static void feedGPSMeasurements(timeUs_t nowUs)
         // altitude_prefer_baro=100 means strongly prefer baro, so GPS R should be higher
         const float baroPreference = positionConfig()->altitude_prefer_baro * 0.01f;
         const uint16_t altDop = gpsDopOrFallback(gpsSol.dop.vdop, gpsSol.dop.pdop);
-        const float gpsAltR = gpsR(R_GPS_ALT_BASE, altDop) * (1.0f + baroPreference * 2.0f);
+        const float gpsAltR = gpsR(R_GPS_ALT_BASE, altDop) * (1.0f + baroPreference * 2.0f) * noiseScale;
 
         const float gpsRelativeAltCm = gpsSol.llh.altCm - gpsAltOffsetCm;
         kalmanUpdatePosition(&kfUp, gpsRelativeAltCm, gpsAltR);

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -209,6 +209,10 @@ static bool baroOffsetSet = false;
 #ifdef USE_RANGEFINDER
 static float rangefinderAltOffsetCm = 0.0f;
 static bool rangefinderOffsetSet = false;
+static bool rangefinderDataAvailable = false;
+static timeUs_t rangefinderTimestampUs = 0;
+static timeDelta_t rangefinderHoldDurationUs = 0;
+static float rangefinderMeasurementNoiseScale = 1.0f;
 #endif
 
 #ifdef USE_OPTICALFLOW
@@ -271,6 +275,10 @@ void positionEstimatorInit(void)
 #ifdef USE_RANGEFINDER
     rangefinderAltOffsetCm = 0.0f;
     rangefinderOffsetSet = false;
+    rangefinderDataAvailable = false;
+    rangefinderTimestampUs = 0;
+    rangefinderHoldDurationUs = 0;
+    rangefinderMeasurementNoiseScale = 1.0f;
 #endif
 #ifdef USE_OPTICALFLOW
     opticalFlowDataAvailable = false;
@@ -375,6 +383,39 @@ STATIC_UNIT_TESTED bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *nois
     }
 
     *noiseScale = gpsMeasurementNoiseScale;
+    return true;
+}
+#endif
+
+#ifdef USE_RANGEFINDER
+// rangefinderProcess() timestamps only actual device samples, so its measured
+// interval remains correct when a driver task polls faster than the hardware
+// data rate (the UP-T1 polls at 100 Hz for a 50 Hz data stream, for example).
+STATIC_UNIT_TESTED bool rangefinderMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale)
+{
+    const timeUs_t sampleTimeUs = rangefinderGetLatestSampleTimeUs();
+    const bool hasNewData = !rangefinderDataAvailable || sampleTimeUs != rangefinderTimestampUs;
+    if (hasNewData) {
+        const timeDelta_t sourceIntervalUs = rangefinderGetSampleIntervalUs();
+
+        rangefinderDataAvailable = true;
+        rangefinderTimestampUs = sampleTimeUs;
+        rangefinderHoldDurationUs = sourceIntervalUs;
+        rangefinderMeasurementNoiseScale = fmaxf(
+            (float)TASK_ALTITUDE_RATE_HZ * sourceIntervalUs * 1e-6f,
+            1.0f);
+    }
+
+    const timeDelta_t sampleAgeUs = cmpTimeUs(nowUs, rangefinderTimestampUs);
+    const bool withinHoldInterval = rangefinderDataAvailable &&
+        rangefinderHoldDurationUs > 0 &&
+        sampleAgeUs >= 0 &&
+        sampleAgeUs < rangefinderHoldDurationUs;
+    if ((!hasNewData || rangefinderHoldDurationUs > 0) && !withinHoldInterval) {
+        return false;
+    }
+
+    *noiseScale = rangefinderMeasurementNoiseScale;
     return true;
 }
 #endif
@@ -558,6 +599,12 @@ static void feedRangefinderMeasurements(timeUs_t nowUs)
 
     float altCm;
     if (!rangefinderSampleAltitudeCm(&altCm, positionConfig()->rangefinder_max_range_cm)) {
+        rangefinderDataAvailable = false;
+        return;
+    }
+
+    float noiseScale;
+    if (!rangefinderMeasurementReadyForFusion(nowUs, &noiseScale)) {
         return;
     }
 
@@ -573,7 +620,7 @@ static void feedRangefinderMeasurements(timeUs_t nowUs)
         rfR *= 0.25f;  // even lower noise -> stronger pull
     }
 
-    kalmanUpdatePosition(&kfUp, altCm - rangefinderAltOffsetCm, rfR);
+    kalmanUpdatePosition(&kfUp, altCm - rangefinderAltOffsetCm, rfR * noiseScale);
     lastZMeasurementUs = nowUs;
 
     zCal[CAL_Z_RF].rawReading = altCm;

--- a/src/main/pg/autopilot.c
+++ b/src/main/pg/autopilot.c
@@ -50,11 +50,8 @@ PG_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig,
 
     // Velocity-based position control with drag compensation
     .velocityControlEnable = 1,       // Enabled by default
-    .velocityP = 50,                  // 5.0 P gain
-    .velocityI = 10,                  // 1.0 I gain
-    .velocityD = 5,                   // 0.5 D gain
     .velocityDragCoeff = 50,          // 0.0050 drag coefficient
-    .maxVelocity = 1000,              // 10 m/s max velocity
+    .maxVelocity = 500,              // 5 m/s max velocity
 
     // Waypoint navigation parameters
     .waypointArrivalRadius = 500,     // 5m for FLYOVER/FLYBY

--- a/src/main/pg/autopilot.h
+++ b/src/main/pg/autopilot.h
@@ -70,9 +70,6 @@ typedef struct autopilotConfig_s {
 
     // Velocity-based position control with drag compensation (nav path only; pos-hold is unaffected)
     uint8_t velocityControlEnable;    // 0=legacy pseudo-distance→angle, 1=velocity-PID→angle (default 1)
-    uint8_t velocityP;                // velocity loop P gain, scaled by 10 (default 50 = 5.0)
-    uint8_t velocityI;                // velocity loop I gain, scaled by 10 (default 10 = 1.0)
-    uint8_t velocityD;                // velocity loop D gain, scaled by 10 (default 5 = 0.5)
     uint16_t velocityDragCoeff;       // linear drag feedforward: degrees = coeff * target cm/s, scaled by 10000 (default 50 = 0.0050, 2.5 deg at 5 m/s)
     uint16_t maxVelocity;             // cm/s, maximum velocity setpoint (default 1000 = 10 m/s)
 

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -380,6 +380,8 @@ static bool baroDetect(baroDev_t *baroDev, baroSensor_e baroHardwareToUse)
 
 void baroInit(void)
 {
+    baro.lastDataTimeUs = 0;
+    baro.dataIntervalUs = 0;
 #ifndef USE_VIRTUAL_BARO
     baroReady = baroDetect(&baro.dev, barometerConfig()->baro_hardware);
 #else
@@ -514,6 +516,14 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
                     performBaroCalibrationCycle(altitude);
                     baro.altitude = 0.0f;
                 }
+
+                if (baro.lastDataTimeUs != 0) {
+                    const timeDelta_t intervalUs = cmpTimeUs(currentTimeUs, baro.lastDataTimeUs);
+                    if (intervalUs > 0) {
+                        baro.dataIntervalUs = intervalUs;
+                    }
+                }
+                baro.lastDataTimeUs = currentTimeUs;
             } else {
                 // return 0 during calibration, reuse last value otherwise
                 if (!baroIsCalibrated()) {
@@ -563,6 +573,16 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
 float getBaroAltitude(void)
 {
     return baro.altitude;
+}
+
+timeUs_t getBaroLatestSampleTimeUs(void)
+{
+    return baro.lastDataTimeUs;
+}
+
+timeDelta_t getBaroSampleIntervalUs(void)
+{
+    return baro.dataIntervalUs;
 }
 
 static void performBaroCalibrationCycle(const float altitude)

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "common/time.h"
+
 #include "pg/pg.h"
 #include "drivers/barometer/barometer.h"
 
@@ -64,6 +66,8 @@ typedef struct baro_s {
     float altitude;
     int32_t temperature;                    // Use temperature for telemetry
     int32_t pressure;                       // Use pressure for telemetry
+    timeUs_t lastDataTimeUs;
+    timeDelta_t dataIntervalUs;
 } baro_t;
 
 extern baro_t baro;
@@ -76,3 +80,5 @@ void baroSetGroundLevel(void);
 uint32_t baroUpdate(timeUs_t currentTimeUs);
 bool isBaroReady(void);
 float getBaroAltitude(void);
+timeUs_t getBaroLatestSampleTimeUs(void);
+timeDelta_t getBaroSampleIntervalUs(void);

--- a/src/main/sensors/rangefinder.c
+++ b/src/main/sensors/rangefinder.c
@@ -193,6 +193,8 @@ bool rangefinderInit(void)
     rangefinder.calculatedAltitude = RANGEFINDER_OUT_OF_RANGE;
     rangefinder.maxTiltCos = cos_approx(DECIDEGREES_TO_RADIANS(rangefinder.dev.detectionConeExtendedDeciDegrees / 2.0f));
     rangefinder.lastValidResponseTimeMs = millis();
+    rangefinder.lastDataTimeUs = 0;
+    rangefinder.dataIntervalUs = 0;
     rangefinder.snr = 0;
 
     rangefinderResetDynamicThreshold();
@@ -307,6 +309,15 @@ bool rangefinderProcess(float cosTiltAngle)
             return false;
         }
 
+        const timeUs_t nowUs = micros();
+        if (rangefinder.lastDataTimeUs != 0) {
+            const timeDelta_t intervalUs = cmpTimeUs(nowUs, rangefinder.lastDataTimeUs);
+            if (intervalUs > 0) {
+                rangefinder.dataIntervalUs = intervalUs;
+            }
+        }
+        rangefinder.lastDataTimeUs = nowUs;
+
         if (distance >= 0) {
             rangefinder.lastValidResponseTimeMs = millis();
             rangefinder.rawAltitude = applyMedianFilter(distance);
@@ -378,6 +389,16 @@ int32_t rangefinderGetLatestAltitude(void)
 int32_t rangefinderGetLatestRawAltitude(void)
 {
     return rangefinder.rawAltitude;
+}
+
+timeUs_t rangefinderGetLatestSampleTimeUs(void)
+{
+    return rangefinder.lastDataTimeUs;
+}
+
+timeDelta_t rangefinderGetSampleIntervalUs(void)
+{
+    return rangefinder.dataIntervalUs;
 }
 
 bool rangefinderIsHealthy(void)

--- a/src/main/sensors/rangefinder.h
+++ b/src/main/sensors/rangefinder.h
@@ -58,6 +58,8 @@ typedef struct rangefinder_s {
     int32_t rawAltitude;
     int32_t calculatedAltitude;
     timeMs_t lastValidResponseTimeMs;
+    timeUs_t lastDataTimeUs;
+    timeDelta_t dataIntervalUs;
 
     bool snrThresholdReached;
     int32_t dynamicDistanceThreshold;
@@ -69,6 +71,8 @@ bool rangefinderInit(void);
 
 int32_t rangefinderGetLatestAltitude(void);
 int32_t rangefinderGetLatestRawAltitude(void);
+timeUs_t rangefinderGetLatestSampleTimeUs(void);
+timeDelta_t rangefinderGetSampleIntervalUs(void);
 
 void rangefinderUpdate(void);
 bool rangefinderProcess(float cosTiltAngle);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -574,7 +574,8 @@ position_estimator_unittest_SRC := \
 position_estimator_unittest_DEFINES := \
 		USE_GPS= \
 		USE_BARO= \
-		USE_RANGEFINDER=
+		USE_RANGEFINDER= \
+		USE_OPTICALFLOW=
 
 position_nav_unittest_SRC := \
 		$(USER_DIR)/flight/position_nav.c \

--- a/src/test/unit/althold_unittest.cc
+++ b/src/test/unit/althold_unittest.cc
@@ -244,7 +244,11 @@ extern "C" {
         UNUSED(axis);
         return 0.0f;
     }
-
+    float getMaxRcRate(int axis)
+{
+    UNUSED(axis);
+    return 720.0f;
+}
     void GPS_distance2d(const gpsLocation_t* /*from*/, const gpsLocation_t* /*to*/, vector2_t* /*dest*/) { }
 
     static positionEstimate3d_t stubEstimate = {};

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -1198,6 +1198,11 @@ void GPS_distance2d(const gpsLocation_t* /*from*/, const gpsLocation_t* /*to*/, 
         UNUSED(axis);
         return 0.0f;
     }
+    float getMaxRcRate(int axis)
+{
+    UNUSED(axis);
+    return 720.0f;
+}
 
     float getGpsCosLat(void) { return 1.0f; }
 }

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -409,32 +409,32 @@ TEST(pidControllerTest, testPidLevel)
 
     currentPidSetpointRoll = 200;
     calculatedAngleSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpointRoll, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(51.456356, calculatedAngleSetpoint);
+    EXPECT_FLOAT_EQ(26.1591, calculatedAngleSetpoint);
     currentPidSetpointPitch = -200;
     calculatedAngleSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpointPitch, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-51.456356, calculatedAngleSetpoint);
+    EXPECT_FLOAT_EQ(-26.1591, calculatedAngleSetpoint);
 
     currentPidSetpointRoll = 400;
     calculatedAngleSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpointRoll, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(128.94597, calculatedAngleSetpoint);
+    EXPECT_FLOAT_EQ(78.724869, calculatedAngleSetpoint);
     currentPidSetpointPitch = -400;
     calculatedAngleSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpointPitch, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-128.94597, calculatedAngleSetpoint);
+    EXPECT_FLOAT_EQ(-78.724869, calculatedAngleSetpoint);
 
     // Test attitude response
     attitude.values.roll = -275;
     attitude.values.pitch = 275;
     calculatedAngleSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpointRoll, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(242.76686, calculatedAngleSetpoint);
+    EXPECT_FLOAT_EQ(163.06772, calculatedAngleSetpoint);
     calculatedAngleSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpointPitch, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-242.76686, calculatedAngleSetpoint);
+    EXPECT_FLOAT_EQ(-163.06772, calculatedAngleSetpoint);
 
     // Disable ANGLE_MODE
     disableFlightMode(ANGLE_MODE);
     calculatedAngleSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpointRoll, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(393.44571, calculatedAngleSetpoint);
+    EXPECT_FLOAT_EQ(389.57309, calculatedAngleSetpoint);
     calculatedAngleSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpointPitch, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-392.88422, calculatedAngleSetpoint);
+    EXPECT_FLOAT_EQ(-388.67987, calculatedAngleSetpoint);
 
     // Test level mode expo
     enableFlightMode(ANGLE_MODE);
@@ -444,9 +444,9 @@ TEST(pidControllerTest, testPidLevel)
     currentPidSetpointPitch = -400;
     // need to set some rates type and some expo here ??? HELP !!
     calculatedAngleSetpoint = pidLevel(FD_ROLL, pidProfile, &angleTrim, currentPidSetpointRoll, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(231.55479, calculatedAngleSetpoint);
+    EXPECT_FLOAT_EQ(233.46765, calculatedAngleSetpoint);
     calculatedAngleSetpoint = pidLevel(FD_PITCH, pidProfile, &angleTrim, currentPidSetpointPitch, calcHorizonLevelStrength());
-    EXPECT_FLOAT_EQ(-231.55479, calculatedAngleSetpoint);
+    EXPECT_FLOAT_EQ(-233.46765, calculatedAngleSetpoint);
 }
 
 

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -444,7 +444,7 @@ TEST_F(PosHoldTest, SticksActiveButCentered)
     runIterations(SETTLE_ITERATIONS);
 
     // Assert your new baseline calculation output
-    EXPECT_NEAR(autopilotAngle[AI_ROLL], -0.9045f, 0.01f);
+    EXPECT_NEAR(autopilotAngle[AI_ROLL], -2.8f, 0.01f);
     EXPECT_NEAR(autopilotAngle[AI_PITCH], 0.0f, 0.01f);
 }
 
@@ -481,7 +481,7 @@ TEST_F(PosHoldTest, VelocityTransitionSimulatesFallbackAndRecovery)
 
     testEstimate.velocity.x = 0.0f;
     runIterations(SETTLE_ITERATIONS);
-    EXPECT_NEAR(-0.7f, autopilotAngle[AI_ROLL], 0.1f);
+    EXPECT_NEAR(0.26f, autopilotAngle[AI_ROLL], 0.1f);
 }
 
 // -- Feedforward (stick push) is a term of its own, apart from damping --

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -116,6 +116,19 @@ extern "C" {
         return 0.0f;
     }
 
+
+    float simulatedMaxRcRate = 720.0f;
+    float getMaxRcRate(int axis)
+    {
+        if (axis == FD_ROLL) {
+            return simulatedMaxRcRate;
+        }
+        if (axis == FD_PITCH) {
+            return simulatedMaxRcRate;
+        }
+        return 720.0f;
+    }
+
     timeDelta_t getTaskDeltaTimeUs(taskId_e taskId)
     {
         UNUSED(taskId);
@@ -802,7 +815,7 @@ static void stepVelocityPlant(float kDragPerS, float *vNorthCmS)
 
 class VelocityModeTest : public PosHoldTest {
 protected:
-    void engageVelocityNav(uint8_t velocityP, uint8_t velocityI, uint8_t velocityD,
+    void engageVelocityNav(uint8_t positionD, uint8_t positionP, uint8_t positionA,
                             uint16_t velocityDragCoeff, uint8_t velocityBuildupMaxPitch,
                             uint8_t maxAngle = 45, bool enable = true)
     {
@@ -812,9 +825,9 @@ protected:
         cfg->maxAngle = maxAngle;
         cfg->positionCutoff = 30;
         cfg->velocityControlEnable = enable ? 1 : 0;
-        cfg->velocityP = velocityP;
-        cfg->velocityI = velocityI;
-        cfg->velocityD = velocityD;
+        cfg->positionD = positionD;
+        cfg->positionP = positionP;
+        cfg->positionA = positionA;
         cfg->velocityDragCoeff = velocityDragCoeff;
         cfg->velocityBuildupMaxPitch = velocityBuildupMaxPitch;
         autopilotInit();

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -22,6 +22,7 @@ extern "C" {
 // STATIC_UNIT_TESTED in position_estimator.c — gravity-removed earth-frame
 // linear acceleration in ENU (cm/s^2).
 void getLinearAccelENU(float *accelEast, float *accelNorth, float *accelUp);
+bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
 
 #include "io/gps.h"
 
@@ -51,6 +52,9 @@ static bool rfHealthy = false;
 static float rfAltCm = 0.0f;
 static float baroAltCm = 0.0f;
 static timeUs_t fakeMicros = 0;
+static bool gpsAlwaysHasNewData = true;
+static bool gpsDataIsNew = false;
+static float gpsDataFrequencyHz = 100.0f;
 
 bool sensors(uint32_t mask) { return (enabledSensors & mask) != 0; }
 bool rangefinderIsHealthy(void) { return rfHealthy; }
@@ -61,9 +65,16 @@ timeUs_t micros(void) { return fakeMicros; }
 
 bool gpsHasNewData(uint16_t *gpsStamp)
 {
+    if (!gpsAlwaysHasNewData && !gpsDataIsNew) {
+        return false;
+    }
+
+    gpsDataIsNew = false;
     (*gpsStamp)++;
     return true;
 }
+
+float getGpsDataFrequencyHz(void) { return gpsDataFrequencyHz; }
 
 void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *dest)
 {
@@ -107,6 +118,9 @@ protected:
         stateFlags = GPS_FIX;
         armingFlags = ARMED;
         fakeMicros = 0;
+        gpsAlwaysHasNewData = true;
+        gpsDataIsNew = false;
+        gpsDataFrequencyHz = 100.0f;
 
         positionConfigMutable()->altitude_source = ALTITUDE_SOURCE_RANGEFINDER_PREFER;
         positionConfigMutable()->altitude_prefer_baro = 100;
@@ -115,6 +129,50 @@ protected:
         positionEstimatorInit();
     }
 };
+
+TEST_F(PositionEstimatorTest, GPSMeasurementsAreHeldAtAltitudeTaskRate)
+{
+    gpsAlwaysHasNewData = false;
+    gpsDataFrequencyHz = 10.0f;
+    gpsDataIsNew = true;
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(10000, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 10.0f);
+
+    // A 10 Hz GPS sample is reused for all ten 100 Hz altitude-task calls in
+    // its 100 ms source interval.
+    for (timeUs_t nowUs = 20000; nowUs <= 100000; nowUs += 10000) {
+        EXPECT_TRUE(gpsMeasurementReadyForFusion(nowUs, &noiseScale));
+        EXPECT_FLOAT_EQ(noiseScale, 10.0f);
+    }
+
+    // Do not continue fusing a stale held sample if the next one is late.
+    EXPECT_FALSE(gpsMeasurementReadyForFusion(110000, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, GPSUpsamplingTracksSourceFrequency)
+{
+    gpsAlwaysHasNewData = false;
+    gpsDataFrequencyHz = 20.0f;
+    gpsDataIsNew = true;
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(0, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 5.0f);
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(40000, &noiseScale));
+    EXPECT_FALSE(gpsMeasurementReadyForFusion(50000, &noiseScale));
+
+    // The source rate can change at runtime as the receiver's nav interval changes.
+    gpsDataFrequencyHz = 5.0f;
+    gpsDataIsNew = true;
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(50000, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 20.0f);
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(240000, &noiseScale));
+    EXPECT_FALSE(gpsMeasurementReadyForFusion(250000, &noiseScale));
+}
 
 TEST_F(PositionEstimatorTest, RangefinderPreferFallsBackAndRecovers)
 {

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -28,8 +28,11 @@ bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
 
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
+#include "sensors/opticalflow.h"
 #include "sensors/rangefinder.h"
 #include "sensors/sensors.h"
+
+bool opticalFlowMeasurementReadyForFusion(timeUs_t nowUs, const opticalflow_t *flow, float *noiseScale);
 
 PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
 }
@@ -46,6 +49,7 @@ int16_t debug[DEBUG16_VALUE_COUNT];
 acc_t acc;
 matrix33_t rMat;
 gpsSolutionData_t gpsSol;
+attitudeEulerAngles_t attitude;
 
 static uint32_t enabledSensors = 0;
 static bool rfHealthy = false;
@@ -55,6 +59,8 @@ static timeUs_t fakeMicros = 0;
 static bool gpsAlwaysHasNewData = true;
 static bool gpsDataIsNew = false;
 static float gpsDataFrequencyHz = 100.0f;
+static opticalflow_t testOpticalFlow;
+static bool opticalFlowHealthy = true;
 
 bool sensors(uint32_t mask) { return (enabledSensors & mask) != 0; }
 bool rangefinderIsHealthy(void) { return rfHealthy; }
@@ -75,6 +81,8 @@ bool gpsHasNewData(uint16_t *gpsStamp)
 }
 
 float getGpsDataFrequencyHz(void) { return gpsDataFrequencyHz; }
+bool isOpticalflowHealthy(void) { return opticalFlowHealthy; }
+const opticalflow_t *getOpticalFlowData(void) { return &testOpticalFlow; }
 
 void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *dest)
 {
@@ -99,6 +107,8 @@ protected:
         memset(&acc, 0, sizeof(acc));
         memset(&rMat, 0, sizeof(rMat));
         memset(&gpsSol, 0, sizeof(gpsSol));
+        memset(&attitude, 0, sizeof(attitude));
+        memset(&testOpticalFlow, 0, sizeof(testOpticalFlow));
         memset(debug, 0, sizeof(debug));
 
         // Identity rotation and 1G reciprocal scale so zero accel stays zero.
@@ -121,6 +131,7 @@ protected:
         gpsAlwaysHasNewData = true;
         gpsDataIsNew = false;
         gpsDataFrequencyHz = 100.0f;
+        opticalFlowHealthy = true;
 
         positionConfigMutable()->altitude_source = ALTITUDE_SOURCE_RANGEFINDER_PREFER;
         positionConfigMutable()->altitude_prefer_baro = 100;
@@ -172,6 +183,41 @@ TEST_F(PositionEstimatorTest, GPSUpsamplingTracksSourceFrequency)
     EXPECT_FLOAT_EQ(noiseScale, 20.0f);
     EXPECT_TRUE(gpsMeasurementReadyForFusion(240000, &noiseScale));
     EXPECT_FALSE(gpsMeasurementReadyForFusion(250000, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, OpticalFlowMeasurementsUseNominalRateForFirstSample)
+{
+    testOpticalFlow.dev.delayMs = 20; // UP-T1 optical flow is nominally 50 Hz.
+    testOpticalFlow.timeStampUs = 100000;
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(100000, &testOpticalFlow, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 2.0f);
+    EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(110000, &testOpticalFlow, &noiseScale));
+    EXPECT_FALSE(opticalFlowMeasurementReadyForFusion(120000, &testOpticalFlow, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, OpticalFlowUpsamplingTracksMeasuredSampleRate)
+{
+    testOpticalFlow.dev.delayMs = 20;
+    testOpticalFlow.timeStampUs = 100000;
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(100000, &testOpticalFlow, &noiseScale));
+
+    // A timestamp change after 20 ms confirms the nominal 50 Hz source rate.
+    testOpticalFlow.timeStampUs = 120000;
+    EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(120000, &testOpticalFlow, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 2.0f);
+
+    // If the actual sensor cadence changes, use it instead of the task/polling rate.
+    testOpticalFlow.timeStampUs = 160000;
+    EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(160000, &testOpticalFlow, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 4.0f);
+    EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(190000, &testOpticalFlow, &noiseScale));
+    EXPECT_FALSE(opticalFlowMeasurementReadyForFusion(200000, &testOpticalFlow, &noiseScale));
 }
 
 TEST_F(PositionEstimatorTest, RangefinderPreferFallsBackAndRecovers)

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -33,6 +33,7 @@ bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
 #include "sensors/sensors.h"
 
 bool opticalFlowMeasurementReadyForFusion(timeUs_t nowUs, const opticalflow_t *flow, float *noiseScale);
+bool rangefinderMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
 
 PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
 }
@@ -54,6 +55,9 @@ attitudeEulerAngles_t attitude;
 static uint32_t enabledSensors = 0;
 static bool rfHealthy = false;
 static float rfAltCm = 0.0f;
+static bool rfUseFakeMicrosTimestamp = true;
+static timeUs_t rfSampleTimeUs = 0;
+static timeDelta_t rfSampleIntervalUs = 10000;
 static float baroAltCm = 0.0f;
 static timeUs_t fakeMicros = 0;
 static bool gpsAlwaysHasNewData = true;
@@ -65,6 +69,8 @@ static bool opticalFlowHealthy = true;
 bool sensors(uint32_t mask) { return (enabledSensors & mask) != 0; }
 bool rangefinderIsHealthy(void) { return rfHealthy; }
 int32_t rangefinderGetLatestAltitude(void) { return lrintf(rfAltCm); }
+timeUs_t rangefinderGetLatestSampleTimeUs(void) { return rfUseFakeMicrosTimestamp ? fakeMicros : rfSampleTimeUs; }
+timeDelta_t rangefinderGetSampleIntervalUs(void) { return rfSampleIntervalUs; }
 float getBaroAltitude(void) { return baroAltCm; }
 
 timeUs_t micros(void) { return fakeMicros; }
@@ -121,6 +127,9 @@ protected:
         enabledSensors = SENSOR_GPS | SENSOR_BARO | SENSOR_RANGEFINDER;
         rfHealthy = true;
         rfAltCm = 100.0f;
+        rfUseFakeMicrosTimestamp = true;
+        rfSampleTimeUs = 0;
+        rfSampleIntervalUs = 10000;
         baroAltCm = 100.0f;
         gpsSol.llh.altCm = 100.0f;
         gpsSol.dop.pdop = 100; // pDOP 1.0
@@ -218,6 +227,39 @@ TEST_F(PositionEstimatorTest, OpticalFlowUpsamplingTracksMeasuredSampleRate)
     EXPECT_FLOAT_EQ(noiseScale, 4.0f);
     EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(190000, &testOpticalFlow, &noiseScale));
     EXPECT_FALSE(opticalFlowMeasurementReadyForFusion(200000, &testOpticalFlow, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, RangefinderMeasurementsUseMeasuredDataRate)
+{
+    rfUseFakeMicrosTimestamp = false;
+    rfSampleTimeUs = 100000;
+    rfSampleIntervalUs = 20000; // UP-T1 frames are 50 Hz despite 100 Hz polling.
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(rangefinderMeasurementReadyForFusion(100000, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 2.0f);
+
+    // Reuse the 50 Hz sample on the intervening 100 Hz estimator call.
+    EXPECT_TRUE(rangefinderMeasurementReadyForFusion(110000, &noiseScale));
+    EXPECT_FALSE(rangefinderMeasurementReadyForFusion(120000, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, RangefinderUpsamplingTracksSourceInterval)
+{
+    rfUseFakeMicrosTimestamp = false;
+    rfSampleTimeUs = 100000;
+    rfSampleIntervalUs = 100000; // e.g. a 10 Hz HC-SR04.
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(rangefinderMeasurementReadyForFusion(100000, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 10.0f);
+    EXPECT_TRUE(rangefinderMeasurementReadyForFusion(190000, &noiseScale));
+    EXPECT_FALSE(rangefinderMeasurementReadyForFusion(200000, &noiseScale));
+
+    rfSampleTimeUs = 200000;
+    EXPECT_TRUE(rangefinderMeasurementReadyForFusion(200000, &noiseScale));
 }
 
 TEST_F(PositionEstimatorTest, RangefinderPreferFallsBackAndRecovers)

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -34,6 +34,7 @@ bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
 
 bool opticalFlowMeasurementReadyForFusion(timeUs_t nowUs, const opticalflow_t *flow, float *noiseScale);
 bool rangefinderMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
+bool baroMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
 
 PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
 }
@@ -59,6 +60,9 @@ static bool rfUseFakeMicrosTimestamp = true;
 static timeUs_t rfSampleTimeUs = 0;
 static timeDelta_t rfSampleIntervalUs = 10000;
 static float baroAltCm = 0.0f;
+static bool baroUseFakeMicrosTimestamp = true;
+static timeUs_t baroSampleTimeUs = 0;
+static timeDelta_t baroSampleIntervalUs = 10000;
 static timeUs_t fakeMicros = 0;
 static bool gpsAlwaysHasNewData = true;
 static bool gpsDataIsNew = false;
@@ -72,6 +76,8 @@ int32_t rangefinderGetLatestAltitude(void) { return lrintf(rfAltCm); }
 timeUs_t rangefinderGetLatestSampleTimeUs(void) { return rfUseFakeMicrosTimestamp ? fakeMicros : rfSampleTimeUs; }
 timeDelta_t rangefinderGetSampleIntervalUs(void) { return rfSampleIntervalUs; }
 float getBaroAltitude(void) { return baroAltCm; }
+timeUs_t getBaroLatestSampleTimeUs(void) { return baroUseFakeMicrosTimestamp ? fakeMicros : baroSampleTimeUs; }
+timeDelta_t getBaroSampleIntervalUs(void) { return baroSampleIntervalUs; }
 
 timeUs_t micros(void) { return fakeMicros; }
 
@@ -131,6 +137,9 @@ protected:
         rfSampleTimeUs = 0;
         rfSampleIntervalUs = 10000;
         baroAltCm = 100.0f;
+        baroUseFakeMicrosTimestamp = true;
+        baroSampleTimeUs = 0;
+        baroSampleIntervalUs = 10000;
         gpsSol.llh.altCm = 100.0f;
         gpsSol.dop.pdop = 100; // pDOP 1.0
 
@@ -260,6 +269,38 @@ TEST_F(PositionEstimatorTest, RangefinderUpsamplingTracksSourceInterval)
 
     rfSampleTimeUs = 200000;
     EXPECT_TRUE(rangefinderMeasurementReadyForFusion(200000, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, BarometerMeasurementsUseCompletedSampleRate)
+{
+    baroUseFakeMicrosTimestamp = false;
+    baroSampleTimeUs = 100000;
+    baroSampleIntervalUs = 25000; // Default barometer rate is 40 Hz.
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(baroMeasurementReadyForFusion(100000, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 2.5f);
+    EXPECT_TRUE(baroMeasurementReadyForFusion(110000, &noiseScale));
+    EXPECT_TRUE(baroMeasurementReadyForFusion(120000, &noiseScale));
+    EXPECT_FALSE(baroMeasurementReadyForFusion(130000, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, BarometerUpsamplingTracksSlowerTargetRate)
+{
+    baroUseFakeMicrosTimestamp = false;
+    baroSampleTimeUs = 100000;
+    baroSampleIntervalUs = 50000; // Some targets configure barometers at 20 Hz.
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(baroMeasurementReadyForFusion(100000, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 5.0f);
+    EXPECT_TRUE(baroMeasurementReadyForFusion(140000, &noiseScale));
+    EXPECT_FALSE(baroMeasurementReadyForFusion(150000, &noiseScale));
+
+    baroSampleTimeUs = 150000;
+    EXPECT_TRUE(baroMeasurementReadyForFusion(150000, &noiseScale));
 }
 
 TEST_F(PositionEstimatorTest, RangefinderPreferFallsBackAndRecovers)


### PR DESCRIPTION
Huge THANK YOU to @SteveCEvans for the upsampling improvements!

This PR is for evaluation only at the moment. It flies REALLY WELL and has been solidly tested, but it's for experienced pilots only at this point. GPS Rescue still works if you make a mess of things.

Changes:
- Stronger feedforward implementation.

Feedforward acts as the 'driver' or 'target velocity' setting that pushes velocity forwards. It includes an offset component that is proportional to  targetVelocity. The gain factor for this is the kD factor, exactly the same as that for D, so that one opposes the other. This is the same as D from error. However the user can change the D value while stationary without changing stick feel, because  in addition there is a true 'feedforward' element,  that has an offset component from stick position and uses classic feedfoward settings,  for stick inputs. For nav modes the feedforward elements are derived from the target velocity and the rate of change of target velocity. Because FF gets noisy, and to retain the area under the curve of the FF spikes , feedforward is included in the PT3  output smoothing.
- drag compensation is not user-adjustable but is a positive feedback proportional to velocity. The gain factor for this must be well below the D gain factor for obvious reasonsIt won't be hard to make this a bit user-adjustable for craft like whoops with more drag but that's not done yet.
- the acceleration factor is now a bit less noisy because of Steve's improvements but it is also included in the PT3 output filter. That does lag it a bit, but not so much that it becomes unusable.
- stick control is now purely velocity targeting, with a 'virtual' distance error' derived from integrated velocity error. This works OK without requiring complicated attenuations, at least with typical control inputs.
- the user-facing maxVelocity setting is now honored while using stick control. The default is a max speed of 5 m/s. Any higher makes center stick sensitivity more twitchy than is nice for close quarter flying. For indoor use a max speed of 3-4m/s is plenty. The stick feel comes from setpoint; you get maxVelocity at full stick travel, and a fraction of that according to stick deflection and rates.
- A lot of fussing around in the code handles what happens when sticks first move, and when they stop. Some of this may be simplified.
- in pid.c there is a final smoothing filter for all angle modes that was set at 50Hz. I've reduced this to 20Hz to better remove the 100Hz stepping from autopilot  requested angle.
- the legacy velocity PIDs for Nav mode are gone, from the refactoring. Instead of Velocity_P, use ap_position_D, for velocity_I  use ap_position_P, and for velocity_D, use ap_position_A.
- the exiting Nav code unit tests are all broken now, and probably others. What we do there depends on how we intend to progress the implentation of Nav modes. Sticks active in position hold  is now basically the same velocity control mode as in VelocityMode for Nav solutions; this I am confident can be simplified very effectively since they do the same things.
- I hoped to remove the D boost in braking mode but we simply must have high D to stop from higher velocity. At this point I don't know for sure  if we can tolerate much higher D at high velocity more readily than higher D at rest.  If higher D at higher velocity is benign then we can just make the D scaling nonlinear and boost it whenever velocity is high, rather than boosting it only while stopping. It is annoying to boost it when stopping only because this causes steps in D at the start and end of the braking phase, and these are ugly. This requires further testing. One solution is to boost only when braking and to ease it in. At present the D value is doubled when stopping from 20m/s but not much for lower speeds, eg only 5% at 1m/s.
Filters and default gains have been carefully worked over and are nice for a normal 5in freestyle machine. Most gains can go to 40 or 50 without issues. Lower gains make for smoother flight but if too low the position hold gets loose. if you explicitly want a more aggressive stick feel, increase the autopilot F parameter or increase max velocity.

Pilots who are trying purely optical builds may be able to push the ap_position_cutoff up from the default of 30 (3Hz) to say 50 (5Hz) or maybe higher, because they won't have to worry so much about GPS steps. This may improve position hold stability by reducing lag in the acceleration signal, but may also cause stick feel to become too twitchy and jerky. I strongly suggest leaving it at default until you get curious.

On my testing, position hold is now very good good, in still air I get 10-15cm  or less of typical movement once  the GPS has fully stabilised and is no longer adding more satellites.  In gusty conditions the higher the PIDs are, the more stable it will be, probably up to about 50, but it's tough to stay rock solid in those kinds of conditions and if the PIDs are in the 50's you'll see it twitching all the time from tiny GPS data step changes.I recommend not worrying so much about absolute precision of the hold and run relaxed (default) PIDs.

Altitude control isn't so good and needs more work but that's for a different PR.

I absolutely strongly recommend that you put a Mag on any build for which positionHold etc is to be used. A small mag module can be mounted in the centre of the quad above the FC very easily.  You won't regret it. It can work perfectly well without a mag, but you should always power the quad up with the nose facing North, and you must take off and fly straight and fast to calibrate the IMU to the GPS course over ground.  It's far better with a Mag, just take off and lock it in position as soon as you're up :-)

Position Hold  does work with optical flow sensors ( with or without a mag). 

This all works thanks to the awesome improvements in sensor calibration from @SteveCEvans SteveCEvans :-) 

Sorry that there are so many changes in one PR. Looking forward to reviews and suggestions, but fixing the unit tests is a bit tough for me, so please lets focus on the content and leave them until the Nav integration is sorted out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Position estimation now fuses measurements based on per-sensor freshness and expected cadence, including noise scaling.
  * Added barometer and rangefinder sample-timing telemetry.
* **Improvements**
  * Rangefinder TF data is now consumed once per fresh frame; distance reads report “no new data” until updated.
  * Multirotor XY control updated for more consistent braking/response.
  * Lowered attitude filter cutoff frequency.
* **Configuration**
  * Reduced position-control cutoff maximum (to 50).
  * Reduced default max velocity (to 5 m/s) and removed configurable velocity-loop gain settings.
* **Tests**
  * Expanded unit tests for sensor fusion readiness/gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->