### PR TITLE
esp32: run ESP32-S3 at max CPU clock, derive SystemCoreClock at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -498,7 +498,7 @@ $(TARGET_LST): $(TARGET_ELF)
 	$(V0) $(OBJDUMP) -S --disassemble $< > $@
 
 ifeq ($(EXST),no)
-$(TARGET_BIN): $(TARGET_ELF)
+$(TARGET_BIN): $(TARGET_ELF) $(BIN_FROM_ELF_DEPS)
 	@echo "Creating BIN $(TARGET_BIN)" "$(STDOUT)"
 # A platform may set BIN_FROM_ELF_CMD to generate the binary from the ELF its
 # own way (e.g. ESP32 wraps it into a bootable image with esptool elf2image);

--- a/src/platform/ESP32/bootloader/bootloader_components/betaflight_clock/CMakeLists.txt
+++ b/src/platform/ESP32/bootloader/bootloader_components/betaflight_clock/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "clock.c" PRIV_REQUIRES esp_hw_support)

--- a/src/platform/ESP32/bootloader/bootloader_components/betaflight_clock/clock.c
+++ b/src/platform/ESP32/bootloader/bootloader_components/betaflight_clock/clock.c
@@ -1,0 +1,32 @@
+/*
+ * Betaflight ESP32-S3 bootloader clock hook.
+ *
+ * The ESP-IDF second-stage bootloader intentionally runs the CPU at its
+ * conservative boot frequency (80 MHz on ESP32-S3).  A normal ESP-IDF
+ * application changes that later from call_start_cpu0(), but Betaflight uses
+ * its own bare-metal entry point and therefore never executes that code.
+ */
+
+#include "sdkconfig.h"
+
+#if defined(CONFIG_IDF_TARGET_ESP32S3)
+#include "soc/rtc.h"
+
+// Referenced with -u by the ESP-IDF bootloader build so this component and its
+// strong hook symbols are retained even though the default hooks are weak.
+void bootloader_hooks_include(void)
+{
+}
+
+void bootloader_after_init(void)
+{
+    rtc_cpu_freq_config_t config;
+
+    // Use Espressif's clock routine rather than touching PLL/LDO registers
+    // directly.  It raises the S3 voltage bias, selects the 480 MHz PLL / 2,
+    // keeps APB at 80 MHz and updates the ROM ticks-per-microsecond value.
+    if (rtc_clk_cpu_freq_mhz_to_config(240, &config)) {
+        rtc_clk_cpu_freq_set_config(&config);
+    }
+}
+#endif

--- a/src/platform/ESP32/mk/ESP32.mk
+++ b/src/platform/ESP32/mk/ESP32.mk
@@ -10,6 +10,7 @@ DEFAULT_OUTPUT := bin
 # transient _tmp.bin, then merge bootloader + partition table + app into the
 # final $(TARGET_BIN) for one-step flashing at 0x0 and delete the temp.
 BIN_FROM_ELF_CMD = $(ESP_ELF2IMAGE_TMP) && $(ESP_FLASH_IMAGE_CMD)
+BIN_FROM_ELF_DEPS = $(ESP_BOOTLOADER_INPUTS)
 
 # Auto-hydrate esp-idf submodule when building ESP32 targets
 PLATFORM_SDK := esp_idf

--- a/src/platform/ESP32/mk/ESP32C5.mk
+++ b/src/platform/ESP32/mk/ESP32C5.mk
@@ -10,6 +10,7 @@ DEFAULT_OUTPUT := bin
 # transient _tmp.bin, then merge bootloader + partition table + app into the
 # final $(TARGET_BIN) for one-step flashing at 0x0 and delete the temp.
 BIN_FROM_ELF_CMD = $(ESP_ELF2IMAGE_TMP) && $(ESP_FLASH_IMAGE_CMD)
+BIN_FROM_ELF_DEPS = $(ESP_BOOTLOADER_INPUTS)
 
 # Auto-hydrate esp-idf submodule when building ESP32 targets
 PLATFORM_SDK := esp_idf

