### PR TITLE
fix(h5,h7): PF8/PF9 carry TIM13_CH1 and TIM14_CH1, not CH1N

### DIFF
--- a/src/platform/STM32/timer_def.h
+++ b/src/platform/STM32/timer_def.h
@@ -790,8 +790,8 @@
 #define DEF_TIM_AF__PF8__TCH_TIM16_CH1N   D(1, 16)
 #define DEF_TIM_AF__PF9__TCH_TIM17_CH1N   D(1, 17)
 
-#define DEF_TIM_AF__PF8__TCH_TIM13_CH1N   D(9, 13)
-#define DEF_TIM_AF__PF9__TCH_TIM14_CH1N   D(9, 14)
+#define DEF_TIM_AF__PF8__TCH_TIM13_CH1    D(9, 13)
+#define DEF_TIM_AF__PF9__TCH_TIM14_CH1    D(9, 14)
 
 #if defined(STM32H723xx) || defined(STM32H725xx) || defined(STM32H735xx)
 #define DEF_TIM_AF__PF0__TCH_TIM23_CH1    D(13, 23)
@@ -1109,8 +1109,6 @@
 #define DEF_TIM_AF__PF8__TCH_TIM16_CH1N   D(1, 16)
 #define DEF_TIM_AF__PF9__TCH_TIM17_CH1N   D(1, 17)
 
-#define DEF_TIM_AF__PF8__TCH_TIM13_CH1N   D(9, 13)
-#define DEF_TIM_AF__PF9__TCH_TIM14_CH1N   D(9, 14)
 #define DEF_TIM_AF__PF8__TCH_TIM13_CH1    D(9, 13)
 #define DEF_TIM_AF__PF9__TCH_TIM14_CH1    D(9, 14)
 

--- a/src/platform/STM32/timer_stm32h7xx.c
+++ b/src/platform/STM32/timer_stm32h7xx.c
@@ -144,8 +144,8 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM17, CH1, PF7, 0, 0, 0),
     DEF_TIM(TIM16, CH1N, PF8, 0, 0, 0),
     DEF_TIM(TIM17, CH1N, PF9, 0, 0, 0),
-    DEF_TIM(TIM13, CH1N, PF8, 0, 0, 0),
-    DEF_TIM(TIM14, CH1N, PF9, 0, 0, 0),
+    DEF_TIM(TIM13, CH1,  PF8, 0, 0, 0),
+    DEF_TIM(TIM14, CH1,  PF9, 0, 0, 0),
 
 // Port H
     DEF_TIM(TIM5, CH1, PH10, 0, 0, 0),


### PR DESCRIPTION
`TIM13` and `TIM14` have a single channel and no complementary output, so a
`CH1N` cannot exist on them. Both datasheets agree, read off the rendered
alternate-function tables:

```
STM32H562/563  DS14258 Rev 6    PF8  AF1 TIM16_CH1N   AF9 TIM13_CH1
                                PF9  AF1 TIM17_CH1N   AF9 TIM14_CH1
STM32H742/743  DS12110 Rev 10   PF8  AF1 TIM16_CH1N   AF9 TIM13_CH1
                                PF9  AF1 TIM17_CH1N   AF9 TIM14_CH1
```

Both parts also put `TIM16_CH1` on `PF6` and `TIM17_CH1` on `PF7`, so the pairing
is consistent: TIM16/TIM17 own the complementary outputs on PF8/PF9, TIM13/TIM14
own the plain ones.

## H5 was already half-fixed

Its timer table has used `TIM13_CH1`/`TIM14_CH1` for a while — the source even
carries a `// AF9 (WAS TIM13_CH1N)` note — but the superseded AF macros were left
behind, sitting directly above the correct ones:

```c
#define DEF_TIM_AF__PF8__TCH_TIM13_CH1N   D(9, 13)   // removed
#define DEF_TIM_AF__PF9__TCH_TIM14_CH1N   D(9, 14)   // removed
#define DEF_TIM_AF__PF8__TCH_TIM13_CH1    D(9, 13)   // already correct
#define DEF_TIM_AF__PF9__TCH_TIM14_CH1    D(9, 14)   // already correct
```

Nothing referenced them, so they are simply removed.

## H7 needed both halves

H7 still used the wrong spelling in the table *and* the AF map, so they move
together. Renaming only the macro would leave the table referencing a name that
no longer exists; renaming only the table fails to compile on an undeclared
`DEF_TIM_AF__PF8__TCH_TIM13_CH1`.

## Impact

Latent on H5, where the table was already right. On H7 a board asking for TIM13
or TIM14 on those pins got a channel the timer does not have.

## Not addressed here

**STM32N6 has the same class of problem, but larger.** Its timer table references
several entries the silicon lacks — `TIM2_CH4`, `TIM5_CH4` and `TIM15_CH2` on
`PA3`, `TIM3_CH3` and `TIM15_CH1N` on `PB0`, and `TIM15_CH1N`/`CH1`/`CH2` on
`PE4`/`PE5`/`PE6`. The N6 datasheet (DS14791 Rev 6) gives `PA3` only `TIM16_CH1`
at AF1, and puts `TIM15_CH1` on `PA2` with `TIM15_CH1N` on `PA1`; `PE5` and `PE6`
carry `I2C1_SCL`/`I2C1_SDA` at AF4.

That is a rewrite rather than a rename, so it wants its own change by someone who
can decide the intended mapping — not folded in here.

## Testing

Builds verified on an H562 and an H743 target. Both families' audits go from two
findings to clean; no other family's result changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected STM32H7 timer output mappings for PF8 and PF9.
  * TIM13 and TIM14 now use the standard CH1 outputs instead of complementary CH1N outputs.
  * Removed obsolete timer mappings from STM32H5 configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->