### PR TITLE
Add MSP2_CLI_COMMAND for running CLI commands over MSP

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -8658,15 +8658,7 @@ void cliEnter(serialPort_t *serialPort, bool interactive)
     }
 }
 
-#ifdef CONFIG_IN_FILE
-#include <stdio.h>
-
-static void stdoutBufWrite(void *arg, const uint8_t *data, int count)
-{
-    UNUSED(arg);
-    fwrite(data, 1, count, stdout);
-}
-
+#if defined(CONFIG_IN_FILE) || defined(USE_MSP_CLI_COMMAND)
 // Check if a line (after stripping comments/whitespace) matches a command name
 static bool lineIsCommand(const char *line, const char *command)
 {
@@ -8683,6 +8675,92 @@ static bool lineIsCommand(const char *line, const char *command)
     char next = line[cmdLen];
     return (next == '\0' || next == ' ' || next == '\t' ||
             next == '\n' || next == '\r' || next == '#');
+}
+#endif
+
+#ifdef USE_MSP_CLI_COMMAND
+typedef struct cliCaptureSink_s {
+    char *buf;
+    int cap;
+    int total;
+} cliCaptureSink_t;
+
+static void cliCaptureBufWrite(void *arg, const uint8_t *data, int count)
+{
+    cliCaptureSink_t *sink = (cliCaptureSink_t *)arg;
+    for (int i = 0; i < count; i++) {
+        if (sink->total < sink->cap) {
+            sink->buf[sink->total] = (char)data[i];
+        }
+        sink->total++;
+    }
+}
+
+int cliExecuteCommand(const char *cmdline, char *outBuf, int outBufLen)
+{
+    if (cliMode || !cmdline || !outBuf || outBufLen <= 0) {
+        return CLI_COMMAND_REFUSED;
+    }
+
+    // The fabricated port below has a NULL vTable, so any command that reaches
+    // waitForSerialPortToFinishTransmitting() (reboot/mode-switch/passthrough) would
+    // fault. Handle those here instead of dispatching them: 'save' persists without
+    // the reboot, 'exit' is a no-op, bare 'defaults' (which reboots) is refused.
+    if (lineIsCommand(cmdline, "exit")) {
+        return 0;
+    }
+    if (lineIsCommand(cmdline, "bl") || lineIsCommand(cmdline, "msc") ||
+        lineIsCommand(cmdline, "serialpassthrough")) {
+        return CLI_COMMAND_REFUSED;
+    }
+    if (lineIsCommand(cmdline, "defaults") && !strcasestr(cmdline, "nosave")) {
+        return CLI_COMMAND_REFUSED;
+    }
+
+    cliCaptureSink_t sink = { .buf = outBuf, .cap = outBufLen, .total = 0 };
+
+    cliMode = true;
+    cliInteractive = false;
+
+    static serialPort_t dummyPort;
+    memset(&dummyPort, 0, sizeof(dummyPort));
+    cliPort = &dummyPort;
+
+    bufWriterInit(&cliWriterDesc, cliWriteBuffer, sizeof(cliWriteBuffer),
+                  (bufWrite_t)cliCaptureBufWrite, &sink);
+    cliErrorWriter = cliWriter = &cliWriterDesc;
+    cliClearInputBuffer();
+
+    if (lineIsCommand(cmdline, "save")) {
+        if (tryPrepareSave("save")) {
+            writeEEPROM();
+            cliPrintHashLine("saving");
+        }
+    } else {
+        for (const char *p = cmdline; *p; p++) {
+            processCharacter(*p);
+        }
+        processCharacter('\n');
+    }
+
+    cliWriterFlush();
+
+    cliMode = false;
+    cliInteractive = false;
+    cliWriter = cliErrorWriter = NULL;
+    cliPort = NULL;
+
+    return sink.total;
+}
+#endif
+
+#ifdef CONFIG_IN_FILE
+#include <stdio.h>
+
+static void stdoutBufWrite(void *arg, const uint8_t *data, int count)
+{
+    UNUSED(arg);
+    fwrite(data, 1, count, stdout);
 }
 
 void cliProcessConfigFile(const char *filename)

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -8679,6 +8679,35 @@ static bool lineIsCommand(const char *line, const char *command)
 #endif
 
 #ifdef USE_MSP_CLI_COMMAND
