### PR TITLE
fix(n6): drop timer options the STM32N657 does not have

### DIFF
--- a/src/platform/STM32/timer_def.h
+++ b/src/platform/STM32/timer_def.h
@@ -1684,9 +1684,6 @@
 #define DEF_TIM_AF__PA2__TCH_TIM2_CH3     D(1, 2)
 #define DEF_TIM_AF__PA2__TCH_TIM5_CH3     D(2, 5)
 #define DEF_TIM_AF__PA2__TCH_TIM15_CH1    D(4, 15)
-#define DEF_TIM_AF__PA3__TCH_TIM2_CH4     D(1, 2)
-#define DEF_TIM_AF__PA3__TCH_TIM5_CH4     D(2, 5)
-#define DEF_TIM_AF__PA3__TCH_TIM15_CH2    D(4, 15)
 #define DEF_TIM_AF__PA3__TCH_TIM16_CH1    D(1, 16)
 #define DEF_TIM_AF__PA5__TCH_TIM2_CH1     D(1, 2)
 #define DEF_TIM_AF__PA5__TCH_TIM9_CH2     D(3, 9)
@@ -1705,7 +1702,6 @@
 
 //PORTB
 #define DEF_TIM_AF__PB0__TCH_TIM1_CH4     D(1, 1)
-#define DEF_TIM_AF__PB0__TCH_TIM3_CH3     D(2, 3)
 #define DEF_TIM_AF__PB0__TCH_TIM15_CH1N   D(7, 15)
 #define DEF_TIM_AF__PB1__TCH_TIM1_CH3N    D(1, 1)
 #define DEF_TIM_AF__PB1__TCH_TIM3_CH4     D(2, 3)
@@ -1749,12 +1745,9 @@
 
 //PORTE
 #define DEF_TIM_AF__PE2__TCH_TIM1_CH2N    D(13, 1)
-#define DEF_TIM_AF__PE4__TCH_TIM15_CH1N   D(4, 15)
 #define DEF_TIM_AF__PE5__TCH_TIM4_CH1     D(2, 4)
-#define DEF_TIM_AF__PE5__TCH_TIM15_CH1    D(4, 15)
 #define DEF_TIM_AF__PE5__TCH_TIM16_CH1N   D(1, 16)
 #define DEF_TIM_AF__PE6__TCH_TIM4_CH2     D(2, 4)
-#define DEF_TIM_AF__PE6__TCH_TIM15_CH2    D(4, 15)
 #define DEF_TIM_AF__PE6__TCH_TIM17_CH1N   D(1, 17)
 #define DEF_TIM_AF__PE8__TCH_TIM1_CH1N    D(1, 1)
 #define DEF_TIM_AF__PE9__TCH_TIM1_CH1     D(1, 1)

--- a/src/platform/STM32/timer_stm32n6xx.c
+++ b/src/platform/STM32/timer_stm32n6xx.c
@@ -67,9 +67,6 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM2,  CH3,  PA2,  0, 0, 0),
     DEF_TIM(TIM5,  CH3,  PA2,  0, 0, 0),
     DEF_TIM(TIM15, CH1,  PA2,  0, 0, 0),
-    DEF_TIM(TIM2,  CH4,  PA3,  0, 0, 0),
-    DEF_TIM(TIM5,  CH4,  PA3,  0, 0, 0),
-    DEF_TIM(TIM15, CH2,  PA3,  0, 0, 0),
     DEF_TIM(TIM16, CH1,  PA3,  0, 0, 0),
     DEF_TIM(TIM2,  CH1,  PA5,  0, 0, 0),
     DEF_TIM(TIM9,  CH2,  PA5,  0, 0, 0),
@@ -88,7 +85,6 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
 
 // Port B
     DEF_TIM(TIM1,  CH4,  PB0,  0, 0, 0),
-    DEF_TIM(TIM3,  CH3,  PB0,  0, 0, 0),
     DEF_TIM(TIM15, CH1N, PB0,  0, 0, 0),
     DEF_TIM(TIM1,  CH3N, PB1,  0, 0, 0),
     DEF_TIM(TIM3,  CH4,  PB1,  0, 0, 0),
