### PR TITLE
esp32: optimise SPI/GDMA transfers on ESP32

### DIFF
--- a/src/platform/ESP32/bus_spi_esp32.c
+++ b/src/platform/ESP32/bus_spi_esp32.c
@@ -85,6 +85,26 @@
 // DMA threshold: use DMA for transfers >= this many bytes
 #define SPI_DMA_THRESHOLD  8
 
+// RX descriptor capacity is rounded to a 32-bit boundary, so use Espressif's
+// largest four-byte-aligned descriptor payload rather than the raw 12-bit max.
+#define SPI_DMA_MAX_DESCRIPTOR_SIZE  4092
+
+// Per-bus storage covers a complete descriptor.  Besides supplying a missing
+// TX/RX direction it is used as an RX bounce buffer when a caller supplies an
+// address that GDMA cannot access on a 32-bit boundary.
+#define SPI_DMA_DUMMY_BUFFER_SIZE  SPI_DMA_MAX_DESCRIPTOR_SIZE
+
+#if defined(ESP32S3)
+// For very short full-duplex sensor reads the fixed GDMA setup plus a second
+// interrupt costs more CPU time than filling/polling the 64-byte SPI FIFO.
+// Sixteen bytes covers the common 8/9/13/14/15-byte gyro bursts while keeping
+// longer/background transfers asynchronous on DMA.  A board target may set
+// this to zero (or another measured limit) without changing the common driver.
+#ifndef ESP32S3_SPI_SHORT_POLLED_MAX_SIZE
+#define ESP32S3_SPI_SHORT_POLLED_MAX_SIZE  16
+#endif
+#endif
+
 // GPIO matrix signal indices for SPI2 (FSPI) and SPI3 (HSPI)
 static const struct {
     uint8_t clkOut;
@@ -184,13 +204,23 @@ extern busDevice_t spiBusDevice[SPIDEV_COUNT];
 
 #ifdef USE_DMA
 // DMA descriptors for SPI transfers (one TX + one RX per SPI bus).
-static lldesc_t dmaTxDesc[SPIDEV_COUNT];
-static lldesc_t dmaRxDesc[SPIDEV_COUNT];
+static lldesc_t dmaTxDesc[SPIDEV_COUNT] __attribute__((aligned(4)));
+static lldesc_t dmaRxDesc[SPIDEV_COUNT] __attribute__((aligned(4)));
+
+typedef struct spiDmaDescriptorCache_s {
+    const uint8_t *txBuffer;
+    uint8_t *rxBuffer;
+    uint8_t *rxCopyTarget;
+    uint16_t length;
+    uint16_t rxCopyLength;
+} spiDmaDescriptorCache_t;
+
+static spiDmaDescriptorCache_t dmaDescriptorCache[SPIDEV_COUNT];
 
 // Dummy buffers for DMA when no TX/RX buffer is provided.
-#define SPI_DMA_DUMMY_BUFFER_SIZE  SPI_MAX_TRANSFER_SIZE
-static uint8_t dummyTxBuf[SPI_DMA_DUMMY_BUFFER_SIZE];
-static uint8_t dummyRxBuf[SPI_DMA_DUMMY_BUFFER_SIZE];
+// Keep one pair per bus so simultaneous SPI2/SPI3 activity cannot alias them.
+static uint8_t dummyTxBuf[SPIDEV_COUNT][SPI_DMA_DUMMY_BUFFER_SIZE] __attribute__((aligned(4)));
+static uint8_t dummyRxBuf[SPIDEV_COUNT][SPI_DMA_DUMMY_BUFFER_SIZE] __attribute__((aligned(4)));
 #endif
 
 // Map from Betaflight SPI device number (0/1) to ESP-IDF SPI host ID.
@@ -360,11 +390,21 @@ FAST_IRQ_HANDLER static void spiRxIrqHandler(dmaChannelDescriptor_t *descriptor)
 
     spiInternalStopDMA(dev);
 
+    // ESP32-S3 GDMA requires an aligned RX start address.  Copy from the
+    // per-bus bounce buffer before the segment callback consumes the data.
+    int deviceNum = SPI_INST((SPI_TypeDef *)bus->busType_u.spi.instance);
+    spiDmaDescriptorCache_t *cache = &dmaDescriptorCache[deviceNum];
+    if (cache->rxCopyTarget) {
+        memcpy(cache->rxCopyTarget, dummyRxBuf[deviceNum], cache->rxCopyLength);
+        cache->rxCopyTarget = NULL;
+        cache->rxCopyLength = 0;
+    }
+
     spiIrqHandler(dev);
 }
 #endif
 
