### PR TITLE
fix: keep MSP_OSD_CONFIG within the DJI V1 wire format

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -94,6 +94,7 @@
 
 #include "io/asyncfatfs/asyncfatfs.h"
 #include "io/beeper.h"
+#include "io/displayport_msp.h"
 #include "io/flashfs.h"
 #include "io/gimbal.h"
 #include "io/gps.h"
@@ -643,10 +644,32 @@ RAM_CODE static void serializeDataflashReadReply(sbuf_t *dst, uint32_t address, 
 #endif // USE_FLASHFS
 
 /*
+ * Returns true when the request arrived on the UART shared between FUNCTION_MSP and
+ * FUNCTION_VTX_MSP, i.e. from an HD VTX rather than from Configurator.
+ *
+ * Replies to that port have to stay within the wire format the oldest MSP-query type OSD
+ * consumers can still parse. The DJI V1 air unit / Caddx Vista renders the OSD itself from
+ * MSP_OSD_CONFIG and silently drops the whole reply - and with it every OSD element - once it
+ * outgrows the Betaflight 4.5 layout. Configurator, on VCP, keeps receiving the full reply.
+ */
+RAM_CODE static bool mspSrcIsVtxPort(mspDescriptor_t srcDesc)
+{
+#ifdef USE_MSP_DISPLAYPORT
+    const serialPortIdentifier_e vtxPort = displayPortMspGetSerial();
+
+    return vtxPort != SERIAL_PORT_NONE && srcDesc == getMspSerialPortDescriptor(vtxPort);
+#else
+    UNUSED(srcDesc);
+
+    return false;
+#endif
+}
+
+/*
  * Returns true if the command was processd, false otherwise.
  * May set mspPostProcessFunc to a function to be called once the command has been processed
  */
-RAM_CODE static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn)
+RAM_CODE static bool mspCommonProcessOutCommand(mspDescriptor_t srcDesc, int16_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn)
 {
     UNUSED(mspPostProcessFn);
 
@@ -665,7 +688,10 @@ RAM_CODE static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, msp
         sbufWriteU8(dst, (uint8_t)(FC_VERSION_YEAR - FC_CALVER_BASE_YEAR)); // year since 2000
         sbufWriteU8(dst, FC_VERSION_MONTH);
         sbufWriteU8(dst, FC_VERSION_PATCH_LEVEL);
-        sbufWritePString(dst, FC_VERSION_STRING);
+        if (!mspSrcIsVtxPort(srcDesc)) {
+            // this reply was 3 bytes up to and including API 1.46; keep that shape for HD VTXs
+            sbufWritePString(dst, FC_VERSION_STRING);
+        }
         break;
 
     case MSP2_MCU_INFO: {
@@ -978,6 +1004,10 @@ RAM_CODE static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, msp
 #define OSD_FLAGS_OSD_HARDWARE_FB_OSD   (1 << 4)
 #endif
 
+        // HD VTXs are served the MSP API 1.46 layout, see mspSrcIsVtxPort()
+        const bool legacyLayout = mspSrcIsVtxPort(srcDesc);
+        const uint8_t itemCount = legacyLayout ? OSD_ITEM_COUNT_API_1_46 : OSD_ITEM_COUNT;
+
         uint8_t osdFlags = 0;
 
         osdFlags |= OSD_FLAGS_OSD_FEATURE;
@@ -1044,12 +1074,12 @@ RAM_CODE static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, msp
 
         // Reuse old timer alarm (U16) as OSD_ITEM_COUNT
         sbufWriteU8(dst, 0);
-        sbufWriteU8(dst, OSD_ITEM_COUNT);
+        sbufWriteU8(dst, itemCount);
 
         sbufWriteU16(dst, osdConfig()->alt_alarm);
 
         // Element position and visibility
-        for (int i = 0; i < OSD_ITEM_COUNT; i++) {
+        for (int i = 0; i < itemCount; i++) {
             sbufWriteU16(dst, osdElementConfig()->item_pos[i]);
         }
 
@@ -1098,8 +1128,10 @@ RAM_CODE static bool mspCommonProcessOutCommand(int16_t cmdMSP, sbuf_t *dst, msp
         // API >= 1.46
         sbufWriteU16(dst, osdConfig()->link_quality_alarm);
 
-        // API >= 1.47
-        sbufWriteU16(dst, osdConfig()->rssi_dbm_alarm);
+        if (!legacyLayout) {
+            // API >= 1.47
+            sbufWriteU16(dst, osdConfig()->rssi_dbm_alarm);
+        }
 
         break;
     }
@@ -4776,7 +4808,7 @@ RAM_CODE mspResult_e mspFcProcessCommand(mspDescriptor_t srcDesc, mspPacket_t *c
     // initialize reply by default
     reply->cmd = cmd->cmd;
 
-    if (mspCommonProcessOutCommand(cmdMSP, dst, mspPostProcessFn)) {
+    if (mspCommonProcessOutCommand(srcDesc, cmdMSP, dst, mspPostProcessFn)) {
         ret = MSP_RESULT_ACK;
     } else if (mspProcessOutCommand(srcDesc, cmdMSP, dst)) {
         ret = MSP_RESULT_ACK;
@@ -4804,7 +4836,7 @@ RAM_CODE static mspResult_e mspFcProcessOutCommand(mspDescriptor_t srcDesc, int1
     // initialize reply by default
     reply->cmd = cmdMSP;
 
-    if (mspCommonProcessOutCommand(cmdMSP, dst, mspPostProcessFn)) {
+    if (mspCommonProcessOutCommand(srcDesc, cmdMSP, dst, mspPostProcessFn)) {
         ret = MSP_RESULT_ACK;
     } else if (mspProcessOutCommand(srcDesc, cmdMSP, dst)) {
         ret = MSP_RESULT_ACK;

--- a/src/main/osd/osd.h
+++ b/src/main/osd/osd.h
@@ -225,6 +225,12 @@ typedef enum {
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
+// Number of elements that existed as of MSP API 1.46 (Betaflight 4.5). MSP-query type OSD
+// consumers - the DJI V1 air unit / Caddx Vista render the OSD themselves from MSP_OSD_CONFIG -
+// stop accepting the reply once it grows beyond what 4.5 produced, so they are served a reply
+// truncated to this many elements. Never change this value; it describes a released wire format.
+#define OSD_ITEM_COUNT_API_1_46 80
+
 // *** IMPORTANT ***
 // Whenever new elements are added to 'osd_items_e', make sure to increment
 // the parameter group version for 'osdConfig' in 'osd.c'


### PR DESCRIPTION
Fixes #15431, and #14531 which was the same report closed as stale.

## Symptom

Betaflight OSD elements stop rendering entirely on DJI V1 hardware — original Air Unit, Air Unit Lite, Caddx Vista, Goggles V1/V2. The MSP link stays healthy: DJI's own overlay keeps drawing and Configurator connects normally. DJI O3/O4 are unaffected.

Works on 4.5.5, broken on 2025.12.0 through 2025.12.5 and 2026.6.0-RC3. Reported on NeutronRC F435 Mini, Mamba F405, DALRCF405 and MATEKF722SE, so it is not board-specific.

## Diagnosis

Two support IDs from the same airframe and session — `e9e94de3-e4d8-4751-86e9-2ac5d7ad9067` (4.5.5, works) and `b69a6f26-a35c-4d1d-8e71-78f086a32752` (2025.12.5, broken) — agree on everything that matters: `serial UART5 131073` (`FUNCTION_MSP | FUNCTION_VTX_MSP`), `osd_displayport_device = MSP`, `vcd_video_system = HD`, every `osd_*_pos` byte-identical, and `status` reporting `OSD: MSP (53 x 20)` on both. The cloud build keys carry an identical option list and the same `configHash`.

`displayport_msp.c` is unchanged between the two releases apart from the never-defined `USE_MSP_DISPLAYPORT_FONT` block, so the DisplayPort byte stream is the same — consistent with O3/O4 still working.

DJI V1 is not a DisplayPort device. It is an **MSP-query OSD**: the goggles poll the FC and render Betaflight's elements themselves from `MSP_OSD_CONFIG` (see 84b6730cd, "...for MSP query type OSD implementations (like DJI)"). That is the one message V1 depends on and O3/O4 does not, and it has been growing:

| Release | OSD items | `MSP_OSD_CONFIG` payload |
|---|---|---|
| 4.3.2 | 62 | 176 B |
| 4.4.3 | 77 | 208 B |
| **4.5.5 (works)** | **80** | **221 B** |
| **2025.12.x (broken)** | **86** | **235 B** |
| master, no `USE_FLIGHT_PLAN` | 88 | 239 B |
| master, `USE_FLIGHT_PLAN` | 97 | **257 B** — exceeds MSP v1, sent as JUMBO |

Four commits, all landed before the first report (2025-07-09):

| Commit | PR | Δ |
|---|---|---|
| dc40b8f65 | #13682 Add RSSI dBm alarm to MSP | +2 B, API 1.46 → 1.47 |
| 665a42e29 | #13800 2nd block of debug values | +2 B (`OSD_DEBUG2`) |
| ac82d8b99 | #14097 custom OSD messages | +8 B (`OSD_CUSTOM_MSG0..3`) |
| 60aaf1ef1 | #14376 rangefinder TF-Nova | +2 B (`OSD_LIDAR_DIST`) |

`osd_items_e` is append-only — the first 80 entries are identical between 4.5.5 and master — so nothing about the elements DJI already knew changed. Only the count and the total length did.

Separately, 21eba1793 (calver prep, #14642) changed `MSP_FC_VERSION` from a fixed 3-byte payload to 13 bytes (`25, 12, 5` plus a pascal string). That landed after the first report so it is not the trigger, but it is a wire-shape change on a handshake message every legacy consumer parses, so it is eliminated here too.

## Change

Requests arriving on the UART that carries both `FUNCTION_MSP` and `FUNCTION_VTX_MSP` — an HD VTX rather than Configurator — are served the MSP API 1.46 wire format:

- `MSP_OSD_CONFIG` reports and emits `OSD_ITEM_COUNT_API_1_46` (80) elements and stops after `link_quality_alarm`, omitting the API 1.47 `rssi_dbm_alarm` tail. Payload is 221 bytes, byte-identical to 4.5.5.
- `MSP_FC_VERSION` omits the appended version string, restoring the historical 3-byte reply.

Configurator on VCP is unaffected and keeps receiving the full reply. Nothing changes for O3/O4, HDZero or Walksnail beyond the `MSP_FC_VERSION` tail, which only appeared in 2025.12 and was never parsed before that.

## Testing

`make TARGET=SITL` and `make CONFIG=DALRCF405` (the reporter's board) both build clean, and `nm` confirms `msp.o` references `displayPortMspGetSerial` and `getMspSerialPortDescriptor`, so the guarded path is compiled in rather than stubbed out.

**Not yet verified on hardware.** Needs a Vista or V1 Air Unit owner to confirm. Two minimal diagnostic patches against `2025.12.5` exist that separate the two variables (drop the API 1.47 tail only vs. cap the item count only) if we want to know exactly which property DJI trips on — happy to attach them.

## Follow-up, not addressed here

This caps the VTX-port reply, so DJI V1 never sees a jumbo `MSP_OSD_CONFIG`. It does not address the Configurator-facing reply crossing 255 bytes on `USE_FLIGHT_PLAN` builds on master, which switches `mspSerialEncode()` into JUMBO framing for that command. `MSP_OSD_CONFIG` has effectively run out of room in MSP v1 and wants an MSP v2 successor — worth tracking separately before 2026.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older HD VTX OSD and flight controller version parsing.
  * Ensured HD VTX connections receive the appropriate OSD layout and version data.
  * Preserved legacy OSD behavior while supporting newer layouts and alarm information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->