### PR TITLE
fix(g4,n6): correct alternate-function errors in the I2C and UART tables

### DIFF
--- a/src/platform/STM32/bus_i2c_ll_init.c
+++ b/src/platform/STM32/bus_i2c_ll_init.c
@@ -142,7 +142,7 @@ const i2cHardware_t i2cHardware[I2CDEV_COUNT] = {
         // Some boards are overloading SWD pins with I2C1 for maximum pin utilization on 48-pin CE(U) packages.
         // Be carefull when using SWD on these boards if I2C1 pins are defined by default.
 
-        .sclPins = { I2CPINDEF(PA13, GPIO_AF4_I2C1), I2CPINDEF(PA15, GPIO_AF4_I2C1), I2CPINDEF(PB6,  GPIO_AF4_I2C1), I2CPINDEF(PB8,  GPIO_AF4_I2C1), },
+        .sclPins = { I2CPINDEF(PA13, GPIO_AF4_I2C1), I2CPINDEF(PA15, GPIO_AF4_I2C1), I2CPINDEF(PB8,  GPIO_AF4_I2C1), },
         .sdaPins = { I2CPINDEF(PA14, GPIO_AF4_I2C1), I2CPINDEF(PB7,  GPIO_AF4_I2C1), I2CPINDEF(PB9,  GPIO_AF4_I2C1), },
         .rcc = RCC_APB11(I2C1),
         .ev_irq = I2C1_EV_IRQn,
@@ -153,8 +153,8 @@ const i2cHardware_t i2cHardware[I2CDEV_COUNT] = {
     {
         .device = I2CDEV_2,
         .reg = (i2cResource_t *)I2C2,
-        .sclPins = { I2CPINDEF(PA9,  GPIO_AF4_I2C2) },
-        .sdaPins = { I2CPINDEF(PA8, GPIO_AF4_I2C2), I2CPINDEF(PF6, GPIO_AF4_I2C2) },
+        .sclPins = { I2CPINDEF(PA9,  GPIO_AF4_I2C2), I2CPINDEF(PF6, GPIO_AF4_I2C2) },
+        .sdaPins = { I2CPINDEF(PA8,  GPIO_AF4_I2C2) },
         .rcc = RCC_APB11(I2C2),
         .ev_irq = I2C2_EV_IRQn,
         .er_irq = I2C2_ER_IRQn,
@@ -179,8 +179,8 @@ const i2cHardware_t i2cHardware[I2CDEV_COUNT] = {
         // Here, SWDIO(PA13) is overloaded with I2C4_SCL, too.
         // See comment in the I2C1 section above.
 
-        .sclPins = { I2CPINDEF(PA13, GPIO_AF3_I2C4), I2CPINDEF(PB6,  GPIO_AF3_I2C4), I2CPINDEF(PC6,  GPIO_AF8_I2C4), },
-        .sdaPins = { I2CPINDEF(PB7,  GPIO_AF4_I2C4), I2CPINDEF(PC7,  GPIO_AF8_I2C4), },
+        .sclPins = { I2CPINDEF(PA13, GPIO_AF3_I2C4), I2CPINDEF(PC6,  GPIO_AF8_I2C4), },
+        .sdaPins = { I2CPINDEF(PB7,  GPIO_AF3_I2C4), I2CPINDEF(PC7,  GPIO_AF8_I2C4), },
         .rcc = RCC_APB12(I2C4),
         .ev_irq = I2C4_EV_IRQn,
         .er_irq = I2C4_ER_IRQn,

--- a/src/platform/STM32/serial_uart_stm32n6xx.c
+++ b/src/platform/STM32/serial_uart_stm32n6xx.c
@@ -315,7 +315,7 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
             { DEFIO_TAG_E(PA15), GPIO_AF10_UART7 },
             { DEFIO_TAG_E(PB4),  GPIO_AF10_UART7 },
             { DEFIO_TAG_E(PE8),  GPIO_AF8_UART7 },
-            { DEFIO_TAG_E(PG12), GPIO_AF10_UART7 },
+            { DEFIO_TAG_E(PG12), GPIO_AF8_UART7 },
             { DEFIO_TAG_E(PH3),  GPIO_AF8_UART7 },
             { DEFIO_TAG_E(PH4),  GPIO_AF8_UART7 },
         },


### PR DESCRIPTION
Cross-checked every `(pin, AF)` pair in the STM32G4 and STM32N6 pin tables against
the datasheet alternate-function tables. Each finding below was then confirmed by
**reading the rendered table**, not by trusting the extraction — a second script
written to cross-check the first dropped cells of its own, so two parsers sharing
the same column geometry would only have agreed on each other's blind spots.

Follows the same method as #15506 (H5).

## STM32G4

Verified against **both** DS12712 Rev 5 (G473) and DS12288 Rev 6 (G474), because
the `STM32G474` target serves boards built on either part.

### `I2C4_SDA` on `PB7` is AF3, not AF4

The one that fails quietly. AF4 on PB7 is a real I2C function — it is
`I2C1_SDA` — so requesting I2C4 SDA there silently selects I2C1 SDA instead.

```
PB7   AF1 TIM17_CH1N   AF2 TIM4_CH2   AF3 I2C4_SDA   AF4 I2C1_SDA   AF5 TIM8_BKIN
```

### `PB6` carries no I2C function at all

Removed from `I2C1_SCL` and `I2C4_SCL`. Its AF3 and AF4 cells are empty on both
parts:

```
PB6   AF1 TIM16_CH1N   AF2 TIM4_CH1   AF3 -   AF4 -   AF5 TIM8_CH1   AF6 TIM8_ETR
```

`PB6` *is* `I2C1_SCL` on F4, F7, H5 and H7, which is the likely origin.

### `PF6` is `I2C2_SCL`, not `I2C2_SDA`

Moved between the two lists. `PF6` AF4 is `I2C2_SCL`; `I2C2_SDA` on that port is
`PF0`, which this PR does not add.

## STM32N6

### `USART7_TX` on `PG12` is AF8, not AF10

`AF10` is empty on that pin, so UART7 TX could not work there. `UART7_RX` is
already correct on `PG11` AF8, so the pair now matches.

```
PG12  (Table 20)  AF8 UART7_TX   AF9 -   AF10 -   AF11 -   AF12 FMC_A18
```

## Deliberately not changed

G473 and G474 genuinely disagree on two pins, and the table is shared:

| Entry | G473 | G474 |
|---|---|---|
| `I2C3_SCL PA10` AF2 | present | **absent** (it is `PA8` AF2) |
| `I2C1_SCL` / `I2C4_SCL` on `PA13` | **absent** | present |

Removing either pair would break boards built on the other part, so both stay.
Worth knowing if anyone audits these tables again and sees them flagged.

## One thing for review

`CRAZYBEE473` sets `I2C1_SCL_PIN PB6` and is the only shipped G4 config using a
pin this PR removes. Since PB6 has no I2C1 function on either part, that bus
cannot be working. This PR does not change that — it stops the table claiming
otherwise.

It declares no baro or mag driver, only `BARO_I2C_INSTANCE` / `MAG_I2C_INSTANCE`,
so this affects users attaching an external compass or baro rather than an
onboard sensor.

**Deliberately not "fixed" here.** `PB8` is a valid `I2C1_SCL` pin and is unused
in that config, so swapping it in would look like a fix — but the board is in
production and the PCB decides where SCL actually goes. If the trace runs to PB6,
relabelling the pin changes nothing. Worth noting that every other CrazyBee is
F4/F411, where PB6 *is* `I2C1_SCL`; this is the first G4 in the line, so the
layout may have carried over with the config. Someone with the board or the
schematic should decide, and soft I2C on PB6/PB7 is the option if the trace is
genuinely there.

## Testing

`AOCODARCG473V1` and `CRAZYBEE473` both build clean. Re-running the audit against
the patched tree leaves only the two part-specific entries listed above, which is
the intended result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected STM32G4 I2C pin mappings for improved peripheral connectivity.
  * Fixed the STM32N6 UART7 transmit pin configuration to enable proper serial communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
