### PR TITLE
fix(crsf): don't gate chunked MSP replies on inbound frames

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -699,6 +699,15 @@ bool crsfRxInit(const rxConfig_t *rxConfig, rxRuntimeState_t *rxRuntimeState)
 }
 
 #if defined(USE_CRSF_V3)
+static bool eventDrivenTelemetry = false;
+
+// Only set once a baud negotiation has succeeded, so receivers that never negotiate (ELRS)
+// keep the fixed-rate telemetry task and must not be gated on inbound frames.
+bool crsfRxIsEventDrivenTelemetry(void)
+{
+    return eventDrivenTelemetry;
+}
+
 void crsfRxUpdateBaudrate(uint32_t baudrate)
 {
     serialSetBaudRate(serialPort, baudrate);
@@ -711,11 +720,10 @@ void crsfRxUpdateBaudrate(uint32_t baudrate)
     }
 #if defined(USE_TELEMETRY_CRSF)
     task_t* tlmTask = getTask(TASK_TELEMETRY);
-    if (tlmTask && baudrate > CRSF_BAUDRATE) {
-        // switch telemetry task to event driven
-        tlmTask->attribute->checkFunc = crsfTelemetryUpdateCheck;
-    } else if (tlmTask) {
-        tlmTask->attribute->checkFunc = NULL;
+    if (tlmTask) {
+        // above the default baudrate let the inbound frame rate dictate the outbound rate
+        eventDrivenTelemetry = baudrate > CRSF_BAUDRATE;
+        tlmTask->attribute->checkFunc = eventDrivenTelemetry ? crsfTelemetryUpdateCheck : NULL;
     }
 #endif
 }

--- a/src/main/rx/crsf.h
+++ b/src/main/rx/crsf.h
@@ -86,5 +86,8 @@ struct rxRuntimeState_s;
 bool crsfRxInit(const struct rxConfig_s *initialRxConfig, struct rxRuntimeState_s *rxRuntimeState);
 void crsfRxUpdateBaudrate(uint32_t baudrate);
 bool crsfRxUseNegotiatedBaud(void);
