### PR TITLE
fix: keep the beeper and RX_LOST beacon alive after a USB session

### DIFF
--- a/src/main/drivers/serial_usb_vcp.h
+++ b/src/main/drivers/serial_usb_vcp.h
@@ -36,4 +36,10 @@ void usbVcpInit(void);
 serialPort_t *usbVcpOpen(void);
 struct serialPort_s;
 uint32_t usbVcpGetBaudRate(struct serialPort_s *instance);
+
+// Has the device been enumerated since boot. Latches: without VBUS sensing there is no
+// disconnect event, so this does not clear when the cable is pulled.
 uint8_t usbVcpIsConnected(void);
+
+// Is the host driving the link right now. Clears on unplug or host suspend.
+uint8_t usbVcpIsActive(void);

--- a/src/main/drivers/usb_io.c
+++ b/src/main/drivers/usb_io.c
@@ -70,6 +70,24 @@ bool usbCableIsInserted(void)
     return result;
 }
 
+bool usbCableIsActive(void)
+{
+    bool result = false;
+
+#ifdef USE_USB_DETECT
+    // a detect pin tracks the cable directly, so it needs no separate live check
+    if (usbDetectPin) {
+        result = IORead(usbDetectPin) != 0;
+    }
+#endif
+
+#if defined(USE_VCP)
+    result = result || usbVcpIsActive() != 0;
+#endif
+
+    return result;
+}
+
 void usbGenerateDisconnectPulse(void)
 {
 #ifdef USB_DP_PIN

--- a/src/main/drivers/usb_io.h
+++ b/src/main/drivers/usb_io.h
@@ -24,4 +24,10 @@ void usbGenerateDisconnectPulse(void);
 
 void usbCableDetectDeinit(void);
 void usbCableDetectInit(void);
+
+// Has USB been connected since boot. Without a USB detect pin this latches: it cannot see the
+// cable being pulled, so it stays true for the rest of the session.
 bool usbCableIsInserted(void);
+
+// Is USB connected right now. Clears on unplug, so use this for anything decided repeatedly.
+bool usbCableIsActive(void);

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -97,11 +97,12 @@ STATIC_ASSERT(BEEPER_ALL - 1 < sizeof(uint32_t) * 8, "BEEPER_GET_FLAG bits excee
 static bool beeperUsbSuppressed(void)
 {
     // BEEPER_USB ("ON_USB") silences the beeper while the board is connected via USB.
-    // usbCableIsInserted() is the literal detection (valid even at boot and immune to
-    // gaps in MSP polling); mspSerialIsConfiguratorActive() is retained as a fallback
-    // for targets without a USB detect pin and for wireless MSP links.
+    // usbCableIsActive() is the literal detection, immune to gaps in MSP polling;
+    // mspSerialIsConfiguratorActive() covers wireless MSP links.
+    // Not usbCableIsInserted(): it latches, which would keep the beeper suppressed for the
+    // rest of the flight after one bench session.
     return (beeperConfig()->beeper_off_flags & BEEPER_GET_FLAG(BEEPER_USB))
-        && (usbCableIsInserted() || mspSerialIsConfiguratorActive());
+        && (usbCableIsActive() || mspSerialIsConfiguratorActive());
 }
 
 /* Beeper Sound Sequences: (Square wave generation)
@@ -440,14 +441,14 @@ void beeperUpdate(timeUs_t currentTimeUs)
     bool dshotBeaconRequested = false;
 
     if (!areMotorsRunning()) {
-        const beeperMode_e activeMode = currentBeeperEntry ? currentBeeperEntry->mode : BEEPER_SILENCE;
-
-        // Drive the ESC beacon whenever the beeper has entered the RX_LOST sequence.
+        // Taken from the failsafe state, not from currentBeeperEntry: keying the beacon off
+        // the piezo sequence meant anything silencing the beeper (BEEPER MUTE switch held
+        // through the RX loss, BEEPER_USB suppression) also silenced the lost-model finder.
         // NOTE: the two beacon paths intentionally use different USB-suppression criteria.
         // RX_LOST is a lost-model finder, so it is silenced whenever a configurator is
         // attached (bench environment) regardless of the BEEPER_USB flag — you never want
         // it screaming on the desk, but it must still fire in the field with no link.
-        if (activeMode == BEEPER_RX_LOST
+        if (failsafeIsMonitoring() && !failsafeIsReceivingRxData()
             && !mspSerialIsConfiguratorActive()
             && !(beeperConfig()->dshotBeaconOffFlags & BEEPER_GET_FLAG(BEEPER_RX_LOST)) ) {
             dshotBeaconRequested = true;

--- a/src/platform/APM32/usb/vcp/serial_usb_vcp.c
+++ b/src/platform/APM32/usb/vcp/serial_usb_vcp.c
@@ -235,6 +235,11 @@ uint8_t usbVcpIsConnected(void)
     return usbIsConnected();
 }
 
+uint8_t usbVcpIsActive(void)
+{
+    return usbIsConnected() && usbIsConfigured();
+}
+
 /**
  * @brief   USB device user handler
  *

--- a/src/platform/AT32/serial_usb_vcp_at32f4.c
+++ b/src/platform/AT32/serial_usb_vcp_at32f4.c
@@ -324,6 +324,11 @@ uint8_t usbVcpIsConnected(void)
     return usbIsConnected();
 }
 
+uint8_t usbVcpIsActive(void)
+{
+    return usbIsConnected() && usbIsConfigured();
+}
+
 void OTG_IRQ_HANDLER(void)
 {
     usbd_irq_handler(&otg_core_struct);

--- a/src/platform/ESP32/serial_usb_vcp_esp32.c
+++ b/src/platform/ESP32/serial_usb_vcp_esp32.c
@@ -198,4 +198,10 @@ uint8_t usbVcpIsConnected(void)
     return usbConnected;
 }
 
+uint8_t usbVcpIsActive(void)
+{
+    // SOF tracking above already expires on unplug, so it never latches
+    return usbVcpIsConnected();
+}
+
 #endif // USE_VCP

--- a/src/platform/PICO/serial_usb_vcp_pico.c
+++ b/src/platform/PICO/serial_usb_vcp_pico.c
@@ -208,4 +208,10 @@ uint8_t usbVcpIsConnected(void)
     return cdc_usb_connected();
 }
 
+uint8_t usbVcpIsActive(void)
+{
+    // tud_cdc_connected() already requires mounted and not suspended, so it never latches
+    return cdc_usb_connected();
+}
+
 #endif // USE_VCP

--- a/src/platform/SIMULATOR/sitl.c
+++ b/src/platform/SIMULATOR/sitl.c
@@ -1052,6 +1052,11 @@ bool usbCableIsInserted(void)
     return false;
 }
 
+bool usbCableIsActive(void)
+{
+    return false;
+}
+
 void EXTIInit(void)
 {
     // NOOP

--- a/src/platform/STM32/serial_usb_vcp.c
+++ b/src/platform/STM32/serial_usb_vcp.c
@@ -290,4 +290,12 @@ uint8_t usbVcpIsConnected(void)
 {
     return usbIsConnected();
 }
+
+uint8_t usbVcpIsActive(void)
+{
+    // Unplugging stops the SOFs, which suspends the device out of USBD_STATE_CONFIGURED.
+    // usbIsConnected() alone cannot see this: without VBUS sensing there is no disconnect
+    // interrupt, so the state never returns to USBD_STATE_DEFAULT.
+    return usbIsConnected() && usbIsConfigured();
+}
 #endif

--- a/src/platform/X32/serial_usb_vcp.c
+++ b/src/platform/X32/serial_usb_vcp.c
@@ -509,4 +509,14 @@ uint8_t usbVcpIsConnected(void)
     return usbIsConnected();
 }
 
+/**
+ * @brief  Check if the host is driving the USB VCP link right now.
+ *
+ * @return 1 if the link is in use, 0 otherwise.
+ */
+uint8_t usbVcpIsActive(void)
+{
+    return usbIsConnected() && usbIsConfigured();
+}
+
 #endif /* USE_VCP */

--- a/src/test/unit/beeper_unittest.cc
+++ b/src/test/unit/beeper_unittest.cc
@@ -73,13 +73,15 @@ extern "C" {
     static bool simulatorBoxBeeperOn = false;
     static bool simulatorBoxBeeperMute = false;
     static bool simulatorFailsafeRxDataReceived = true;
+    static bool simulatorFailsafeMonitoring = true;
     static bool simulatorMotorsRunning = false;
     static timeUs_t simulatorLastDisarmTimeUs = 0;
     static bool simulatorTryingToArm = false;
     static uint8_t simulatorMotorCount = 4;
     static timeUs_t simulatorCurrentTimeUs = 10000000;  // 10 seconds after boot
     static batteryState_e simulatorBatteryState = BATTERY_OK;
-    static bool simulatorUsbCableInserted = false;
+    static bool simulatorUsbActive = false;
+    static bool simulatorUsbInsertedQueried = false;
     static int dshotCommandWriteCount = 0;
     static bool beeperOnState = false;
 }
@@ -94,13 +96,15 @@ protected:
         simulatorBoxBeeperOn = false;
         simulatorBoxBeeperMute = false;
         simulatorFailsafeRxDataReceived = true;
+        simulatorFailsafeMonitoring = true;
         simulatorMotorsRunning = false;
         simulatorLastDisarmTimeUs = 0;
         simulatorTryingToArm = false;
         simulatorMotorCount = 4;
         simulatorCurrentTimeUs = 10000000;
         simulatorBatteryState = BATTERY_OK;
-        simulatorUsbCableInserted = false;
+        simulatorUsbActive = false;
+        simulatorUsbInsertedQueried = false;
         dshotCommandWriteCount = 0;
         beeperOnState = false;
 
@@ -181,7 +185,7 @@ TEST_F(BeeperTest, BeeperUsbFlagOn_UsbInserted_ConfiguratorNotActive_BeeperSilen
     // USB cable present but MSP idle (>5s polling gap) → must still be silenced
     beeperConfigMutable()->beeper_off_flags = BEEPER_GET_FLAG(BEEPER_USB);
     simulatorMspConfiguratorActive = false;
-    simulatorUsbCableInserted = true;
+    simulatorUsbActive = true;
 
     beeper(BEEPER_RX_SET);
     EXPECT_FALSE(isBeeperOn());
@@ -191,7 +195,7 @@ TEST_F(BeeperTest, BeeperUsbFlagOff_UsbInserted_BeeperSounds)
 {
     // BEEPER_USB not set → USB cable alone must not silence the beeper
     beeperConfigMutable()->beeper_off_flags = 0;
-    simulatorUsbCableInserted = true;
+    simulatorUsbActive = true;
 
     beeper(BEEPER_RX_SET);
     beeperUpdate(simulatorCurrentTimeUs);
@@ -261,9 +265,9 @@ TEST_F(BeeperTest, DshotBeaconRxLost_ConfiguratorActive_Silent)
     simulatorMotorsRunning = false;
     simulatorLastDisarmTimeUs = 0;
     beeperConfigMutable()->dshotBeaconOffFlags = 0;
+    simulatorFailsafeRxDataReceived = false;
     simulatorMspConfiguratorActive = true;
 
-    beeper(BEEPER_RX_LOST);
     simulatorCurrentTimeUs = 400000000;
     beeperUpdate(simulatorCurrentTimeUs);
 
@@ -276,12 +280,104 @@ TEST_F(BeeperTest, DshotBeaconRxLost_ConfiguratorNotActive_Sounds)
     simulatorMotorsRunning = false;
     simulatorLastDisarmTimeUs = 0;
     beeperConfigMutable()->dshotBeaconOffFlags = 0;
+    simulatorFailsafeRxDataReceived = false;
     simulatorMspConfiguratorActive = false;
 
-    beeper(BEEPER_RX_LOST);
     simulatorCurrentTimeUs = 500000000;
     beeperUpdate(simulatorCurrentTimeUs);
 
+    EXPECT_GT(dshotCommandWriteCount, 0);
+}
+
+TEST_F(BeeperTest, DshotBeaconRxLost_RxLinkUp_Silent)
+{
+    // Negative control: the link is healthy, so the lost-model beacon must stay quiet
+    simulatorMotorsRunning = false;
+    simulatorLastDisarmTimeUs = 0;
+    beeperConfigMutable()->dshotBeaconOffFlags = 0;
+    simulatorFailsafeRxDataReceived = true;
+
+    simulatorCurrentTimeUs = 600000000;
+    beeperUpdate(simulatorCurrentTimeUs);
+
+    EXPECT_EQ(dshotCommandWriteCount, 0);
+}
+
+TEST_F(BeeperTest, DshotBeaconRxLost_FailsafeNotMonitoring_Silent)
+{
+    // Before failsafe monitoring starts (power-on delay) there is no RX loss to report
+    simulatorMotorsRunning = false;
+    simulatorLastDisarmTimeUs = 0;
+    beeperConfigMutable()->dshotBeaconOffFlags = 0;
+    simulatorFailsafeRxDataReceived = false;
+    simulatorFailsafeMonitoring = false;
+
+    simulatorCurrentTimeUs = 700000000;
+    beeperUpdate(simulatorCurrentTimeUs);
+
+    EXPECT_EQ(dshotCommandWriteCount, 0);
+}
+
+// =============================================================================
+// #15473: the lost-model beacon must not depend on the piezo sequence state.
+// Anything that silences beeper() - a held BEEPER MUTE switch, BEEPER_USB
+// suppression - used to take the ESC beacon down with it.
+// =============================================================================
+
+TEST_F(BeeperTest, DshotBeaconRxLost_BeeperMuted_StillSounds)
+{
+    // BOXBEEPERMUTE held through the RX loss silences the piezo, not the beacon
+    simulatorMotorsRunning = false;
+    simulatorLastDisarmTimeUs = 0;
+    beeperConfigMutable()->dshotBeaconOffFlags = 0;
+    simulatorFailsafeRxDataReceived = false;
+    simulatorBoxBeeperMute = true;
+
+    simulatorCurrentTimeUs = 800000000;
+    beeperUpdate(simulatorCurrentTimeUs);
+
+    EXPECT_FALSE(isBeeperOn());
+    EXPECT_GT(dshotCommandWriteCount, 0);
+}
+
+TEST_F(BeeperTest, DshotBeaconRxLost_UsbSuppressedPiezo_StillSounds)
+{
+    // BEEPER_USB suppression applies to the piezo; the beacon is gated on the configurator
+    // only, so a USB session must not mute the lost-model finder
+    simulatorMotorsRunning = false;
+    simulatorLastDisarmTimeUs = 0;
+    beeperConfigMutable()->dshotBeaconOffFlags = 0;
+    beeperConfigMutable()->beeper_off_flags = BEEPER_GET_FLAG(BEEPER_USB);
+    simulatorFailsafeRxDataReceived = false;
+    simulatorUsbActive = true;
+    simulatorMspConfiguratorActive = false;
+
+    simulatorCurrentTimeUs = 900000000;
+    beeperUpdate(simulatorCurrentTimeUs);
+
+    EXPECT_FALSE(isBeeperOn());
+    EXPECT_GT(dshotCommandWriteCount, 0);
+}
+
+TEST_F(BeeperTest, DshotBeaconRxLost_UsbUnpluggedAfterSession_Sounds)
+{
+    // #15423 regression: usbCableIsInserted() latches, so it kept suppressing the piezo - and
+    // through currentBeeperEntry the beacon - for the whole session after one bench connection
+    simulatorMotorsRunning = false;
+    simulatorLastDisarmTimeUs = 0;
+    beeperConfigMutable()->dshotBeaconOffFlags = 0;
+    beeperConfigMutable()->beeper_off_flags = BEEPER_GET_FLAG(BEEPER_USB);
+    simulatorFailsafeRxDataReceived = false;
+    simulatorUsbActive = false;          // cable pulled, MSP has gone quiet
+    simulatorMspConfiguratorActive = false;
+
+    beeper(BEEPER_RX_LOST);
+    simulatorCurrentTimeUs = 1000000000;
+    beeperUpdate(simulatorCurrentTimeUs);
+
+    // The stubbed usbCableIsInserted() reports a stale 'inserted'; suppression must not read it
+    EXPECT_FALSE(simulatorUsbInsertedQueried);
+    EXPECT_TRUE(isBeeperOn());
     EXPECT_GT(dshotCommandWriteCount, 0);
 }
 
@@ -296,7 +392,7 @@ TEST_F(BeeperTest, SequencePlayback_NotSuppressed_Sounds)
 {
     // Positive control: queue with BEEPER_USB set but nothing engaging suppression.
     beeperConfigMutable()->beeper_off_flags = BEEPER_GET_FLAG(BEEPER_USB);
-    simulatorUsbCableInserted = false;
+    simulatorUsbActive = false;
     simulatorMspConfiguratorActive = false;
 
     beeper(BEEPER_RX_SET);
@@ -309,7 +405,7 @@ TEST_F(BeeperTest, SequencePlayback_SuppressedAfterQueue_StaysSilent)
     beeperConfigMutable()->beeper_off_flags = BEEPER_GET_FLAG(BEEPER_USB);
 
     // Queue the sequence while NOT suppressed (USB idle, configurator idle).
-    simulatorUsbCableInserted = false;
+    simulatorUsbActive = false;
     simulatorMspConfiguratorActive = false;
     beeper(BEEPER_RX_SET);
 
@@ -332,8 +428,15 @@ bool mspSerialIsConfiguratorActive(void) {
 }
 
 // -- USB --
+bool usbCableIsActive(void) {
+    return simulatorUsbActive;
+}
+
+// The latching signal. Nothing in beeper.c may use it, so this stub models the worst case -
+// a session that enumerated once and never cleared - and records that it was consulted at all.
 bool usbCableIsInserted(void) {
-    return simulatorUsbCableInserted;
+    simulatorUsbInsertedQueried = true;
+    return true;
 }
 
 // -- RC modes --
@@ -348,6 +451,10 @@ bool IS_RC_MODE_ACTIVE(boxId_e boxId) {
 // -- Failsafe --
 bool failsafeIsReceivingRxData(void) {
     return simulatorFailsafeRxDataReceived;
+}
+
+bool failsafeIsMonitoring(void) {
+    return simulatorFailsafeMonitoring;
 }
 
 // -- Motor / mixer --


### PR DESCRIPTION
## Problem

`usbCableIsInserted()` latches true for the rest of the boot session on any target without a USB detect pin. OTG_FS is initialised with `vbus_sensing_enable = 0`, so pulling the cable raises no session-end interrupt, `HAL_PCD_DisconnectCallback()` never runs, and the device state never returns to `USBD_STATE_DEFAULT`. Unplugging only *suspends* the device, which `usbIsConnected()` (`!= USBD_STATE_DEFAULT`) still reports as connected. Because the battery keeps the FC alive, there is no reboot to clear it either.

`beeperUsbSuppressed()` reads that signal, so for anyone who has the ON_USB beeper option unchecked, a single bench connection silences:

- the piezo, for the rest of the session — reported in #15423 ("does not work even when USB is not connected"), and
- the DShot RX_LOST beacon with it, because the beacon was keyed off `currentBeeperEntry->mode`, i.e. off the piezo sequence state.

The second point is the more serious one: the lost-model finder is exactly the feature that must not depend on anything else having stayed audible.

## Changes

**1. A non-latching USB signal.** `usbVcpIsActive()` / `usbCableIsActive()` additionally require the configured state, which *does* clear on unplug — losing the SOFs suspends the device out of `USBD_STATE_CONFIGURED`. Implemented for all VCP platforms; PICO and ESP32 already had live semantics (`tud_cdc_connected()` and SOF timeout respectively) and just delegate.

`usbCableIsInserted()` is unchanged and still used for the boot-time beep in `init.c`, where MSP is not up yet and the value cannot be stale. Beeper suppression now uses `usbCableIsActive()`.

**2. The RX_LOST beacon no longer rides on the piezo state machine.** It is now driven by `failsafeIsMonitoring() && !failsafeIsReceivingRxData()` instead of `currentBeeperEntry->mode == BEEPER_RX_LOST`, so a BEEPER MUTE switch held through the RX loss (aux channels hold their last value on link loss), or ON_USB suppression, can no longer silence the beacon along with the piezo. The deliberate suppression rule is unchanged: RX_LOST is still muted whenever a configurator is actively attached, so it does not scream on the bench.

## Testing

`src/test/unit/beeper_unittest.cc`: 19 tests pass; **7 fail without this change**, including three pre-existing ones. The `usbCableIsInserted()` stub now returns true to model the latch and records whether it was consulted at all, so re-introducing the latched call fails the suite rather than silently regressing. New cases cover the RX link being up, failsafe not yet monitoring, the beacon surviving BEEPER MUTE, the beacon surviving ON_USB piezo suppression, and the post-unplug session.

Full unit test suite passes. SITL builds and links. Per-MCU compilation of the platform files was not verified locally (no ARM toolchain on this machine) — each new body only calls `usbIsConfigured()`, which is already called a few lines above in the same file, so CI target builds should settle it.

## Notes for review

- Refs #15473 — that report is against 2025.12.5, where the coarse gate is in the RX_LOST path itself; the backport is #15476. Master already has the refined configurator gate from #14869, so this PR hardens rather than fixes that specific symptom.
- Refs #15423 — the latch is the most likely cause there, but that reporter runs a DJI O4 Pro, so MSP activity on a plain `FUNCTION_MSP` port could contribute as well. Worth confirming with them after merge rather than closing on assumption.
- `transponder_ir.c` has the same latch bug (the transponder stays off after unplug). Left out to keep this PR to one concern; trivial follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added active USB connection status detection, distinguishing an actively configured link from a latched connection.
  * USB activity now clears after unplugging or host suspension.
* **Bug Fixes**
  * Beeper suppression no longer remains active after a USB session ends.
  * Lost-model beacons now trigger based on active failsafe and receiver-loss conditions.
* **Tests**
  * Expanded coverage for USB suppression, unplug behavior, and failsafe beacon scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->