### PR TITLE
Upsample low rate sensor data into Kalman filter and add accelerometer state

### DIFF
--- a/src/main/drivers/rangefinder/rangefinder_lidartf.c
+++ b/src/main/drivers/rangefinder/rangefinder_lidartf.c
@@ -131,6 +131,7 @@ static uint8_t tfReceivePosition;
 static const uint8_t tfConfigCmd[] = { 0x42, 0x57, 0x02, 0x00, 0x00, 0x00, 0x01, 0x06 };
 
 static int lidarTFValue;
+static bool hasLidarTFNewData = false;
 static unsigned lidarTFerrors = 0;
 
 
@@ -165,6 +166,7 @@ static void lidarTFInit(rangefinderDev_t *dev)
 
     tfFrameState = TF_FRAME_STATE_WAIT_START1;
     tfReceivePosition = 0;
+    hasLidarTFNewData = false;
 }
 
 static int tfProcessFrame(const uint8_t* frame, int len)
@@ -250,6 +252,7 @@ static void lidarTFUpdate(rangefinderDev_t *dev)
 
             if (c == cksum) {
                 lidarTFValue = tfProcessFrame(tfFrame, TF_FRAME_LENGTH);
+                hasLidarTFNewData = true;
                 lastFrameReceivedMs = timeNowMs;
             } else {
                 // Checksum error. Simply ignore the current frame.
@@ -272,11 +275,15 @@ static void lidarTFUpdate(rangefinderDev_t *dev)
 }
 
 // Return most recent device output in cm
-// TODO - handle timeout; return value only once (see lidarMT)
 static int32_t lidarTFGetDistance(rangefinderDev_t *dev)
 {
     UNUSED(dev);
 
+    if (!hasLidarTFNewData) {
+        return RANGEFINDER_NO_NEW_DATA;
+    }
+
+    hasLidarTFNewData = false;
     return lidarTFValue;
 }
 

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -199,7 +199,6 @@ typedef struct autopilotState_s {
     bool speedSlowing;          // speed is meaningfully below its own trend
     bool isPosHoldBraking;      // decelerating toward a captured hold point
     unsigned brakingTimer;      // loops spent in the current braking phase
-    bool derivativeStale;       // output was frozen past the fence: re-baseline the A-term on resume
     xyAnchorMode_e anchor;      // position-anchor selection for this loop
     xyIntegralPolicy_e iPolicy; // integral policy for this loop
     unsigned debugAxis;
@@ -445,7 +444,6 @@ void positionControlReanchor(void)
     ap.sanityCheckDistance = calculateSanityCheckDistance();
     ap.sanityViolationS = 0.0f;
     ap.violationFreeS = 0.0f;
-    ap.derivativeStale = false;
 }
 
 static void initNavMode(void)
@@ -480,7 +478,6 @@ void resetPositionControl(unsigned taskRateHz)
     ap.sanityViolationS = 0.0f;
     ap.violationFreeS = 0.0f;
     ap.sanityRetryUsed = false;
-    ap.derivativeStale = false;
     initPositionHold(); // sets target location, resets distance error, enables start mode
     previousVelocity = *(const vector2_t *)&positionEstimatorGetEstimate()->velocity.v; // for smooth A in any mode
     resetDistanceErrorIntegral();
@@ -838,10 +835,6 @@ bool positionControl(void)
                     if (ap.sanityViolationS > SANITY_VIOLATION_LATCH_S) {
                         return sanityViolationExpired();
                     }
-                    // The A-term history is now stale; mark it so the resume
-                    // loop re-baselines instead of differentiating across the
-                    // frozen window (one spurious spike against old velocity)
-                    ap.derivativeStale = true;
                     return true; // brief excursion: hold the previous command
                 } else {
                     ap.sanityViolationS = 0.0f;
@@ -868,15 +861,9 @@ bool positionControl(void)
     for (unsigned axis = 0; axis < EF_AXIS_COUNT; axis++) {
         velocityError.v[axis] = targetVelocity.v[axis] - velocity.v[axis];
 
-        // Acceleration (A term), differentiated from measured velocity. One-shot
-        // re-baseline after a frozen sanity window so resumption cannot spike
-        // against stale velocity; previousVelocity is refreshed every loop.
-        float acceleration;
-        if (ap.derivativeStale) {
-            acceleration = 0.0f;
-        } else {
-            acceleration = (previousVelocity.v[axis] - velocity.v[axis]) * POSHOLD_TASK_RATE_HZ;
-        }
+        // Preserve the A-term's opposing sign while consuming the Kalman
+        // acceleration state directly instead of differentiating velocity.
+        const float acceleration = -est->acceleration.v[axis];
         previousVelocity.v[axis] = velocity.v[axis];
 
         // Distance error: real (position anchor) or virtual (integral of the
@@ -929,8 +916,6 @@ bool positionControl(void)
         // tunable acceleration feedforward.
         pidF.v[axis] = targetVelocity.v[axis] * xyPid.Kd + targetVelDelta * xyPid.Kf;
     } // End for loop
-    ap.derivativeStale = false;
-
     // Buildup clamp: only in the anchor-off fallback, where the velocity-error
     // drive (D + F = Kd*velocityError plus the accel feedforward) itself carries
     // the cruise tilt and would otherwise slam the pitch while accelerating. When

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -204,6 +204,10 @@ static bool gpsAltOffsetSet = false;
 static float baroAltOffsetCm = 0.0f;
 static float baroAltAccumulator = 0.0f;
 static bool baroOffsetSet = false;
+static bool baroDataAvailable = false;
+static timeUs_t baroTimestampUs = 0;
+static timeDelta_t baroHoldDurationUs = 0;
+static float baroMeasurementNoiseScale = 1.0f;
 #endif
 
 #ifdef USE_RANGEFINDER
@@ -271,6 +275,10 @@ void positionEstimatorInit(void)
     baroAltOffsetCm = 0.0f;
     baroAltAccumulator = 0.0f;
     baroOffsetSet = false;
+    baroDataAvailable = false;
+    baroTimestampUs = 0;
+    baroHoldDurationUs = 0;
+    baroMeasurementNoiseScale = 1.0f;
 #endif
 #ifdef USE_RANGEFINDER
     rangefinderAltOffsetCm = 0.0f;
@@ -383,6 +391,39 @@ STATIC_UNIT_TESTED bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *nois
     }
 
     *noiseScale = gpsMeasurementNoiseScale;
+    return true;
+}
+#endif
+
+#ifdef USE_BARO
+// A complete pressure-conversion cycle can be slower than the barometer task's
+// scheduler rate. Use timestamps from valid altitude samples so conversion
+// delays and target-specific barometer rates are both accounted for.
+STATIC_UNIT_TESTED bool baroMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale)
+{
+    const timeUs_t sampleTimeUs = getBaroLatestSampleTimeUs();
+    const bool hasNewData = !baroDataAvailable || sampleTimeUs != baroTimestampUs;
+    if (hasNewData) {
+        const timeDelta_t sourceIntervalUs = getBaroSampleIntervalUs();
+
+        baroDataAvailable = true;
+        baroTimestampUs = sampleTimeUs;
+        baroHoldDurationUs = sourceIntervalUs;
+        baroMeasurementNoiseScale = fmaxf(
+            (float)TASK_ALTITUDE_RATE_HZ * sourceIntervalUs * 1e-6f,
+            1.0f);
+    }
+
+    const timeDelta_t sampleAgeUs = cmpTimeUs(nowUs, baroTimestampUs);
+    const bool withinHoldInterval = baroDataAvailable &&
+        baroHoldDurationUs > 0 &&
+        sampleAgeUs >= 0 &&
+        sampleAgeUs < baroHoldDurationUs;
+    if ((!hasNewData || baroHoldDurationUs > 0) && !withinHoldInterval) {
+        return false;
+    }
+
+    *noiseScale = baroMeasurementNoiseScale;
     return true;
 }
 #endif
@@ -556,6 +597,7 @@ static void feedBaroMeasurements(timeUs_t nowUs)
 {
 #ifdef USE_BARO
     if (!sensors(SENSOR_BARO)) {
+        baroDataAvailable = false;
         return;
     }
 
@@ -566,6 +608,11 @@ static void feedBaroMeasurements(timeUs_t nowUs)
     }
 
     const float baroAltCm = getBaroAltitude();
+
+    float noiseScale;
+    if (!baroMeasurementReadyForFusion(nowUs, &noiseScale)) {
+        return;
+    }
 
     if (!baroOffsetSet) {
         // Capture disarmed baseline once; keep live relative altitude while disarmed.
@@ -578,7 +625,7 @@ static void feedBaroMeasurements(timeUs_t nowUs)
     const float baroPreference = constrainf(positionConfig()->altitude_prefer_baro * 0.01f, 0.01f, 1.0f);
     const float baroR = R_BARO_ALT / baroPreference;
 
-    kalmanUpdatePosition(&kfUp, baroAltCm - baroAltOffsetCm, baroR);
+    kalmanUpdatePosition(&kfUp, baroAltCm - baroAltOffsetCm, baroR * noiseScale);
     lastZMeasurementUs = nowUs;
 
     zCal[CAL_Z_BARO].rawReading = baroAltCm;

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -211,6 +211,13 @@ static float rangefinderAltOffsetCm = 0.0f;
 static bool rangefinderOffsetSet = false;
 #endif
 
+#ifdef USE_OPTICALFLOW
+static bool opticalFlowDataAvailable = false;
+static timeUs_t opticalFlowTimestampUs = 0;
+static timeDelta_t opticalFlowHoldDurationUs = 0;
+static float opticalFlowMeasurementNoiseScale = 1.0f;
+#endif
+
 static void initZCalEntries(void)
 {
     for (int i = 0; i < CAL_Z_COUNT; i++) {
@@ -264,6 +271,12 @@ void positionEstimatorInit(void)
 #ifdef USE_RANGEFINDER
     rangefinderAltOffsetCm = 0.0f;
     rangefinderOffsetSet = false;
+#endif
+#ifdef USE_OPTICALFLOW
+    opticalFlowDataAvailable = false;
+    opticalFlowTimestampUs = 0;
+    opticalFlowHoldDurationUs = 0;
+    opticalFlowMeasurementNoiseScale = 1.0f;
 #endif
 
     initZCalEntries();
@@ -380,6 +393,43 @@ static float opticalFlowR(int16_t quality)
     // Scale R inversely with quality: better quality = lower noise
     const float qualityNorm = constrainf((float)(quality - minQuality) / (100.0f - minQuality), 0.01f, 1.0f);
     return R_OPTICALFLOW_VEL / qualityNorm;
+}
+
+// Optical-flow drivers expose the timestamp of the last processed sensor
+// sample. Use its measured cadence after the first sample; delayMs is only the
+// nominal first-sample fallback. This avoids mistaking a driver's faster
+// polling rate (such as the UP-T1 rangefinder's 2x polling) for its data rate.
+STATIC_UNIT_TESTED bool opticalFlowMeasurementReadyForFusion(timeUs_t nowUs, const opticalflow_t *flow, float *noiseScale)
+{
+    const bool hasNewData = !opticalFlowDataAvailable || flow->timeStampUs != opticalFlowTimestampUs;
+    if (hasNewData) {
+        timeDelta_t sourceIntervalUs = (timeDelta_t)flow->dev.delayMs * 1000;
+        if (opticalFlowDataAvailable) {
+            const timeDelta_t measuredIntervalUs = cmpTimeUs(flow->timeStampUs, opticalFlowTimestampUs);
+            if (measuredIntervalUs > 0 && measuredIntervalUs <= OPTICALFLOW_HARDWARE_TIMEOUT_US) {
+                sourceIntervalUs = measuredIntervalUs;
+            }
+        }
+
+        opticalFlowDataAvailable = true;
+        opticalFlowTimestampUs = flow->timeStampUs;
+        opticalFlowHoldDurationUs = sourceIntervalUs;
+        opticalFlowMeasurementNoiseScale = fmaxf(
+            (float)TASK_ALTITUDE_RATE_HZ * sourceIntervalUs * 1e-6f,
+            1.0f);
+    }
+
+    const timeDelta_t sampleAgeUs = cmpTimeUs(nowUs, opticalFlowTimestampUs);
+    const bool withinHoldInterval = opticalFlowDataAvailable &&
+        opticalFlowHoldDurationUs > 0 &&
+        sampleAgeUs >= 0 &&
+        sampleAgeUs < opticalFlowHoldDurationUs;
+    if (!hasNewData && !withinHoldInterval) {
+        return false;
+    }
+
+    *noiseScale = opticalFlowMeasurementNoiseScale;
+    return true;
 }
 #endif
 
@@ -541,6 +591,7 @@ static void feedOpticalFlowMeasurements(timeUs_t nowUs)
     }
 
     if (!sensors(SENSOR_OPTICALFLOW) || !isOpticalflowHealthy()) {
+        opticalFlowDataAvailable = false;
         return;
     }
 
@@ -581,6 +632,11 @@ static void feedOpticalFlowMeasurements(timeUs_t nowUs)
         return;  // quality too low
     }
 
+    float noiseScale;
+    if (!opticalFlowMeasurementReadyForFusion(nowUs, flow, &noiseScale)) {
+        return;
+    }
+
     // Convert flow rates (rad/s) to velocity (cm/s) in body frame, scaled by rangefinder height.
     // Flow sensor X axis measures rightward motion; Y axis measures forward motion.
     const float flowRight   = flow->processedFlowRates.x * altitudeCm;
@@ -599,8 +655,8 @@ static void feedOpticalFlowMeasurements(timeUs_t nowUs)
     const float velEast  =  velForward * sinYaw - velRight * cosYaw;
     const float velNorth =  velForward * cosYaw + velRight * sinYaw;
 
-    kalmanUpdateVelocity(&kfEast, velEast, flowR);
-    kalmanUpdateVelocity(&kfNorth, velNorth, flowR);
+    kalmanUpdateVelocity(&kfEast, velEast, flowR * noiseScale);
+    kalmanUpdateVelocity(&kfNorth, velNorth, flowR * noiseScale);
 
     lastXYMeasurementUs = nowUs;
 #else

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -190,6 +190,10 @@ static sensorCalEntry_t zCal[CAL_Z_COUNT];
 
 #ifdef USE_GPS
 static uint16_t gpsStamp = 0;
+static bool gpsDataAvailable = false;
+static timeUs_t gpsDataReceivedAtUs = 0;
+static timeDelta_t gpsDataHoldDurationUs = 0;
+static float gpsMeasurementNoiseScale = 1.0f;
 static gpsLocation_t armLocationGps;
 static bool gpsArmLocationSet = false;
 static float gpsAltOffsetCm = 0.0f;
@@ -244,6 +248,10 @@ void positionEstimatorInit(void)
 
 #ifdef USE_GPS
     gpsStamp = 0;
+    gpsDataAvailable = false;
+    gpsDataReceivedAtUs = 0;
+    gpsDataHoldDurationUs = 0;
+    gpsMeasurementNoiseScale = 1.0f;
     gpsArmLocationSet = false;
     gpsAltOffsetCm = 0.0f;
     gpsAltOffsetSet = false;
@@ -324,6 +332,38 @@ static uint16_t gpsDopOrFallback(uint16_t preferredDop, uint16_t fallbackDop)
 {
     return (preferredDop >= GPS_DOP_MIN_VALID) ? preferredDop : fallbackDop;
 }
