### PR TITLE
fix(x32): make SDIO card identification follow the SD spec timing (SDK fix variant)

### DIFF
--- a/src/platform/X32/sdio_x32.c
+++ b/src/platform/X32/sdio_x32.c
@@ -405,6 +405,13 @@ static Status_card SD_PowerOnInit(sd_card_t* card)
     
     /* Enable SD card power and clock */
     SDMMC_EnablePower(card->SDHOSTx,ENABLE);
+
+    /* The SD physical layer spec requires at least 1ms after VDD is stable before the host
+     * may start the identification sequence. Without this the card is still powering up when
+     * CMD0 goes out and it never answers CMD8.
+     */
+    SDMMC_Delay(2);
+
     if(((SD_XIN_CLK % 400000U) != 0)  || ((SD_XIN_CLK/400000U)%2 != 0))
     {
         if(SD_XIN_CLK <= card->card_workmode.busClock_Hz)
@@ -421,8 +428,18 @@ static Status_card SD_PowerOnInit(sd_card_t* card)
         persacle_value = SD_XIN_CLK/400000U/2;
     }
     
-    SDMMC_SetSdClock(card->SDHOSTx,DISABLE,persacle_value);  //100MHz/250 = 400KHz
-     
+    /* SDMMC_SetSdClock() reports whether the clock actually went stable; ignoring it means a
+     * dead clock only shows up later as an unexplained command timeout.
+     */
+    if (SDMMC_SetSdClock(card->SDHOSTx,DISABLE,persacle_value) != SDMMC_SUCCESS) {  //100MHz/250 = 400KHz
+        return Status_Fail;
+    }
+
+    /* The card needs at least 74 clock cycles with CMD high before it will respond, which is
+     * ~185us at 400kHz.
+     */
+    SDMMC_Delay(1);
+
     /** A series of commands begins to begin the card identification process. **/
     
     /* CMD0 */

--- a/src/platform/X32/sdio_x32.c
+++ b/src/platform/X32/sdio_x32.c
@@ -633,8 +633,13 @@ static Status_card SD_PowerOnInit(sd_card_t* card)
     {
         persacle_value = SD_XIN_CLK/card->card_workmode.busClock_Hz/2;
     }
-    SDMMC_SetSdClock(card->SDHOSTx,DISABLE,persacle_value);
-     
+    /* Switching to the working clock can fail the same way as the 400kHz setup above;
+     * continuing would leave the card configured for a clock that is not running.
+     */
+    if (SDMMC_SetSdClock(card->SDHOSTx,DISABLE,persacle_value) != SDMMC_SUCCESS) {
+        return Status_Fail;
+    }
+
     /* This function is not necessary. Depending on the hardware and card, 
        you can decide whether to enable TX CLK delay and how much delay to use */
     SDMMC_EnableManualTuningOut(card->SDMMCx,8,ENABLE);


### PR DESCRIPTION
Fixes #15491 — **option B of two. Only one of the two PRs should be merged.** The alternative is #15492.

SD card initialisation never completed on X32: `sd_info` reported `Startup failed` and the card was written off for the rest of the session, while the same card worked in other flight controllers.

## What this changes

**SD spec power-up timing** (`src/platform/X32/sdio_x32.c`). `SDMMC_EnablePower()` was followed immediately by the identification sequence. The spec requires ≥1 ms after VDD is stable plus ≥74 clock cycles with CMD high before the first command; neither wait existed, so CMD0 went out while the card was still powering up and CMD8 timed out. `PRESTS` confirmed it — the CMD line signal level read low when the commands were issued and high afterwards, i.e. the card had not yet released it.

**`SDMMC_SetSdClock()` return value** (`src/platform/X32/sdio_x32.c`). Both call sites discarded it. It reports whether the clock ever reached a stable state, so a dead clock would only surface later as an unexplained command timeout.

That is everything in this PR's diff. The third defect is in the vendor SDK, and is **deliberately not included here** — see below.

## The part that is not in this diff

`SDMMC_WaitCommandDone()` returns on any pending `SDHOST_CommandFlag` bit, clears it, and then reads the response registers unconditionally, so a flag left by the previous command makes it report success for a command still in flight with an empty response. CMD8 hits this because it directly follows CMD0:

```
TMODE   = 0x081a0000   index 0x08 = CMD8, resp-type 48-bit, CRC + index check on
PRESTS  = 0x019f0001   bit 0 CMDINHC set -> command still in flight
CMDRSP0 = 0x00000000   nothing latched
INTSTS  = 0x00000140   CINS + CINT only; no CMDC, no error bits
```

The R7 check pattern then compared against 0 and the card was rejected as unsupported.

The fix is one line in `SDMMC_SendCommand()` — clear the command interrupt just before the command is written to `TMODE`, so the wait can only ever observe the flag belonging to the command just issued. That covers every caller, including `SD_AutoCMD_Send()` whose internal CMD55/ACMD pair has the same exposure.

But `lib/modules/X32M7` is a submodule of https://github.com/X-CORE-LABS-PTE-LTD/X32M7_Std_SDK — the vendor's own repository, currently at *"Merge pull request #5 from Romin0615/fix_sdmmc"*, so they are already working in this area. **The submodule pointer is intentionally not bumped in this PR**, because it would reference a commit that does not exist upstream and would break submodule checkout for everyone else.

Consequence: **this branch does not build the complete fix on its own.** It needs the SDK change to land in the vendor repo and the pointer bumped afterwards. The change is prepared as a standalone commit for submission to them.

## Why two PRs

The platform-only alternative (#15492) works around the SDK entirely inside `sdio_x32.c` and is self-contained and mergeable today, at the cost of not fixing the underlying defect and not covering the ACMD path. This PR is the cleaner fix but has an external dependency. Offered as a pair so the decision on where the fix belongs can be made deliberately rather than by whichever was written first.

## Testing

Card enumerates and mounts on a Hummingbird FC305 M7V2 with a 32 GB SanDisk card, with the SDK change applied locally:

```
SD-CARD: Manufacturer 0x3, 31166976kB, v8.5, 'SD32G' FS: Ready
```

⚠️ **Needs a hardware retest.** The verified build was an instrumented one that adopted the late response inline rather than clearing the flag up front.

Also still untested: the data path. Enumeration and mount only exercise the CMD line — blackbox logging goes over the DAT lines and SDMA.

## Out of scope

`sdcard_poll()` treats `SDCARD_STATE_NOT_PRESENT` as terminal, so a single failed init at boot disables the card until reboot — that is what made the timing bug permanent rather than transient. It is common code shared by all SDIO platforms and wants its own change. Tracked in #15491.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SD card initialization reliability by adding required post–power-on settling time.
  * Added validation so SD clock setup failures stop the initialization sequence.
  * Ensured enough clock cycles are provided before issuing the initial identification commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->