### PR TITLE
wing: enable the flight-plan guidance engine on USE_WING builds

### DIFF
--- a/src/main/flight/autopilot_wing.c
+++ b/src/main/flight/autopilot_wing.c
@@ -97,4 +97,20 @@ void autopilotSetYawRateLimit(float rateLimitDps)
     UNUSED(rateLimitDps);
 }
 
+void autopilotSetNavHeadingOverride(bool valid, float headingDeg)
+{
+    UNUSED(valid);
+    UNUSED(headingDeg);
+}
+
+void autopilotForceLevelPark(bool request)
+{
+    UNUSED(request);
+}
+
+void pitchForwardOverride(bool request)
+{
+    UNUSED(request);
+}
+
 #endif // USE_WING

--- a/src/main/flight/autopilot_wing.h
+++ b/src/main/flight/autopilot_wing.h
@@ -38,4 +38,10 @@ float autopilotGetYawRate(void);
 bool autopilotYawControlActive(void);
 void autopilotSetYawRateLimit(float rateLimitDps);
 
+// Nav inner-loop hooks driven by the shared flight-plan engine. Stubbed until
+// the wing control law lands (Phase 3+); present so the engine links on wing.
+void autopilotSetNavHeadingOverride(bool valid, float headingDeg);
+void autopilotForceLevelPark(bool request);
+void pitchForwardOverride(bool request);
+
 #endif // USE_WING

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -27,8 +27,7 @@
 
 #include "platform.h"
 
-// positionNav is multirotor-only; flight plan execution follows suit.
-#if ENABLE_FLIGHT_PLAN && !defined(USE_WING)
+#if ENABLE_FLIGHT_PLAN
 
 #include "common/maths.h"
 #include "common/time.h"
@@ -884,7 +883,7 @@ static void startLandingAtNavTarget(timeUs_t currentTimeUs)
 // behaviour). Falls back to landing in place if the plan can't be injected.
 static void injectReturnHomePlan(timeUs_t currentTimeUs)
 {
-#ifdef USE_GPS_RESCUE
+#if defined(USE_GPS_RESCUE) && !defined(USE_WING)
     const int32_t returnAltCm = MAX(GPS_home_llh.altCm + (int32_t)gpsRescueConfig()->returnAltitudeM * 100, gpsSol.llh.altCm);
     const uint16_t speedCmS = gpsRescueConfig()->groundSpeedCmS;
 #else
@@ -1627,4 +1626,4 @@ void flightPlanNavSetReachedListener(flightPlanWaypointReachedFn fn)
     reachedListener = fn;
 }
 
-#endif // ENABLE_FLIGHT_PLAN && !USE_WING
+#endif // ENABLE_FLIGHT_PLAN

--- a/src/main/flight/position_nav.c
+++ b/src/main/flight/position_nav.c
@@ -25,8 +25,6 @@
 
 #include "platform.h"
 
-#ifndef USE_WING
-
 #include "common/maths.h"
 #include "common/vector.h"
 
@@ -243,5 +241,3 @@ vector3_t positionNavGetTargetVelocityCmS(void)
 {
     return currentTargetVelCmS;
 }
-
-#endif // !USE_WING


### PR DESCRIPTION
Un-gates the shared waypoint and carrot guidance (position_nav, flight_plan_nav) so it compiles and links on USE_WING targets, with the GPS-rescue plan staying multirotor-only and the geofence return-home plan falling back to a return-at-current-altitude leg on wing. Adds the nav inner-loop stubs the engine references (heading override, level park, pitch-forward override).

Runtime AUTOPILOT_MODE engagement is intentionally not wired on wing, so this is inert at runtime and cannot engage a stub controller on an armed aircraft. It is the structural prerequisite for a fixed-wing autopilot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added wing autopilot controls for navigation heading overrides, forced level/parking, and pitch-forward requests.
  - Enabled flight-plan and position-navigation support for wing configurations.
- **Bug Fixes**
  - Improved return-home behavior across supported flight configurations by applying the appropriate rescue and fallback altitude handling.
- **Compatibility**
  - Expanded navigation feature availability across additional aircraft configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->