+
+// Hold each GPS sample until the next one is expected so it can be fused at the
+// altitude task rate. Scaling R by the number of repeated updates preserves
+// approximately the same information per second as fusion at the GPS rate.
+STATIC_UNIT_TESTED bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale)
+{
+    const bool hasNewData = gpsHasNewData(&gpsStamp);
+    if (hasNewData) {
+        const float gpsFrequencyHz = getGpsDataFrequencyHz();
+
+        gpsDataAvailable = true;
+        gpsDataReceivedAtUs = nowUs;
+        if (gpsFrequencyHz > 0.0f) {
+            gpsDataHoldDurationUs = (timeDelta_t)lrintf(1000000.0f / gpsFrequencyHz);
+            gpsMeasurementNoiseScale = fmaxf((float)TASK_ALTITUDE_RATE_HZ / gpsFrequencyHz, 1.0f);
+        } else {
+            // An invalid frequency cannot define a safe hold interval.
+            gpsDataHoldDurationUs = 0;
+            gpsMeasurementNoiseScale = 1.0f;
+        }
+    }
+
+    const bool withinHoldInterval = gpsDataAvailable &&
+        gpsDataHoldDurationUs > 0 &&
+        cmpTimeUs(nowUs, gpsDataReceivedAtUs) < gpsDataHoldDurationUs;
+    if (!hasNewData && !withinHoldInterval) {
+        return false;
+    }
+
+    *noiseScale = gpsMeasurementNoiseScale;
+    return true;
+}
 #endif
 
 #ifdef USE_OPTICALFLOW
@@ -347,10 +387,12 @@ static void feedGPSMeasurements(timeUs_t nowUs)
 {
 #ifdef USE_GPS
     if (!sensors(SENSOR_GPS) || !STATE(GPS_FIX)) {
+        gpsDataAvailable = false;
         return;
     }
 
-    if (!gpsHasNewData(&gpsStamp)) {
+    float noiseScale;
+    if (!gpsMeasurementReadyForFusion(nowUs, &noiseScale)) {
         return;
     }
 
@@ -382,12 +424,12 @@ static void feedGPSMeasurements(timeUs_t nowUs)
         // v[EF_EAST] = East (lon), v[EF_NORTH] = North (lat) relative to the arm point.
 
         const uint16_t xyDop = gpsDopOrFallback(gpsSol.dop.hdop, gpsSol.dop.pdop);
-        const float rPos = gpsR(R_GPS_POS_BASE, xyDop);
+        const float rPos = gpsR(R_GPS_POS_BASE, xyDop) * noiseScale;
         kalmanUpdatePosition(&kfEast, gpsDistCm.v[EF_EAST], rPos);
         kalmanUpdatePosition(&kfNorth, gpsDistCm.v[EF_NORTH], rPos);
 
         // GPS velocity (NED from UBX) -> ENU
-        const float rVel = gpsR(R_GPS_VEL_BASE, xyDop);
+        const float rVel = gpsR(R_GPS_VEL_BASE, xyDop) * noiseScale;
         kalmanUpdateVelocity(&kfEast, (float)gpsSol.velned.velE, rVel);
         kalmanUpdateVelocity(&kfNorth, (float)gpsSol.velned.velN, rVel);
 
@@ -405,7 +447,7 @@ static void feedGPSMeasurements(timeUs_t nowUs)
         // altitude_prefer_baro=100 means strongly prefer baro, so GPS R should be higher
         const float baroPreference = positionConfig()->altitude_prefer_baro * 0.01f;
         const uint16_t altDop = gpsDopOrFallback(gpsSol.dop.vdop, gpsSol.dop.pdop);
-        const float gpsAltR = gpsR(R_GPS_ALT_BASE, altDop) * (1.0f + baroPreference * 2.0f);
+        const float gpsAltR = gpsR(R_GPS_ALT_BASE, altDop) * (1.0f + baroPreference * 2.0f) * noiseScale;
 
         const float gpsRelativeAltCm = gpsSol.llh.altCm - gpsAltOffsetCm;
         kalmanUpdatePosition(&kfUp, gpsRelativeAltCm, gpsAltR);

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -209,6 +209,10 @@ static bool baroOffsetSet = false;
 #ifdef USE_RANGEFINDER
 static float rangefinderAltOffsetCm = 0.0f;
 static bool rangefinderOffsetSet = false;
+static bool rangefinderDataAvailable = false;
+static timeUs_t rangefinderTimestampUs = 0;
+static timeDelta_t rangefinderHoldDurationUs = 0;
+static float rangefinderMeasurementNoiseScale = 1.0f;
 #endif
 
 #ifdef USE_OPTICALFLOW
@@ -271,6 +275,10 @@ void positionEstimatorInit(void)
 #ifdef USE_RANGEFINDER
     rangefinderAltOffsetCm = 0.0f;
     rangefinderOffsetSet = false;
+    rangefinderDataAvailable = false;
+    rangefinderTimestampUs = 0;
+    rangefinderHoldDurationUs = 0;
+    rangefinderMeasurementNoiseScale = 1.0f;
 #endif
 #ifdef USE_OPTICALFLOW
     opticalFlowDataAvailable = false;
@@ -375,6 +383,39 @@ STATIC_UNIT_TESTED bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *nois
     }
 
     *noiseScale = gpsMeasurementNoiseScale;
+    return true;
+}
+#endif
+
+#ifdef USE_RANGEFINDER
+// rangefinderProcess() timestamps only actual device samples, so its measured
+// interval remains correct when a driver task polls faster than the hardware
+// data rate (the UP-T1 polls at 100 Hz for a 50 Hz data stream, for example).
+STATIC_UNIT_TESTED bool rangefinderMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale)
+{
+    const timeUs_t sampleTimeUs = rangefinderGetLatestSampleTimeUs();
+    const bool hasNewData = !rangefinderDataAvailable || sampleTimeUs != rangefinderTimestampUs;
+    if (hasNewData) {
+        const timeDelta_t sourceIntervalUs = rangefinderGetSampleIntervalUs();
+
+        rangefinderDataAvailable = true;
+        rangefinderTimestampUs = sampleTimeUs;
+        rangefinderHoldDurationUs = sourceIntervalUs;
+        rangefinderMeasurementNoiseScale = fmaxf(
+            (float)TASK_ALTITUDE_RATE_HZ * sourceIntervalUs * 1e-6f,
+            1.0f);
+    }
+
+    const timeDelta_t sampleAgeUs = cmpTimeUs(nowUs, rangefinderTimestampUs);
+    const bool withinHoldInterval = rangefinderDataAvailable &&
+        rangefinderHoldDurationUs > 0 &&
+        sampleAgeUs >= 0 &&
+        sampleAgeUs < rangefinderHoldDurationUs;
+    if ((!hasNewData || rangefinderHoldDurationUs > 0) && !withinHoldInterval) {
+        return false;
+    }
+
+    *noiseScale = rangefinderMeasurementNoiseScale;
     return true;
 }
 #endif
@@ -558,6 +599,12 @@ static void feedRangefinderMeasurements(timeUs_t nowUs)
 
     float altCm;
     if (!rangefinderSampleAltitudeCm(&altCm, positionConfig()->rangefinder_max_range_cm)) {
+        rangefinderDataAvailable = false;
+        return;
+    }
+
+    float noiseScale;
+    if (!rangefinderMeasurementReadyForFusion(nowUs, &noiseScale)) {
         return;
     }
 
@@ -573,7 +620,7 @@ static void feedRangefinderMeasurements(timeUs_t nowUs)
         rfR *= 0.25f;  // even lower noise -> stronger pull
     }
 
-    kalmanUpdatePosition(&kfUp, altCm - rangefinderAltOffsetCm, rfR);
+    kalmanUpdatePosition(&kfUp, altCm - rangefinderAltOffsetCm, rfR * noiseScale);
     lastZMeasurementUs = nowUs;
 
     zCal[CAL_Z_RF].rawReading = altCm;

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -192,8 +192,11 @@ static sensorCalEntry_t zCal[CAL_Z_COUNT];
 static uint16_t gpsStamp = 0;
 static bool gpsDataAvailable = false;
 static timeUs_t gpsDataReceivedAtUs = 0;
-static timeDelta_t gpsDataHoldDurationUs = 0;
+static timeUs_t gpsDataHoldDurationUs = 0;
 static float gpsMeasurementNoiseScale = 1.0f;
+static vector2_t gpsVelocityMeasurement;
+static vector2_t previousGpsVelocityMeasurement;
+static bool previousGpsVelocityMeasurementValid = false;
 static gpsLocation_t armLocationGps;
 static bool gpsArmLocationSet = false;
 static float gpsAltOffsetCm = 0.0f;
@@ -267,6 +270,9 @@ void positionEstimatorInit(void)
     gpsDataReceivedAtUs = 0;
     gpsDataHoldDurationUs = 0;
     gpsMeasurementNoiseScale = 1.0f;
+    gpsVelocityMeasurement = (vector2_t){{0.0f, 0.0f}};
+    previousGpsVelocityMeasurement = (vector2_t){{0.0f, 0.0f}};
+    previousGpsVelocityMeasurementValid = false;
     gpsArmLocationSet = false;
     gpsAltOffsetCm = 0.0f;
     gpsAltOffsetSet = false;
@@ -362,6 +368,33 @@ static uint16_t gpsDopOrFallback(uint16_t preferredDop, uint16_t fallbackDop)
     return (preferredDop >= GPS_DOP_MIN_VALID) ? preferredDop : fallbackDop;
 }
 
+// Average adjacent native-rate GPS velocity samples before upsampling. This
+// suppresses alternating sample noise with only half a GPS interval of group
+// delay; keeping the previous raw sample avoids turning this into a recursive
+// low-pass filter.
+static void gpsUpdateVelocityMeasurement(void)
+{
+    const vector2_t current = {{
+        (float)gpsSol.velned.velE,
+        (float)gpsSol.velned.velN,
+    }};
+
+    if (previousGpsVelocityMeasurementValid) {
+        gpsVelocityMeasurement.x = 0.5f * (current.x + previousGpsVelocityMeasurement.x);
+        gpsVelocityMeasurement.y = 0.5f * (current.y + previousGpsVelocityMeasurement.y);
+    } else {
+        gpsVelocityMeasurement = current;
+    }
+
+    previousGpsVelocityMeasurement = current;
+    previousGpsVelocityMeasurementValid = true;
+}
+
+STATIC_UNIT_TESTED const vector2_t *gpsGetVelocityMeasurement(void)
+{
+    return &gpsVelocityMeasurement;
+}
+
 // Hold each GPS sample until the next one is expected so it can be fused at the
 // altitude task rate. Scaling R by the number of repeated updates preserves
 // approximately the same information per second as fusion at the GPS rate.