@@ -132,12 +128,9 @@ const timerHardware_t fullTimerHardware[FULL_TIMER_CHANNEL_COUNT] = {
 
 // Port E
     DEF_TIM(TIM1,  CH2N, PE2,  0, 0, 0),
-    DEF_TIM(TIM15, CH1N, PE4,  0, 0, 0),
     DEF_TIM(TIM4,  CH1,  PE5,  0, 0, 0),
-    DEF_TIM(TIM15, CH1,  PE5,  0, 0, 0),
     DEF_TIM(TIM16, CH1N, PE5,  0, 0, 0),
     DEF_TIM(TIM4,  CH2,  PE6,  0, 0, 0),
-    DEF_TIM(TIM15, CH2,  PE6,  0, 0, 0),
     DEF_TIM(TIM17, CH1N, PE6,  0, 0, 0),
     DEF_TIM(TIM1,  CH1N, PE8,  0, 0, 0),
     DEF_TIM(TIM1,  CH1,  PE9,  0, 0, 0),


### PR DESCRIPTION
Seven timer entries name a channel the STM32N657 datasheet (DS14791 **Rev 9**,
December 2025) does not give that pin. Each affected pin already carries its correct entries, so
these are removals rather than remappings:

| Entry | Datasheet |
|---|---|
| `TIM2_CH4 PA3` | `PA3` has only `TIM16_CH1` (AF1); `TIM2_CH4` is on `PB11`, `PF6` |
| `TIM5_CH4 PA3` | `TIM5_CH4` is on `PF6` |
| `TIM15_CH2 PA3` | `TIM15_CH2` is on `PB7`, `PD6`, `PF6` |
| `TIM3_CH3 PB0` | `PB0` has `TIM1_CH4` and `TIM15_CH1N`; `TIM3_CH3` is on `PC8`, `PF7` |
| `TIM15_CH1N PE4` | `PE4` has no timer function at all |
| `TIM15_CH1 PE5` | `PE5` has `TIM4_CH1` and `TIM16_CH1N`; `TIM15_CH1` is on `PA2`, `PB6`, `PC12` |
| `TIM15_CH2 PE6` | `PE6` has `TIM4_CH2` and `TIM17_CH1N` |

`PA3`, `PB0`, `PE5` and `PE6` keep every entry the datasheet does support, and
`PE4` is left with none — which is correct for that pin.

## The rest of the table is right

Worth stating, because the first impression was worse than the reality. `TIM15`
is correct on `PA1`, `PA2`, `PB6`, `PB7`, `PB0`, `PC12`, `PD2`, `PD6`, `PD7` and
`PF6`. The errors cluster on four pins rather than being a wholesale copy from
another family.

## Both halves move together

The AF macros in `timer_def.h` are removed alongside the table entries. Leaving
them would keep firmware asserting a mapping the silicon does not have even with
nothing referencing them — which is exactly what happened on H5, where the table
was corrected and the superseded macros stayed behind next to the correct ones
(see #15511).

## Impact

Neither shipped N6 config (`OPENN657V1`, `STM32N657DK`) uses these pins as timer
pins, so this removes options that could not have worked rather than changing any
board's behaviour.

## How it was found

Cross-checking the pin tables against the datasheet alternate-function tables,
same method as #15506, #15508, #15510 and #15511. Every entry above was read off
the rendered AF table, not taken from the extraction.

With this, the N6 audit goes from seven findings to clean, at **239/239 pairs
corroborated (100%)**.

## Testing

Builds verified on `OPENN657V1` and `STM32N657DK`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected STM32N6 timer pin configuration by removing unsupported or obsolete timer-channel mappings.
  * Prevented unavailable timer assignments on PA3, PB0, and PE4–PE6 from being offered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

### Re-checked against a newer datasheet revision

This was first written against DS14791 Rev 6 and has since been re-run against
**Rev 9**. The findings are unchanged: the same seven entries on unmodified
master, and clean on this branch at **239/239 pairs corroborated**.

Diffing the two revisions' alternate-function maps, the only change anywhere in
the part is 11 `LCD_*` functions moving from AF15 to AF14 — same 115 pins, and
nothing touching timers, UART, SPI or I2C. Betaflight uses none of those
functions.