-void spiInternalStopDMA(const extDevice_t *dev)
+FAST_CODE void spiInternalStopDMA(const extDevice_t *dev)
 {
 #ifndef USE_DMA
     UNUSED(dev);
@@ -390,34 +430,21 @@ void spiInternalStopDMA(const extDevice_t *dev)
 #endif
 }
 
-void spiInternalInitStream(const extDevice_t *dev, volatile busSegment_t *segment)
+FAST_CODE void spiInternalInitStream(const extDevice_t *dev, volatile busSegment_t *segment)
 {
 #ifndef USE_DMA
     UNUSED(dev);
     UNUSED(segment);
 #else
-    busDevice_t *bus = dev->bus;
-
-    if (!bus->dmaTx || !bus->dmaRx) {
-        return;
-    }
-
-    // Cache whether we have real TX/RX buffers for this segment.
-    // The actual descriptor setup happens in spiInternalStartDMA.
-    // Store the increment flags in the dmaInit fields.
-    // Non-zero = has buffer (increment address), zero = use dummy (no increment).
-    int txCh = bus->dmaTx->channel;
-    int rxCh = bus->dmaRx->channel;
-
-    *(bus->dmaInitTx) = (segment->u.buffers.txData != NULL) ? 1 : 0;
-    *(bus->dmaInitRx) = (segment->u.buffers.rxData != NULL) ? 1 : 0;
-
-    UNUSED(txCh);
-    UNUSED(rxCh);
+    // ESP32 descriptors are bound immediately before launch.  Keeping the
+    // STM32-style per-segment init hook as a no-op avoids a store/load pair in
+    // the gyro ISR while preserving the shared bus API.
+    UNUSED(dev);
+    UNUSED(segment);
 #endif
 }
 