@@ -371,10 +404,18 @@ STATIC_UNIT_TESTED bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *nois
     if (hasNewData) {
         const float gpsFrequencyHz = getGpsDataFrequencyHz();
 
+        const timeUs_t timeSincePreviousDataUs = nowUs - gpsDataReceivedAtUs;
+        if (gpsDataAvailable &&
+            gpsDataHoldDurationUs > 0 &&
+            timeSincePreviousDataUs > gpsDataHoldDurationUs + gpsDataHoldDurationUs / 2) {
+            // Do not average across a missing frame or receiver outage.
+            previousGpsVelocityMeasurementValid = false;
+        }
+        gpsUpdateVelocityMeasurement();
         gpsDataAvailable = true;
         gpsDataReceivedAtUs = nowUs;
         if (gpsFrequencyHz > 0.0f) {
-            gpsDataHoldDurationUs = (timeDelta_t)lrintf(1000000.0f / gpsFrequencyHz);
+            gpsDataHoldDurationUs = (timeUs_t)lrintf(1000000.0f / gpsFrequencyHz);
             gpsMeasurementNoiseScale = fmaxf((float)TASK_ALTITUDE_RATE_HZ / gpsFrequencyHz, 1.0f);
         } else {
             // An invalid frequency cannot define a safe hold interval.
@@ -385,7 +426,7 @@ STATIC_UNIT_TESTED bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *nois
 
     const bool withinHoldInterval = gpsDataAvailable &&
         gpsDataHoldDurationUs > 0 &&
-        cmpTimeUs(nowUs, gpsDataReceivedAtUs) < gpsDataHoldDurationUs;
+        nowUs - gpsDataReceivedAtUs < gpsDataHoldDurationUs;
     if (!hasNewData && !withinHoldInterval) {
         return false;
     }
@@ -520,6 +561,7 @@ static void feedGPSMeasurements(timeUs_t nowUs)
 #ifdef USE_GPS
     if (!sensors(SENSOR_GPS) || !STATE(GPS_FIX)) {
         gpsDataAvailable = false;
+        previousGpsVelocityMeasurementValid = false;
         return;
     }
 
@@ -562,8 +604,9 @@ static void feedGPSMeasurements(timeUs_t nowUs)
 
         // GPS velocity (NED from UBX) -> ENU
         const float rVel = gpsR(R_GPS_VEL_BASE, xyDop) * noiseScale;
-        kalmanUpdateVelocity(&kfEast, (float)gpsSol.velned.velE, rVel);
-        kalmanUpdateVelocity(&kfNorth, (float)gpsSol.velned.velN, rVel);
+        const vector2_t *gpsVelocity = gpsGetVelocityMeasurement();
+        kalmanUpdateVelocity(&kfEast, gpsVelocity->v[EF_EAST], rVel);
+        kalmanUpdateVelocity(&kfNorth, gpsVelocity->v[EF_NORTH], rVel);
 
         lastXYMeasurementUs = nowUs;
     }

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -66,15 +66,17 @@
 #include "pg/pos_hold.h"
 #endif
 
-// Accelerometer process noise in (cm/s^2)^2.
-// Accounts for vibration, bias drift, attitude errors.
-// Higher = less trust in accel dead-reckoning, more reliance on sensor corrections.
-#define Q_ACCEL_XY          50000.0f
-#define Q_ACCEL_Z           20000.0f // lower value favours faster acc changes, 700.0f is too low
+// Constant-acceleration model tuning. Jerk process noise allows acceleration
+// to change; accelerometer R accounts for vibration, bias, and attitude error.
+#define Q_JERK_XY           50000.0f
+#define Q_JERK_Z            20000.0f
+#define R_ACCEL_XY          50000.0f
+#define R_ACCEL_Z           20000.0f
 
 // Initial covariance values
 #define INITIAL_POS_VAR     10000.0f    // cm^2  (1m uncertainty)
 #define INITIAL_VEL_VAR     10000.0f    // (cm/s)^2
+#define INITIAL_ACCEL_VAR   1000000.0f  // (cm/s^2)^2; acquire IMU acceleration quickly
 
 // Measurement noise base values (R)
 #define R_GPS_POS_BASE       500.0f      // cm^2 at pDOP=1.0
@@ -181,7 +183,7 @@ static positionKalman_t kfUp;
 static positionEstimate3d_t estimate;
 
 static bool xyEnabled = false;
-static float qaccelXY = Q_ACCEL_XY; // value to use for QAccel
+static float qJerkXY = Q_JERK_XY;
 
 static timeUs_t lastXYMeasurementUs = 0;
 static timeUs_t lastZMeasurementUs = 0;
@@ -194,9 +196,6 @@ static bool gpsDataAvailable = false;
 static timeUs_t gpsDataReceivedAtUs = 0;
 static timeUs_t gpsDataHoldDurationUs = 0;
 static float gpsMeasurementNoiseScale = 1.0f;
-static vector2_t gpsVelocityMeasurement;
-static vector2_t previousGpsVelocityMeasurement;
-static bool previousGpsVelocityMeasurementValid = false;
 static gpsLocation_t armLocationGps;
 static bool gpsArmLocationSet = false;
 static float gpsAltOffsetCm = 0.0f;
@@ -247,14 +246,15 @@ void positionEstimatorInit(void)
 {
 
 #if defined(USE_POSITION_HOLD)
-    qaccelXY = Q_ACCEL_XY * ((autopilotConfig()->positionA > 1) ?  (30.0f / autopilotConfig()->positionA ) : 15.0f);
+    qJerkXY = Q_JERK_XY * ((autopilotConfig()->positionA > 1) ?  (30.0f / autopilotConfig()->positionA ) : 15.0f);
     // when user reduces positionA, , they want more accelerometer influence (up to 15x more), and vice versa
 #endif
-    kalmanInit(&kfEast, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, qaccelXY);
-    kalmanInit(&kfNorth, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, qaccelXY);
-    kalmanInit(&kfUp, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_Z);
+    kalmanInit(&kfEast, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY);
+    kalmanInit(&kfNorth, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY);
+    kalmanInit(&kfUp, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, Q_JERK_Z);
     estimate.position = (vector3_t){{0, 0, 0}};
     estimate.velocity = (vector3_t){{0, 0, 0}};
+    estimate.acceleration = (vector3_t){{0, 0, 0}};
     estimate.trustXY = 0.0f;
     estimate.trustZ = 0.0f;
     estimate.isValidXY = false;
@@ -270,9 +270,6 @@ void positionEstimatorInit(void)
     gpsDataReceivedAtUs = 0;
     gpsDataHoldDurationUs = 0;
     gpsMeasurementNoiseScale = 1.0f;
-    gpsVelocityMeasurement = (vector2_t){{0.0f, 0.0f}};
-    previousGpsVelocityMeasurement = (vector2_t){{0.0f, 0.0f}};
-    previousGpsVelocityMeasurementValid = false;
     gpsArmLocationSet = false;
     gpsAltOffsetCm = 0.0f;
     gpsAltOffsetSet = false;
@@ -307,12 +304,14 @@ void positionEstimatorInit(void)
 void positionEstimatorEnableXY(bool enable)
 {
     if (enable && !xyEnabled) {
-        kalmanInit(&kfEast, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, qaccelXY);
-        kalmanInit(&kfNorth, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, qaccelXY);
+        kalmanInit(&kfEast, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY);
+        kalmanInit(&kfNorth, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY);
         estimate.position.v[ENU_E] = 0.0f;
         estimate.position.v[ENU_N] = 0.0f;
         estimate.velocity.v[ENU_E] = 0.0f;
         estimate.velocity.v[ENU_N] = 0.0f;
+        estimate.acceleration.v[ENU_E] = 0.0f;
+        estimate.acceleration.v[ENU_N] = 0.0f;
         lastXYMeasurementUs = 0;
         estimate.isValidXY = false;
 #ifdef USE_GPS
@@ -368,33 +367,6 @@ static uint16_t gpsDopOrFallback(uint16_t preferredDop, uint16_t fallbackDop)
     return (preferredDop >= GPS_DOP_MIN_VALID) ? preferredDop : fallbackDop;
 }
 
-// Average adjacent native-rate GPS velocity samples before upsampling. This
-// suppresses alternating sample noise with only half a GPS interval of group
-// delay; keeping the previous raw sample avoids turning this into a recursive
-// low-pass filter.
-static void gpsUpdateVelocityMeasurement(void)
-{
-    const vector2_t current = {{
-        (float)gpsSol.velned.velE,
-        (float)gpsSol.velned.velN,
-    }};
-
-    if (previousGpsVelocityMeasurementValid) {
-        gpsVelocityMeasurement.x = 0.5f * (current.x + previousGpsVelocityMeasurement.x);
-        gpsVelocityMeasurement.y = 0.5f * (current.y + previousGpsVelocityMeasurement.y);
-    } else {
-        gpsVelocityMeasurement = current;
-    }
-
-    previousGpsVelocityMeasurement = current;
-    previousGpsVelocityMeasurementValid = true;
-}
-
-STATIC_UNIT_TESTED const vector2_t *gpsGetVelocityMeasurement(void)
-{
-    return &gpsVelocityMeasurement;
-}
-
 // Hold each GPS sample until the next one is expected so it can be fused at the
 // altitude task rate. Scaling R by the number of repeated updates preserves
 // approximately the same information per second as fusion at the GPS rate.
@@ -404,14 +376,6 @@ STATIC_UNIT_TESTED bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *nois
     if (hasNewData) {
         const float gpsFrequencyHz = getGpsDataFrequencyHz();
 
-        const timeUs_t timeSincePreviousDataUs = nowUs - gpsDataReceivedAtUs;
-        if (gpsDataAvailable &&
-            gpsDataHoldDurationUs > 0 &&
-            timeSincePreviousDataUs > gpsDataHoldDurationUs + gpsDataHoldDurationUs / 2) {
-            // Do not average across a missing frame or receiver outage.
-            previousGpsVelocityMeasurementValid = false;
-        }
-        gpsUpdateVelocityMeasurement();
         gpsDataAvailable = true;
         gpsDataReceivedAtUs = nowUs;
         if (gpsFrequencyHz > 0.0f) {
@@ -561,7 +525,6 @@ static void feedGPSMeasurements(timeUs_t nowUs)
 #ifdef USE_GPS
     if (!sensors(SENSOR_GPS) || !STATE(GPS_FIX)) {
         gpsDataAvailable = false;
-        previousGpsVelocityMeasurementValid = false;
         return;
     }
 
@@ -604,9 +567,8 @@ static void feedGPSMeasurements(timeUs_t nowUs)
 
         // GPS velocity (NED from UBX) -> ENU
         const float rVel = gpsR(R_GPS_VEL_BASE, xyDop) * noiseScale;
-        const vector2_t *gpsVelocity = gpsGetVelocityMeasurement();
-        kalmanUpdateVelocity(&kfEast, gpsVelocity->v[EF_EAST], rVel);
-        kalmanUpdateVelocity(&kfNorth, gpsVelocity->v[EF_NORTH], rVel);
+        kalmanUpdateVelocity(&kfEast, (float)gpsSol.velned.velE, rVel);
+        kalmanUpdateVelocity(&kfNorth, (float)gpsSol.velned.velN, rVel);
 
         lastXYMeasurementUs = nowUs;
     }
@@ -835,15 +797,18 @@ void positionEstimatorUpdate(void)
     float accelEast, accelNorth, accelUp;
     getLinearAccelENU(&accelEast, &accelNorth, &accelUp);
 
-    // Z-axis: always runs (for altitude hold, OSD, vario).
-    // While disarmed, predict with zero acceleration so covariance continues to evolve
-    // and incoming baro/rangefinder updates remain responsive.
-    kalmanPredict(&kfUp, dt, ARMING_FLAG(ARMED) ? accelUp : 0.0f);
+    // Z-axis: always runs (for altitude hold, OSD, vario). While disarmed,
+    // measure zero acceleration so covariance continues to evolve without
+    // integrating small gravity-removal errors.
+    kalmanPredict(&kfUp, dt);
+    kalmanUpdateAcceleration(&kfUp, ARMING_FLAG(ARMED) ? accelUp : 0.0f, R_ACCEL_Z);
 
     // XY axes: only when a consumer is active
     if (xyEnabled && ARMING_FLAG(ARMED)) {
-        kalmanPredict(&kfEast, dt, accelEast);
-        kalmanPredict(&kfNorth, dt, accelNorth);
+        kalmanPredict(&kfEast, dt);
+        kalmanPredict(&kfNorth, dt);
+        kalmanUpdateAcceleration(&kfEast, accelEast, R_ACCEL_XY);
+        kalmanUpdateAcceleration(&kfNorth, accelNorth, R_ACCEL_XY);
     }
 
     // Feed sensor measurements (order does not matter)
@@ -863,6 +828,9 @@ void positionEstimatorUpdate(void)
     estimate.velocity.v[ENU_E] = kalmanGetVelocity(&kfEast);
     estimate.velocity.v[ENU_N] = kalmanGetVelocity(&kfNorth);
     estimate.velocity.v[ENU_U] = kalmanGetVelocity(&kfUp);
+    estimate.acceleration.v[ENU_E] = kalmanGetAcceleration(&kfEast);
+    estimate.acceleration.v[ENU_N] = kalmanGetAcceleration(&kfNorth);
+    estimate.acceleration.v[ENU_U] = kalmanGetAcceleration(&kfUp);
 
     // Validity: based on recent measurement updates
     if (xyEnabled) {
@@ -935,9 +903,10 @@ bool positionEstimatorIsHeadingRequired(void)
 
 void positionEstimatorResetZ(void)
 {
-    kalmanInit(&kfUp, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_Z);
+    kalmanInit(&kfUp, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, Q_JERK_Z);
     estimate.position.v[ENU_U] = 0.0f;
     estimate.velocity.v[ENU_U] = 0.0f;
+    estimate.acceleration.v[ENU_U] = 0.0f;
     estimate.isValidZ = false;
     lastZMeasurementUs = 0;
 #ifdef USE_GPS
@@ -959,12 +928,14 @@ void positionEstimatorResetZ(void)
 
 void positionEstimatorResetXY(void)
 {
-    kalmanInit(&kfEast, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
-    kalmanInit(&kfNorth, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, Q_ACCEL_XY);
+    kalmanInit(&kfEast, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY);
+    kalmanInit(&kfNorth, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY);
     estimate.position.v[ENU_E] = 0.0f;
     estimate.position.v[ENU_N] = 0.0f;
     estimate.velocity.v[ENU_E] = 0.0f;
     estimate.velocity.v[ENU_N] = 0.0f;
+    estimate.acceleration.v[ENU_E] = 0.0f;
+    estimate.acceleration.v[ENU_N] = 0.0f;
     estimate.isValidXY = false;
     lastXYMeasurementUs = 0;
 #ifdef USE_GPS

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -67,11 +67,20 @@
 #endif
 
 // Constant-acceleration model tuning. Jerk process noise allows acceleration
-// to change; accelerometer R accounts for vibration, bias, and attitude error.
-#define Q_JERK_XY           50000.0f
+// to change; accelerometer R accounts for vibration and residual attitude error.
+#define Q_JERK_XY           3000.0f
 #define Q_JERK_Z            20000.0f
-#define R_ACCEL_XY          50000.0f
+#define R_ACCEL_XY          2000.0f
 #define R_ACCEL_Z           20000.0f
+
+// How fast the accelerometer bias state may be re-learned, as a random walk. The bias is
+// physically slow (attitude error, calibration, thermal drift), so this only has to be
+// large enough to follow it, and there is a real penalty for going higher: the bias state
+// competes with the acceleration state to explain the same reading, so an over-permissive
+// value lets it absorb genuine manoeuvres. Above roughly 10 the velocity estimate visibly
+// loses both amplitude and phase lead. At this value a standing bias is tracked to within
+// a few cm/s^2 while velocity behaviour is indistinguishable from having no bias state.
+#define Q_ACCEL_BIAS        1.0f        // (cm/s^2)^2 per second
 
 // Initial covariance values
 #define INITIAL_POS_VAR     10000.0f    // cm^2  (1m uncertainty)
@@ -80,7 +89,12 @@
 
 // Measurement noise base values (R)
 #define R_GPS_POS_BASE       500.0f      // cm^2 at pDOP=1.0
-#define R_GPS_VEL_BASE       100.0f      // (cm/s)^2 at pDOP=1.0 //  low value to tightly track GPS but allow some acc influence
+// GPS velocity is internally lagged and arrives as steps. Trusting it tightly pins the
+// estimate to that lagged value and cancels the accelerometer's contribution, which is
+// the faster and, over short intervals, more reliable source of velocity change. This is
+// deliberately loose so the accelerometer sets the short-term shape of the velocity
+// estimate while GPS anchors it against drift.
+#define R_GPS_VEL_BASE      2000.0f      // (cm/s)^2 at pDOP=1.0
 #define R_GPS_ALT_BASE     60000.0f      // cm^2 at pDOP=1.0, higher favours other sensors over GPS
 #define R_BARO_ALT          1500.0f     // cm^2 lower value favours rapid baro changes
 #define R_RANGEFINDER_ALT    100.0f     // cm^2
@@ -249,12 +263,13 @@ void positionEstimatorInit(void)
     qJerkXY = Q_JERK_XY * ((autopilotConfig()->positionA > 1) ?  (30.0f / autopilotConfig()->positionA ) : 15.0f);
     // when user reduces positionA, , they want more accelerometer influence (up to 15x more), and vice versa
 #endif
-    kalmanInit(&kfEast, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY);
-    kalmanInit(&kfNorth, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY);
-    kalmanInit(&kfUp, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, Q_JERK_Z);
+    kalmanInit(&kfEast, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY, Q_ACCEL_BIAS);
+    kalmanInit(&kfNorth, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY, Q_ACCEL_BIAS);
+    kalmanInit(&kfUp, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, Q_JERK_Z, Q_ACCEL_BIAS);
     estimate.position = (vector3_t){{0, 0, 0}};
     estimate.velocity = (vector3_t){{0, 0, 0}};
     estimate.acceleration = (vector3_t){{0, 0, 0}};
+    estimate.accelBias = (vector3_t){{0, 0, 0}};
     estimate.trustXY = 0.0f;
     estimate.trustZ = 0.0f;
     estimate.isValidXY = false;
@@ -304,8 +319,8 @@ void positionEstimatorInit(void)
 void positionEstimatorEnableXY(bool enable)
 {
     if (enable && !xyEnabled) {
-        kalmanInit(&kfEast, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY);
-        kalmanInit(&kfNorth, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY);
+        kalmanInit(&kfEast, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY, Q_ACCEL_BIAS);
+        kalmanInit(&kfNorth, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY, Q_ACCEL_BIAS);
         estimate.position.v[ENU_E] = 0.0f;
         estimate.position.v[ENU_N] = 0.0f;
         estimate.velocity.v[ENU_E] = 0.0f;
@@ -801,14 +816,14 @@ void positionEstimatorUpdate(void)
     // measure zero acceleration so covariance continues to evolve without
     // integrating small gravity-removal errors.
     kalmanPredict(&kfUp, dt);
-    kalmanUpdateAcceleration(&kfUp, ARMING_FLAG(ARMED) ? accelUp : 0.0f, R_ACCEL_Z);
+    kalmanUpdateAcceleration(&kfUp, ARMING_FLAG(ARMED) ? accelUp : 0.0f, R_ACCEL_Z, dt);
 
     // XY axes: only when a consumer is active
     if (xyEnabled && ARMING_FLAG(ARMED)) {
         kalmanPredict(&kfEast, dt);
         kalmanPredict(&kfNorth, dt);
-        kalmanUpdateAcceleration(&kfEast, accelEast, R_ACCEL_XY);
-        kalmanUpdateAcceleration(&kfNorth, accelNorth, R_ACCEL_XY);
+        kalmanUpdateAcceleration(&kfEast, accelEast, R_ACCEL_XY, dt);
+        kalmanUpdateAcceleration(&kfNorth, accelNorth, R_ACCEL_XY, dt);
     }
 
     // Feed sensor measurements (order does not matter)
@@ -831,6 +846,11 @@ void positionEstimatorUpdate(void)
     estimate.acceleration.v[ENU_E] = kalmanGetAcceleration(&kfEast);
     estimate.acceleration.v[ENU_N] = kalmanGetAcceleration(&kfNorth);
     estimate.acceleration.v[ENU_U] = kalmanGetAcceleration(&kfUp);
+    // Exported for diagnostics rather than for control. A bias that fails to settle, or
+    // that sits at the clamp, points to an accelerometer or attitude problem upstream.
+    estimate.accelBias.v[ENU_E] = kalmanGetAccelBias(&kfEast);
+    estimate.accelBias.v[ENU_N] = kalmanGetAccelBias(&kfNorth);
+    estimate.accelBias.v[ENU_U] = kalmanGetAccelBias(&kfUp);
 
     // Validity: based on recent measurement updates
     if (xyEnabled) {
@@ -903,10 +923,11 @@ bool positionEstimatorIsHeadingRequired(void)
 
 void positionEstimatorResetZ(void)
 {
-    kalmanInit(&kfUp, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, Q_JERK_Z);
+    kalmanInit(&kfUp, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, Q_JERK_Z, Q_ACCEL_BIAS);
     estimate.position.v[ENU_U] = 0.0f;
     estimate.velocity.v[ENU_U] = 0.0f;
     estimate.acceleration.v[ENU_U] = 0.0f;
+    estimate.accelBias.v[ENU_U] = 0.0f;
     estimate.isValidZ = false;
     lastZMeasurementUs = 0;
 #ifdef USE_GPS
@@ -928,14 +949,16 @@ void positionEstimatorResetZ(void)
 
 void positionEstimatorResetXY(void)
 {
-    kalmanInit(&kfEast, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY);
-    kalmanInit(&kfNorth, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY);
+    kalmanInit(&kfEast, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY, Q_ACCEL_BIAS);
+    kalmanInit(&kfNorth, 0.0f, 0.0f, 0.0f, INITIAL_POS_VAR, INITIAL_VEL_VAR, INITIAL_ACCEL_VAR, qJerkXY, Q_ACCEL_BIAS);
     estimate.position.v[ENU_E] = 0.0f;
     estimate.position.v[ENU_N] = 0.0f;
     estimate.velocity.v[ENU_E] = 0.0f;
     estimate.velocity.v[ENU_N] = 0.0f;
     estimate.acceleration.v[ENU_E] = 0.0f;
     estimate.acceleration.v[ENU_N] = 0.0f;
+    estimate.accelBias.v[ENU_E] = 0.0f;
+    estimate.accelBias.v[ENU_N] = 0.0f;
     estimate.isValidXY = false;
     lastXYMeasurementUs = 0;
 #ifdef USE_GPS

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -73,14 +73,25 @@
 #define R_ACCEL_XY          2000.0f
 #define R_ACCEL_Z           20000.0f
 
-// How fast the accelerometer bias state may be re-learned, as a random walk. The bias is
-// physically slow (attitude error, calibration, thermal drift), so this only has to be
-// large enough to follow it, and there is a real penalty for going higher: the bias state
-// competes with the acceleration state to explain the same reading, so an over-permissive
-// value lets it absorb genuine manoeuvres. Above roughly 10 the velocity estimate visibly
-// loses both amplitude and phase lead. At this value a standing bias is tracked to within
-// a few cm/s^2 while velocity behaviour is indistinguishable from having no bias state.
-#define Q_ACCEL_BIAS        1.0f        // (cm/s^2)^2 per second
+// How fast the accelerometer bias state may be re-learned, as a random walk.
+//
+// Note that this does not control how much a sustained manoeuvre leaks into the bias.
+// Acceleration held in one direction is genuinely indistinguishable from a bias, so some
+// of it is always absorbed: 400 cm/s^2 held for 2 s reaches about 77 cm/s^2 even with this
+// set to zero, and 4 s pins the bias at ACCEL_BIAS_LIMIT whatever the value. Only a
+// manoeuvre-magnitude gate would prevent that, which is not implemented.
+//
+// What this value does control is how contaminated the bias is left when aiding stops,
+// which is the case that matters, because the whole point of the state is to bound velocity
+// during a dropout. For a learned 30 cm/s^2 bias followed by a hard 2 s manoeuvre and then
+// 10 s without GPS, velocity error is 0.3 m/s here against 14 m/s at 1.0 — and with no bias
+// state at all it is 9.7 m/s, so too permissive a value is worse than not having the state.
+//
+// The cost of being this slow is only the time to re-learn a bias that genuinely changes
+// mid-flight, tens of seconds. Initial acquisition after arming is unaffected at roughly
+// 1 s because that is driven by INITIAL_ACCEL_BIAS_VAR, and the dominant physical cause is
+// horizon tilt error that drifts over minutes.
+#define Q_ACCEL_BIAS        0.03f       // (cm/s^2)^2 per second
 
 // Initial covariance values
 #define INITIAL_POS_VAR     10000.0f    // cm^2  (1m uncertainty)

--- a/src/main/flight/position_estimator.h
+++ b/src/main/flight/position_estimator.h
@@ -32,6 +32,7 @@
 typedef struct positionEstimate3d_s {
     vector3_t position;        // cm, ENU
     vector3_t velocity;        // cm/s, ENU
+    vector3_t acceleration;    // cm/s^2, ENU
     float trustXY;             // 0-1, derived from KF XY covariance
     float trustZ;              // 0-1, derived from KF Z covariance
     bool isValidXY;            // true if at least one XY measurement source active

--- a/src/main/flight/position_estimator.h
+++ b/src/main/flight/position_estimator.h
@@ -33,6 +33,7 @@ typedef struct positionEstimate3d_s {
     vector3_t position;        // cm, ENU
     vector3_t velocity;        // cm/s, ENU
     vector3_t acceleration;    // cm/s^2, ENU
+    vector3_t accelBias;       // cm/s^2, ENU; estimated accelerometer bias, mostly attitude error
     float trustXY;             // 0-1, derived from KF XY covariance
     float trustZ;              // 0-1, derived from KF Z covariance
     bool isValidXY;            // true if at least one XY measurement source active

--- a/src/main/flight/position_filter.c
+++ b/src/main/flight/position_filter.c
@@ -23,123 +23,121 @@
 
 #include "position_filter.h"
 
-void kalmanInit(positionKalman_t *kf, float initialPos, float initialVel,
-                float initialPosVar, float initialVelVar, float qAccel)
+enum {
+    KF_POSITION = 0,
+    KF_VELOCITY,
+    KF_ACCELERATION,
+    KF_STATE_COUNT
+};
+
+void kalmanInit(positionKalman_t *kf, float initialPos, float initialVel, float initialAccel,
+                float initialPosVar, float initialVelVar, float initialAccelVar, float qJerk)
 {
     kf->x[0] = initialPos;
     kf->x[1] = initialVel;
-    kf->P[0][0] = initialPosVar;
-    kf->P[0][1] = 0.0f;
-    kf->P[1][0] = 0.0f;
-    kf->P[1][1] = initialVelVar;
-    kf->Q_accel = qAccel;
+    kf->x[2] = initialAccel;
+
+    for (unsigned row = 0; row < KF_STATE_COUNT; row++) {
+        for (unsigned column = 0; column < KF_STATE_COUNT; column++) {
+            kf->P[row][column] = 0.0f;
+        }
+    }
+    kf->P[KF_POSITION][KF_POSITION] = initialPosVar;
+    kf->P[KF_VELOCITY][KF_VELOCITY] = initialVelVar;
+    kf->P[KF_ACCELERATION][KF_ACCELERATION] = initialAccelVar;
+    kf->Q_jerk = qJerk;
 }
 
-// Predict step with acceleration control input.
+// Constant-acceleration prediction with continuous white jerk process noise.
 //
-// State transition:  x = F*x + B*u
-//   F = [1, dt]    B = [0.5*dt^2]
-//       [0,  1]        [dt      ]
-//
-// Covariance:  P = F*P*F' + B*Q_accel*B'
-void kalmanPredict(positionKalman_t *kf, float dt, float accel)
+//       [1  dt  dt^2/2]
+// F  =  [0   1  dt    ]
+//       [0   0   1    ]
+void kalmanPredict(positionKalman_t *kf, float dt)
 {
     const float dt2 = dt * dt;
     const float halfDt2 = 0.5f * dt2;
 
-    // State prediction
-    kf->x[0] += kf->x[1] * dt + halfDt2 * accel;
-    kf->x[1] += dt * accel;
+    kf->x[KF_POSITION] += kf->x[KF_VELOCITY] * dt + halfDt2 * kf->x[KF_ACCELERATION];
+    kf->x[KF_VELOCITY] += kf->x[KF_ACCELERATION] * dt;
 
-    // Covariance prediction: P = F*P*F' + B*Q*B'
-    // F*P*F':
-    //   P00' = P00 + dt*(P10 + P01) + dt^2*P11
-    //   P01' = P01 + dt*P11
-    //   P10' = P10 + dt*P11
-    //   P11' = P11
-    // B*Q*B':
-    //   [0.25*dt^4, 0.5*dt^3] * Q_accel
-    //   [0.5*dt^3,  dt^2     ]
-    const float q = kf->Q_accel;
-    const float p00 = kf->P[0][0];
-    const float p01 = kf->P[0][1];
-    const float p10 = kf->P[1][0];
-    const float p11 = kf->P[1][1];
+    const float F[KF_STATE_COUNT][KF_STATE_COUNT] = {
+        { 1.0f, dt, halfDt2 },
+        { 0.0f, 1.0f, dt },
+        { 0.0f, 0.0f, 1.0f },
+    };
+    float FP[KF_STATE_COUNT][KF_STATE_COUNT] = {{0}};
+    float predictedP[KF_STATE_COUNT][KF_STATE_COUNT] = {{0}};
 
-    kf->P[0][0] = p00 + dt * (p10 + p01) + dt2 * p11 + 0.25f * dt2 * dt2 * q;
-    kf->P[0][1] = p01 + dt * p11 + halfDt2 * dt * q;
-    kf->P[1][0] = p10 + dt * p11 + halfDt2 * dt * q;
-    kf->P[1][1] = p11 + dt2 * q;
+    for (unsigned row = 0; row < KF_STATE_COUNT; row++) {
+        for (unsigned column = 0; column < KF_STATE_COUNT; column++) {
+            for (unsigned i = 0; i < KF_STATE_COUNT; i++) {
+                FP[row][column] += F[row][i] * kf->P[i][column];
+            }
+        }
+    }
+    for (unsigned row = 0; row < KF_STATE_COUNT; row++) {
+        for (unsigned column = 0; column < KF_STATE_COUNT; column++) {
+            for (unsigned i = 0; i < KF_STATE_COUNT; i++) {
+                predictedP[row][column] += FP[row][i] * F[column][i];
+            }
+        }
+    }
+
+    const float dt3 = dt2 * dt;
+    const float dt4 = dt3 * dt;
+    const float dt5 = dt4 * dt;
+    const float q = kf->Q_jerk;
+    const float processNoise[KF_STATE_COUNT][KF_STATE_COUNT] = {
+        { q * dt5 / 20.0f, q * dt4 / 8.0f, q * dt3 / 6.0f },
+        { q * dt4 / 8.0f, q * dt3 / 3.0f, q * dt2 / 2.0f },
+        { q * dt3 / 6.0f, q * dt2 / 2.0f, q * dt },
+    };
+
+    for (unsigned row = 0; row < KF_STATE_COUNT; row++) {
+        for (unsigned column = 0; column < KF_STATE_COUNT; column++) {
+            kf->P[row][column] = predictedP[row][column] + processNoise[row][column];
+        }
+    }
 }
 
-// Scalar measurement update for position: H = [1, 0]
+static void kalmanUpdateScalar(positionKalman_t *kf, unsigned measuredState, float measurement, float R)
+{
+    const float S = kf->P[measuredState][measuredState] + R;
+    if (S < 1e-9f) {
+        return;
+    }
+
+    float gain[KF_STATE_COUNT];
+    float measuredRow[KF_STATE_COUNT];
+    for (unsigned i = 0; i < KF_STATE_COUNT; i++) {
+        gain[i] = kf->P[i][measuredState] / S;
+        measuredRow[i] = kf->P[measuredState][i];
+    }
+
+    const float innovation = measurement - kf->x[measuredState];
+    for (unsigned i = 0; i < KF_STATE_COUNT; i++) {
+        kf->x[i] += gain[i] * innovation;
+    }
+
+    for (unsigned row = 0; row < KF_STATE_COUNT; row++) {
+        for (unsigned column = 0; column < KF_STATE_COUNT; column++) {
+            kf->P[row][column] -= gain[row] * measuredRow[column];
+        }
+    }
+}
+
 void kalmanUpdatePosition(positionKalman_t *kf, float measuredPos, float R)
 {
-    const float p00 = kf->P[0][0];
-    const float p10 = kf->P[1][0];
-
-    // Innovation covariance: S = H*P*H' + R = P[0][0] + R
-    const float S = p00 + R;
-    if (S < 1e-9f) {
-        return;
-    }
-    const float Sinv = 1.0f / S;
-
-    // Kalman gain: K = P*H' / S = [P[0][0], P[1][0]]' / S
-    const float K0 = p00 * Sinv;
-    const float K1 = p10 * Sinv;
-
-    // Innovation
-    const float y = measuredPos - kf->x[0];
-
-    // State update
-    kf->x[0] += K0 * y;
-    kf->x[1] += K1 * y;
-
-    // Covariance update: P = (I - K*H) * P
-    // Using Joseph form for numerical stability: P = (I-KH)*P*(I-KH)' + K*R*K'
-    // Simplified since H = [1,0]:
-    const float I_K0 = 1.0f - K0;
-    const float p01 = kf->P[0][1];
-    const float p11 = kf->P[1][1];
-
-    kf->P[0][0] = I_K0 * p00 - K0 * 0.0f;   // simplified: (1-K0)*P00
-    kf->P[0][1] = I_K0 * p01;
-    kf->P[1][0] = p10 - K1 * p00;
-    kf->P[1][1] = p11 - K1 * p01;
+    kalmanUpdateScalar(kf, KF_POSITION, measuredPos, R);
 }
 
-// Scalar measurement update for velocity: H = [0, 1]
 void kalmanUpdateVelocity(positionKalman_t *kf, float measuredVel, float R)
 {
-    const float p01 = kf->P[0][1];
-    const float p11 = kf->P[1][1];
+    kalmanUpdateScalar(kf, KF_VELOCITY, measuredVel, R);
+}
 
-    // Innovation covariance: S = H*P*H' + R = P[1][1] + R
-    const float S = p11 + R;
-    if (S < 1e-9f) {
-        return;
-    }
-    const float Sinv = 1.0f / S;
-
-    // Kalman gain: K = P*H' / S = [P[0][1], P[1][1]]' / S
-    const float K0 = p01 * Sinv;
-    const float K1 = p11 * Sinv;
-
-    // Innovation
-    const float y = measuredVel - kf->x[1];
-
-    // State update
-    kf->x[0] += K0 * y;
-    kf->x[1] += K1 * y;
-
-    // Covariance update: P = (I - K*H) * P, H = [0,1]
-    const float p00 = kf->P[0][0];
-    const float p10 = kf->P[1][0];
-    const float I_K1 = 1.0f - K1;
-
-    kf->P[0][0] = p00 - K0 * p10;
-    kf->P[0][1] = p01 - K0 * p11;
-    kf->P[1][0] = I_K1 * p10;
-    kf->P[1][1] = I_K1 * p11;
+void kalmanUpdateAcceleration(positionKalman_t *kf, float measuredAccel, float R)
+{
+    kalmanUpdateScalar(kf, KF_ACCELERATION, measuredAccel, R);
 }

--- a/src/main/flight/position_filter.c
+++ b/src/main/flight/position_filter.c
@@ -21,21 +21,48 @@
 
 #include "platform.h"
 
+#include "common/maths.h"
+
 #include "position_filter.h"
 
+// KF_ACCELERATION is the true earth-frame acceleration of the craft. KF_ACCEL_BIAS is
+// the slowly varying offset between that and what the accelerometer reports, dominated
+// in practice by attitude estimate error rather than by the sensor itself: horizontal
+// acceleration is obtained by rotating body acceleration into ENU, so one degree of
+// attitude error manufactures about 17 cm/s^2 of acceleration that never happened.
+// Separating the two keeps that error out of the velocity integration.
 enum {
     KF_POSITION = 0,
     KF_VELOCITY,
     KF_ACCELERATION,
+    KF_ACCEL_BIAS,
     KF_STATE_COUNT
 };
 
+// The prior is deliberately wide relative to the bias values actually seen in flight, so
+// that a standing bias is acquired within a few seconds of arming instead of over the
+// course of a flight. Steady-state tracking speed is set by Q_accelBias, not by this.
+#define INITIAL_ACCEL_BIAS_VAR  2500.0f     // (cm/s^2)^2
+
+// Hard bound on the bias, needed because the bias is only observable while position or
+// velocity aiding is present. Without aiding the accelerometer alone cannot distinguish
+// bias from acceleration, so the state must not be free to wander somewhere that would
+// corrupt velocity once it is trusted again. 150 cm/s^2 is around 8.8 degrees of
+// attitude error, far beyond anything legitimate, so clipping here indicates a real
+// calibration or alignment fault rather than normal operation.
+#define ACCEL_BIAS_LIMIT        150.0f      // cm/s^2
+
 void kalmanInit(positionKalman_t *kf, float initialPos, float initialVel, float initialAccel,
-                float initialPosVar, float initialVelVar, float initialAccelVar, float qJerk)
+                float initialPosVar, float initialVelVar, float initialAccelVar,
+                float qJerk, float qAccelBias)
 {
-    kf->x[0] = initialPos;
-    kf->x[1] = initialVel;
-    kf->x[2] = initialAccel;
+    kf->x[KF_POSITION] = initialPos;
+    kf->x[KF_VELOCITY] = initialVel;
+    kf->x[KF_ACCELERATION] = initialAccel;
+    // Always start from no assumed bias and re-learn it. Carrying a stale value across a
+    // reset would be worse than starting from zero, since the attitude error it mostly
+    // represents depends on conditions that may have changed.
+    kf->x[KF_ACCEL_BIAS] = 0.0f;
 
     for (unsigned row = 0; row < KF_STATE_COUNT; row++) {
         for (unsigned column = 0; column < KF_STATE_COUNT; column++) {
@@ -45,14 +72,24 @@ void kalmanInit(positionKalman_t *kf, float initialPos, float initialVel, float 
     kf->P[KF_POSITION][KF_POSITION] = initialPosVar;
     kf->P[KF_VELOCITY][KF_VELOCITY] = initialVelVar;
     kf->P[KF_ACCELERATION][KF_ACCELERATION] = initialAccelVar;
+    kf->P[KF_ACCEL_BIAS][KF_ACCEL_BIAS] = INITIAL_ACCEL_BIAS_VAR;
     kf->Q_jerk = qJerk;
+    kf->Q_accelBias = qAccelBias;
 }
 
 // Constant-acceleration prediction with continuous white jerk process noise.
 //
-//       [1  dt  dt^2/2]
-// F  =  [0   1  dt    ]
-//       [0   0   1    ]
+// The bias occupies its own uncoupled row: it is modelled as a random walk that holds
+// its value between updates and never drives position or velocity, because it is not a
+// property of the craft's motion. It affects the estimate only in
+// kalmanUpdateAcceleration, where the accelerometer reading is corrected by it. Its
+// correlation with the motion states, which is what lets GPS correct it, is built up by
+// the accelerometer update rather than here.
+//
+//       [1  dt  dt^2/2  0]
+// F  =  [0   1  dt      0]
+//       [0   0   1      0]
+//       [0   0   0      1]
 void kalmanPredict(positionKalman_t *kf, float dt)
 {
     const float dt2 = dt * dt;
@@ -62,9 +99,10 @@ void kalmanPredict(positionKalman_t *kf, float dt)
     kf->x[KF_VELOCITY] += kf->x[KF_ACCELERATION] * dt;
 
     const float F[KF_STATE_COUNT][KF_STATE_COUNT] = {
-        { 1.0f, dt, halfDt2 },
-        { 0.0f, 1.0f, dt },
-        { 0.0f, 0.0f, 1.0f },
+        { 1.0f, dt, halfDt2, 0.0f },
+        { 0.0f, 1.0f, dt, 0.0f },
+        { 0.0f, 0.0f, 1.0f, 0.0f },
+        { 0.0f, 0.0f, 0.0f, 1.0f },
     };
     float FP[KF_STATE_COUNT][KF_STATE_COUNT] = {{0}};
     float predictedP[KF_STATE_COUNT][KF_STATE_COUNT] = {{0}};
@@ -88,10 +126,12 @@ void kalmanPredict(positionKalman_t *kf, float dt)
     const float dt4 = dt3 * dt;
     const float dt5 = dt4 * dt;
     const float q = kf->Q_jerk;
+    const float qb = kf->Q_accelBias;
     const float processNoise[KF_STATE_COUNT][KF_STATE_COUNT] = {
-        { q * dt5 / 20.0f, q * dt4 / 8.0f, q * dt3 / 6.0f },
-        { q * dt4 / 8.0f, q * dt3 / 3.0f, q * dt2 / 2.0f },
-        { q * dt3 / 6.0f, q * dt2 / 2.0f, q * dt },
+        { q * dt5 / 20.0f, q * dt4 / 8.0f, q * dt3 / 6.0f, 0.0f },
+        { q * dt4 / 8.0f, q * dt3 / 3.0f, q * dt2 / 2.0f, 0.0f },
+        { q * dt3 / 6.0f, q * dt2 / 2.0f, q * dt, 0.0f },
+        { 0.0f, 0.0f, 0.0f, qb * dt },
     };
 
     for (unsigned row = 0; row < KF_STATE_COUNT; row++) {
@@ -137,7 +177,80 @@ void kalmanUpdateVelocity(positionKalman_t *kf, float measuredVel, float R)
     kalmanUpdateScalar(kf, KF_VELOCITY, measuredVel, R);
 }
 
-void kalmanUpdateAcceleration(positionKalman_t *kf, float measuredAccel, float R)
+// Fuse an earth-frame accelerometer reading.
+//
+// Unlike position and velocity, the accelerometer does not observe a single state. It
+// reports acceleration plus bias, so H = [0 0 1 1] and this cannot go through
+// kalmanUpdateScalar, which assumes H selects one state. Only the sum of the two states
+// is visible here; what separates them is the position and velocity aiding. A bias makes
+// velocity drift, GPS contradicts that drift, and the resulting correction is pushed into
+// the bias because acceleration alone cannot explain a persistent disagreement. This is
+// why the bias converges within seconds while aiding is available and simply holds its
+// last value when it is not.
+//
+// The reason for estimating it at all is dead reckoning. Velocity here is integrated from
+// the accelerometer, so an uncorrected offset integrates without limit: 30 cm/s^2, about
+// 1.8 degrees of attitude error, reaches roughly 10 m/s of velocity error over 15 seconds
+// without GPS to pull it back. Removing the estimated bias first bounds that to a few
+// tens of cm/s, which is what makes a GPS dropout survivable.
+void kalmanUpdateAcceleration(positionKalman_t *kf, float measuredAccel, float R, float dt)
 {
-    kalmanUpdateScalar(kf, KF_ACCELERATION, measuredAccel, R);
+    // P*H^T and H*P. These are transposes of each other for a symmetric P, but the
+    // covariance update below uses the non-Joseph form, which can let P drift slightly
+    // out of symmetry, so both are read directly rather than one being reused.
+    float PHt[KF_STATE_COUNT];
+    float HP[KF_STATE_COUNT];
+    for (unsigned i = 0; i < KF_STATE_COUNT; i++) {
+        PHt[i] = kf->P[i][KF_ACCELERATION] + kf->P[i][KF_ACCEL_BIAS];
+        HP[i] = kf->P[KF_ACCELERATION][i] + kf->P[KF_ACCEL_BIAS][i];
+    }
+
+    // Innovation variance H*P*H^T + R. Because H sums two states, this picks up their
+    // cross-covariance as well as both variances.
+    const float S = PHt[KF_ACCELERATION] + PHt[KF_ACCEL_BIAS] + R;
+    if (S < 1e-9f) {
+        return;
+    }
+
+    float gain[KF_STATE_COUNT];
+    for (unsigned i = 0; i < KF_STATE_COUNT; i++) {
+        gain[i] = PHt[i] / S;
+    }
+
+    // The prediction being tested is (acceleration + bias), not acceleration alone,
+    // so a correctly learned bias produces no innovation and is left undisturbed.
+    const float innovation = measuredAccel - (kf->x[KF_ACCELERATION] + kf->x[KF_ACCEL_BIAS]);
+    const float debiasedAccel = measuredAccel - kf->x[KF_ACCEL_BIAS];
+    const float velocityBeforeUpdate = kf->x[KF_VELOCITY];
+
+    for (unsigned i = 0; i < KF_STATE_COUNT; i++) {
+        kf->x[i] += gain[i] * innovation;
+    }
+
+    // Velocity is then overwritten to integrate the debiased reading directly, instead of
+    // keeping the covariance-weighted share of the innovation it just received above.
+    //
+    // The purpose is to make the accelerometer's authority over velocity constant. That
+    // share is gain[KF_VELOCITY], which is derived from the covariance and therefore moves
+    // with GPS trust: measured across realistic conditions it ranged from 18% of a full dt
+    // integration with GPS tightly fused, through 58% at normal settings, to 95% with GPS
+    // absent. Because GPS trust tracks DOP, the accelerometer's contribution shifted while
+    // flying and jumped when the fix dropped, so the estimator's dynamics were not stable
+    // enough to tune a position controller against. Integrating directly fixes the
+    // contribution at exactly dt regardless of covariance state.
+    //
+    // The cost is that P no longer describes how velocity was actually propagated. It stays
+    // a valid covariance matrix and the GPS weighting it produces is unchanged, but velocity
+    // variance is understated, so trustXY and trustZ derived from it read optimistically.
+    kf->x[KF_VELOCITY] = velocityBeforeUpdate + debiasedAccel * dt;
+
+    // P = P - K*H*P, applied to the full matrix so the acceleration/bias correlation and
+    // its correlation with the motion states are both maintained.
+    for (unsigned row = 0; row < KF_STATE_COUNT; row++) {
+        for (unsigned column = 0; column < KF_STATE_COUNT; column++) {
+            kf->P[row][column] -= gain[row] * HP[column];
+        }
+    }
+
+    kf->x[KF_ACCEL_BIAS] = constrainf(kf->x[KF_ACCEL_BIAS], -ACCEL_BIAS_LIMIT, ACCEL_BIAS_LIMIT);
 }

--- a/src/main/flight/position_filter.h
+++ b/src/main/flight/position_filter.h
@@ -23,20 +23,25 @@
 
 #include <stdbool.h>
 
-// 2-state Kalman filter for one axis: [position, velocity]
-// Driven by acceleration control input, corrected by position or velocity measurements.
+// 3-state constant-acceleration Kalman filter for one axis:
+// [position, velocity, acceleration]. Process noise models unknown jerk;
+// position, velocity, and acceleration are all accepted as measurements.
 typedef struct positionKalman_s {
-    float x[2];      // state: [0]=position (cm), [1]=velocity (cm/s)
-    float P[2][2];   // error covariance
-    float Q_accel;   // process noise: accelerometer variance (cm/s^2)^2
+    float x[3];
+    float P[3][3];
+    float Q_jerk;    // continuous jerk spectral density
 } positionKalman_t;
 
-void kalmanInit(positionKalman_t *kf, float initialPos, float initialVel, float initialPosVar, float initialVelVar, float qAccel);
-void kalmanPredict(positionKalman_t *kf, float dt, float accel);
+void kalmanInit(positionKalman_t *kf, float initialPos, float initialVel, float initialAccel,
+                float initialPosVar, float initialVelVar, float initialAccelVar, float qJerk);
+void kalmanPredict(positionKalman_t *kf, float dt);
 void kalmanUpdatePosition(positionKalman_t *kf, float measuredPos, float R);
 void kalmanUpdateVelocity(positionKalman_t *kf, float measuredVel, float R);
+void kalmanUpdateAcceleration(positionKalman_t *kf, float measuredAccel, float R);
 
 static inline float kalmanGetPosition(const positionKalman_t *kf) { return kf->x[0]; }
 static inline float kalmanGetVelocity(const positionKalman_t *kf) { return kf->x[1]; }
+static inline float kalmanGetAcceleration(const positionKalman_t *kf) { return kf->x[2]; }
 static inline float kalmanGetPositionVariance(const positionKalman_t *kf) { return kf->P[0][0]; }
 static inline float kalmanGetVelocityVariance(const positionKalman_t *kf) { return kf->P[1][1]; }
+static inline float kalmanGetAccelerationVariance(const positionKalman_t *kf) { return kf->P[2][2]; }

--- a/src/main/flight/position_filter.h
+++ b/src/main/flight/position_filter.h
@@ -23,25 +23,44 @@
 
 #include <stdbool.h>
 
-// 3-state constant-acceleration Kalman filter for one axis:
-// [position, velocity, acceleration]. Process noise models unknown jerk;
-// position, velocity, and acceleration are all accepted as measurements.
+// 4-state constant-acceleration Kalman filter for one axis:
+// [position, velocity, acceleration, accelerometer bias].
+//
+// Position and velocity are accepted as direct measurements from GPS, baro,
+// rangefinder and optical flow. The accelerometer is different: it is observed as
+// (acceleration + bias), so the part of its reading that comes from attitude error,
+// calibration error and thermal drift is estimated as a separate state rather than
+// being integrated into velocity as if it were real motion. Without that state a
+// small standing offset accumulates without limit whenever aiding is unavailable.
+//
+// Note that velocity does not take its share of the accelerometer correction from
+// the covariance; kalmanUpdateAcceleration integrates the reading directly so the
+// accelerometer's authority over velocity does not vary with GPS trust. See the
+// comment there, including what that costs in covariance accuracy.
 typedef struct positionKalman_s {
-    float x[3];
-    float P[3][3];
-    float Q_jerk;    // continuous jerk spectral density
+    float x[4];
+    float P[4][4];
+    float Q_jerk;       // continuous jerk spectral density; how freely acceleration may change
+    float Q_accelBias;  // accelerometer bias random-walk spectral density; how fast the bias
+                        // may be re-learned. Too high and it absorbs real manoeuvres.
 } positionKalman_t;
 
 void kalmanInit(positionKalman_t *kf, float initialPos, float initialVel, float initialAccel,
-                float initialPosVar, float initialVelVar, float initialAccelVar, float qJerk);
+                float initialPosVar, float initialVelVar, float initialAccelVar,
+                float qJerk, float qAccelBias);
 void kalmanPredict(positionKalman_t *kf, float dt);
 void kalmanUpdatePosition(positionKalman_t *kf, float measuredPos, float R);
 void kalmanUpdateVelocity(positionKalman_t *kf, float measuredVel, float R);
-void kalmanUpdateAcceleration(positionKalman_t *kf, float measuredAccel, float R);
+void kalmanUpdateAcceleration(positionKalman_t *kf, float measuredAccel, float R, float dt);
 
 static inline float kalmanGetPosition(const positionKalman_t *kf) { return kf->x[0]; }
 static inline float kalmanGetVelocity(const positionKalman_t *kf) { return kf->x[1]; }
+// Bias-corrected acceleration, suitable as a controller feed-forward or damping term.
 static inline float kalmanGetAcceleration(const positionKalman_t *kf) { return kf->x[2]; }
+// Mostly a measure of attitude estimate error. Useful for diagnostics: it should settle
+// soon after arming and stay steady, and reaching the clamp indicates a real sensor fault.
+static inline float kalmanGetAccelBias(const positionKalman_t *kf) { return kf->x[3]; }
 static inline float kalmanGetPositionVariance(const positionKalman_t *kf) { return kf->P[0][0]; }
 static inline float kalmanGetVelocityVariance(const positionKalman_t *kf) { return kf->P[1][1]; }
 static inline float kalmanGetAccelerationVariance(const positionKalman_t *kf) { return kf->P[2][2]; }
+static inline float kalmanGetAccelBiasVariance(const positionKalman_t *kf) { return kf->P[3][3]; }

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -380,6 +380,8 @@ static bool baroDetect(baroDev_t *baroDev, baroSensor_e baroHardwareToUse)
 
 void baroInit(void)
 {
+    baro.lastDataTimeUs = 0;
+    baro.dataIntervalUs = 0;
 #ifndef USE_VIRTUAL_BARO
     baroReady = baroDetect(&baro.dev, barometerConfig()->baro_hardware);
 #else
@@ -514,6 +516,14 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
                     performBaroCalibrationCycle(altitude);
                     baro.altitude = 0.0f;
                 }
+
+                if (baro.lastDataTimeUs != 0) {
+                    const timeDelta_t intervalUs = cmpTimeUs(currentTimeUs, baro.lastDataTimeUs);
+                    if (intervalUs > 0) {
+                        baro.dataIntervalUs = intervalUs;
+                    }
+                }
+                baro.lastDataTimeUs = currentTimeUs;
             } else {
                 // return 0 during calibration, reuse last value otherwise
                 if (!baroIsCalibrated()) {
@@ -563,6 +573,16 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
 float getBaroAltitude(void)
 {
     return baro.altitude;
+}
+
+timeUs_t getBaroLatestSampleTimeUs(void)
+{
+    return baro.lastDataTimeUs;
+}
+
+timeDelta_t getBaroSampleIntervalUs(void)
+{
+    return baro.dataIntervalUs;
 }
 
 static void performBaroCalibrationCycle(const float altitude)

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "common/time.h"
+
 #include "pg/pg.h"
 #include "drivers/barometer/barometer.h"
 
@@ -64,6 +66,8 @@ typedef struct baro_s {
     float altitude;
     int32_t temperature;                    // Use temperature for telemetry
     int32_t pressure;                       // Use pressure for telemetry
+    timeUs_t lastDataTimeUs;
+    timeDelta_t dataIntervalUs;
 } baro_t;
 
 extern baro_t baro;
@@ -76,3 +80,5 @@ void baroSetGroundLevel(void);
 uint32_t baroUpdate(timeUs_t currentTimeUs);
 bool isBaroReady(void);
 float getBaroAltitude(void);
+timeUs_t getBaroLatestSampleTimeUs(void);
+timeDelta_t getBaroSampleIntervalUs(void);

--- a/src/main/sensors/rangefinder.c
+++ b/src/main/sensors/rangefinder.c
@@ -193,6 +193,8 @@ bool rangefinderInit(void)
     rangefinder.calculatedAltitude = RANGEFINDER_OUT_OF_RANGE;
     rangefinder.maxTiltCos = cos_approx(DECIDEGREES_TO_RADIANS(rangefinder.dev.detectionConeExtendedDeciDegrees / 2.0f));
     rangefinder.lastValidResponseTimeMs = millis();
+    rangefinder.lastDataTimeUs = 0;
+    rangefinder.dataIntervalUs = 0;
     rangefinder.snr = 0;
 
     rangefinderResetDynamicThreshold();
@@ -307,6 +309,15 @@ bool rangefinderProcess(float cosTiltAngle)
             return false;
         }
 
+        const timeUs_t nowUs = micros();
+        if (rangefinder.lastDataTimeUs != 0) {
+            const timeDelta_t intervalUs = cmpTimeUs(nowUs, rangefinder.lastDataTimeUs);
+            if (intervalUs > 0) {
+                rangefinder.dataIntervalUs = intervalUs;
+            }
+        }
+        rangefinder.lastDataTimeUs = nowUs;
+
         if (distance >= 0) {
             rangefinder.lastValidResponseTimeMs = millis();
             rangefinder.rawAltitude = applyMedianFilter(distance);
@@ -378,6 +389,16 @@ int32_t rangefinderGetLatestAltitude(void)
 int32_t rangefinderGetLatestRawAltitude(void)
 {
     return rangefinder.rawAltitude;
+}
+
+timeUs_t rangefinderGetLatestSampleTimeUs(void)
+{
+    return rangefinder.lastDataTimeUs;
+}
+
+timeDelta_t rangefinderGetSampleIntervalUs(void)
+{
+    return rangefinder.dataIntervalUs;
 }
 
 bool rangefinderIsHealthy(void)

--- a/src/main/sensors/rangefinder.h
+++ b/src/main/sensors/rangefinder.h
@@ -58,6 +58,8 @@ typedef struct rangefinder_s {
     int32_t rawAltitude;
     int32_t calculatedAltitude;
     timeMs_t lastValidResponseTimeMs;
+    timeUs_t lastDataTimeUs;
+    timeDelta_t dataIntervalUs;
 
     bool snrThresholdReached;
     int32_t dynamicDistanceThreshold;
@@ -69,6 +71,8 @@ bool rangefinderInit(void);
 
 int32_t rangefinderGetLatestAltitude(void);
 int32_t rangefinderGetLatestRawAltitude(void);
+timeUs_t rangefinderGetLatestSampleTimeUs(void);
+timeDelta_t rangefinderGetSampleIntervalUs(void);
 
 void rangefinderUpdate(void);
 bool rangefinderProcess(float cosTiltAngle);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -574,7 +574,8 @@ position_estimator_unittest_SRC := \
 position_estimator_unittest_DEFINES := \
 		USE_GPS= \
 		USE_BARO= \
-		USE_RANGEFINDER=
+		USE_RANGEFINDER= \
+		USE_OPTICALFLOW=
 
 position_nav_unittest_SRC := \
 		$(USER_DIR)/flight/position_nav.c \

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -373,11 +373,13 @@ TEST_F(PosHoldTest, KalmanAccelerationDrivesAccelerationTerm)
 
     testEstimate.acceleration.x = 100.0f;
     positionControl();
-    EXPECT_EQ(debug[5], -15);
+    const int16_t positiveAccelerationTerm = debug[5];
+    EXPECT_LT(positiveAccelerationTerm, 0);
 
     testEstimate.acceleration.x = -100.0f;
     positionControl();
-    EXPECT_EQ(debug[5], 15);
+    EXPECT_GT(debug[5], 0);
+    EXPECT_EQ(debug[5], -positiveAccelerationTerm);
 
     debugMode = DEBUG_NONE;
 }

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -270,26 +270,23 @@ TEST_F(PosHoldTest, ResumeAfterFrozenExcursionDoesNotSpikeTheOutput)
 {
     initAndSettleAt(0, 0, 0);
 
-    // real motion first, so the A-term history holds a meaningful velocity
+    // Establish real motion before a sub-latch excursion freezes the output.
     testEstimate.velocity.x = 300.0f;
     for (int i = 0; i < 50; i++) {
         EXPECT_TRUE(positionControl());
     }
 
-    // a sub-latch excursion freezes the output; meanwhile the craft stops,
-    // so the frozen A-term history goes badly stale
+    // The estimator reports that the craft has stopped during the excursion.
     testEstimate.position.x = 3000.0f;
     testEstimate.velocity.x = 0.0f;
+    testEstimate.acceleration.x = 0.0f;
     for (int i = 0; i < 80; i++) {   // 0.8 s, inside the 1 s latch window
         EXPECT_TRUE(positionControl());
     }
     const float rollFrozen = autopilotAngle[AI_ROLL];
 
-    // Resume. previousVelocity was not refreshed during the frozen window, so
-    // without the A-term one-shot re-baseline the loop would differentiate the
-    // 300 cm/s of stale velocity into an enormous acceleration term and slam the
-    // angle to maxAngle. The one-shot forces A = 0 for the first resumed loop, so
-    // the output reflects the now-stopped craft rather than a spike.
+    // Resume. The A-term consumes the current Kalman acceleration state rather
+    // than differentiating velocity across the frozen window, so it cannot spike.
     testEstimate.position.x = 0.0f;
     EXPECT_TRUE(positionControl());
     EXPECT_LT(fabsf(autopilotAngle[AI_ROLL]), fabsf(rollFrozen)); // no upward spike past the held value
@@ -367,6 +364,22 @@ TEST_F(PosHoldTest, EastVelocityProducesNegativeRollResponse)
 
     EXPECT_LT(autopilotAngle[AI_ROLL], 0.0f); // Roll must be NEGATIVE (Roll Left)
     EXPECT_NEAR(autopilotAngle[AI_PITCH], 0.0f, 0.1f); // Pitch must be flat
+}
+
+TEST_F(PosHoldTest, KalmanAccelerationDrivesAccelerationTerm)
+{
+    initAndSettleAt(0, 0, 0);
+    debugMode = DEBUG_AUTOPILOT_PID;
+
+    testEstimate.acceleration.x = 100.0f;
+    positionControl();
+    EXPECT_EQ(debug[5], -15);
+
+    testEstimate.acceleration.x = -100.0f;
+    positionControl();
+    EXPECT_EQ(debug[5], 15);
+
+    debugMode = DEBUG_NONE;
 }
 
 TEST_F(PosHoldTest, WestVelocityProducesBrakingRollResponse)

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -22,6 +22,7 @@ extern "C" {
 // STATIC_UNIT_TESTED in position_estimator.c — gravity-removed earth-frame
 // linear acceleration in ENU (cm/s^2).
 void getLinearAccelENU(float *accelEast, float *accelNorth, float *accelUp);
+bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
 
 #include "io/gps.h"
 
@@ -51,6 +52,9 @@ static bool rfHealthy = false;
 static float rfAltCm = 0.0f;
 static float baroAltCm = 0.0f;
 static timeUs_t fakeMicros = 0;
+static bool gpsAlwaysHasNewData = true;
+static bool gpsDataIsNew = false;
+static float gpsDataFrequencyHz = 100.0f;
 
 bool sensors(uint32_t mask) { return (enabledSensors & mask) != 0; }
 bool rangefinderIsHealthy(void) { return rfHealthy; }
@@ -61,9 +65,16 @@ timeUs_t micros(void) { return fakeMicros; }
 
 bool gpsHasNewData(uint16_t *gpsStamp)
 {
+    if (!gpsAlwaysHasNewData && !gpsDataIsNew) {
+        return false;
+    }
+
+    gpsDataIsNew = false;
     (*gpsStamp)++;
     return true;
 }
+
+float getGpsDataFrequencyHz(void) { return gpsDataFrequencyHz; }
 
 void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *dest)
 {
@@ -107,6 +118,9 @@ protected:
         stateFlags = GPS_FIX;
         armingFlags = ARMED;
         fakeMicros = 0;
+        gpsAlwaysHasNewData = true;
+        gpsDataIsNew = false;
+        gpsDataFrequencyHz = 100.0f;
 
         positionConfigMutable()->altitude_source = ALTITUDE_SOURCE_RANGEFINDER_PREFER;
         positionConfigMutable()->altitude_prefer_baro = 100;
@@ -115,6 +129,50 @@ protected:
         positionEstimatorInit();
     }
 };
+
+TEST_F(PositionEstimatorTest, GPSMeasurementsAreHeldAtAltitudeTaskRate)
+{
+    gpsAlwaysHasNewData = false;
+    gpsDataFrequencyHz = 10.0f;
+    gpsDataIsNew = true;
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(10000, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 10.0f);
+
+    // A 10 Hz GPS sample is reused for all ten 100 Hz altitude-task calls in
+    // its 100 ms source interval.
+    for (timeUs_t nowUs = 20000; nowUs <= 100000; nowUs += 10000) {
+        EXPECT_TRUE(gpsMeasurementReadyForFusion(nowUs, &noiseScale));
+        EXPECT_FLOAT_EQ(noiseScale, 10.0f);
+    }
+
+    // Do not continue fusing a stale held sample if the next one is late.
+    EXPECT_FALSE(gpsMeasurementReadyForFusion(110000, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, GPSUpsamplingTracksSourceFrequency)
+{
+    gpsAlwaysHasNewData = false;
+    gpsDataFrequencyHz = 20.0f;
+    gpsDataIsNew = true;
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(0, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 5.0f);
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(40000, &noiseScale));
+    EXPECT_FALSE(gpsMeasurementReadyForFusion(50000, &noiseScale));
+
+    // The source rate can change at runtime as the receiver's nav interval changes.
+    gpsDataFrequencyHz = 5.0f;
+    gpsDataIsNew = true;
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(50000, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 20.0f);
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(240000, &noiseScale));
+    EXPECT_FALSE(gpsMeasurementReadyForFusion(250000, &noiseScale));
+}
 
 TEST_F(PositionEstimatorTest, RangefinderPreferFallsBackAndRecovers)
 {

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -28,8 +28,11 @@ bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
 
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
+#include "sensors/opticalflow.h"
 #include "sensors/rangefinder.h"
 #include "sensors/sensors.h"
+
+bool opticalFlowMeasurementReadyForFusion(timeUs_t nowUs, const opticalflow_t *flow, float *noiseScale);
 
 PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
 }
@@ -46,6 +49,7 @@ int16_t debug[DEBUG16_VALUE_COUNT];
 acc_t acc;
 matrix33_t rMat;
 gpsSolutionData_t gpsSol;
+attitudeEulerAngles_t attitude;
 
 static uint32_t enabledSensors = 0;
 static bool rfHealthy = false;
@@ -55,6 +59,8 @@ static timeUs_t fakeMicros = 0;
 static bool gpsAlwaysHasNewData = true;
 static bool gpsDataIsNew = false;
 static float gpsDataFrequencyHz = 100.0f;
+static opticalflow_t testOpticalFlow;
+static bool opticalFlowHealthy = true;
 
 bool sensors(uint32_t mask) { return (enabledSensors & mask) != 0; }
 bool rangefinderIsHealthy(void) { return rfHealthy; }
@@ -75,6 +81,8 @@ bool gpsHasNewData(uint16_t *gpsStamp)
 }
 
 float getGpsDataFrequencyHz(void) { return gpsDataFrequencyHz; }
+bool isOpticalflowHealthy(void) { return opticalFlowHealthy; }
+const opticalflow_t *getOpticalFlowData(void) { return &testOpticalFlow; }
 
 void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *dest)
 {
@@ -99,6 +107,8 @@ protected:
         memset(&acc, 0, sizeof(acc));
         memset(&rMat, 0, sizeof(rMat));
         memset(&gpsSol, 0, sizeof(gpsSol));
+        memset(&attitude, 0, sizeof(attitude));
+        memset(&testOpticalFlow, 0, sizeof(testOpticalFlow));
         memset(debug, 0, sizeof(debug));
 
         // Identity rotation and 1G reciprocal scale so zero accel stays zero.
@@ -121,6 +131,7 @@ protected:
         gpsAlwaysHasNewData = true;
         gpsDataIsNew = false;
         gpsDataFrequencyHz = 100.0f;
+        opticalFlowHealthy = true;
 
         positionConfigMutable()->altitude_source = ALTITUDE_SOURCE_RANGEFINDER_PREFER;
         positionConfigMutable()->altitude_prefer_baro = 100;
@@ -172,6 +183,41 @@ TEST_F(PositionEstimatorTest, GPSUpsamplingTracksSourceFrequency)
     EXPECT_FLOAT_EQ(noiseScale, 20.0f);
     EXPECT_TRUE(gpsMeasurementReadyForFusion(240000, &noiseScale));
     EXPECT_FALSE(gpsMeasurementReadyForFusion(250000, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, OpticalFlowMeasurementsUseNominalRateForFirstSample)
+{
+    testOpticalFlow.dev.delayMs = 20; // UP-T1 optical flow is nominally 50 Hz.
+    testOpticalFlow.timeStampUs = 100000;
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(100000, &testOpticalFlow, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 2.0f);
+    EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(110000, &testOpticalFlow, &noiseScale));
+    EXPECT_FALSE(opticalFlowMeasurementReadyForFusion(120000, &testOpticalFlow, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, OpticalFlowUpsamplingTracksMeasuredSampleRate)
+{
+    testOpticalFlow.dev.delayMs = 20;
+    testOpticalFlow.timeStampUs = 100000;
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(100000, &testOpticalFlow, &noiseScale));
+
+    // A timestamp change after 20 ms confirms the nominal 50 Hz source rate.
+    testOpticalFlow.timeStampUs = 120000;
+    EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(120000, &testOpticalFlow, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 2.0f);
+
+    // If the actual sensor cadence changes, use it instead of the task/polling rate.
+    testOpticalFlow.timeStampUs = 160000;
+    EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(160000, &testOpticalFlow, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 4.0f);
+    EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(190000, &testOpticalFlow, &noiseScale));
+    EXPECT_FALSE(opticalFlowMeasurementReadyForFusion(200000, &testOpticalFlow, &noiseScale));
 }
 
 TEST_F(PositionEstimatorTest, RangefinderPreferFallsBackAndRecovers)

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -33,6 +33,7 @@ bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
 #include "sensors/sensors.h"
 
 bool opticalFlowMeasurementReadyForFusion(timeUs_t nowUs, const opticalflow_t *flow, float *noiseScale);
+bool rangefinderMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
 
 PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
 }
@@ -54,6 +55,9 @@ attitudeEulerAngles_t attitude;
 static uint32_t enabledSensors = 0;
 static bool rfHealthy = false;
 static float rfAltCm = 0.0f;
+static bool rfUseFakeMicrosTimestamp = true;
+static timeUs_t rfSampleTimeUs = 0;
+static timeDelta_t rfSampleIntervalUs = 10000;
 static float baroAltCm = 0.0f;
 static timeUs_t fakeMicros = 0;
 static bool gpsAlwaysHasNewData = true;
@@ -65,6 +69,8 @@ static bool opticalFlowHealthy = true;
 bool sensors(uint32_t mask) { return (enabledSensors & mask) != 0; }
 bool rangefinderIsHealthy(void) { return rfHealthy; }
 int32_t rangefinderGetLatestAltitude(void) { return lrintf(rfAltCm); }
+timeUs_t rangefinderGetLatestSampleTimeUs(void) { return rfUseFakeMicrosTimestamp ? fakeMicros : rfSampleTimeUs; }
+timeDelta_t rangefinderGetSampleIntervalUs(void) { return rfSampleIntervalUs; }
 float getBaroAltitude(void) { return baroAltCm; }
 
 timeUs_t micros(void) { return fakeMicros; }
@@ -121,6 +127,9 @@ protected:
         enabledSensors = SENSOR_GPS | SENSOR_BARO | SENSOR_RANGEFINDER;
         rfHealthy = true;
         rfAltCm = 100.0f;
+        rfUseFakeMicrosTimestamp = true;
+        rfSampleTimeUs = 0;
+        rfSampleIntervalUs = 10000;
         baroAltCm = 100.0f;
         gpsSol.llh.altCm = 100.0f;
         gpsSol.dop.pdop = 100; // pDOP 1.0
@@ -218,6 +227,39 @@ TEST_F(PositionEstimatorTest, OpticalFlowUpsamplingTracksMeasuredSampleRate)
     EXPECT_FLOAT_EQ(noiseScale, 4.0f);
     EXPECT_TRUE(opticalFlowMeasurementReadyForFusion(190000, &testOpticalFlow, &noiseScale));
     EXPECT_FALSE(opticalFlowMeasurementReadyForFusion(200000, &testOpticalFlow, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, RangefinderMeasurementsUseMeasuredDataRate)
+{
+    rfUseFakeMicrosTimestamp = false;
+    rfSampleTimeUs = 100000;
+    rfSampleIntervalUs = 20000; // UP-T1 frames are 50 Hz despite 100 Hz polling.
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(rangefinderMeasurementReadyForFusion(100000, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 2.0f);
+
+    // Reuse the 50 Hz sample on the intervening 100 Hz estimator call.
+    EXPECT_TRUE(rangefinderMeasurementReadyForFusion(110000, &noiseScale));
+    EXPECT_FALSE(rangefinderMeasurementReadyForFusion(120000, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, RangefinderUpsamplingTracksSourceInterval)
+{
+    rfUseFakeMicrosTimestamp = false;
+    rfSampleTimeUs = 100000;
+    rfSampleIntervalUs = 100000; // e.g. a 10 Hz HC-SR04.
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(rangefinderMeasurementReadyForFusion(100000, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 10.0f);
+    EXPECT_TRUE(rangefinderMeasurementReadyForFusion(190000, &noiseScale));
+    EXPECT_FALSE(rangefinderMeasurementReadyForFusion(200000, &noiseScale));
+
+    rfSampleTimeUs = 200000;
+    EXPECT_TRUE(rangefinderMeasurementReadyForFusion(200000, &noiseScale));
 }
 
 TEST_F(PositionEstimatorTest, RangefinderPreferFallsBackAndRecovers)

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -34,6 +34,7 @@ bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
 
 bool opticalFlowMeasurementReadyForFusion(timeUs_t nowUs, const opticalflow_t *flow, float *noiseScale);
 bool rangefinderMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
+bool baroMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
 
 PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
 }
@@ -59,6 +60,9 @@ static bool rfUseFakeMicrosTimestamp = true;
 static timeUs_t rfSampleTimeUs = 0;
 static timeDelta_t rfSampleIntervalUs = 10000;
 static float baroAltCm = 0.0f;
+static bool baroUseFakeMicrosTimestamp = true;
+static timeUs_t baroSampleTimeUs = 0;
+static timeDelta_t baroSampleIntervalUs = 10000;
 static timeUs_t fakeMicros = 0;
 static bool gpsAlwaysHasNewData = true;
 static bool gpsDataIsNew = false;
@@ -72,6 +76,8 @@ int32_t rangefinderGetLatestAltitude(void) { return lrintf(rfAltCm); }
 timeUs_t rangefinderGetLatestSampleTimeUs(void) { return rfUseFakeMicrosTimestamp ? fakeMicros : rfSampleTimeUs; }
 timeDelta_t rangefinderGetSampleIntervalUs(void) { return rfSampleIntervalUs; }
 float getBaroAltitude(void) { return baroAltCm; }
+timeUs_t getBaroLatestSampleTimeUs(void) { return baroUseFakeMicrosTimestamp ? fakeMicros : baroSampleTimeUs; }
+timeDelta_t getBaroSampleIntervalUs(void) { return baroSampleIntervalUs; }
 
 timeUs_t micros(void) { return fakeMicros; }
 
@@ -131,6 +137,9 @@ protected:
         rfSampleTimeUs = 0;
         rfSampleIntervalUs = 10000;
         baroAltCm = 100.0f;
+        baroUseFakeMicrosTimestamp = true;
+        baroSampleTimeUs = 0;
+        baroSampleIntervalUs = 10000;
         gpsSol.llh.altCm = 100.0f;
         gpsSol.dop.pdop = 100; // pDOP 1.0
 
@@ -260,6 +269,38 @@ TEST_F(PositionEstimatorTest, RangefinderUpsamplingTracksSourceInterval)
 
     rfSampleTimeUs = 200000;
     EXPECT_TRUE(rangefinderMeasurementReadyForFusion(200000, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, BarometerMeasurementsUseCompletedSampleRate)
+{
+    baroUseFakeMicrosTimestamp = false;
+    baroSampleTimeUs = 100000;
+    baroSampleIntervalUs = 25000; // Default barometer rate is 40 Hz.
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(baroMeasurementReadyForFusion(100000, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 2.5f);
+    EXPECT_TRUE(baroMeasurementReadyForFusion(110000, &noiseScale));
+    EXPECT_TRUE(baroMeasurementReadyForFusion(120000, &noiseScale));
+    EXPECT_FALSE(baroMeasurementReadyForFusion(130000, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, BarometerUpsamplingTracksSlowerTargetRate)
+{
+    baroUseFakeMicrosTimestamp = false;
+    baroSampleTimeUs = 100000;
+    baroSampleIntervalUs = 50000; // Some targets configure barometers at 20 Hz.
+    positionEstimatorInit();
+
+    float noiseScale;
+    EXPECT_TRUE(baroMeasurementReadyForFusion(100000, &noiseScale));
+    EXPECT_FLOAT_EQ(noiseScale, 5.0f);
+    EXPECT_TRUE(baroMeasurementReadyForFusion(140000, &noiseScale));
+    EXPECT_FALSE(baroMeasurementReadyForFusion(150000, &noiseScale));
+
+    baroSampleTimeUs = 150000;
+    EXPECT_TRUE(baroMeasurementReadyForFusion(150000, &noiseScale));
 }
 
 TEST_F(PositionEstimatorTest, RangefinderPreferFallsBackAndRecovers)

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -23,6 +23,7 @@ extern "C" {
 // linear acceleration in ENU (cm/s^2).
 void getLinearAccelENU(float *accelEast, float *accelNorth, float *accelUp);
 bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
+const vector2_t *gpsGetVelocityMeasurement(void);
 
 #include "io/gps.h"
 
@@ -201,6 +202,51 @@ TEST_F(PositionEstimatorTest, GPSUpsamplingTracksSourceFrequency)
     EXPECT_FLOAT_EQ(noiseScale, 20.0f);
     EXPECT_TRUE(gpsMeasurementReadyForFusion(240000, &noiseScale));
     EXPECT_FALSE(gpsMeasurementReadyForFusion(250000, &noiseScale));
+}
+
+TEST_F(PositionEstimatorTest, GPSVelocityUsesNativeRateTwoPointAverage)
+{
+    gpsAlwaysHasNewData = false;
+    gpsDataFrequencyHz = 10.0f;
+    positionEstimatorInit();
+
+    float noiseScale;
+    gpsSol.velned.velE = 100;
+    gpsSol.velned.velN = -40;
+    gpsDataIsNew = true;
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(0, &noiseScale));
+    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_EAST], 100.0f);
+    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_NORTH], -40.0f);
+
+    gpsSol.velned.velE = 140;
+    gpsSol.velned.velN = 20;
+    gpsDataIsNew = true;
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(100000, &noiseScale));
+    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_EAST], 120.0f);
+    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_NORTH], -10.0f);
+
+    // Changing gpsSol without a new GPS frame must not change the held average.
+    gpsSol.velned.velE = 1000;
+    gpsSol.velned.velN = 1000;
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(110000, &noiseScale));
+    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_EAST], 120.0f);
+    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_NORTH], -10.0f);
+
+    // Average adjacent raw samples, not the previous averaged result.
+    gpsSol.velned.velE = 180;
+    gpsSol.velned.velN = 40;
+    gpsDataIsNew = true;
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(200000, &noiseScale));
+    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_EAST], 160.0f);
+    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_NORTH], 30.0f);
+
+    // A missing GPS frame resets the average instead of mixing stale velocity.
+    gpsSol.velned.velE = 220;
+    gpsSol.velned.velN = 60;
+    gpsDataIsNew = true;
+    EXPECT_TRUE(gpsMeasurementReadyForFusion(400000, &noiseScale));
+    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_EAST], 220.0f);
+    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_NORTH], 60.0f);
 }
 
 TEST_F(PositionEstimatorTest, OpticalFlowMeasurementsUseNominalRateForFirstSample)

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -42,20 +42,107 @@ PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
 
 #include "gtest/gtest.h"
 
