### PR TITLE
[2025.12] fix: sound the RX_LOST beeper and beacon after a USB session

### DIFF
--- a/src/main/drivers/serial_usb_vcp.h
+++ b/src/main/drivers/serial_usb_vcp.h
@@ -36,4 +36,9 @@ void usbVcpInit(void);
 serialPort_t *usbVcpOpen(void);
 struct serialPort_s;
 uint32_t usbVcpGetBaudRate(struct serialPort_s *instance);
+// Has the device been enumerated since boot. Latches: without VBUS sensing there is no
+// disconnect event, so this does not clear when the cable is pulled.
 uint8_t usbVcpIsConnected(void);
+
+// Is the host driving the link right now. Clears on unplug or host suspend.
+uint8_t usbVcpIsActive(void);

--- a/src/main/drivers/usb_io.c
+++ b/src/main/drivers/usb_io.c
@@ -70,6 +70,24 @@ bool usbCableIsInserted(void)
     return result;
 }
 
+bool usbCableIsActive(void)
+{
+    bool result = false;
+
+#ifdef USE_USB_DETECT
+    // a detect pin tracks the cable directly, so it needs no separate live check
+    if (usbDetectPin) {
+        result = IORead(usbDetectPin) != 0;
+    }
+#endif
+
+#if defined(USE_VCP)
+    result = result || usbVcpIsActive() != 0;
+#endif
+
+    return result;
+}
+
 void usbGenerateDisconnectPulse(void)
 {
 #ifdef USB_DP_PIN

--- a/src/main/drivers/usb_io.h
+++ b/src/main/drivers/usb_io.h
@@ -24,4 +24,9 @@ void usbGenerateDisconnectPulse(void);
 
 void usbCableDetectDeinit(void);
 void usbCableDetectInit(void);
+// Has USB been connected since boot. Without a USB detect pin this latches: it cannot see the
+// cable being pulled, so it stays true for the rest of the session.
 bool usbCableIsInserted(void);
+
+// Is USB connected right now. Clears on unplug, so use this for anything decided repeatedly.
+bool usbCableIsActive(void);

--- a/src/main/flight/failsafe.c
+++ b/src/main/flight/failsafe.c
@@ -248,8 +248,10 @@ FAST_CODE_NOINLINE void failsafeUpdateState(void)
         receivingRxData = false;
     }
 