--- a/src/platform/ESP32/mk/ESP32P4.mk
+++ b/src/platform/ESP32/mk/ESP32P4.mk
@@ -10,6 +10,7 @@ DEFAULT_OUTPUT := bin
 # transient _tmp.bin, then merge bootloader + partition table + app into the
 # final $(TARGET_BIN) for one-step flashing at 0x0 and delete the temp.
 BIN_FROM_ELF_CMD = $(ESP_ELF2IMAGE_TMP) && $(ESP_FLASH_IMAGE_CMD)
+BIN_FROM_ELF_DEPS = $(ESP_BOOTLOADER_INPUTS)
 
 # Auto-hydrate esp-idf submodule when building ESP32 targets
 PLATFORM_SDK := esp_idf

--- a/src/platform/ESP32/mk/ESP32S3.mk
+++ b/src/platform/ESP32/mk/ESP32S3.mk
@@ -12,6 +12,7 @@ DEFAULT_OUTPUT := bin
 # final $(TARGET_BIN) for one-step flashing at 0x0 and delete the temp. The
 # bootloader is built from source by default; see tools.mk and bin/README.md.
 BIN_FROM_ELF_CMD = $(ESP_ELF2IMAGE_TMP) && $(ESP_FLASH_IMAGE_CMD)
+BIN_FROM_ELF_DEPS = $(ESP_BOOTLOADER_INPUTS)
 
 # Auto-hydrate esp-idf submodule when building ESP32 targets
 PLATFORM_SDK := esp_idf

--- a/src/platform/ESP32/mk/tools.mk
+++ b/src/platform/ESP32/mk/tools.mk
@@ -61,12 +61,17 @@ ESP_ELF2IMAGE_TMP   = $(ESP_PYTHON) $(ESP_ESPTOOL) --chip $(ESP_CHIP) elf2image 
 # in-tree IDF project (src/platform/ESP32/bootloader) using `idf.py bootloader`;
 # set ESP_BOOTLOADER_FROM_SOURCE=no to use the committed prebuilt blob instead
 # (handy where CMake/Ninja or the full IDF aren't available). The from-source
-# build is guarded on the output existing, so it runs once per clean tree and
-# then incremental app builds skip it; `make clean` (or removing the build dir)
-# forces a rebuild.
+# build is guarded on the output being newer than the in-tree bootloader
+# project, so incremental app builds skip it while clock hook/config changes
+# still force a rebuild.
 ESP_BOOTLOADER_FROM_SOURCE ?= yes
 ESP_BOOTLOADER_PROJ  = $(TARGET_PLATFORM_DIR)/bootloader
 ESP_PYTHON_ENV_DIR   = $(patsubst %/bin/python,%,$(ESP_PYTHON))
+# Inputs exposed to the generic BIN rule. Without this dependency a changed clock
+# hook leaves an already-created merged firmware image looking up to date, so the
+# freshness check below never gets a chance to run.
+ESP_BOOTLOADER_INPUTS = $(if $(filter yes,$(ESP_BOOTLOADER_FROM_SOURCE)),\
+    $(shell find $(ESP_BOOTLOADER_PROJ) -type f),$(ESP_BOOTLOADER_BIN))
 
 ifeq ($(ESP_BOOTLOADER_FROM_SOURCE),yes)
 # Absolute paths: idf.py resolves -B against the CWD but -DSDKCONFIG against the
@@ -80,7 +85,8 @@ ESP_BOOTLOADER_BIN       = $(ESP_BOOTLOADER_BUILD_DIR)/bootloader/bootloader.bin
 # on top of the project's sdkconfig.defaults, so the bootloader header matches
 # the target's module. Generated into the (size-keyed) build dir, not the source
 # tree. esptool still patches the size into the merged image at merge_bin time.
