### PR TITLE
docs: move release schedule to org profile, drop beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,41 +7,9 @@ Betaflight is flight controller software (firmware) used to fly multi-rotor craf
 
 ## Release Schedule
 
-| Date       | Release | Stage             | Status    |
-| ---------- | ------- | ----------------- | --------- |
-| 26-12-2025 | 2025.12 | Release           | Completed |
-| 01-04-2026 | 2026.6  | Beta              |           |
-| 01-05-2026 | 2026.6  | Release Candidate |           |
-| 01-06-2026 | 2026.6  | Release           |           |
-| 01-10-2026 | 2026.12 | Beta              |           |
-| 01-11-2026 | 2026.12 | Release Candidate |           |
-| 01-12-2026 | 2026.12 | Release           |           |
+The Betaflight release schedule and development cadence are published at [betaflight.com](https://betaflight.com/blog/2025/09/01/Calendar%20Versioning%20Change).
 
-## News
-
-### 📣 Announcement: New Versioning Scheme & Release Cadence 📣
-
-To create a more predictable release schedule, we're moving to a new versioning system and development cycle, starting with the next release.
-
-**New Format**: `YYYY.M.PATCH` (e.g., `2025.12.1`)
-
-**Release Cadence**: Two major releases per year.
-
-**Target Months**: June and December.
-
-This means the successor to our current `4.x` series will be Betaflight `2025.12.x`, followed by Betaflight `2026.6.x`. We will also align the Betaflight App and Firmware to the same `YYYY.M.PATCH` releases (and cadence).
-
-**Our New Release Cycle**
-
-To support this schedule, our development phases will be structured as follows:
-
-**Alpha**: For new feature development. Alpha builds for the next version will be available shortly after a stable release is published.
-
-**Beta**: A one-month feature freeze for bug fixes only, and existing pull requests currently being reviewed, starting approximately two months before a release.
-
-**Release Candidate (RC)**: A one-month period for final stabilization and testing before the official release.
-
-### Requirements for the submission of new and updated target configuration
+## Requirements for the submission of new and updated target configuration
 
 The requirements for pull requests adding new targets or modifying existing targets are available on the [betaflight.com website](https://www.betaflight.com/docs/development/manufacturer/requirements-for-submission-of-targets).
 


### PR DESCRIPTION
Moves the release schedule out of the firmware README and into the org default profile (betaflight/.github), which renders at github.com/betaflight, so it lives in one place instead of being duplicated per repo. The README now points to betaflight.com for the schedule and cadence.

Also drops the beta phase from the cadence (we now go Alpha then Release Candidate then Release). The org profile update (with the refreshed schedule table, 2026.6 completed and 2027.6 added) is in a companion PR on betaflight/.github.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced detailed release-cycle and versioning information with a link to the published Betaflight release schedule.
  * Added a section introducing requirements for submitting new or updated target configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->