-void spiInternalStartDMA(const extDevice_t *dev)
+FAST_CODE void spiInternalStartDMA(const extDevice_t *dev)
 {
 #ifndef USE_DMA
     UNUSED(dev);
@@ -433,13 +460,16 @@ void spiInternalStartDMA(const extDevice_t *dev)
     bus->dmaRx->userParam = (uint32_t)dev;
 
     volatile busSegment_t *segment = bus->curSegment;
-    int xferLen = segment->len;
+    int xferLen = segment->len & BUS_SEGMENT_LEN_LENGTH_MASK;
 
     const uint8_t *txBuffer = segment->u.buffers.txData;
     uint8_t *rxBuffer = segment->u.buffers.rxData;
 
-    bool hasTx = *(bus->dmaInitTx) != 0;
-    bool hasRx = *(bus->dmaInitRx) != 0;
+    const bool hasTx = txBuffer != NULL;
+    const bool hasRx = rxBuffer != NULL;
+    const bool rxNeedsBounce = hasRx && (((uintptr_t)rxBuffer & 3U) != 0);
+    const uint8_t *effectiveTxBuffer = hasTx ? txBuffer : dummyTxBuf[deviceNum];
+    uint8_t *effectiveRxBuffer = hasRx && !rxNeedsBounce ? rxBuffer : dummyRxBuf[deviceNum];
 
     // Reset GDMA channels
     gdma_ll_tx_reset_channel(&GDMA, txCh);
@@ -449,23 +479,43 @@ void spiInternalStartDMA(const extDevice_t *dev)
     spi_ll_dma_tx_fifo_reset(hw);
     spi_ll_dma_rx_fifo_reset(hw);
 
-    // Configure TX DMA descriptor
+    // Configure TX DMA descriptor.  The invariant fields (offset, sosf and
+    // next link) are zeroed once in spiInitBusDMA(); only fields changed by a
+    // transaction or by GDMA are re-armed here.
     lldesc_t *txDesc = &dmaTxDesc[deviceNum];
-    memset(txDesc, 0, sizeof(*txDesc));
-    txDesc->size = xferLen;
+    lldesc_t *rxDesc = &dmaRxDesc[deviceNum];
+    spiDmaDescriptorCache_t *cache = &dmaDescriptorCache[deviceNum];
+    const uint16_t rxDmaSize = (xferLen + 3U) & ~3U;
+
+    if (cache->length != xferLen || cache->txBuffer != effectiveTxBuffer) {
+        txDesc->size = xferLen;
+        txDesc->buf = effectiveTxBuffer;
+        cache->txBuffer = effectiveTxBuffer;
+    }
+    if (cache->length != xferLen || cache->rxBuffer != effectiveRxBuffer) {
+        rxDesc->size = rxDmaSize;
+        rxDesc->buf = effectiveRxBuffer;
+        cache->rxBuffer = effectiveRxBuffer;
+    }
+    cache->length = xferLen;
+    cache->rxCopyTarget = rxNeedsBounce ? rxBuffer : NULL;
+    cache->rxCopyLength = rxNeedsBounce ? xferLen : 0;
+
     txDesc->length = xferLen;
-    txDesc->buf = hasTx ? txBuffer : dummyTxBuf;
     txDesc->eof = 1;
-    txDesc->owner = 1;  // owned by DMA hardware
 
     // Configure RX DMA descriptor
-    lldesc_t *rxDesc = &dmaRxDesc[deviceNum];
-    memset(rxDesc, 0, sizeof(*rxDesc));
-    rxDesc->size = xferLen;
     rxDesc->length = 0;  // filled by hardware
-    rxDesc->buf = hasRx ? rxBuffer : dummyRxBuf;
     rxDesc->eof = 0;
+
+    // Hand ownership over only after all descriptor contents are visible.
+    txDesc->owner = 1;
     rxDesc->owner = 1;  // owned by DMA hardware
+#if defined(ESP32S3)
+    __asm__ volatile ("memw" ::: "memory");
+#else
+    __asm__ volatile ("" ::: "memory");
+#endif
 
     // Set SPI transfer length
     spi_ll_set_mosi_bitlen(hw, xferLen * 8);
@@ -475,18 +525,12 @@ void spiInternalStartDMA(const extDevice_t *dev)
     spi_ll_dma_tx_enable(hw, true);
     spi_ll_dma_rx_enable(hw, true);
 
-    // Configure EOF generation by SPI transaction done
-    spi_ll_dma_set_rx_eof_generation(hw, true);
-
     // Set descriptor addresses
     gdma_ll_tx_set_desc_addr(&GDMA, txCh, (uint32_t)txDesc);
     gdma_ll_rx_set_desc_addr(&GDMA, rxCh, (uint32_t)rxDesc);
 
     // Clear any pending RX interrupt
     gdma_ll_rx_clear_interrupt_status(&GDMA, rxCh, GDMA_LL_EVENT_RX_SUC_EOF);
-
-    // Enable RX SUC_EOF interrupt for transfer completion notification
-    gdma_ll_rx_enable_interrupt(&GDMA, rxCh, GDMA_LL_EVENT_RX_SUC_EOF, true);
 
     // Start both DMA channels
     gdma_ll_rx_start(&GDMA, rxCh);
@@ -498,7 +542,7 @@ void spiInternalStartDMA(const extDevice_t *dev)
 #endif
 }
 