-TEST(PositionFilterTest, AccelerationMeasurementDrivesAllThreeStates)
+TEST(PositionFilterTest, AccelerationMeasurementDrivesAllStates)
 {
     positionKalman_t kf;
     kalmanInit(&kf, 0.0f, 0.0f, 0.0f,
-        10000.0f, 10000.0f, 1000000.0f, 1000.0f);
+        10000.0f, 10000.0f, 1000000.0f, 1000.0f, 1.0f);
 
     for (int i = 0; i < 100; i++) {
         kalmanPredict(&kf, 0.01f);
-        kalmanUpdateAcceleration(&kf, 100.0f, 100.0f);
+        kalmanUpdateAcceleration(&kf, 100.0f, 100.0f, 0.01f);
     }
 
-    EXPECT_NEAR(kalmanGetAcceleration(&kf), 100.0f, 1.0f);
-    EXPECT_NEAR(kalmanGetVelocity(&kf), 99.0f, 2.0f);
-    EXPECT_NEAR(kalmanGetPosition(&kf), 49.0f, 2.0f);
+    // With no position or velocity aiding the split between acceleration and bias is
+    // unobservable, so only their sum is pinned to the accelerometer.
+    EXPECT_NEAR(kalmanGetAcceleration(&kf) + kalmanGetAccelBias(&kf), 100.0f, 1.0f);
+    EXPECT_GT(kalmanGetVelocity(&kf), 0.0f);
+    EXPECT_GT(kalmanGetPosition(&kf), 0.0f);
+}
+
+// Velocity is driven by integrating the measured acceleration, so one update must move
+// velocity by measuredAccel * dt whatever the covariance happens to be. Previously this
+// share was covariance-weighted and collapsed as GPS velocity was trusted more tightly.
+TEST(PositionFilterTest, AccelerometerAuthorityOverVelocityIsIndependentOfGpsTrust)
+{
+    const float dt = 0.01f;
+    positionKalman_t tight;
+    positionKalman_t loose;
+    kalmanInit(&tight, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, 1.0f);
+    kalmanInit(&loose, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, 1.0f);
+
+    // Settle both at rest, differing only in how tightly GPS velocity is fused.
+    for (int i = 0; i < 500; i++) {
+        kalmanPredict(&tight, dt);
+        kalmanPredict(&loose, dt);
+        kalmanUpdateAcceleration(&tight, 0.0f, 2000.0f, dt);
+        kalmanUpdateAcceleration(&loose, 0.0f, 2000.0f, dt);
+        kalmanUpdateVelocity(&tight, 0.0f, 20.0f);
+        kalmanUpdateVelocity(&loose, 0.0f, 20000.0f);
+    }
+
+    kalmanPredict(&tight, dt);
+    kalmanPredict(&loose, dt);
+    const float tightBefore = kalmanGetVelocity(&tight);
+    const float looseBefore = kalmanGetVelocity(&loose);
+    kalmanUpdateAcceleration(&tight, 200.0f, 2000.0f, dt);
+    kalmanUpdateAcceleration(&loose, 200.0f, 2000.0f, dt);
+
+    const float tightStep = kalmanGetVelocity(&tight) - tightBefore;
+    const float looseStep = kalmanGetVelocity(&loose) - looseBefore;
+
+    EXPECT_NEAR(tightStep, 200.0f * dt, 0.05f);
+    EXPECT_NEAR(looseStep, 200.0f * dt, 0.05f);
+    EXPECT_NEAR(tightStep, looseStep, 0.01f);
+}
+
+// A standing accelerometer bias (attitude error, calibration, thermal drift) must be
+// estimated rather than integrated into velocity.
+TEST(PositionFilterTest, AccelerometerBiasIsEstimatedAndKeptOutOfVelocity)
+{
+    const float dt = 0.01f;
+    const float injectedBias = 40.0f;
+    positionKalman_t kf;
+    kalmanInit(&kf, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, 1.0f);
+
+    // Stationary craft: aiding says the position and velocity are zero, but the
+    // accelerometer reads a constant offset.
+    for (int i = 0; i < 6000; i++) {
+        kalmanPredict(&kf, dt);
+        kalmanUpdateAcceleration(&kf, injectedBias, 2000.0f, dt);
+        kalmanUpdatePosition(&kf, 0.0f, 500.0f);
+        kalmanUpdateVelocity(&kf, 0.0f, 2000.0f);
+    }
+
+    EXPECT_NEAR(kalmanGetAccelBias(&kf), injectedBias, 10.0f);
+    EXPECT_NEAR(kalmanGetAcceleration(&kf), 0.0f, 15.0f);
+    EXPECT_NEAR(kalmanGetVelocity(&kf), 0.0f, 15.0f);
+}
+
+// Once the bias is learned, velocity must stay bounded when aiding is lost, instead of
+// integrating the bias without limit.
+TEST(PositionFilterTest, LearnedBiasBoundsVelocityDriftWhenAidingStops)
+{
+    const float dt = 0.01f;
+    const float injectedBias = 40.0f;
+    positionKalman_t kf;
+    kalmanInit(&kf, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, 1.0f);
+
+    for (int i = 0; i < 6000; i++) {
+        kalmanPredict(&kf, dt);
+        kalmanUpdateAcceleration(&kf, injectedBias, 2000.0f, dt);
+        kalmanUpdatePosition(&kf, 0.0f, 500.0f);
+        kalmanUpdateVelocity(&kf, 0.0f, 2000.0f);
+    }
+
+    // Aiding stops; only the accelerometer remains.
+    for (int i = 0; i < 1500; i++) {
+        kalmanPredict(&kf, dt);
+        kalmanUpdateAcceleration(&kf, injectedBias, 2000.0f, dt);
+    }
+
+    // Integrating the raw 40 cm/s^2 offset unchecked for 15 s would reach 600 cm/s.
+    EXPECT_LT(fabsf(kalmanGetVelocity(&kf)), 100.0f);
 }
 
 extern "C" {

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -18,12 +18,12 @@ extern "C" {
 #include "flight/imu.h"
 #include "flight/position.h"
 #include "flight/position_estimator.h"
+#include "flight/position_filter.h"
 
 // STATIC_UNIT_TESTED in position_estimator.c — gravity-removed earth-frame
 // linear acceleration in ENU (cm/s^2).
 void getLinearAccelENU(float *accelEast, float *accelNorth, float *accelUp);
 bool gpsMeasurementReadyForFusion(timeUs_t nowUs, float *noiseScale);
-const vector2_t *gpsGetVelocityMeasurement(void);
 
 #include "io/gps.h"
 
@@ -41,6 +41,22 @@ PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
 }
 
 #include "gtest/gtest.h"
+
+TEST(PositionFilterTest, AccelerationMeasurementDrivesAllThreeStates)
+{
+    positionKalman_t kf;
+    kalmanInit(&kf, 0.0f, 0.0f, 0.0f,
+        10000.0f, 10000.0f, 1000000.0f, 1000.0f);
+
+    for (int i = 0; i < 100; i++) {
+        kalmanPredict(&kf, 0.01f);
+        kalmanUpdateAcceleration(&kf, 100.0f, 100.0f);
+    }
+
+    EXPECT_NEAR(kalmanGetAcceleration(&kf), 100.0f, 1.0f);
+    EXPECT_NEAR(kalmanGetVelocity(&kf), 99.0f, 2.0f);
+    EXPECT_NEAR(kalmanGetPosition(&kf), 49.0f, 2.0f);
+}
 
 extern "C" {
 uint8_t armingFlags = 0;
@@ -202,51 +218,6 @@ TEST_F(PositionEstimatorTest, GPSUpsamplingTracksSourceFrequency)
     EXPECT_FLOAT_EQ(noiseScale, 20.0f);
     EXPECT_TRUE(gpsMeasurementReadyForFusion(240000, &noiseScale));
     EXPECT_FALSE(gpsMeasurementReadyForFusion(250000, &noiseScale));
-}
-
-TEST_F(PositionEstimatorTest, GPSVelocityUsesNativeRateTwoPointAverage)
-{
-    gpsAlwaysHasNewData = false;
-    gpsDataFrequencyHz = 10.0f;
-    positionEstimatorInit();
-
-    float noiseScale;
-    gpsSol.velned.velE = 100;
-    gpsSol.velned.velN = -40;
-    gpsDataIsNew = true;
-    EXPECT_TRUE(gpsMeasurementReadyForFusion(0, &noiseScale));
-    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_EAST], 100.0f);
-    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_NORTH], -40.0f);
-
-    gpsSol.velned.velE = 140;
-    gpsSol.velned.velN = 20;
-    gpsDataIsNew = true;
-    EXPECT_TRUE(gpsMeasurementReadyForFusion(100000, &noiseScale));
-    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_EAST], 120.0f);
-    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_NORTH], -10.0f);
-
-    // Changing gpsSol without a new GPS frame must not change the held average.
-    gpsSol.velned.velE = 1000;
-    gpsSol.velned.velN = 1000;
-    EXPECT_TRUE(gpsMeasurementReadyForFusion(110000, &noiseScale));
-    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_EAST], 120.0f);
-    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_NORTH], -10.0f);
-
-    // Average adjacent raw samples, not the previous averaged result.
-    gpsSol.velned.velE = 180;
-    gpsSol.velned.velN = 40;
-    gpsDataIsNew = true;
-    EXPECT_TRUE(gpsMeasurementReadyForFusion(200000, &noiseScale));
-    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_EAST], 160.0f);
-    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_NORTH], 30.0f);
-
-    // A missing GPS frame resets the average instead of mixing stale velocity.
-    gpsSol.velned.velE = 220;
-    gpsSol.velned.velN = 60;
-    gpsDataIsNew = true;
-    EXPECT_TRUE(gpsMeasurementReadyForFusion(400000, &noiseScale));
-    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_EAST], 220.0f);
-    EXPECT_FLOAT_EQ(gpsGetVelocityMeasurement()->v[EF_NORTH], 60.0f);
 }
 
 TEST_F(PositionEstimatorTest, OpticalFlowMeasurementsUseNominalRateForFirstSample)

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -42,11 +42,14 @@ PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
 
 #include "gtest/gtest.h"
 
