### PR TITLE
fix(f4,f7): PA11 is TIM1_CH4, not TIM1_CH1N

### DIFF
--- a/src/platform/STM32/timer_def.h
+++ b/src/platform/STM32/timer_def.h
@@ -374,7 +374,7 @@
 #define DEF_TIM_AF__PA8__TCH_TIM1_CH1     D(1, 1)
 #define DEF_TIM_AF__PA9__TCH_TIM1_CH2     D(1, 1)
 #define DEF_TIM_AF__PA10__TCH_TIM1_CH3    D(1, 1)
-#define DEF_TIM_AF__PA11__TCH_TIM1_CH1N   D(1, 1)
+#define DEF_TIM_AF__PA11__TCH_TIM1_CH4    D(1, 1)
 #define DEF_TIM_AF__PA15__TCH_TIM2_CH1    D(1, 2)
 
 #define DEF_TIM_AF__PA0__TCH_TIM5_CH1     D(2, 5)

--- a/src/platform/STM32/timer_stm32f4xx.c
+++ b/src/platform/STM32/timer_stm32f4xx.c
@@ -69,7 +69,7 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM1, CH1,  PA8, 0, 0),
     DEF_TIM(TIM1, CH2,  PA9, 0, 0),
     DEF_TIM(TIM1, CH3,  PA10, 0, 0),
-    DEF_TIM(TIM1, CH1N, PA11, 0, 0),
+    DEF_TIM(TIM1, CH4,  PA11, 0, 0),
     DEF_TIM(TIM2, CH1,  PA15, 0, 0),
 
     DEF_TIM(TIM5, CH1,  PA0, 0, 0),

--- a/src/platform/STM32/timer_stm32f7xx.c
+++ b/src/platform/STM32/timer_stm32f7xx.c
@@ -63,7 +63,7 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM1, CH1,  PA8,  0, 0),
     DEF_TIM(TIM1, CH2,  PA9,  0, 0),
     DEF_TIM(TIM1, CH3,  PA10, 0, 0),
-    DEF_TIM(TIM1, CH1N, PA11, 0, 0),
+    DEF_TIM(TIM1, CH4,  PA11, 0, 0),
     DEF_TIM(TIM2, CH1,  PA15, 0, 0),
 
     DEF_TIM(TIM5, CH1,  PA0,  0, 0),


### PR DESCRIPTION
`PA11` is declared as `TIM1_CH1N` on F4 and F7. Both datasheets say it is
`TIM1_CH4`:

```
STM32F405/407  DS8626 Rev 12, Table 9    PA11  AF1 = TIM1_CH4
STM32F722      DS11853,      Table 12    PA11  AF1 = TIM1_CH4
```

Neither lists `TIM1_CH1N` on `PA11` at all — that function is on `PA7`, which both
tables already carry. The surrounding lines show what happened:

```c
DEF_TIM(TIM1, CH1,  PA8,  0, 0),
DEF_TIM(TIM1, CH2,  PA9,  0, 0),
DEF_TIM(TIM1, CH3,  PA10, 0, 0),
DEF_TIM(TIM1, CH1N, PA11, 0, 0),   // <- duplicated from the PA7 line, should be CH4
```

## Every other family is already correct

| Family | `PA11` | |
|---|---|---|
| H5, H7, C5, N6 | `CH4` | correct |
| G4 | `CH1N` **and** `CH4` | also correct — G4 genuinely offers both, `CH1N` on AF6 and `CH4` on AF11, with its own AF numbers |
| **F4, F7** | `CH1N` | **wrong** |

## Two files for F7, one for F4

F7 resolves the AF from a per-pin macro, so `timer_def.h` had to move with the
table — otherwise the build fails on an undeclared
`DEF_TIM_AF__PA11__TCH_TIM1_CH4`. F4 resolves timer AF from `GPIO_AF_TIMn`
rather than per-pin macros, so it needed only the table entry.

## Impact

Latent. No shipped config uses `PA11` as a timer pin — it is USB DM on most
flight controllers. But a board wanting `TIM1_CH4` there could not have it, and
selecting it would have programmed `CH1N`'s registers against a pin wired to
`CH4`: configured, and dead.

## How it was found

Cross-checking the pin tables against the datasheet alternate-function tables,
same method as #15506 and #15508. **F4 was the last family with no datasheet
coverage at all, and is the largest by board count** — its UART, I2C and SPI
tables came back clean at 100% extraction (50/50 pairs exact), and this was the
single timer finding.

Not addressed here, and pre-existing on master: H5 and H7 declare
`TIM13_CH1N`/`TIM14_CH1N` on `PF8`/`PF9`, and N6 has several `TIM15`/`TIM2`/
`TIM3`/`TIM5` rows that do not match its datasheet. Those need reading against
the rendered tables before anyone acts on them.

## Testing

Builds verified on an F405 and an F722 target. Both families' audits go from one
finding to clean; no other family's result changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected STM32 timer mapping for pin PA11 to use TIM1 channel 4.
  * Improved timer functionality and compatibility on STM32F4 and STM32F7 hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->