### PR TITLE
esp32: implement real ATOMIC_BLOCK critical sections on ESP32-S3

### DIFF
--- a/src/main/build/atomic.h
+++ b/src/main/build/atomic.h
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 
-#if !defined(UNIT_TEST)
+#if !defined(UNIT_TEST) && !defined(PLATFORM_CUSTOM_BASEPRI_NB)
 // BASEPRI manipulation functions
 // only set_BASEPRI is implemented in device library. It does always create memory barrier
 // missing versions are implemented here

--- a/src/platform/ESP32/include/platform/interrupt.h
+++ b/src/platform/ESP32/include/platform/interrupt.h
@@ -23,10 +23,22 @@
 
 #include <stdint.h>
 
-// CPU interrupt number assignments for ESP32-S3.
-// The ESP32-S3 Xtensa core has 32 CPU interrupt lines (0-31).
-// Peripheral interrupt sources are routed to these via the interrupt matrix.
-// Numbers chosen from the level-1 interrupt pool to avoid conflicts.
+// CPU interrupt number assignments.  ESP32-S3 C handlers must use external,
+// level-triggered lines at a maskable C-compatible level.  Keep this mapping
+// S3-specific: the other ESP variants have different interrupt controllers and
+// retain their existing bring-up assignments below.
+#if defined(ESP32S3)
+#define ESP32_CPU_INTR_GPIO      0
+#define ESP32_CPU_INTR_UART0     1
+#define ESP32_CPU_INTR_UART1     2
+#define ESP32_CPU_INTR_UART2     3
+#define ESP32_CPU_INTR_DMA_CH0   4
+#define ESP32_CPU_INTR_DMA_CH1   5
+#define ESP32_CPU_INTR_DMA_CH2   8
+#define ESP32_CPU_INTR_DMA_CH3   9
+#define ESP32_CPU_INTR_DMA_CH4  12
+#define ESP32_CPU_INTR_USB      13
+#else
 #define ESP32_CPU_INTR_GPIO     19
 #define ESP32_CPU_INTR_UART0    20
 #define ESP32_CPU_INTR_UART1    21
@@ -37,6 +49,7 @@
 #define ESP32_CPU_INTR_DMA_CH3  27
 #define ESP32_CPU_INTR_DMA_CH4  28
 #define ESP32_CPU_INTR_USB      29
+#endif
 
 typedef void (*esp32IsrHandler_t)(void *arg);
 

--- a/src/platform/ESP32/include/platform/platform.h
+++ b/src/platform/ESP32/include/platform/platform.h
@@ -40,15 +40,67 @@
 
 typedef enum { ESP32_IRQ_0 = 0 } IRQn_Type;
 
-// BASEPRI stubs - ESP32 (Xtensa) has no BASEPRI register.
-// These are no-ops to satisfy the shared atomic.h code.
+// Xtensa has no ARM BASEPRI register.  On ESP32-S3 all Betaflight peripheral
+// handlers are routed to level-1 CPU interrupts, so raising PS.INTLEVEL to one
+// provides the critical-section semantics required by ATOMIC_BLOCK.  Preserve
+// the old level so nested blocks and ISR callers restore it correctly.
+#if defined(ESP32S3)
+__attribute__((always_inline)) static inline uint32_t esp32GetInterruptLevel(void)
+{
+    uint32_t ps;
+    __asm__ volatile ("rsr.ps %0" : "=a"(ps));
+    return ps & 0x0FU;
+}
+
+__attribute__((always_inline)) static inline void esp32SetInterruptLevel(uint32_t level)
+{
+    uint32_t ps;
+    __asm__ volatile ("rsr.ps %0" : "=a"(ps));
+    ps = (ps & ~0x0FU) | (level & 0x0FU);
+    __asm__ volatile ("wsr.ps %0; rsync" :: "a"(ps) : "memory");
+}
+
+__attribute__((always_inline)) static inline void __set_BASEPRI(uint32_t basePri)
+{
+    // Values saved by __get_BASEPRI are raw Xtensa levels.  Other callers pass
+    // ARM-style encoded priorities; any non-zero value masks our level-1 IRQs.
+    esp32SetInterruptLevel(basePri <= 0x0FU ? basePri : 1U);
+}
+
+__attribute__((always_inline)) static inline uint32_t __get_BASEPRI(void)
+{
+    return esp32GetInterruptLevel();
+}
+
+__attribute__((always_inline)) static inline void __set_BASEPRI_MAX(uint32_t basePri)
+{
+    if (basePri != 0 && esp32GetInterruptLevel() < 1U) {
+        uint32_t oldPs __attribute__((unused));
+        __asm__ volatile ("rsil %0, 1" : "=a"(oldPs) :: "memory");
+    }
+}
+
+static inline void __enable_irq(void) { esp32SetInterruptLevel(0); }
+static inline void __disable_irq(void) { esp32SetInterruptLevel(5); }
+#else
+// Bring-up stubs retained for the other ESP variants until their native
+// interrupt-controller critical sections are implemented.
 __attribute__((always_inline)) static inline void __set_BASEPRI(uint32_t basePri) { (void)basePri; }
 __attribute__((always_inline)) static inline uint32_t __get_BASEPRI(void) { return 0; }
 __attribute__((always_inline)) static inline void __set_BASEPRI_MAX(uint32_t basePri) { (void)basePri; }
