### PR TITLE
Fix USB MSC initialization for internal SDMMC DMA platforms

### DIFF
--- a/src/platform/common/stm32/msc_sdio_storage.c
+++ b/src/platform/common/stm32/msc_sdio_storage.c
@@ -10,16 +10,16 @@
 
 bool mscSdioInitDma(void)
 {
-#ifdef USE_DMA_SPEC
+#if ENABLE_SDIO_EXTERNAL_DMA
     const dmaChannelSpec_t *dmaChannelSpec =
         dmaGetChannelSpecByPeripheral(DMA_PERIPH_SDIO, 0, sdioConfig()->dmaopt);
     dmaResource_t *dmaRef = dmaChannelSpec ? dmaChannelSpec->ref : NULL;
-#else
-    dmaResource_t *dmaRef = NULL;
-#endif
     if (!dmaRef) {
         return false;
     }
+#else
+    dmaResource_t *dmaRef = NULL;
+#endif
     return SD_InitialiseHardware(dmaRef);
 }
 


### PR DESCRIPTION
During SD card initialization for USB MSC, USE_DMA_SPEC incorrectly selects the external SDIO DMA path on STM32H7, potentially causing initialization to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SD card storage initialization when external DMA support is disabled.
  * Prevented unnecessary initialization failures in configurations that do not use external DMA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->