### PR TITLE
fix(x32): make SDIO card identification follow the SD spec timing (platform-only)

### DIFF
--- a/src/platform/X32/sdio_x32.c
+++ b/src/platform/X32/sdio_x32.c
@@ -326,6 +326,49 @@ static void SDMMC_Config(void)
 }
 
 
+/* Number of polls to wait for the CMD line to go idle after a command. The identification
+ * sequence runs at 400kHz, where a 48-bit response takes ~120us, so this is generous.
+ */
+#define SD_CMD_IDLE_TIMEOUT 100000
+
+/**
+ * Issue a command, working around a race in SDMMC_WaitCommandDone().
+ *
+ * That function returns as soon as it sees any bit of SDHOST_CommandFlag, clears it, and
+ * then reads the response registers unconditionally. A command interrupt left over from the
+ * previous command therefore makes it report success for a command that is still in flight
+ * and hand back an empty response - which is what CMD8 hits, arriving immediately after
+ * CMD0. The caller then rejects a perfectly good card because the check pattern reads zero.
+ *
+ * Clearing the command flags before issuing removes the stale flag, and waiting for
+ * SDHOST_PRESTS_CMDINHC afterwards guarantees the response has actually landed.
+ */
+static Status_card sdSendCommand(sd_card_t *card, uint32_t index, uint32_t argument, SDMMC_CardRspType responseType)
+{
+    SDMMC_ClrFlag(card->SDHOSTx, (uint32_t)SDHOST_CommandFlag);
+
+    const Status_card status = SD_NormalCMD_Send(card, index, argument, responseType);
+
+    if (status != Status_Success) {
+        return status;
+    }
+
+    for (uint32_t spins = 0; spins < SD_CMD_IDLE_TIMEOUT; spins++) {
+        if ((card->SDHOSTx->PRESTS & SDHOST_PRESTS_CMDINHC) == 0) {
+            break;
+        }
+    }
+
+    // Pick up a response that landed after SDMMC_WaitCommandDone() had already sampled the
+    // registers. Only R2 needs the multi-word unpacking, which it has already done.
+    if ((responseType != CARD_ResponseTypeNone) && (responseType != CARD_ResponseTypeR2)
+            && (card->command.response[0] == 0)) {
+        card->command.response[0] = card->SDHOSTx->CMDRSP0;
+    }
+
+    return status;
+}
+
 /**
  *\*\name   SD_DefaultSpeedModeInit.
  *\*\fun    Configure to communicate in Default Speed mode.
@@ -405,6 +448,13 @@ static Status_card SD_PowerOnInit(sd_card_t* card)
     
     /* Enable SD card power and clock */
     SDMMC_EnablePower(card->SDHOSTx,ENABLE);
+
+    /* The SD physical layer spec requires at least 1ms after VDD is stable before the host
+     * may start the identification sequence. Without this the card is still powering up when
+     * CMD0 goes out and it never answers CMD8.
+     */
+    SDMMC_Delay(2);
+
     if(((SD_XIN_CLK % 400000U) != 0)  || ((SD_XIN_CLK/400000U)%2 != 0))
     {
         if(SD_XIN_CLK <= card->card_workmode.busClock_Hz)
@@ -421,19 +471,29 @@ static Status_card SD_PowerOnInit(sd_card_t* card)
         persacle_value = SD_XIN_CLK/400000U/2;
     }
     
-    SDMMC_SetSdClock(card->SDHOSTx,DISABLE,persacle_value);  //100MHz/250 = 400KHz
-     
+    /* SDMMC_SetSdClock() reports whether the clock actually went stable; ignoring it means a
+     * dead clock only shows up later as an unexplained command timeout.
+     */
+    if (SDMMC_SetSdClock(card->SDHOSTx,DISABLE,persacle_value) != SDMMC_SUCCESS) {  //100MHz/250 = 400KHz
+        return Status_Fail;
+    }
+
+    /* The card needs at least 74 clock cycles with CMD high before it will respond, which is
+     * ~185us at 400kHz.
+     */
+    SDMMC_Delay(1);
+
     /** A series of commands begins to begin the card identification process. **/
     
     /* CMD0 */