-
-// NVIC stubs
 static inline void __enable_irq(void) { }
 static inline void __disable_irq(void) { }
+#endif
+
+// atomic.h's default non-barrier helpers contain ARM MSR instructions.  Keep
+// them native on every ESP target as well; on S3 these inherit the real Xtensa
+// critical-section implementation above, while the bring-up targets retain
+// their existing stub semantics.
+#define PLATFORM_CUSTOM_BASEPRI_NB
+__attribute__((always_inline)) static inline void __set_BASEPRI_nb(uint32_t basePri) { __set_BASEPRI(basePri); }
+__attribute__((always_inline)) static inline void __set_BASEPRI_MAX_nb(uint32_t basePri) { __set_BASEPRI_MAX(basePri); }
+
+// NVIC compatibility stub
 static inline void NVIC_SystemReset(void) { while(1); }
 
 #define NVIC_PriorityGroup_2         0x500

--- a/src/platform/ESP32/include/platform/platform.h
+++ b/src/platform/ESP32/include/platform/platform.h
@@ -74,14 +74,16 @@ __attribute__((always_inline)) static inline uint32_t __get_BASEPRI(void)
 
 __attribute__((always_inline)) static inline void __set_BASEPRI_MAX(uint32_t basePri)
 {
-    if (basePri != 0 && esp32GetInterruptLevel() < 1U) {
-        uint32_t oldPs __attribute__((unused));
-        __asm__ volatile ("rsil %0, 1" : "=a"(oldPs) :: "memory");
+    // Normalise like __set_BASEPRI (raw Xtensa level, or 1 for an ARM-encoded
+    // priority) and only ever raise the level, never lower it.
+    const uint32_t requestedLevel = basePri <= 0x0FU ? basePri : 1U;
+    if (esp32GetInterruptLevel() < requestedLevel) {
+        esp32SetInterruptLevel(requestedLevel);
     }
 }
 
 static inline void __enable_irq(void) { esp32SetInterruptLevel(0); }
-static inline void __disable_irq(void) { esp32SetInterruptLevel(5); }
+static inline void __disable_irq(void) { esp32SetInterruptLevel(15); }
 #else
 // Bring-up stubs retained for the other ESP variants until their native
 // interrupt-controller critical sections are implemented.


### PR DESCRIPTION
On ESP32 the `__set_BASEPRI`/`__get_BASEPRI`/`__set_BASEPRI_MAX` helpers were no-op stubs, so `ATOMIC_BLOCK()` expanded to nothing and gave no protection against ISRs. This implements them for real on the ESP32-S3 using the Xtensa `PS.INTLEVEL` register: raising the level to 1 masks all Betaflight peripheral interrupts, and the S3 CPU interrupt assignments are renumbered to the low external maskable lines so that masking is actually effective. Nesting is preserved by restoring the saved level.

`PLATFORM_CUSTOM_BASEPRI_NB` is defined so the shared `atomic.h` stops supplying its ARM `MSR` based non-barrier helpers on ESP targets (they only survived on master because nothing referenced them); ESP now provides native `_nb` helpers that inherit the real implementation on S3. The other ESP variants (C5/P4/classic) keep their existing bring-up stubs, so this is S3-only and does not affect their builds.

Needs validation on ESP32-S3 hardware: confirm peripheral IRQs are genuinely masked inside `ATOMIC_BLOCK` and that nothing deadlocks.

Extracted from @hussam-qawaqzeh's work in hussam-qawaqzeh/betaflight@2db57c1252f81fdbb732ea77a4ab923f9b1a4131, split out and scoped to the critical-section change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved interrupt support for ESP32-S3 hardware, including GPIO, UART, DMA, and USB peripherals.
  * Added reliable nested critical-section handling for ESP32-S3, including support for interrupt service routines.

* **Bug Fixes**
  * Improved interrupt enable/disable behavior and platform compatibility across ESP32 variants.
  * Prevented conflicts when custom interrupt-priority handling is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->