+// Mirrors Q_ACCEL_BIAS in position_estimator.c so these tests exercise the shipped tuning.
+static const float TEST_Q_ACCEL_BIAS = 0.03f;
+
 TEST(PositionFilterTest, AccelerationMeasurementDrivesAllStates)
 {
     positionKalman_t kf;
     kalmanInit(&kf, 0.0f, 0.0f, 0.0f,
-        10000.0f, 10000.0f, 1000000.0f, 1000.0f, 1.0f);
+        10000.0f, 10000.0f, 1000000.0f, 1000.0f, TEST_Q_ACCEL_BIAS);
 
     for (int i = 0; i < 100; i++) {
         kalmanPredict(&kf, 0.01f);
@@ -68,8 +71,8 @@ TEST(PositionFilterTest, AccelerometerAuthorityOverVelocityIsIndependentOfGpsTru
     const float dt = 0.01f;
     positionKalman_t tight;
     positionKalman_t loose;
-    kalmanInit(&tight, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, 1.0f);
-    kalmanInit(&loose, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, 1.0f);
+    kalmanInit(&tight, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, TEST_Q_ACCEL_BIAS);
+    kalmanInit(&loose, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, TEST_Q_ACCEL_BIAS);
 
     // Settle both at rest, differing only in how tightly GPS velocity is fused.
     for (int i = 0; i < 500; i++) {
@@ -103,7 +106,7 @@ TEST(PositionFilterTest, AccelerometerBiasIsEstimatedAndKeptOutOfVelocity)
     const float dt = 0.01f;
     const float injectedBias = 40.0f;
     positionKalman_t kf;
-    kalmanInit(&kf, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, 1.0f);
+    kalmanInit(&kf, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, TEST_Q_ACCEL_BIAS);
 
     // Stationary craft: aiding says the position and velocity are zero, but the
     // accelerometer reads a constant offset.
@@ -126,7 +129,7 @@ TEST(PositionFilterTest, LearnedBiasBoundsVelocityDriftWhenAidingStops)
     const float dt = 0.01f;
     const float injectedBias = 40.0f;
     positionKalman_t kf;
-    kalmanInit(&kf, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, 1.0f);
+    kalmanInit(&kf, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, TEST_Q_ACCEL_BIAS);
 
     for (int i = 0; i < 6000; i++) {
         kalmanPredict(&kf, dt);
@@ -143,6 +146,89 @@ TEST(PositionFilterTest, LearnedBiasBoundsVelocityDriftWhenAidingStops)
 
     // Integrating the raw 40 cm/s^2 offset unchecked for 15 s would reach 600 cm/s.
     EXPECT_LT(fabsf(kalmanGetVelocity(&kf)), 100.0f);
+}
+
+// Runs a hard manoeuvre with aiding that confirms it, and returns how much of it the bias
+// state absorbed and where the acceleration state ended up.
+static void runConfirmedManoeuvre(positionKalman_t *kf, float accel, int cycles,
+                                  float dt, float *worstBias, float *trueVelOut)
+{
+    float trueVel = 0.0f;
+    float truePos = 0.0f;
+    *worstBias = 0.0f;
+    for (int i = 0; i < cycles; i++) {
+        trueVel += accel * dt;
+        truePos += trueVel * dt;
+        kalmanPredict(kf, dt);
+        kalmanUpdateAcceleration(kf, accel, 2000.0f, dt);
+        kalmanUpdatePosition(kf, truePos, 500.0f);
+        kalmanUpdateVelocity(kf, trueVel, 2000.0f);
+        const float bias = fabsf(kalmanGetAccelBias(kf));
+        if (bias > *worstBias) {
+            *worstBias = bias;
+        }
+    }
+    *trueVelOut = trueVel;
+}
+
+// Acceleration held in one direction is genuinely ambiguous with a bias, so some of it is
+// always absorbed regardless of Q_ACCEL_BIAS. What must hold is that the acceleration state
+// still carries the bulk of a manoeuvre the aiding has confirmed, and that a manoeuvre of
+// realistic length does not drive the bias all the way to its clamp.
+TEST(PositionFilterTest, ConfirmedManoeuvreIsAttributedMostlyToAcceleration)
+{
+    const float dt = 0.01f;
+    const float manoeuvreAccel = 400.0f;
+    positionKalman_t kf;
+    kalmanInit(&kf, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, TEST_Q_ACCEL_BIAS);
+
+    for (int i = 0; i < 500; i++) {
+        kalmanPredict(&kf, dt);
+        kalmanUpdateAcceleration(&kf, 0.0f, 2000.0f, dt);
+        kalmanUpdatePosition(&kf, 0.0f, 500.0f);
+        kalmanUpdateVelocity(&kf, 0.0f, 2000.0f);
+    }
+
+    float worstBias = 0.0f;
+    float trueVel = 0.0f;
+    runConfirmedManoeuvre(&kf, manoeuvreAccel, 200, dt, &worstBias, &trueVel);
+
+    // Around 77 cm/s^2 leaks into the bias over 2 s, against 306 of 400 held by the
+    // acceleration state. Sustaining the manoeuvre for 4 s does reach the clamp.
+    EXPECT_LT(worstBias, 120.0f);
+    EXPECT_GT(kalmanGetAcceleration(&kf), 2.0f * worstBias);
+}
+
+// The case Q_ACCEL_BIAS is chosen for. A bias learned in the hover, then contaminated by a
+// hard manoeuvre, must still leave velocity bounded once aiding disappears. Too permissive a
+// value fails this badly: 1.0 gives around 1400 cm/s here, worse than the 970 cm/s that
+// having no bias state at all produces.
+TEST(PositionFilterTest, DropoutAfterManoeuvreKeepsVelocityBounded)
+{
+    const float dt = 0.01f;
+    const float injectedBias = 30.0f;
+    positionKalman_t kf;
+    kalmanInit(&kf, 0.0f, 0.0f, 0.0f, 10000.0f, 10000.0f, 1000000.0f, 3000.0f, TEST_Q_ACCEL_BIAS);
+
+    // Hover long enough to learn the bias.
+    for (int i = 0; i < 6000; i++) {
+        kalmanPredict(&kf, dt);
+        kalmanUpdateAcceleration(&kf, injectedBias, 2000.0f, dt);
+        kalmanUpdatePosition(&kf, 0.0f, 500.0f);
+        kalmanUpdateVelocity(&kf, 0.0f, 2000.0f);
+    }
+
+    float worstBias = 0.0f;
+    float trueVel = 0.0f;
+    runConfirmedManoeuvre(&kf, injectedBias + 400.0f, 200, dt, &worstBias, &trueVel);
+
+    // Aiding disappears. The craft coasts, so true velocity holds at trueVel.
+    for (int i = 0; i < 1000; i++) {
+        kalmanPredict(&kf, dt);
+        kalmanUpdateAcceleration(&kf, injectedBias, 2000.0f, dt);
+    }
+
+    EXPECT_LT(fabsf(kalmanGetVelocity(&kf) - trueVel), 200.0f);
 }
 
 extern "C" {


### PR DESCRIPTION
## Summary

This PR updates the position estimator to fuse lower-rate sensor measurements consistently at the 100 Hz altitude-task rate and extends the Kalman state with acceleration.

This is a joint effort between myself and @ctzsnooze looking into optical flow and GPS position hold respectively.

@blckmn I've rebased this to include your navigation updates, so I hope I've not broken anything,

## Motivation

GPS, barometer, rangefinder and optical-flow measurements generally arrive below the position estimator task rate. Fusing them only when new data arrives produces uneven corrections, while repeatedly fusing an unchanged measurement without compensation makes the filter overconfident.

The position controller also previously obtained acceleration by differentiating Kalman velocity. Measurement corrections could therefore create acceleration spikes even when the underlying motion was smooth.

## Changes

- Upsample GPS, optical-flow, rangefinder and barometer measurements to the altitude-task rate.
- Hold each measurement until the next source sample is expected.
- Scale measurement noise for repeated updates, preserving approximately the same information per source sample.
- Use measured source timestamps and intervals where available.
- Expose completed-sample timing from the barometer and rangefinder layers.
- Ensure Benewake rangefinder frames are reported as new data only once.
- Convert the per-axis Kalman filter from two states to three:
  - position
  - velocity
  - acceleration
- Model unknown jerk as process noise.
- Fuse IMU acceleration as a Kalman measurement rather than an external control input.
- Expose the estimated ENU acceleration through `positionEstimate3d_t`.
- Use Kalman-estimated acceleration for the autopilot A-term instead of differentiating velocity.
- Remove the derivative-staleness workaround, which is no longer required.
- Add unit coverage for sensor cadence, measurement holding, noise scaling, acceleration estimation and controller integration.

## Testing

Tested on a `CADDX_PROTOS_F4`. A log with `debug_mode = AUTOPILOT_PID` is attached below.

[kalman_acc_CADDX_PROTOS_F4_AUTOPILOT_PID.bbl.zip](https://github.com/user-attachments/files/30556669/kalman_acc_CADDX_PROTOS_F4_AUTOPILOT_PID.bbl.zip)

@ctzsnooze Please add your GPS logs to this PR along with your explanation of the behaviours you've observed.

## Known Issues

Altitude hold has taken a step backwards and needs some investigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved position-hold stability and responsiveness using acceleration estimates.
  * Enhanced navigation accuracy through improved motion estimation and sensor fusion.
  * Improved handling of GPS, barometer, rangefinder, and optical-flow data across varying update rates.
  * Prevented stale rangefinder measurements from being delivered repeatedly.
  * Added sensor timing information for more consistent measurement processing.
  * Improved resilience to acceleration bias and velocity drift when external positioning data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->