-bool spiInternalReadWriteBufPolled(spiResource_t *instance, const uint8_t *txData, uint8_t *rxData, int len)
+FAST_CODE bool spiInternalReadWriteBufPolled(spiResource_t *instance, const uint8_t *txData, uint8_t *rxData, int len)
 {
     int deviceNum = SPI_INST((SPI_TypeDef *)instance);
     spi_dev_t *hw = spiGetHw(deviceNum);
@@ -553,12 +597,13 @@ bool spiInternalReadWriteBufPolled(spiResource_t *instance, const uint8_t *txDat
     return true;
 }
 
-void spiSequenceStart(const extDevice_t *dev)
+FAST_CODE void spiSequenceStart(const extDevice_t *dev)
 {
     busDevice_t *bus = dev->bus;
     spiResource_t *instance = bus->busType_u.spi.instance;
     spiDevice_t *spi = &spiDevice[spiDeviceByInstance(instance)];
     bool dmaSafe = dev->useDMA;
+    bool shortPolledTransfer = false;
     uint32_t xferLen = 0;
     uint32_t segmentCount = 0;
 
@@ -597,15 +642,31 @@ void spiSequenceStart(const extDevice_t *dev)
 
     // Count segments and total transfer length
     for (busSegment_t *checkSegment = (busSegment_t *)bus->curSegment; checkSegment->len; checkSegment++) {
+        const uint32_t segmentLen = checkSegment->len & BUS_SEGMENT_LEN_LENGTH_MASK;
         segmentCount++;
-        xferLen += checkSegment->len;
+        xferLen += segmentLen;
+
+        // A single descriptor cannot represent a larger segment.  Larger
+        // transactions retain the existing chunked polling fallback.
+        if (segmentLen > SPI_DMA_MAX_DESCRIPTOR_SIZE) {
+            dmaSafe = false;
+        }
     }
+
+#if defined(ESP32S3)
+    shortPolledTransfer = ESP32S3_SPI_SHORT_POLLED_MAX_SIZE > 0 &&
+        segmentCount == 1 &&
+        xferLen <= ESP32S3_SPI_SHORT_POLLED_MAX_SIZE &&
+        bus->curSegment->negateCS &&
+        bus->curSegment->u.buffers.txData &&
+        bus->curSegment->u.buffers.rxData;
+#endif
 
     // Use DMA if possible:
     // - Bus supports DMA (bus->useDMA set by spiInitBusDMA)
     // - Device allows DMA (dev->useDMA)
     // - Multiple segments, or single segment >= threshold, or CS held after last segment
-    if (bus->useDMA && dmaSafe && ((segmentCount > 1) ||
+    if (!shortPolledTransfer && bus->useDMA && dmaSafe && ((segmentCount > 1) ||
                                     (xferLen >= SPI_DMA_THRESHOLD) ||
                                     !bus->curSegment[segmentCount].negateCS)) {
         spiProcessSegmentsDMA(dev);
@@ -650,6 +711,9 @@ void spiInitBusDMA(void)
 
     // Fill TX dummy buffer with 0xFF (SPI idle byte convention)
     memset(dummyTxBuf, 0xFF, sizeof(dummyTxBuf));
+    memset(dmaTxDesc, 0, sizeof(dmaTxDesc));
+    memset(dmaRxDesc, 0, sizeof(dmaRxDesc));
+    memset(dmaDescriptorCache, 0, sizeof(dmaDescriptorCache));
 
     for (uint32_t device = 0; device < SPIDEV_COUNT; device++) {
         busDevice_t *bus = &spiBusDevice[device];
@@ -702,6 +766,9 @@ void spiInitBusDMA(void)
         gdma_ll_tx_enable_descriptor_burst(&GDMA, txCh, true);
         gdma_ll_rx_enable_data_burst(&GDMA, rxCh, true);
         gdma_ll_rx_enable_descriptor_burst(&GDMA, rxCh, true);
+
+        spi_dev_t *hw = spiGetHw(deviceNum);
+        spi_ll_dma_set_rx_eof_generation(hw, true);
 
         // Register RX DMA completion interrupt handler
         dmaSetHandler(rxId, spiRxIrqHandler, 0, 0);

--- a/src/platform/ESP32/bus_spi_esp32.c
+++ b/src/platform/ESP32/bus_spi_esp32.c
@@ -390,8 +390,9 @@ FAST_IRQ_HANDLER static void spiRxIrqHandler(dmaChannelDescriptor_t *descriptor)
 
     spiInternalStopDMA(dev);
 
-    // ESP32-S3 GDMA requires an aligned RX start address.  Copy from the
-    // per-bus bounce buffer before the segment callback consumes the data.
+    // GDMA requires a word-aligned RX start address (all ESP GDMA SoCs, not
+    // just S3).  Copy from the per-bus bounce buffer before the segment
+    // callback consumes the data.
     int deviceNum = SPI_INST((SPI_TypeDef *)bus->busType_u.spi.instance);
     spiDmaDescriptorCache_t *cache = &dmaDescriptorCache[deviceNum];
     if (cache->rxCopyTarget) {
@@ -657,7 +658,7 @@ FAST_CODE void spiSequenceStart(const extDevice_t *dev)
     shortPolledTransfer = ESP32S3_SPI_SHORT_POLLED_MAX_SIZE > 0 &&
         segmentCount == 1 &&
         xferLen <= ESP32S3_SPI_SHORT_POLLED_MAX_SIZE &&
-        bus->curSegment->negateCS &&
+        bus->curSegment[segmentCount].negateCS &&
         bus->curSegment->u.buffers.txData &&
         bus->curSegment->u.buffers.rxData;
 #endif

--- a/src/platform/ESP32/dma_esp32.c
+++ b/src/platform/ESP32/dma_esp32.c
@@ -77,19 +77,15 @@ static const int gdmaCpuIntrPool[] = {
 
 static int nextFreeCpuIntr = 0;
 
-// Map from CPU interrupt number back to GDMA channel index for ISR dispatch
-static int cpuIntrToChannel[32];
-
 // Common GDMA RX interrupt handler - dispatches to the registered callback
-static void gdmaRxIsrDispatch(void *arg)
+FAST_IRQ_HANDLER static void gdmaRxIsrDispatch(void *arg)
 {
-    int cpuIntr = (int)(uintptr_t)arg;
-    int channel = cpuIntrToChannel[cpuIntr];
+    dmaChannelDescriptor_t *descriptor = (dmaChannelDescriptor_t *)arg;
+    const int channel = descriptor->channel;
 
     // Clear RX done interrupt
     gdma_ll_rx_clear_interrupt_status(&GDMA, channel, GDMA_LL_EVENT_RX_SUC_EOF);
 
-    dmaChannelDescriptor_t *descriptor = &dmaDescriptors[channel];
     if (descriptor->irqHandlerCallback) {
         descriptor->irqHandlerCallback(descriptor);
     }
@@ -108,7 +104,6 @@ void esp32DmaInit(void)
         gdma_ll_reset_register(0);
     }
 
-    memset(cpuIntrToChannel, 0, sizeof(cpuIntrToChannel));
     gdmaInitialised = true;
 }
 
@@ -135,14 +130,13 @@ void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callbac
     // Dynamically assign a CPU interrupt line from the pool to this channel
     if (nextFreeCpuIntr < GDMA_CPU_INTR_POOL_SIZE) {
         int cpuIntr = gdmaCpuIntrPool[nextFreeCpuIntr++];
-        cpuIntrToChannel[cpuIntr] = index;
 
         // Enable RX SUC_EOF interrupt for this GDMA channel
         gdma_ll_rx_enable_interrupt(&GDMA, index, GDMA_LL_EVENT_RX_SUC_EOF, true);
 
         // Route GDMA RX interrupt source to CPU interrupt line
         esp32IntrRoute(cpuIntr, gdmaRxIntrSource[index]);
-        esp32IntrRegister(cpuIntr, gdmaRxIsrDispatch, (void *)(uintptr_t)cpuIntr);
+        esp32IntrRegister(cpuIntr, gdmaRxIsrDispatch, &dmaDescriptors[index]);
         esp32IntrEnable(cpuIntr);
     }
 }


### PR DESCRIPTION
Reduces per-transfer overhead on the ESP32 SPI/GDMA path:

- Cache the DMA descriptor setup per bus so repeated transfers only re-arm the fields that actually change, instead of memset-ing and rebuilding both descriptors every time.
- Add a per-bus RX bounce buffer for callers whose RX address is not 32-bit aligned (GDMA cannot write an unaligned RX start), copying back in the completion ISR.
- Order descriptor ownership handoff behind a memory barrier (`memw` on S3, plain compiler barrier on the RISC-V parts).
- On the S3, route short full-duplex sensor reads (<=16 bytes, e.g. gyro bursts) through the FIFO polling path rather than paying the fixed GDMA setup plus a second interrupt; longer/background transfers stay on DMA. Arm RX EOF generation and the completion interrupt once at init instead of per transfer.
- Simplify the GDMA RX ISR dispatch to carry the channel descriptor pointer directly, dropping the 32-entry CPU-interrupt-to-channel lookup table.

Scope note: the descriptor caching and bounce buffer apply to all ESP SPI (the bounce buffer is a correctness fix for unaligned RX); the short-poll path and `memw` are S3-only. The `FAST_CODE`/`FAST_IRQ_HANDLER` annotations here are no-ops until the IRAM PR (#15531) lands, after which these paths move into IRAM. The per-bus dummy/bounce buffers increase static DRAM, so this wants a hardware check on its own and especially alongside #15531.

Needs validation on ESP32-S3 hardware: confirm the gyro read path is correct at rate through both the short-poll and DMA branches.

Extracted from @hussam-qawaqzeh's work in hussam-qawaqzeh/betaflight@2db57c1252f81fdbb732ea77a4ab923f9b1a4131, split out and scoped to the SPI/DMA change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved ESP32 SPI transfer efficiency through enhanced DMA handling and descriptor reuse.
  * Added faster execution paths for SPI operations and reduced repeated transfer setup.

* **Reliability**
  * Improved support for large and unaligned SPI transfers.
  * Added safer handling for bounced receive data and DMA completion.
  * Oversized or unsupported transfers now automatically fall back to polling.
  * Improved DMA interrupt handling for more dependable transfer completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->