-    if(SD_NormalCMD_Send(card,SDMMC_GoIdleState,0x00,CARD_ResponseTypeNone) != Status_Success)
+    if(sdSendCommand(card,SDMMC_GoIdleState,0x00,CARD_ResponseTypeNone) != Status_Success)
     {
         return Status_Fail;
     }
     
     /* CMD8 */
     //arg[19:16] = 0001b 2.7V~3.6V,arg[15:8] = 0xAA check pattern
-    if(SD_NormalCMD_Send(card,SD_SendInterfaceCondition,0x1AAU,CARD_ResponseTypeR7) != Status_Success)
+    if(sdSendCommand(card,SD_SendInterfaceCondition,0x1AAU,CARD_ResponseTypeR7) != Status_Success)
     {
         return Status_Fail;
     }
@@ -515,7 +575,7 @@ static Status_card SD_PowerOnInit(sd_card_t* card)
     
     
     /* CMD2 */
-    if(SD_NormalCMD_Send(card,SDMMC_AllSendCid,0x00,CARD_ResponseTypeR2) != Status_Success)
+    if(sdSendCommand(card,SDMMC_AllSendCid,0x00,CARD_ResponseTypeR2) != Status_Success)
     {
         return Status_Fail;
     }
@@ -528,7 +588,7 @@ static Status_card SD_PowerOnInit(sd_card_t* card)
     
     
     /* CMD3 */
-    if(SD_NormalCMD_Send(card,SD_SendRelativeAddress,0x00,CARD_ResponseTypeR6) != Status_Success)
+    if(sdSendCommand(card,SD_SendRelativeAddress,0x00,CARD_ResponseTypeR6) != Status_Success)
     {
         return Status_Fail;
     }
@@ -536,7 +596,7 @@ static Status_card SD_PowerOnInit(sd_card_t* card)
     
     
     /* CMD9 */
-    if(SD_NormalCMD_Send(card,SDMMC_SendCsd,card->sd_card_information.rca << 16,CARD_ResponseTypeR2) != Status_Success)
+    if(sdSendCommand(card,SDMMC_SendCsd,card->sd_card_information.rca << 16,CARD_ResponseTypeR2) != Status_Success)
     {
         return Status_Fail;
     }
@@ -548,7 +608,7 @@ static Status_card SD_PowerOnInit(sd_card_t* card)
     SD_Handle.CSD[3] = card->command.response[0U];
     
     /* CMD7 */
-    if(SD_NormalCMD_Send(card,SDMMC_SelectCard,card->sd_card_information.rca << 16,CARD_ResponseTypeR1b) != Status_Success)
+    if(sdSendCommand(card,SDMMC_SelectCard,card->sd_card_information.rca << 16,CARD_ResponseTypeR1b) != Status_Success)
     {
         return Status_Fail;
     }
@@ -566,7 +626,7 @@ static Status_card SD_PowerOnInit(sd_card_t* card)
     }
     
     /* CMD16 */
-    if(SD_NormalCMD_Send(card,SDMMC_SetBlockLength,FSL_SDMMC_DEFAULT_BLOCK_SIZE,CARD_ResponseTypeR1) != Status_Success)
+    if(sdSendCommand(card,SDMMC_SetBlockLength,FSL_SDMMC_DEFAULT_BLOCK_SIZE,CARD_ResponseTypeR1) != Status_Success)
     {
         return Status_Fail;
     }

--- a/src/platform/X32/sdio_x32.c
+++ b/src/platform/X32/sdio_x32.c
@@ -353,10 +353,19 @@ static Status_card sdSendCommand(sd_card_t *card, uint32_t index, uint32_t argum
         return status;
     }
 
+    bool cmdLineIdle = false;
+
     for (uint32_t spins = 0; spins < SD_CMD_IDLE_TIMEOUT; spins++) {
         if ((card->SDHOSTx->PRESTS & SDHOST_PRESTS_CMDINHC) == 0) {
+            cmdLineIdle = true;
             break;
         }
+    }
+
+    if (!cmdLineIdle) {
+        // The command never released the CMD line, so nothing can be trusted about it -
+        // including the success SDMMC_WaitCommandDone() reported.
+        return Status_Fail;
     }
 
     // Pick up a response that landed after SDMMC_WaitCommandDone() had already sampled the