+// Check whether a line carries 'arg' as a discrete argument. Inline comments are stripped
+// first because processCharacter() drops them before dispatch, so a plain substring search
+// would read "defaults # nosave" as carrying the nosave flag when the CLI will not.
+static bool lineHasArg(const char *line, const char *arg)
+{
+    char stripped[CLI_IN_BUFFER_SIZE];
+    strncpy(stripped, line, sizeof(stripped) - 1);
+    stripped[sizeof(stripped) - 1] = '\0';
+
+    char *cp = strchr(stripped, '#');
+    if (cp) {
+        *cp = '\0';
+    }
+    cp = strstr(stripped, "//");
+    if (cp) {
+        *cp = '\0';
+    }
+
+    char *saveptr;
+    for (char *tok = strtok_r(stripped, " \t\r\n", &saveptr); tok;
+         tok = strtok_r(NULL, " \t\r\n", &saveptr)) {
+        if (strcasecmp(tok, arg) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 typedef struct cliCaptureSink_s {
     char *buf;
     int cap;
@@ -8713,7 +8742,14 @@ int cliExecuteCommand(const char *cmdline, char *outBuf, int outBufLen)
         lineIsCommand(cmdline, "serialpassthrough")) {
         return CLI_COMMAND_REFUSED;
     }
-    if (lineIsCommand(cmdline, "defaults") && !strcasestr(cmdline, "nosave")) {
+    // This is reachable from any MSP link, including telemetry links in flight. writeEEPROM()
+    // blocks the flight loop (MSP_EEPROM_WRITE refuses while armed for the same reason) and
+    // wiping the config mid-flight is never safe.
+    if (ARMING_FLAG(ARMED) &&
+        (lineIsCommand(cmdline, "save") || lineIsCommand(cmdline, "defaults"))) {
+        return CLI_COMMAND_REFUSED;
+    }
+    if (lineIsCommand(cmdline, "defaults") && !lineHasArg(cmdline, "nosave")) {
         return CLI_COMMAND_REFUSED;
     }
 

--- a/src/main/cli/cli.h
+++ b/src/main/cli/cli.h
@@ -39,6 +39,10 @@ void cliProcessConfigFile(const char *filename);
 int cliGetSettingByName(const char *name, char *buf, int bufLen);
 int cliGetSettingInfoByName(const char *name, int offset, char *buf, int bufLen, int *totalLen);
 bool cliSetSettingByName(const char *cmdline);
+#ifdef USE_MSP_CLI_COMMAND
+#define CLI_COMMAND_REFUSED (-1)
+int cliExecuteCommand(const char *cmdline, char *outBuf, int outBufLen);
+#endif
 #endif
 
 #ifdef USE_CLI_DEBUG_PRINT

--- a/src/main/cli/cli.h
+++ b/src/main/cli/cli.h
@@ -41,6 +41,8 @@ int cliGetSettingInfoByName(const char *name, int offset, char *buf, int bufLen,
 bool cliSetSettingByName(const char *cmdline);
 #ifdef USE_MSP_CLI_COMMAND
 #define CLI_COMMAND_REFUSED (-1)
+// Returns CLI_COMMAND_REFUSED, or the total logical output length. That length exceeds
+// outBufLen when the output was truncated; only outBufLen bytes are written to outBuf.
 int cliExecuteCommand(const char *cmdline, char *outBuf, int outBufLen);
 #endif
 #endif

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2806,6 +2806,82 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
         break;
 #endif
 
+#ifdef USE_MSP_CLI_COMMAND
+    case MSP2_CLI_COMMAND:
+        {
+            // request: <cmdline>[\0<offset_u16>]  (offset optional, defaults to 0)
+            // response: <total_len_u16><flags_u8><output window from [offset, ...]>
+            static char cliCmdBuffer[MSP_CLI_COMMAND_BUFFER_SIZE];
+            static char cliCmdName[128];
+            static int cliCmdTotalLen = 0;
+
+            const int len = sbufBytesRemaining(src);
+            if (len == 0) {
+                return MSP_RESULT_ERROR;
+            }
+            char req[len + 1];
+            sbufReadData(src, req, len);
+            req[len] = '\0';
+
+            uint16_t offset = 0;
+            int nameLen = len;
+            const void *nul = memchr(req, '\0', len);
+            if (nul) {
+                nameLen = (const char *)nul - req;
+                if (len - nameLen - 1 >= 2) {
+                    offset = (uint8_t)req[nameLen + 1] | ((uint8_t)req[nameLen + 2] << 8);
+                }
+            }
+            req[nameLen] = '\0';
+
+            if (nameLen >= (int)sizeof(cliCmdName) || sbufBytesRemaining(dst) < 3) {
+                return MSP_RESULT_ERROR;
+            }
+
+            uint8_t flags = 0;
+            if (offset == 0) {
+                const int produced = cliExecuteCommand(req, cliCmdBuffer, sizeof(cliCmdBuffer));
+                if (produced == CLI_COMMAND_REFUSED) {
+                    cliCmdName[0] = '\0';
+                    cliCmdTotalLen = 0;
+                    sbufWriteU16(dst, 0);
+                    sbufWriteU8(dst, MSP2_CLI_COMMAND_FLAG_REFUSED);
+                    break;
+                }
+                if (produced > (int)sizeof(cliCmdBuffer)) {
+                    cliCmdTotalLen = sizeof(cliCmdBuffer);
+                    flags |= MSP2_CLI_COMMAND_FLAG_TRUNCATED;
+                } else {
+                    cliCmdTotalLen = produced;
+                }
+                strcpy(cliCmdName, req);
+            } else {
+                // continuation: the client resends the same command line to page further
+                if (cliCmdName[0] == '\0' || strcmp(cliCmdName, req) != 0) {
+                    sbufWriteU16(dst, 0);
+                    sbufWriteU8(dst, MSP2_CLI_COMMAND_FLAG_REFUSED);
+                    break;
+                }
+                if (cliCmdTotalLen == (int)sizeof(cliCmdBuffer)) {
+                    flags |= MSP2_CLI_COMMAND_FLAG_TRUNCATED;
+                }
+            }
+
+            sbufWriteU16(dst, (uint16_t)cliCmdTotalLen);
+            sbufWriteU8(dst, flags);
+
+            if (offset < cliCmdTotalLen) {
+                int window = cliCmdTotalLen - offset;
+                const int room = sbufBytesRemaining(dst);
+                if (window > room) {
+                    window = room;
+                }
+                sbufWriteData(dst, cliCmdBuffer + offset, window);
+            }
+        }
+        break;
+#endif
+
     default:
         return MSP_RESULT_CMD_UNKNOWN;
     }

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2814,12 +2814,19 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
             static char cliCmdBuffer[MSP_CLI_COMMAND_BUFFER_SIZE];
             static char cliCmdName[128];
             static int cliCmdTotalLen = 0;
+            static bool cliCmdTruncated = false;
 
+            // A line the CLI input buffer cannot hold would be silently truncated by
+            // processCharacter() and then executed as a different command.
+            _Static_assert(sizeof(cliCmdName) < CLI_IN_BUFFER_SIZE,
+                           "MSP CLI command line must fit the CLI input buffer");
+
+            // <cmdline> + NUL + optional u16 offset
+            char req[sizeof(cliCmdName) + 3];
             const int len = sbufBytesRemaining(src);
-            if (len == 0) {
+            if (len == 0 || len >= (int)sizeof(req)) {
                 return MSP_RESULT_ERROR;
             }
-            char req[len + 1];
             sbufReadData(src, req, len);
             req[len] = '\0';
 
@@ -2840,20 +2847,19 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
 
             uint8_t flags = 0;
             if (offset == 0) {
+                // 'dump', 'diff' and 'save' can run long; don't bill it to the MSP task
+                schedulerIgnoreTaskStateTime();
                 const int produced = cliExecuteCommand(req, cliCmdBuffer, sizeof(cliCmdBuffer));
                 if (produced == CLI_COMMAND_REFUSED) {
                     cliCmdName[0] = '\0';
                     cliCmdTotalLen = 0;
+                    cliCmdTruncated = false;
                     sbufWriteU16(dst, 0);
                     sbufWriteU8(dst, MSP2_CLI_COMMAND_FLAG_REFUSED);
                     break;
                 }
-                if (produced > (int)sizeof(cliCmdBuffer)) {
-                    cliCmdTotalLen = sizeof(cliCmdBuffer);
-                    flags |= MSP2_CLI_COMMAND_FLAG_TRUNCATED;
-                } else {
-                    cliCmdTotalLen = produced;
-                }
+                cliCmdTruncated = produced > (int)sizeof(cliCmdBuffer);
+                cliCmdTotalLen = cliCmdTruncated ? (int)sizeof(cliCmdBuffer) : produced;
                 strcpy(cliCmdName, req);
             } else {
                 // continuation: the client resends the same command line to page further
@@ -2862,9 +2868,9 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, int16_
                     sbufWriteU8(dst, MSP2_CLI_COMMAND_FLAG_REFUSED);
                     break;
                 }
-                if (cliCmdTotalLen == (int)sizeof(cliCmdBuffer)) {
-                    flags |= MSP2_CLI_COMMAND_FLAG_TRUNCATED;
-                }
+            }
+            if (cliCmdTruncated) {
+                flags |= MSP2_CLI_COMMAND_FLAG_TRUNCATED;
             }
 
             sbufWriteU16(dst, (uint16_t)cliCmdTotalLen);

--- a/src/main/msp/msp_protocol_v2_betaflight.h
+++ b/src/main/msp/msp_protocol_v2_betaflight.h
@@ -36,6 +36,11 @@
 #define MSP2_SET_BATTERY_PROFILE            0x300F
 #define MSP2_CLI_SETTING                    0x3010
 #define MSP2_CLI_SETTING_INFO               0x3011
+#define MSP2_CLI_COMMAND                    0x3012
+
+// MSP2_CLI_COMMAND response flags (byte following the u16 total-length header)
+#define MSP2_CLI_COMMAND_FLAG_TRUNCATED     (1 << 0) // output exceeded the pageable buffer
+#define MSP2_CLI_COMMAND_FLAG_REFUSED       (1 << 1) // command refused or paging session mismatch
 
 // MSP2_SET_TEXT and MSP2_GET_TEXT variable types
 #define MSP2TEXT_PILOT_NAME                      1

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -450,6 +450,13 @@
 #undef USE_MSP_OVER_TELEMETRY
 #endif
 
+#if defined(USE_MSP_CLI_COMMAND) && !defined(USE_CLI)
+#undef USE_MSP_CLI_COMMAND
+#endif
+#if defined(USE_MSP_CLI_COMMAND) && !defined(MSP_CLI_COMMAND_BUFFER_SIZE)
+#define MSP_CLI_COMMAND_BUFFER_SIZE 2048
+#endif
+
 #if !defined(USE_RX_MSP) && defined(USE_RX_MSP_OVERRIDE)
 #undef USE_RX_MSP_OVERRIDE
 #endif

--- a/src/platform/SIMULATOR/target/SITL/target.h
+++ b/src/platform/SIMULATOR/target/SITL/target.h
@@ -123,6 +123,8 @@
 
 #define USE_PARAMETER_GROUPS
 
+#define USE_MSP_CLI_COMMAND
+
 #ifndef USE_PWM_OUTPUT
 #define USE_PWM_OUTPUT
 #endif

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -170,6 +170,7 @@ cli_unittest_SRC := \
 cli_unittest_DEFINES := \
 		USE_OSD= \
 		USE_CLI= \
+		USE_MSP_CLI_COMMAND= \
 		SystemCoreClock=1000000
 
 cms_unittest_SRC := \

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -485,6 +485,33 @@ TEST(CLIUnittest, TestGetSettingByNameZeroBuffer)
     EXPECT_EQ(0, written);
 }
 
+#ifdef USE_MSP_CLI_COMMAND
+// Reboot/mode-switch/passthrough commands must be refused: cliExecuteCommand runs them
+// against a NULL-vTable port, so reaching waitForSerialPortToFinishTransmitting() would fault.
+TEST(CLIUnittest, TestCliExecuteCommandRefusesDangerous)
+{
+    char buf[64];
+    EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand("bl", buf, sizeof(buf)));
+    EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand("msc", buf, sizeof(buf)));
+    EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand("serialpassthrough 1", buf, sizeof(buf)));
+    EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand("defaults", buf, sizeof(buf)));
+    EXPECT_FALSE(cliMode);
+}
+
+// 'exit' is a no-op (never reboots), and bad arguments are rejected.
+TEST(CLIUnittest, TestCliExecuteCommandGuards)
+{
+    char buf[64];
+    EXPECT_EQ(0, cliExecuteCommand("exit", buf, sizeof(buf)));
+    EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand(NULL, buf, sizeof(buf)));
+    EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand("version", buf, 0));
+
+    cliMode = true; // already in a CLI session -> must refuse to avoid clobbering state
+    EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand("version", buf, sizeof(buf)));
+    cliMode = false;
+}
+#endif
+
 // Verifies cliSetSettingByName sets an array value and round-trips via get.
 TEST(CLIUnittest, TestSetSettingByNameArray)
 {

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -510,6 +510,29 @@ TEST(CLIUnittest, TestCliExecuteCommandGuards)
     EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand("version", buf, sizeof(buf)));
     cliMode = false;
 }