-    // Beep RX lost whenever no RC data is received and the USB cable is not connected
-    if (!receivingRxData && !usbCableIsInserted()) {
+    // Beep RX lost whenever no RC data is received and the USB cable is not connected.
+    // Not usbCableIsInserted(): it latches, so after one bench session the RX_LOST beep and
+    // the DShot beacon below would stay suppressed for the rest of the flight.
+    if (!receivingRxData && !usbCableIsActive()) {
         beeperMode = BEEPER_RX_LOST;
     }
 

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -430,7 +430,7 @@ void beeperUpdate(timeUs_t currentTimeUs)
 
     if (!areMotorsRunning()) {
         const beeperMode_e activeMode = currentBeeperEntry ? currentBeeperEntry->mode : BEEPER_SILENCE;
-        const bool usbIn = usbCableIsInserted();
+        const bool usbIn = usbCableIsActive();
 
         // Drive the ESC beacon whenever the beeper has entered the RX_LOST sequence.
         if (activeMode == BEEPER_RX_LOST

--- a/src/platform/APM32/usb/vcp/serial_usb_vcp.c
+++ b/src/platform/APM32/usb/vcp/serial_usb_vcp.c
@@ -235,6 +235,11 @@ uint8_t usbVcpIsConnected(void)
     return usbIsConnected();
 }
 
+uint8_t usbVcpIsActive(void)
+{
+    return usbIsConnected() && usbIsConfigured();
+}
+
 /**
  * @brief   USB device user handler
  *

--- a/src/platform/AT32/serial_usb_vcp_at32f4.c
+++ b/src/platform/AT32/serial_usb_vcp_at32f4.c
@@ -324,6 +324,11 @@ uint8_t usbVcpIsConnected(void)
     return usbIsConnected();
 }
 
+uint8_t usbVcpIsActive(void)
+{
+    return usbIsConnected() && usbIsConfigured();
+}
+
 void OTG_IRQ_HANDLER(void)
 {
     usbd_irq_handler(&otg_core_struct);

--- a/src/platform/PICO/serial_usb_vcp_pico.c
+++ b/src/platform/PICO/serial_usb_vcp_pico.c
@@ -208,4 +208,10 @@ uint8_t usbVcpIsConnected(void)
     return cdc_usb_connected();
 }
 
+uint8_t usbVcpIsActive(void)
+{
+    // tud_cdc_connected() already requires mounted and not suspended, so it never latches
+    return cdc_usb_connected();
+}
+
 #endif // USE_VCP

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -784,6 +784,11 @@ bool usbCableIsInserted(void)
     return false;
 }
 
+bool usbCableIsActive(void)
+{
+    return false;
+}
+
 const mcuTypeInfo_t *getMcuTypeInfo(void)
 {
     static const mcuTypeInfo_t info = { .id = MCU_TYPE_SIMULATOR, .name = "SIMULATOR" };

--- a/src/platform/STM32/serial_usb_vcp.c
+++ b/src/platform/STM32/serial_usb_vcp.c
@@ -290,4 +290,12 @@ uint8_t usbVcpIsConnected(void)
 {
     return usbIsConnected();
 }
+
+uint8_t usbVcpIsActive(void)
+{
+    // Unplugging stops the SOFs, which suspends the device out of USBD_STATE_CONFIGURED.
+    // usbIsConnected() alone cannot see this: without VBUS sensing there is no disconnect
+    // interrupt, so the state never returns to USBD_STATE_DEFAULT.
+    return usbIsConnected() && usbIsConfigured();
+}
 #endif

--- a/src/test/unit/flight_failsafe_unittest.cc
+++ b/src/test/unit/flight_failsafe_unittest.cc
@@ -774,4 +774,9 @@ bool usbCableIsInserted(void)
 {
     return false;
 }
+
+bool usbCableIsActive(void)
+{
+    return false;
+}
 }


### PR DESCRIPTION
Fixes #15473

## Problem

The reporter has both DShot beacon conditions enabled, but only `RX_SET` sounds — `RX_LOST` is silent. That asymmetry is real and is in our code.

On 2025.12.x both RX_LOST paths are gated on the USB cable being absent, while the RX_SET beacon has no USB gate at all:

- `src/main/flight/failsafe.c` — `if (!receivingRxData && !usbCableIsInserted())` sets `BEEPER_RX_LOST`
- `src/main/io/beeper.c` — `activeMode == BEEPER_RX_LOST && !usbIn` requests the beacon

`usbCableIsInserted()` latches true for the rest of the boot session on any target without a USB detect pin (the reporter's board: `resource USB_DETECT 1 NONE`). OTG_FS is initialised with `vbus_sensing_enable = 0`, so pulling the cable raises no session-end interrupt, `HAL_PCD_DisconnectCallback()` never runs, and the device state never returns to `USBD_STATE_DEFAULT` — unplugging only *suspends* the device, which `usbIsConnected()` (`!= USBD_STATE_DEFAULT`) still reports as connected.

So the normal workflow — configure over USB, unplug, test on battery — never clears the latch, because the battery keeps the FC powered and nothing reboots it. RX_LOST stays suppressed for that whole session while RX_SET keeps working, which is exactly what was reported.

## Change

Add `usbVcpIsActive()` / `usbCableIsActive()`, which additionally require the configured state. That *does* clear on unplug, because the resulting loss of SOFs suspends the device out of `USBD_STATE_CONFIGURED`. Use it for the two RX_LOST gates.

`usbCableIsInserted()` itself is untouched, so nothing else changes behaviour. Suppression while USB is genuinely connected is unchanged.

## Why not backport #14869

master replaced this check with `mspSerialIsConfiguratorActive()`, but 2025.12 has no MSP activity tracking at all — that would mean importing `lastActivityMs` plumbing plus the `FUNCTION_VTX_MSP` exclusion into a stable release. This patch fixes the same root cause without new machinery. The equivalent master change is #15477.

## Testing

Full unit test suite passes (`flight_failsafe_unittest` needed a stub for the new function). 2025.12 has no beeper unit test to extend; the master PR carries the regression tests. Per-MCU compilation was not verified locally (no ARM toolchain on this machine) — each new body only calls `usbIsConfigured()`, which is already called a few lines above in the same file, so CI target builds should settle it.

## Confirmation still wanted from the reporter

The mechanism is proven from the code, but that USB had been connected during their specific test is inference from the support dump rather than something they stated. Worth asking them for a `set debug_mode = USB` trace after unplugging — `DEBUG_USB[0]` is `usbCableIsInserted()` and would show the stale `1` directly. Also note their config has `beeper -RX_LOST`, so the piezo will never sound for them regardless; only the ESC beacon can.
