### PR TITLE
fix(spi): re-assert CS when repeating a DMA segment

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -529,6 +529,11 @@ FAST_IRQ_HANDLER void spiIrqHandler(const extDevice_t *dev)
     busDevice_t *bus = dev->bus;
     busSegment_t *nextSegment;
 
+    // Captured before the callback, which rewinds curSegment to repeat a segment on BUS_BUSY. When
+    // the repeated segment is the first of the list that leaves curSegment pointing in front of the
+    // array, so negateCS can no longer be read from it once the callback has run.
+    const bool negateCS = bus->curSegment->negateCS;
+
     if (bus->curSegment->callback) {
         switch(bus->curSegment->callback(dev->callbackArg)) {
         case BUS_BUSY:
@@ -574,8 +579,6 @@ FAST_IRQ_HANDLER void spiIrqHandler(const extDevice_t *dev)
         }
     } else {
         // Do as much processing as possible before asserting CS to avoid violating minimum high time
-        bool negateCS = bus->curSegment->negateCS;
-
         bus->curSegment = nextSegment;
 
         // After the completion of the first segment setup the init structure for the subsequent segment


### PR DESCRIPTION
## Problem

`spiIrqHandler()` repeats a bus segment by decrementing `curSegment` when a segment callback returns `BUS_BUSY`, and then read `negateCS` from the decremented pointer to decide whether to re-assert CS before launching the next transfer:

```c
case BUS_BUSY:
    // Repeat the last DMA segment
    bus->curSegment--;
    ...
} else {
    bool negateCS = bus->curSegment->negateCS;   // <-- segments[-1] when segment 0 repeats
```

`m25p16` enters its page-program, erase and read segment lists at `segments[0]` whenever the chip could be busy, and that first segment is the `READ_STATUS` poll whose callback returns `BUS_BUSY` while WIP is set. So the read lands in front of the array.

Whether the resulting garbage is truthy is a linker-layout accident:

| target | `segments.4` | `segments[-1].negateCS` lands on |
|---|---|---|
| `FOXEERF722V3` | `0x20010004`, `.data` starts `0x20010000` | `0x2000FFFC` — top of DTCM, i.e. the reset stack top, reads non-zero |
| `ARCROBO_C562V1` | `0x20000214`, `.data` starts `0x20000000` | `0x2000020C` — a zero-initialised `.data` neighbour |

Existing targets happen to read non-zero, re-assert CS by accident, and work. Where it reads zero, CS is left deasserted for the repeated status read: MISO returns `0xFF`, WIP looks permanently set, the callback returns `BUS_BUSY` forever, and the caller's `spiWait()` never completes.

The visible symptom is that the board hangs on the **first config save** with `CONFIG_IN_EXTERNAL_FLASH`, from both the CLI and MSP, deterministically. Found while bringing up `ARCROBO_C562V1` (STM32C562, config in a W25Q128 on SPI1). Because the same `&segments[0]`-with-`BUS_BUSY` shape is used by `m25p16_eraseSector()`, `m25p16_eraseCompletely()` and `m25p16_readBytes()` — which build their segment lists on the **stack** — those paths were reading stack garbage for the same reason.

## Fix

Capture `negateCS` from the completed segment before running the callback, so the rewind can no longer affect it.

`BUS_READY` reads the same segment as before and `BUS_ABORT` does not use the value, so only the `BUS_BUSY` repeat changes behaviour. The polled path (`spiProcessSegmentsPolled()`) already handled the repeat correctly and is untouched.

## Testing

- `ARCROBO_C562V1` (STM32C562): saving from CLI and MSP hung 100% of the time before, completes normally after.
- Build-checked `ARCROBO_C562V1` and `FOXEERF722V3`.
- No unit tests cover `bus_spi.c`.

## Note

`m25p16_waitForReady()` is an unbounded `while (!m25p16_isReady(fdevice));`, which is what turned a mis-sequenced status read into a permanent lockup instead of a reported `FAILURE_EXTERNAL_FLASH_WRITE_FAILED`. Left alone here — bounding it risks spurious failures on slow sector erases and deserves its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPI communication reliability when callbacks repeat or rewind DMA segments.
  * Ensured chip-select handling remains consistent during per-segment callback processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->