+
+// An inline comment must not be read as the 'nosave' argument: processCharacter() strips the
+// comment before dispatch, so 'defaults' would run in its saving form and reboot.
+TEST(CLIUnittest, TestCliExecuteCommandRefusesDefaultsWithCommentedNosave)
+{
+    char buf[64];
+    EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand("defaults # nosave", buf, sizeof(buf)));
+    EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand("defaults #nosave", buf, sizeof(buf)));
+    EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand("defaults // nosave", buf, sizeof(buf)));
+    EXPECT_FALSE(cliMode);
+}
+
+// Persisting or wiping the config while armed must be refused: writeEEPROM() blocks the
+// flight loop, and this path is reachable from a telemetry link in flight.
+TEST(CLIUnittest, TestCliExecuteCommandRefusesWhenArmed)
+{
+    char buf[64];
+    armingFlags |= ARMED;
+    EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand("save", buf, sizeof(buf)));
+    EXPECT_EQ(CLI_COMMAND_REFUSED, cliExecuteCommand("defaults nosave", buf, sizeof(buf)));
+    armingFlags &= ~ARMED;
+    EXPECT_FALSE(cliMode);
+}
 #endif
 
 // Verifies cliSetSettingByName sets an array value and round-trips via get.


### PR DESCRIPTION
Adds `MSP2_CLI_COMMAND` (0x3012), which runs an arbitrary CLI command line as a bounded MSP2 request/response. This makes the full CLI (not just single settings via `MSP2_CLI_SETTING`) reachable over MSP transports that only carry discrete packets, in particular MSP-over-CRSF/telemetry links, without needing a raw serial byte stream.