-ESP_BUILD_BOOTLOADER = [ -f $(ESP_BOOTLOADER_BIN) ] || \
+ESP_BUILD_BOOTLOADER = ( [ -f $(ESP_BOOTLOADER_BIN) ] && \
+    [ -z "$$(find $(ESP_BOOTLOADER_PROJ) -type f -newer $(ESP_BOOTLOADER_BIN) -print -quit)" ] ) || \
     ( mkdir -p $(ESP_BOOTLOADER_BUILD_DIR) && \
       echo 'CONFIG_ESPTOOLPY_FLASHSIZE_$(ESP_FLASH_SIZE)=y' > $(ESP_BOOTLOADER_BUILD_DIR)/sdkconfig.flashsize && \
       env IDF_PATH=$(ESP_IDF_PATH) IDF_TOOLS_PATH=$(IDF_TOOLS_PATH) \

--- a/src/platform/ESP32/system.c
+++ b/src/platform/ESP32/system.c
@@ -55,8 +55,11 @@
 #endif
 #include "soc/soc.h"
 
-// Both ESP32 and ESP32-S3 run at 240 MHz by default
-uint32_t SystemCoreClock = 240000000;
+// Derived at runtime in systemInit() from the ROM ticks-per-microsecond value,
+// which reflects whatever frequency the bootloader actually left the CPU at.
+// Avoids baking in a per-target clock, so future SoCs (e.g. P4, which runs
+// faster than the S3's 240 MHz) report the correct frequency without a change.
+uint32_t SystemCoreClock = 0;
 
 // Peripheral instance storage (port numbers for ESP-IDF)
 esp32_peripheral_t esp32SpiDev0 = 0;
@@ -84,6 +87,15 @@ void cycleCounterInit(void)
 
 void systemInit(void)
 {
+    // Read the frequency the bootloader left us at rather than assuming one. The
+    // RTC clock-switch routine updates the ROM ticks-per-microsecond on every ESP
+    // target, so this stays correct as new SoCs are brought up. Must run before
+    // cycleCounterInit(), which derives usTicks from SystemCoreClock.
+    const uint32_t cpuTicksPerUs = esp_rom_get_cpu_ticks_per_us();
+    if (cpuTicksPerUs != 0) {
+        SystemCoreClock = cpuTicksPerUs * 1000000U;
+    }
+
     cycleCounterInit();
 
 #ifdef USE_MULTICORE

--- a/src/platform/ESP32/system.c
+++ b/src/platform/ESP32/system.c
@@ -94,6 +94,11 @@ void systemInit(void)
     const uint32_t cpuTicksPerUs = esp_rom_get_cpu_ticks_per_us();
     if (cpuTicksPerUs != 0) {
         SystemCoreClock = cpuTicksPerUs * 1000000U;
+    } else {
+        // Unreachable in practice: the ROM sets ticks-per-microsecond during
+        // first-stage boot. Fall back to the conservative bootloader boot
+        // frequency purely so cycleCounterInit() below cannot divide by zero.
+        SystemCoreClock = 80000000U;
     }
 
     cycleCounterInit();


### PR DESCRIPTION
The ESP32-S3 uses a bare-metal entry point and never runs the ESP-IDF `call_start_cpu0()` path that raises the CPU from the bootloader's 80 MHz boot frequency to its 240 MHz maximum, so it was running at a third of rated speed. This adds a bootloader clock hook (`bootloader_after_init`) that uses Espressif's `rtc_clk` routine to select 240 MHz; the IDF bootloader retains the override through its existing `-u bootloader_hooks_include` reference.

The hardcoded `SystemCoreClock` is removed. It is now read at runtime from the ROM ticks-per-microsecond value the clock switch updates, so cycle conversions stay honest if a prebuilt/hookless bootloader is used, and any future SoC (e.g. P4, which runs faster than 240 MHz) reports its real frequency with no code change.

The from-source bootloader is treated as a dependency of the merged BIN and rebuilt when its sources change, so edits to the clock hook cannot leave a stale firmware image behind.

Scope is limited to clock speed. The broader S3 performance work (SPI/DMA, interrupt-level critical sections, IRAM hot-path placement) is intentionally left out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ESP32-S3 bootloader now raises the CPU frequency to 240 MHz while maintaining expected peripheral clock timing.
  * System timing now reflects the detected processor frequency, with a safe fallback for improved platform accuracy.

* **Bug Fixes**
  * ESP32 firmware images now rebuild when bootloader source or configuration inputs change, preventing stale generated binaries.
  * Bootloader-related changes are now correctly included when generating firmware images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->