@@ -676,8 +685,13 @@ static Status_card SD_PowerOnInit(sd_card_t* card)
     {
         persacle_value = SD_XIN_CLK/card->card_workmode.busClock_Hz/2;
     }
-    SDMMC_SetSdClock(card->SDHOSTx,DISABLE,persacle_value);
-     
+    /* Switching to the working clock can fail the same way as the 400kHz setup above;
+     * continuing would leave the card configured for a clock that is not running.
+     */
+    if (SDMMC_SetSdClock(card->SDHOSTx,DISABLE,persacle_value) != SDMMC_SUCCESS) {
+        return Status_Fail;
+    }
+
     /* This function is not necessary. Depending on the hardware and card, 
        you can decide whether to enable TX CLK delay and how much delay to use */
     SDMMC_EnableManualTuningOut(card->SDMMCx,8,ENABLE);


### PR DESCRIPTION
Fixes #15491 — **option A of two. Only one of the two PRs should be merged.**

SD card initialisation never completed on X32: `sd_info` reported `Startup failed` and the card was written off for the rest of the session, while the same card worked in other flight controllers.

## What this changes

All in `src/platform/X32/sdio_x32.c`. No vendor sources touched.

**SD spec power-up timing.** `SDMMC_EnablePower()` was followed immediately by the identification sequence. The spec requires ≥1 ms after VDD is stable plus ≥74 clock cycles with CMD high before the first command; neither wait existed, so CMD0 went out while the card was still powering up and CMD8 timed out. `PRESTS` confirmed it — the CMD line signal level read low when the commands were issued and high afterwards, i.e. the card had not yet released it.

**`SDMMC_SetSdClock()` return value.** Both call sites discarded it. It reports whether the clock ever reached a stable state, so a dead clock would only surface later as an unexplained command timeout.

**Stale command interrupt.** `SDMMC_WaitCommandDone()` in the vendor SDK returns on any pending `SDHOST_CommandFlag` bit, clears it, and then reads the response registers unconditionally — so a flag left by the previous command makes it report success for a command still in flight, with an empty response. CMD8 hits this because it directly follows CMD0:

```
TMODE   = 0x081a0000   index 0x08 = CMD8, resp-type 48-bit, CRC + index check on
PRESTS  = 0x019f0001   bit 0 CMDINHC set -> command still in flight
CMDRSP0 = 0x00000000   nothing latched
INTSTS  = 0x00000140   CINS + CINT only; no CMDC, no error bits
```

The R7 check pattern then compared against 0 and the card was rejected as unsupported. This PR routes the seven identification commands through a helper that clears the command flags before issuing and waits for `CMDINHC` to clear afterwards, so a response is guaranteed present before it is read.

## Trade-off vs the alternative

This keeps everything in platform code and leaves `lib/modules/X32M7` alone, which is the pragmatic option given the SDK is a submodule of the vendor's repo. But it works around the SDK defect rather than fixing it, and it does not cover `SD_AutoCMD_Send()`, whose internal CMD55/ACMD pair has the same exposure.

The alternative PR fixes it once for all callers inside the SDK instead. Both are offered so the decision on where the fix belongs can be made deliberately.

## Testing

Card enumerates and mounts on a Hummingbird FC305 M7V2 with a 32 GB SanDisk card:

```
SD-CARD: Manufacturer 0x3, 31166976kB, v8.5, 'SD32G' FS: Ready
```

⚠️ **Needs a hardware retest of this exact branch.** The verified build was an instrumented one that adopted the late response inline; this branch replaces that with clearing the flag up front, which is the correct fix but is not the code that was run.

Also still untested: the data path. Enumeration and mount only exercise the CMD line — blackbox logging goes over the DAT lines and SDMA.

## Out of scope

`sdcard_poll()` treats `SDCARD_STATE_NOT_PRESENT` as terminal, so a single failed init at boot disables the card until reboot — that is what made the timing bug permanent rather than transient. It is common code shared by all SDIO platforms and wants its own change. Tracked in #15491.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SD card initialization reliability by clearing stale SD command interrupts and improving command completion handling.
  * Added additional timing delays during power-on and card identification to better match SD power/clock readiness requirements.
  * Added stricter validation that the SD clock stabilizes (including working-clock switching) before proceeding, failing early when instability is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->