+#if defined(USE_CRSF_V3)
+bool crsfRxIsEventDrivenTelemetry(void);
+#endif
 bool crsfRxIsActive(void);
 void crsfRxBind(void);

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -1127,11 +1127,8 @@ bool crsfTelemetryUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTi
 {
     UNUSED(currentDeltaTimeUs);
 
-    if (!telemetryResponsePending) {
-        return false;
-    }
-
-    // Ad-hoc responses must be serviced as soon as possible, not rate-limited.
+    // Ad-hoc replies span several CRSF payloads and need one task run per chunk, so they are
+    // exempt from both the rate limit and telemetryResponsePending.
 #if defined(USE_MSP_OVER_TELEMETRY)
     if (mspReplyPending) {
         return true;
@@ -1139,6 +1136,10 @@ bool crsfTelemetryUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTi
 #endif
     if (deviceInfoReplyPending) {
         return true;
+    }
+
+    if (!telemetryResponsePending) {
+        return false;
     }
 
     static timeUs_t lastTelemetryCheckTimeUs = 0;
@@ -1331,15 +1332,9 @@ void handleCrsfTelemetry(timeUs_t currentTimeUs)
     // in between the RX frames.
     crsfRxSendTelemetryData();
 
-#if defined(USE_CRSF_V3)
-    // only send responses on recipt of full frames, this ensures the telemetry rate is never faster
-    // than the frame rate
-    if (!telemetryResponsePending) {
-        return;
-    }
-#endif
-
-    // Send ad-hoc response frames as soon as possible
+    // Send ad-hoc response frames as soon as possible, ahead of the gate below: a chunked reply
+    // needs one pass per chunk, and inbound frames can be too sparse to clock them out. ELRS
+    // WiFi passthrough has no RC link, so its only inbound frames are the MSP requests themselves.
 #if defined(USE_MSP_OVER_TELEMETRY)
     if (mspReplyPending) {
         mspReplyPending = handleCrsfMspFrameBuffer(&crsfSendMspResponse);
@@ -1364,6 +1359,15 @@ void handleCrsfTelemetry(timeUs_t currentTimeUs)
         crsfLastCycleTime = currentTimeUs; // reset telemetry timing due to ad-hoc request
         return;
     }
+
+#if defined(USE_CRSF_V3)
+    // Only send periodic telemetry on receipt of a full frame, so the telemetry rate is never
+    // faster than the frame rate. Skipped on fixed-rate links, where it would instead throttle
+    // telemetry down to the inbound frame rate.
+    if (crsfRxIsEventDrivenTelemetry() && !telemetryResponsePending) {
+        return;
+    }
+#endif
 
 #if defined(USE_CRSF_CMS_TELEMETRY)
     if (crsfDisplayPortScreen()->reset) {
@@ -1428,7 +1432,7 @@ void handleCrsfTelemetry(timeUs_t currentTimeUs)
     if (processCrsf(currentTimeUs, crsfLastCycleTime)) {
         crsfLastCycleTime = currentTimeUs;
 #ifdef USE_CRSF_ACCGYRO_TELEMETRY
-    } else if (crsfAccGyroEnabled() && isCrsfV3Running) {  // let the inbound request rate dictate the outbound rate
+    } else if (crsfAccGyroEnabled() && crsfRxIsEventDrivenTelemetry()) {  // let the inbound request rate dictate the outbound rate
         sbuf_t crsfPayloadBuf;
         sbuf_t *dst = &crsfPayloadBuf;
         crsfInitializeFrame(dst);


### PR DESCRIPTION
## Problem

Reported by an ELRS developer: MSP over CRSF works in 2025.12 but is unusable in 2026.6. Whenever a reply from Betaflight exceeds the 62 bytes that fit in a single CRSF payload, the remaining chunk is not sent. The Configurator times out after ~1s and re-requests, that retry clocks out the stale chunk, and from then on every reply lags one request behind until the session falls apart.

2025.12 — request MSP 5, reply. Request MSP 4, split into 62 + 26 bytes, reply 8ms later:

```
5450: MSP in
24 4d 3c 00 04 04                               $M<...
TCP(CRSF) 62
TCP(CRSF) 26
5458 MSP out                                    <-- 8ms
```

2026.6 — the 26-byte chunk only appears after the Configurator's 1s retry:

```
190054: MSP in
24 4d 3c 00 04 04                               $M<...
TCP(CRSF) 62
191090: MSP in                                  <-- 1036ms, Configurator retry
24 4d 3c 00 04 04                               $M<...
TCP(CRSF) 26
191096 MSP out
191112: MSP in
24 4d 3c 00 65 65                               $M<.ee
TCP(CRSF) 62
192217: MSP in                                  <-- 1105ms, and the replies are now off by one
24 4d 3c 00 65 65                               $M<.ee
TCP(CRSF) 32
```

## Cause

de35bd96b (#14870, CRSF AHRS Support) added event-driven CRSF telemetry:

- `crsfScheduleTelemetryResponse()` sets `telemetryResponsePending` from `crsfDataReceive()` on every valid inbound CRSF frame.
- `handleCrsfTelemetry()` gained `if (!telemetryResponsePending) return;`, placed **ahead** of the MSP reply handling.
- Every outbound telemetry frame clears the flag again.

So exactly one telemetry frame is emitted per inbound CRSF frame. `handleCrsfMspFrameBuffer()` correctly reports that more chunks are pending, but the next chunk cannot go out until another frame arrives.

That gate is only correct when `TASK_TELEMETRY` is genuinely event driven, and it only is after a CRSFv3 baud negotiation to a rate above `CRSF_BAUDRATE` installs `crsfTelemetryUpdateCheck()` as its `checkFunc`. **ELRS never negotiates**, so it keeps the fixed-rate 250Hz telemetry task *and* gets the gate — capping all outbound telemetry to the inbound frame rate.

WiFi passthrough is the worst case because there is no RC link at all: the only inbound frames are the MSP requests themselves, so a chunked reply never finishes on its own.

99d688821 (#15358) later exempted `mspReplyPending` from its new 50Hz cap inside `crsfTelemetryUpdateCheck()`, but that exemption was dead — the gate inside `handleCrsfTelemetry()` still blocked the chunk.

In 2025.12 neither the gate nor the `checkFunc` existed, and `mspReplyPending` drained at the full 250Hz task rate — the 8ms in the log above.

## Fix

- Handle ad-hoc MSP and device info replies **ahead** of the gate, so chunks drain at task rate. This also makes #15358's `mspReplyPending` exemption effective.
- Apply the gate only when the telemetry task is actually event driven, via a new `crsfRxIsEventDrivenTelemetry()` that shares the single condition which installs the `checkFunc`, so the two cannot diverge.
- Check the ad-hoc pending flags before `telemetryResponsePending` in `crsfTelemetryUpdateCheck()`, so the task also wakes for chunks 2..n in the negotiated-baud case.
- Key accgyro streaming off `crsfRxIsEventDrivenTelemetry()` instead of `isCrsfV3Running`; it relied on the gate for rate limiting, and a negotiated fast baud is the condition it actually needs.

Periodic telemetry cadence is unchanged: `processCrsf()` still enforces its own `CRSF_CYCLETIME_US / crsfScheduleCount` spacing, and the `crsfRxIsTelemetryBufEmpty()` check still prevents buffer overrun.

## Testing

- `make TARGET=STM32F411` (the reporter's MCU; `USE_CRSF_V3`, `USE_CRSF_ACCGYRO_TELEMETRY` and `USE_MSP_OVER_TELEMETRY` all active) and `make TARGET=SITL` — clean, no new warnings.
- `test_rx_crsf_unittest`, `test_telemetry_crsf_unittest`, `test_telemetry_crsf_msp_unittest` — 20 tests, all pass.

**Not yet verified on hardware.** Needs confirmation from an ELRS user in WiFi passthrough mode, and a check that Crossfire with a negotiated baud is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CRSF V3 telemetry now automatically adapts to the receiver’s negotiated communication rate.
  * Telemetry supports event-driven operation, sending periodic data only when appropriate.

* **Bug Fixes**
  * Improved scheduling to better drain chunked ad-hoc replies without unnecessary rate limiting.
  * Periodic telemetry deferral for CRSF V3 now applies only for event-driven mode when no response is pending.
  * ACCGYRO telemetry now follows the receiver’s request rate in event-driven mode.
  * RTH flight mode selection now also triggers when the rescue plan is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->