### PR TITLE
Allow unrestricted VTX frequency changes while armed

### DIFF
--- a/src/main/drivers/vtx_common.h
+++ b/src/main/drivers/vtx_common.h
@@ -28,8 +28,8 @@
 #include "common/time.h"
 #include "common/streambuf.h"
 
-#define VTX_SETTINGS_MIN_FREQUENCY_MHZ 5000          //min freq (in MHz) for 'vtx_freq' setting
-#define VTX_SETTINGS_MAX_FREQUENCY_MHZ 5999          //max freq (in MHz) for 'vtx_freq' setting
+#define VTX_SETTINGS_MIN_FREQUENCY_MHZ 1             //min freq (in MHz) for 'vtx_freq' setting
+#define VTX_SETTINGS_MAX_FREQUENCY_MHZ 9999          //max freq (in MHz) for 'vtx_freq' setting
 
 #if defined(USE_VTX_RTC6705)
 

--- a/src/main/drivers/vtx_table.h
+++ b/src/main/drivers/vtx_table.h
@@ -45,8 +45,8 @@
 #define VTX_TABLE_POWER_LABEL_LENGTH    3
 #endif
 
-#define VTX_TABLE_MIN_USER_FREQ         5000
-#define VTX_TABLE_MAX_USER_FREQ         5999
+#define VTX_TABLE_MIN_USER_FREQ         1
+#define VTX_TABLE_MAX_USER_FREQ         9999
 #define VTX_TABLE_DEFAULT_BAND          4
 #define VTX_TABLE_DEFAULT_CHANNEL       1
 #define VTX_TABLE_DEFAULT_FREQ          5740

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -139,15 +139,13 @@ STATIC_UNIT_TESTED vtxSettingsConfig_t vtxGetSettings(void)
 
 static bool vtxProcessBandAndChannel(vtxDevice_t *vtxDevice)
 {
-    if (!ARMING_FLAG(ARMED)) {
-        uint8_t vtxBand;
-        uint8_t vtxChan;
-        if (vtxCommonGetBandAndChannel(vtxDevice, &vtxBand, &vtxChan)) {
-            const vtxSettingsConfig_t settings = vtxGetSettings();
-            if (vtxBand != settings.band || vtxChan != settings.channel) {
-                vtxCommonSetBandAndChannel(vtxDevice, settings.band, settings.channel);
-                return true;
-            }
+    uint8_t vtxBand;
+    uint8_t vtxChan;
+    if (vtxCommonGetBandAndChannel(vtxDevice, &vtxBand, &vtxChan)) {
+        const vtxSettingsConfig_t settings = vtxGetSettings();
+        if (vtxBand != settings.band || vtxChan != settings.channel) {
+            vtxCommonSetBandAndChannel(vtxDevice, settings.band, settings.channel);
+            return true;
         }
     }
     return false;
@@ -156,14 +154,12 @@ static bool vtxProcessBandAndChannel(vtxDevice_t *vtxDevice)
 #if defined(VTX_SETTINGS_FREQCMD)
 static bool vtxProcessFrequency(vtxDevice_t *vtxDevice)
 {
-    if (!ARMING_FLAG(ARMED)) {
-        uint16_t vtxFreq;
-        if (vtxCommonGetFrequency(vtxDevice, &vtxFreq)) {
-            const vtxSettingsConfig_t settings = vtxGetSettings();
-            if (vtxFreq != settings.freq) {
-                vtxCommonSetFrequency(vtxDevice, settings.freq);
-                return true;
-            }
+    uint16_t vtxFreq;
+    if (vtxCommonGetFrequency(vtxDevice, &vtxFreq)) {
+        const vtxSettingsConfig_t settings = vtxGetSettings();
+        if (vtxFreq != settings.freq) {
+            vtxCommonSetFrequency(vtxDevice, settings.freq);
+            return true;
         }
     }
     return false;
@@ -277,9 +273,7 @@ void vtxUpdate(timeUs_t currentTimeUs)
             currentSchedule = (currentSchedule + 1) % VTX_PARAM_COUNT;
         } while (!vtxUpdatePending && currentSchedule != startingSchedule);
 
-        if (!ARMING_FLAG(ARMED) || vtxUpdatePending) {
-            vtxCommonProcess(vtxDevice, currentTimeUs);
-        }
+        vtxCommonProcess(vtxDevice, currentTimeUs);
     }
 }
 

--- a/src/main/io/vtx_control.c
+++ b/src/main/io/vtx_control.c
@@ -54,11 +54,6 @@ PG_RESET_TEMPLATE(vtxConfig_t, vtxConfig,
     .halfDuplex = true
 );
 
-// Latched on first arm and intentionally never cleared for the rest of the session, so band
-// and channel can no longer be changed by switch once the craft has been armed. STATIC_UNIT_TESTED
-// (still 'static' in firmware builds) so unit tests can reset it between cases.
-STATIC_UNIT_TESTED uint8_t locked = 0;
-
 void vtxControlInit(void)
 {
     // NOTHING TO DO
@@ -75,11 +70,7 @@ void vtxControlInputPoll(void)
 
 static void vtxUpdateBandAndChannel(uint8_t bandStep, uint8_t channelStep)
 {
-    if (ARMING_FLAG(ARMED)) {
-        locked = 1;
-    }
-
-    if (!locked && vtxCommonDevice()) {
+    if (vtxCommonDevice()) {
         vtxSettingsConfigMutable()->band += bandStep;
         vtxSettingsConfigMutable()->channel += channelStep;
     }
@@ -107,10 +98,6 @@ void vtxDecrementChannel(void)
 
 void vtxUpdateActivatedChannel(void)
 {
-    if (ARMING_FLAG(ARMED)) {
-        locked = 1;
-    }
-
     if (vtxCommonDevice()) {
         // Apply every active activation condition, like updateActivatedModes() does for mode
         // ranges. Stopping at the first match (or remembering only the last applied index)
@@ -121,13 +108,11 @@ void vtxUpdateActivatedChannel(void)
             const vtxChannelActivationCondition_t *vtxChannelActivationCondition = &vtxConfig()->vtxChannelActivationConditions[index];
 
             if (isRangeActive(vtxChannelActivationCondition->auxChannelIndex, &vtxChannelActivationCondition->range)) {
-                if (!locked) {
-                    if (vtxChannelActivationCondition->band > 0) {
-                        vtxSettingsConfigMutable()->band = vtxChannelActivationCondition->band;
-                    }
-                    if (vtxChannelActivationCondition->channel > 0) {
-                        vtxSettingsConfigMutable()->channel = vtxChannelActivationCondition->channel;
-                    }
+                if (vtxChannelActivationCondition->band > 0) {
+                    vtxSettingsConfigMutable()->band = vtxChannelActivationCondition->band;
+                }
+                if (vtxChannelActivationCondition->channel > 0) {
+                    vtxSettingsConfigMutable()->channel = vtxChannelActivationCondition->channel;
                 }
 
                 if (vtxChannelActivationCondition->power > 0) {

--- a/src/main/io/vtx_smartaudio.h
+++ b/src/main/io/vtx_smartaudio.h
@@ -34,8 +34,8 @@
 #define VTX_SMARTAUDIO_MIN_BAND 1
 #define VTX_SMARTAUDIO_MIN_CHANNEL 1
 
-#define VTX_SMARTAUDIO_MIN_FREQUENCY_MHZ 5000        //min freq in MHz
-#define VTX_SMARTAUDIO_MAX_FREQUENCY_MHZ 5999        //max freq in MHz
+#define VTX_SMARTAUDIO_MIN_FREQUENCY_MHZ 1           //min freq in MHz
+#define VTX_SMARTAUDIO_MAX_FREQUENCY_MHZ 9999        //max freq in MHz
 
 // opmode flags, GET side
 #define SA_MODE_GET_FREQ_BY_FREQ            1

--- a/src/main/io/vtx_tramp.h
+++ b/src/main/io/vtx_tramp.h
@@ -24,8 +24,8 @@
 
 #define VTX_TRAMP_POWER_COUNT 5
 
-#define VTX_TRAMP_MIN_FREQUENCY_MHZ 5000             //min freq in MHz
-#define VTX_TRAMP_MAX_FREQUENCY_MHZ 5999             //max freq in MHz
+#define VTX_TRAMP_MIN_FREQUENCY_MHZ 1                //min freq in MHz
+#define VTX_TRAMP_MAX_FREQUENCY_MHZ 9999             //max freq in MHz
 
 bool vtxTrampInit(void);
 

--- a/src/test/unit/vtx_unittest.cc
+++ b/src/test/unit/vtx_unittest.cc
@@ -132,12 +132,6 @@ TEST(VtxTest, PitMode)
 // vTable, so a stub device with no vTable is sufficient.
 static vtxDevice_t testVtxDevice = { .vTable = NULL };
 
-extern "C" {
-    // STATIC_UNIT_TESTED in vtx_control.c — a session-sticky arm latch with no production reset.
-    // Reset it before each case so the tests are independent of execution order (e.g. shuffle).
-    extern uint8_t locked;
-}
-
 static void clearActivationConditions(void)
 {
     for (int i = 0; i < MAX_CHANNEL_ACTIVATION_CONDITION_COUNT; i++) {
@@ -171,7 +165,6 @@ static void setActivationCondition(uint8_t index, uint8_t auxChannelIndex, uint8
 TEST(VtxTest, ActivationConditionsAllAppliedWhenSimultaneouslyActive)
 {
     // given
-    locked = 0;
     DISABLE_ARMING_FLAG(ARMED);
     vtxCommonSetDevice(&testVtxDevice);
     clearActivationConditions();
@@ -198,7 +191,6 @@ TEST(VtxTest, ActivationConditionsAllAppliedWhenSimultaneouslyActive)
 TEST(VtxTest, PowerOnlyConditionDoesNotResetBandAndChannel)
 {
     // given
-    locked = 0;
     DISABLE_ARMING_FLAG(ARMED);
     vtxCommonSetDevice(&testVtxDevice);
     clearActivationConditions();
@@ -224,7 +216,6 @@ TEST(VtxTest, PowerOnlyConditionDoesNotResetBandAndChannel)
 TEST(VtxTest, LastActiveConditionWinsForSameField)
 {
     // given
-    locked = 0;
     DISABLE_ARMING_FLAG(ARMED);
     vtxCommonSetDevice(&testVtxDevice);
     clearActivationConditions();
@@ -251,7 +242,6 @@ TEST(VtxTest, LastActiveConditionWinsForSameField)
 TEST(VtxTest, InactiveConditionLeavesLastValues)
 {
     // given
-    locked = 0;
     DISABLE_ARMING_FLAG(ARMED);
     vtxCommonSetDevice(&testVtxDevice);
     clearActivationConditions();
@@ -277,12 +267,10 @@ TEST(VtxTest, InactiveConditionLeavesLastValues)
     EXPECT_EQ(5, vtxSettingsConfig()->power);
 }
 
-// When armed, band/channel are locked but power may still change. `locked` is reset first so
-// this case no longer depends on running last.
-TEST(VtxTest, ArmedLocksBandAndChannelButNotPower)
+// When armed, band/channel/power are not locked
+TEST(VtxTest, ArmedDoesNotLocksBandOrChannelOrPower)
 {
     // given
-    locked = 0;
     DISABLE_ARMING_FLAG(ARMED);
     vtxCommonSetDevice(&testVtxDevice);
     clearActivationConditions();
@@ -298,9 +286,9 @@ TEST(VtxTest, ArmedLocksBandAndChannelButNotPower)
     vtxUpdateActivatedChannel();
     DISABLE_ARMING_FLAG(ARMED);  // restore global state so later/shuffled tests don't inherit it
 
-    // expect — band/channel locked out, power still applied
-    EXPECT_EQ(0, vtxSettingsConfig()->band);
-    EXPECT_EQ(0, vtxSettingsConfig()->channel);
+    // expect — band/channel/power settings applied
+    EXPECT_EQ(4, vtxSettingsConfig()->band);
+    EXPECT_EQ(6, vtxSettingsConfig()->channel);
     EXPECT_EQ(2, vtxSettingsConfig()->power);
 }
 


### PR DESCRIPTION
## Description

This pull request expands Betaflight VTX control in two related ways:

- Allows VTX band, channel, and direct-frequency changes while the flight controller is armed.
- Expands the accepted VTX frequency range from **5000–5999 MHz** to **1–9999 MHz**.

These changes are intended for VTX hardware that supports in-flight channel switching and operation outside the conventional 5.8 GHz FPV band.

## Motivation

The current implementation prevents this use case through two independent restrictions:

1. VTX band, channel, and frequency updates are blocked while armed.
2. VTX table and protocol validation rejects frequencies outside **5000–5999 MHz**.

Removing only one restriction is insufficient. A VTX that supports additional frequency bands must also be able to receive channel or frequency changes during flight.

This functionality is currently being tested by users through Betaflight Cloud Build using the commit reference. Keeping the changes together allows testers to build and evaluate the complete behavior from one revision.

## Implementation

### Allow VTX updates while armed

The armed-state restrictions have been removed from the VTX update path:

- `vtxProcessBandAndChannel()` can now apply configured band and channel changes while armed.
- `vtxProcessFrequency()` can now apply direct-frequency changes while armed.
- `vtxCommonProcess()` continues processing the VTX device while armed.
- AUX-based VTX activation conditions can update band and channel while armed.
- The session-sticky band and channel lock in `vtx_control.c` has been removed.

Power-setting behavior remains supported as before.

### Expand the accepted VTX frequency range

The accepted frequency range has been changed from **5000–5999 MHz** to **1–9999 MHz** in:

- Common VTX settings validation
- User-defined VTX tables
- SmartAudio frequency validation
- IRC Tramp frequency validation

The following limits are now used:

```c
#define VTX_SETTINGS_MIN_FREQUENCY_MHZ 1
#define VTX_SETTINGS_MAX_FREQUENCY_MHZ 9999
```

Equivalent minimum and maximum values are applied to the VTX table, SmartAudio, and IRC Tramp validation paths.

The upper limit remains four digits because the existing frequency storage and configuration interfaces represent frequency in MHz and are designed around values of this size.

## Use Cases

- Rapid in-flight VTX channel switching
- Interference avoidance
- Coordinated transmitter and receiver frequency changes
- VTX hardware operating on additional frequency bands
- Specialized or experimental RF systems

## Testing

The VTX unit tests were updated to reflect the new intended armed-state behavior.

The armed activation-condition test now verifies that, while armed:

- Band changes are applied.
- Channel changes are applied.
- Power changes continue to be applied.

The obsolete test setup for the removed session-sticky lock was also removed.

Tests performed:

- `make test_vtx_unittest`
- `make test_vtx_msp_unittest`
- `make test-representative`
- `make pre-push`

Hardware testing includes repeated VTX channel changes while armed and firmware generated through Betaflight Cloud Build from this commit.

## Compatibility

Existing 5.8 GHz VTX tables remain valid and continue to behave as before.

VTX devices that do not support runtime channel changes or frequencies outside their hardware range will continue to behave according to their protocol and firmware capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded supported VTX frequency configuration to 1–9999 MHz.
  * VTX band, channel, frequency, and power updates now synchronize while the craft is armed.
  * Activation conditions apply multiple settings consistently, with later matching conditions taking precedence.

* **Bug Fixes**
  * Improved application of VTX changes across simultaneous and power-only updates.
  * Preserved inactive-condition settings until they become active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->