Output is captured into a session buffer and paged back to the client by offset, mirroring the windowing already used by `MSP2_CLI_SETTING_INFO`. The response carries a u16 total length and a flags byte (truncated / refused). Reboot, mode-switch and passthrough commands (bl, msc, serialpassthrough, bare defaults) are refused so they can't reach the blocking serial paths on the fabricated CLI port; `save` persists without the reboot, `exit` is a no-op.

The command and its session buffer are gated behind an opt-in `USE_MSP_CLI_COMMAND` capability (requires `USE_CLI`, buffer size `MSP_CLI_COMMAND_BUFFER_SIZE`, default 2048), so RAM-constrained targets exclude it. Enabled on SITL.

Verified with new cli_unittest coverage for the command interception/guards, and end-to-end against SITL over the TCP MSP port (version/get run, dump reassembles across paged requests with the truncated flag, dangerous commands refused without crashing, link stays MSP-framed afterwards). Configurator support and true interactive streaming are follow-ups, not part of this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for executing CLI commands through the MSP protocol without entering interactive CLI mode.
  * Command responses support bounded and paged output, with indicators for truncated or refused requests.
* **Bug Fixes**
  * Prevented unsafe commands, invalid requests, and conflicting CLI states from executing.
  * Reboot, mode-switch, and configuration commands while armed are rejected.
* **Tests**
  * Added coverage for refused commands, invalid requests, commented arguments, and CLI state preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->