### PR TITLE
dshot_bitbang: don't abort the telemetry capture mid-frame

### DIFF
--- a/src/platform/APM32/dshot_bitbang.c
+++ b/src/platform/APM32/dshot_bitbang.c
@@ -383,6 +383,8 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
 
     // Backstop for bbTelemetryWait(): capture window plus 25% margin.
     // DShot600: ~62 us -> ~78 us, DShot300: ~124 us -> ~155 us.
+    // Called per port group, so the last group wins; harmless only because all
+    // groups share one protocol. Make this and dshotFrameUs per port if that ends.
     bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
 }
 

--- a/src/platform/APM32/dshot_bitbang.c
+++ b/src/platform/APM32/dshot_bitbang.c
@@ -506,13 +506,14 @@ static bool bbTelemetryWait(void)
                     bbPorts[i].telemetryAborted = true;
                 }
             }
+            // Count timeouts only. Spinning here is normal - the capture window
+            // legitimately overlaps the next update on high loop rates - so
+            // counting every wait would leave debug[2] permanently nonzero
+            // instead of flagging a stalled capture.
+            DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);
             break;
         }
     } while (telemetryPending);
-
-    if (telemetryWait) {
-        DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);
-    }
 
     return telemetryWait;
 }

--- a/src/platform/APM32/dshot_bitbang.c
+++ b/src/platform/APM32/dshot_bitbang.c
@@ -367,8 +367,6 @@ static void bbFindPacerTimer(void)
     }
 }
 
-// Maximum time to wait for telemetry reception to complete, derived from the
-// capture window length in bbTimebaseSetup()
 static timeDelta_t bbTelemetryTimeoutUs;
 
 static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocolType)
@@ -383,9 +381,8 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
     uint32_t inputFreq = outputFreq * 5 * 2 * DSHOT_BITBANG_TELEMETRY_OVER_SAMPLE / 24;
     bbPort->inputARR = timerclock / inputFreq - 1;
 
-    // Backstop for bbTelemetryWait(): the length of the timer paced input
-    // capture window, plus 25% margin. DShot600: ~62 us -> ~78 us,
-    // DShot300: ~124 us -> ~155 us.
+    // Backstop for bbTelemetryWait(): capture window plus 25% margin.
+    // DShot600: ~62 us -> ~78 us, DShot300: ~124 us -> ~155 us.
     bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
 }
 
@@ -478,19 +475,14 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
 
 static bool bbTelemetryWait(void)
 {
-    // Wait for telemetry reception to complete.
-    //
-    // The capture must not be cut short. The window is only a few microseconds
+    // The capture must not be cut short: the window is only a few microseconds
     // longer than the ESC reply (~62 us against ~58 us at DShot600), so aborting
-    // it means bbSwitchToOutput() re-enables the push-pull output driver while
-    // the ESC is still driving the line. The resulting contention injects supply
-    // noise that has been observed to corrupt I2C sensors on AIO boards (#15533).
+    // it leaves bbSwitchToOutput() driving the line push-pull against a still
+    // transmitting ESC. That contention couples into the 3.3 V rail and has been
+    // seen to corrupt I2C barometers on AIO boards (#15533).
     //
-    // The window is timer paced and always runs to completion, so this loop
-    // normally exits as soon as the DMA completion IRQ clears telemetryPending.
-    // bbTelemetryTimeoutUs bounds a stalled DMA only, and is derived from the
-    // window rather than the fixed 2000 us it replaces - that was long enough to
-    // starve TASK_RX for tens of milliseconds on 8 kHz targets with bidirDSHOT.
+    // The window is timer paced and always completes, so bbTelemetryTimeoutUs is
+    // a backstop for a stalled DMA only.
     bool telemetryPending;
     bool telemetryWait = false;
     const timeUs_t startTimeUs = micros();
@@ -504,15 +496,11 @@ static bool bbTelemetryWait(void)
         telemetryWait |= telemetryPending;
 
         if (cmpTimeUs(micros(), startTimeUs) > bbTelemetryTimeoutUs) {
-            // Stalled. Leave the DMA running: tearing it down from thread context
-            // races bbDMAIrqHandler() on both the stream (which must not be
-            // reprogrammed before it has actually stopped, which bbSwitchToOutput()
-            // would then do immediately) and on the pacer TMRx DMA request enables
-            // shared with the other port group. bbUpdateComplete() recovers the
-            // direction on this cycle and the next completed capture clears
-            // telemetryPending. Flag the ports that are still pending so
-            // bbDecodeTelemetry() skips a torn buffer rather than decoding a
-            // bad-but-valid GCR frame.
+            // Leave the stream for bbUpdateComplete() to reinitialise, as it does
+            // on every cycle; stopping it here would additionally race
+            // bbDMAIrqHandler() on the pacer TMRx DMA request enables, which are
+            // shared with the other port group. The buffers may hold a partial
+            // frame, so skip them rather than decode a bad-but-valid GCR frame.
             for (int i = 0; i < usedMotorPorts; i++) {
                 if (bbPorts[i].telemetryPending) {
                     bbPorts[i].telemetryAborted = true;

--- a/src/platform/APM32/dshot_bitbang.c
+++ b/src/platform/APM32/dshot_bitbang.c
@@ -367,6 +367,10 @@ static void bbFindPacerTimer(void)
     }
 }
 
+// Maximum time to wait for telemetry reception to complete, derived from the
+// capture window length in bbTimebaseSetup()
+static timeDelta_t bbTelemetryTimeoutUs;
+
 static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocolType)
 {
     uint32_t timerclock = timerClock(bbPort->timhw);
@@ -378,6 +382,11 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
     // XXX Explain this formula
     uint32_t inputFreq = outputFreq * 5 * 2 * DSHOT_BITBANG_TELEMETRY_OVER_SAMPLE / 24;
     bbPort->inputARR = timerclock / inputFreq - 1;
+
+    // Backstop for bbTelemetryWait(): the length of the timer paced input
+    // capture window, plus 25% margin. DShot600: ~62 us -> ~78 us,
+    // DShot300: ~124 us -> ~155 us.
+    bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
 }
 
 //
@@ -469,21 +478,49 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
 
 static bool bbTelemetryWait(void)
 {
-    // If telemetry input DMA is still running, abort it rather than busy-waiting.
-    // Skipping one telemetry frame is harmless; busy-waiting can block TASK_RX for
-    // tens of milliseconds on high-loop-rate targets (e.g. F7 at 8K with bidirDSHOT).
-    // bbUpdateComplete() handles the port still being in INPUT direction.
+    // Wait for telemetry reception to complete.
+    //
+    // The capture must not be cut short. The window is only a few microseconds
+    // longer than the ESC reply (~62 us against ~58 us at DShot600), so aborting
+    // it means bbSwitchToOutput() re-enables the push-pull output driver while
+    // the ESC is still driving the line. The resulting contention injects supply
+    // noise that has been observed to corrupt I2C sensors on AIO boards (#15533).
+    //
+    // The window is timer paced and always runs to completion, so this loop
+    // normally exits as soon as the DMA completion IRQ clears telemetryPending.
+    // bbTelemetryTimeoutUs bounds a stalled DMA only, and is derived from the
+    // window rather than the fixed 2000 us it replaces - that was long enough to
+    // starve TASK_RX for tens of milliseconds on 8 kHz targets with bidirDSHOT.
+    bool telemetryPending;
     bool telemetryWait = false;
+    const timeUs_t startTimeUs = micros();
 
-    for (int i = 0; i < usedMotorPorts; i++) {
-        if (bbPorts[i].telemetryPending) {
-            bbTIM_DMACmd(bbPorts[i].timhw->tim, bbPorts[i].dmaSource, DISABLE);
-            bbDMA_Cmd(&bbPorts[i], DISABLE);
-            bbPorts[i].telemetryPending = false;
-            bbPorts[i].telemetryAborted = true;
-            telemetryWait = true;
+    do {
+        telemetryPending = false;
+        for (int i = 0; i < usedMotorPorts; i++) {
+            telemetryPending |= bbPorts[i].telemetryPending;
         }
-    }
+
+        telemetryWait |= telemetryPending;
+
+        if (cmpTimeUs(micros(), startTimeUs) > bbTelemetryTimeoutUs) {
+            // Stalled. Leave the DMA running: tearing it down from thread context
+            // races bbDMAIrqHandler() on both the stream (which must not be
+            // reprogrammed before it has actually stopped, which bbSwitchToOutput()
+            // would then do immediately) and on the pacer TMRx DMA request enables
+            // shared with the other port group. bbUpdateComplete() recovers the
+            // direction on this cycle and the next completed capture clears
+            // telemetryPending. Flag the ports that are still pending so
+            // bbDecodeTelemetry() skips a torn buffer rather than decoding a
+            // bad-but-valid GCR frame.
+            for (int i = 0; i < usedMotorPorts; i++) {
+                if (bbPorts[i].telemetryPending) {
+                    bbPorts[i].telemetryAborted = true;
+                }
+            }
+            break;
+        }
+    } while (telemetryPending);
 
     if (telemetryWait) {
         DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);

--- a/src/platform/AT32/dshot_bitbang.c
+++ b/src/platform/AT32/dshot_bitbang.c
@@ -354,6 +354,10 @@ static void bbFindPacerTimer(void)
     }
 }
 
+// Maximum time to wait for telemetry reception to complete, derived from the
+// capture window length in bbTimebaseSetup()
+static timeDelta_t bbTelemetryTimeoutUs;
+
 static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocolType)
 {
     uint32_t timerclock = timerClock(bbPort->timhw);
@@ -365,6 +369,11 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
     // XXX Explain this formula
     uint32_t inputFreq = outputFreq * 5 * 2 * DSHOT_BITBANG_TELEMETRY_OVER_SAMPLE / 24;
     bbPort->inputARR = timerclock / inputFreq - 1;
+
+    // Backstop for bbTelemetryWait(): the length of the timer paced input
+    // capture window, plus 25% margin. DShot600: ~62 us -> ~78 us,
+    // DShot300: ~124 us -> ~155 us.
+    bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
 }
 
 //
@@ -450,21 +459,49 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
 
 static bool bbTelemetryWait(void)
 {
-    // If telemetry input DMA is still running, abort it rather than busy-waiting.
-    // Skipping one telemetry frame is harmless; busy-waiting can block TASK_RX for
-    // tens of milliseconds on high-loop-rate targets (e.g. F7 at 8K with bidirDSHOT).
-    // bbUpdateComplete() handles the port still being in INPUT direction.
+    // Wait for telemetry reception to complete.
+    //
+    // The capture must not be cut short. The window is only a few microseconds
+    // longer than the ESC reply (~62 us against ~58 us at DShot600), so aborting
+    // it means bbSwitchToOutput() re-enables the push-pull output driver while
+    // the ESC is still driving the line. The resulting contention injects supply
+    // noise that has been observed to corrupt I2C sensors on AIO boards (#15533).
+    //
+    // The window is timer paced and always runs to completion, so this loop
+    // normally exits as soon as the DMA completion IRQ clears telemetryPending.
+    // bbTelemetryTimeoutUs bounds a stalled DMA only, and is derived from the
+    // window rather than the fixed 2000 us it replaces - that was long enough to
+    // starve TASK_RX for tens of milliseconds on 8 kHz targets with bidirDSHOT.
+    bool telemetryPending;
     bool telemetryWait = false;
+    const timeUs_t startTimeUs = micros();
 
-    for (int i = 0; i < usedMotorPorts; i++) {
-        if (bbPorts[i].telemetryPending) {
-            bbTIM_DMACmd(bbPorts[i].timhw->tim, bbPorts[i].dmaSource, FALSE);
-            bbDMA_Cmd(&bbPorts[i], FALSE);
-            bbPorts[i].telemetryPending = false;
-            bbPorts[i].telemetryAborted = true;
-            telemetryWait = true;
+    do {
+        telemetryPending = false;
+        for (int i = 0; i < usedMotorPorts; i++) {
+            telemetryPending |= bbPorts[i].telemetryPending;
         }
-    }
+
+        telemetryWait |= telemetryPending;
+
+        if (cmpTimeUs(micros(), startTimeUs) > bbTelemetryTimeoutUs) {
+            // Stalled. Leave the DMA running: tearing it down from thread context
+            // races bbDMAIrqHandler() on both the stream (which must not be
+            // reprogrammed before it has actually stopped, which bbSwitchToOutput()
+            // would then do immediately) and on the pacer TMRx DMA request enables
+            // shared with the other port group. bbUpdateComplete() recovers the
+            // direction on this cycle and the next completed capture clears
+            // telemetryPending. Flag the ports that are still pending so
+            // bbDecodeTelemetry() skips a torn buffer rather than decoding a
+            // bad-but-valid GCR frame.
+            for (int i = 0; i < usedMotorPorts; i++) {
+                if (bbPorts[i].telemetryPending) {
+                    bbPorts[i].telemetryAborted = true;
+                }
+            }
+            break;
+        }
+    } while (telemetryPending);
 
     if (telemetryWait) {
         DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);

--- a/src/platform/AT32/dshot_bitbang.c
+++ b/src/platform/AT32/dshot_bitbang.c
@@ -487,13 +487,14 @@ static bool bbTelemetryWait(void)
                     bbPorts[i].telemetryAborted = true;
                 }
             }
+            // Count timeouts only. Spinning here is normal - the capture window
+            // legitimately overlaps the next update on high loop rates - so
+            // counting every wait would leave debug[2] permanently nonzero
+            // instead of flagging a stalled capture.
+            DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);
             break;
         }
     } while (telemetryPending);
-
-    if (telemetryWait) {
-        DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);
-    }
 
     return telemetryWait;
 }

--- a/src/platform/AT32/dshot_bitbang.c
+++ b/src/platform/AT32/dshot_bitbang.c
@@ -370,6 +370,8 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
 
     // Backstop for bbTelemetryWait(): capture window plus 25% margin.
     // DShot600: ~62 us -> ~78 us, DShot300: ~124 us -> ~155 us.
+    // Called per port group, so the last group wins; harmless only because all
+    // groups share one protocol. Make this and dshotFrameUs per port if that ends.
     bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
 }
 

--- a/src/platform/AT32/dshot_bitbang.c
+++ b/src/platform/AT32/dshot_bitbang.c
@@ -354,8 +354,6 @@ static void bbFindPacerTimer(void)
     }
 }
 
-// Maximum time to wait for telemetry reception to complete, derived from the
-// capture window length in bbTimebaseSetup()
 static timeDelta_t bbTelemetryTimeoutUs;
 
 static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocolType)
@@ -370,9 +368,8 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
     uint32_t inputFreq = outputFreq * 5 * 2 * DSHOT_BITBANG_TELEMETRY_OVER_SAMPLE / 24;
     bbPort->inputARR = timerclock / inputFreq - 1;
 
-    // Backstop for bbTelemetryWait(): the length of the timer paced input
-    // capture window, plus 25% margin. DShot600: ~62 us -> ~78 us,
-    // DShot300: ~124 us -> ~155 us.
+    // Backstop for bbTelemetryWait(): capture window plus 25% margin.
+    // DShot600: ~62 us -> ~78 us, DShot300: ~124 us -> ~155 us.
     bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
 }
 
@@ -459,19 +456,14 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
 
 static bool bbTelemetryWait(void)
 {
-    // Wait for telemetry reception to complete.
-    //
-    // The capture must not be cut short. The window is only a few microseconds
+    // The capture must not be cut short: the window is only a few microseconds
     // longer than the ESC reply (~62 us against ~58 us at DShot600), so aborting
-    // it means bbSwitchToOutput() re-enables the push-pull output driver while
-    // the ESC is still driving the line. The resulting contention injects supply
-    // noise that has been observed to corrupt I2C sensors on AIO boards (#15533).
+    // it leaves bbSwitchToOutput() driving the line push-pull against a still
+    // transmitting ESC. That contention couples into the 3.3 V rail and has been
+    // seen to corrupt I2C barometers on AIO boards (#15533).
     //
-    // The window is timer paced and always runs to completion, so this loop
-    // normally exits as soon as the DMA completion IRQ clears telemetryPending.
-    // bbTelemetryTimeoutUs bounds a stalled DMA only, and is derived from the
-    // window rather than the fixed 2000 us it replaces - that was long enough to
-    // starve TASK_RX for tens of milliseconds on 8 kHz targets with bidirDSHOT.
+    // The window is timer paced and always completes, so bbTelemetryTimeoutUs is
+    // a backstop for a stalled DMA only.
     bool telemetryPending;
     bool telemetryWait = false;
     const timeUs_t startTimeUs = micros();
@@ -485,15 +477,11 @@ static bool bbTelemetryWait(void)
         telemetryWait |= telemetryPending;
 
         if (cmpTimeUs(micros(), startTimeUs) > bbTelemetryTimeoutUs) {
-            // Stalled. Leave the DMA running: tearing it down from thread context
-            // races bbDMAIrqHandler() on both the stream (which must not be
-            // reprogrammed before it has actually stopped, which bbSwitchToOutput()
-            // would then do immediately) and on the pacer TMRx DMA request enables
-            // shared with the other port group. bbUpdateComplete() recovers the
-            // direction on this cycle and the next completed capture clears
-            // telemetryPending. Flag the ports that are still pending so
-            // bbDecodeTelemetry() skips a torn buffer rather than decoding a
-            // bad-but-valid GCR frame.
+            // Leave the stream for bbUpdateComplete() to reinitialise, as it does
+            // on every cycle; stopping it here would additionally race
+            // bbDMAIrqHandler() on the pacer TMRx DMA request enables, which are
+            // shared with the other port group. The buffers may hold a partial
+            // frame, so skip them rather than decode a bad-but-valid GCR frame.
             for (int i = 0; i < usedMotorPorts; i++) {
                 if (bbPorts[i].telemetryPending) {
                     bbPorts[i].telemetryAborted = true;

--- a/src/platform/STM32/dshot_bitbang.c
+++ b/src/platform/STM32/dshot_bitbang.c
@@ -542,13 +542,14 @@ static bool bbTelemetryWait(void)
                     bbPorts[i].telemetryAborted = true;
                 }
             }
+            // Count timeouts only. Spinning here is normal - the capture window
+            // legitimately overlaps the next update on high loop rates - so
+            // counting every wait would leave debug[2] permanently nonzero
+            // instead of flagging a stalled capture.
+            DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);
             break;
         }
     } while (telemetryPending);
-
-    if (telemetryWait) {
-        DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);
-    }
 
     return telemetryWait;
 }

--- a/src/platform/STM32/dshot_bitbang.c
+++ b/src/platform/STM32/dshot_bitbang.c
@@ -404,8 +404,6 @@ static void bbFindPacerTimer(void)
     }
 }
 
-// Maximum time to wait for telemetry reception to complete, derived from the
-// capture window length in bbTimebaseSetup()
 static timeDelta_t bbTelemetryTimeoutUs;
 
 static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocolType)
@@ -420,9 +418,8 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
     uint32_t inputFreq = outputFreq * 5 * 2 * DSHOT_BITBANG_TELEMETRY_OVER_SAMPLE / 24;
     bbPort->inputARR = timerclock / inputFreq - 1;
 
-    // Backstop for bbTelemetryWait(): the length of the timer paced input
-    // capture window, plus 25% margin. DShot600: ~62 us -> ~78 us,
-    // DShot300: ~124 us -> ~155 us.
+    // Backstop for bbTelemetryWait(): capture window plus 25% margin.
+    // DShot600: ~62 us -> ~78 us, DShot300: ~124 us -> ~155 us.
     bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
 }
 
@@ -514,19 +511,14 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
 
 static bool bbTelemetryWait(void)
 {
-    // Wait for telemetry reception to complete.
-    //
-    // The capture must not be cut short. The window is only a few microseconds
+    // The capture must not be cut short: the window is only a few microseconds
     // longer than the ESC reply (~62 us against ~58 us at DShot600), so aborting
-    // it means bbSwitchToOutput() re-enables the push-pull output driver while
-    // the ESC is still driving the line. The resulting contention injects supply
-    // noise that has been observed to corrupt I2C sensors on AIO boards (#15533).
+    // it leaves bbSwitchToOutput() driving the line push-pull against a still
+    // transmitting ESC. That contention couples into the 3.3 V rail and has been
+    // seen to corrupt I2C barometers on AIO boards (#15533).
     //
-    // The window is timer paced and always runs to completion, so this loop
-    // normally exits as soon as the DMA completion IRQ clears telemetryPending.
-    // bbTelemetryTimeoutUs bounds a stalled DMA only, and is derived from the
-    // window rather than the fixed 2000 us it replaces - that was long enough to
-    // starve TASK_RX for tens of milliseconds on 8 kHz targets with bidirDSHOT.
+    // The window is timer paced and always completes, so bbTelemetryTimeoutUs is
+    // a backstop for a stalled DMA only.
     bool telemetryPending;
     bool telemetryWait = false;
     const timeUs_t startTimeUs = micros();
@@ -540,15 +532,11 @@ static bool bbTelemetryWait(void)
         telemetryWait |= telemetryPending;
 
         if (cmpTimeUs(micros(), startTimeUs) > bbTelemetryTimeoutUs) {
-            // Stalled. Leave the DMA running: tearing it down from thread context
-            // races bbDMAIrqHandler() on both the stream (the STM32F4 reference
-            // manual forbids reprogramming a stream before EN reads 0, which
-            // bbSwitchToOutput() would then do immediately) and on the pacer
-            // TIMx->DIER shared with the other port group. bbUpdateComplete()
-            // recovers the direction on this cycle and the next completed capture
-            // clears telemetryPending. Flag the ports that are still pending so
-            // bbDecodeTelemetry() skips a torn buffer rather than decoding a
-            // bad-but-valid GCR frame.
+            // Leave the stream for bbUpdateComplete() to reinitialise, as it does
+            // on every cycle; stopping it here would additionally race
+            // bbDMAIrqHandler() on the pacer TIMx->DIER, which is shared with the
+            // other port group. The buffers may hold a partial frame, so skip
+            // them rather than decode a bad-but-valid GCR frame.
             for (int i = 0; i < usedMotorPorts; i++) {
                 if (bbPorts[i].telemetryPending) {
                     bbPorts[i].telemetryAborted = true;

--- a/src/platform/STM32/dshot_bitbang.c
+++ b/src/platform/STM32/dshot_bitbang.c
@@ -420,6 +420,8 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
 
     // Backstop for bbTelemetryWait(): capture window plus 25% margin.
     // DShot600: ~62 us -> ~78 us, DShot300: ~124 us -> ~155 us.
+    // Called per port group, so the last group wins; harmless only because all
+    // groups share one protocol. Make this and dshotFrameUs per port if that ends.
     bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
 }
 

--- a/src/platform/STM32/dshot_bitbang.c
+++ b/src/platform/STM32/dshot_bitbang.c
@@ -404,6 +404,10 @@ static void bbFindPacerTimer(void)
     }
 }
 
+// Maximum time to wait for telemetry reception to complete, derived from the
+// capture window length in bbTimebaseSetup()
+static timeDelta_t bbTelemetryTimeoutUs;
+
 static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocolType)
 {
     uint32_t timerclock = timerClock(bbPort->timhw);
@@ -415,6 +419,11 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
     // XXX Explain this formula
     uint32_t inputFreq = outputFreq * 5 * 2 * DSHOT_BITBANG_TELEMETRY_OVER_SAMPLE / 24;
     bbPort->inputARR = timerclock / inputFreq - 1;
+
+    // Backstop for bbTelemetryWait(): the length of the timer paced input
+    // capture window, plus 25% margin. DShot600: ~62 us -> ~78 us,
+    // DShot300: ~124 us -> ~155 us.
+    bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
 }
 
 //
@@ -505,25 +514,49 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
 
 static bool bbTelemetryWait(void)
 {
-    // If telemetry input DMA is still running, abort it rather than busy-waiting.
-    // Skipping one telemetry frame is harmless; busy-waiting can block TASK_RX for
-    // tens of milliseconds on high-loop-rate targets (e.g. F7 at 8K with bidirDSHOT).
-    // bbUpdateComplete() handles the port still being in INPUT direction.
+    // Wait for telemetry reception to complete.
+    //
+    // The capture must not be cut short. The window is only a few microseconds
+    // longer than the ESC reply (~62 us against ~58 us at DShot600), so aborting
+    // it means bbSwitchToOutput() re-enables the push-pull output driver while
+    // the ESC is still driving the line. The resulting contention injects supply
+    // noise that has been observed to corrupt I2C sensors on AIO boards (#15533).
+    //
+    // The window is timer paced and always runs to completion, so this loop
+    // normally exits as soon as the DMA completion IRQ clears telemetryPending.
+    // bbTelemetryTimeoutUs bounds a stalled DMA only, and is derived from the
+    // window rather than the fixed 2000 us it replaces - that was long enough to
+    // starve TASK_RX for tens of milliseconds on 8 kHz targets with bidirDSHOT.
+    bool telemetryPending;
     bool telemetryWait = false;
+    const timeUs_t startTimeUs = micros();
 
-    for (int i = 0; i < usedMotorPorts; i++) {
-        if (bbPorts[i].telemetryPending) {
-            bbTIM_DMACmd(bbPorts[i].timhw->tim, bbPorts[i].dmaSource, DISABLE);
-            bbDMA_Cmd(&bbPorts[i], DISABLE);
-            bbPorts[i].telemetryPending = false;
-            // The input capture was aborted mid-transfer, so the buffer holds a
-            // partial frame. Mark the port so decodeTelemetry() skips it rather
-            // than decoding a torn buffer (which could yield a bad-but-valid GCR
-            // frame). Skipping one telemetry frame is harmless.
-            bbPorts[i].telemetryAborted = true;
-            telemetryWait = true;
+    do {
+        telemetryPending = false;
+        for (int i = 0; i < usedMotorPorts; i++) {
+            telemetryPending |= bbPorts[i].telemetryPending;
         }
-    }
+
+        telemetryWait |= telemetryPending;
+
+        if (cmpTimeUs(micros(), startTimeUs) > bbTelemetryTimeoutUs) {
+            // Stalled. Leave the DMA running: tearing it down from thread context
+            // races bbDMAIrqHandler() on both the stream (the STM32F4 reference
+            // manual forbids reprogramming a stream before EN reads 0, which
+            // bbSwitchToOutput() would then do immediately) and on the pacer
+            // TIMx->DIER shared with the other port group. bbUpdateComplete()
+            // recovers the direction on this cycle and the next completed capture
+            // clears telemetryPending. Flag the ports that are still pending so
+            // bbDecodeTelemetry() skips a torn buffer rather than decoding a
+            // bad-but-valid GCR frame.
+            for (int i = 0; i < usedMotorPorts; i++) {
+                if (bbPorts[i].telemetryPending) {
+                    bbPorts[i].telemetryAborted = true;
+                }
+            }
+            break;
+        }
+    } while (telemetryPending);
 
     if (telemetryWait) {
         DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);


### PR DESCRIPTION
Fixes #15533 #15587

## Problem

#15332 replaced the bidirectional DShot telemetry busy-wait with an immediate DMA abort. Its premise — that the abort only fires on overrun cycles — is correct, but the consequence was missed.

The input capture window is only a few microseconds longer than the ESC reply, so whenever the abort *does* fire, the ESC is still driving the line:

| | capture window | ESC reply (21b GCR @ 5/4 rate) + ~30 µs turnaround | margin |
|---|---|---|---|
| DShot600 | 140 / 2.25 MHz = **62 µs** | 28 + 30 = **58 µs** | **~4 µs** |
| DShot300 | 140 / 1.125 MHz = **124 µs** | 56 + 30 = **86 µs** | ~38 µs |

`bbTelemetryWait()` returns straight into `bbUpdateComplete()` → `bbSwitchToOutput()` (`motor.c:96-101`), which re-enables the push-pull output driver (`GPIO_OType_PP`) and writes the idle level. Two push-pull drivers then fight over the motor signal for up to ~28 µs, on up to 4 pins, repeating at loop rate.

On compact AIO boards that couples enough noise into the 3.3 V rail to disturb the I2C barometer. #15533 reports persistent bogus altitude (`ALT -4215.2 M`) on FLYWOOF405S_AIO and SpeedyBee F405 AIO — both with the baro on I2C1 — bisected to 7f2ce3976 and confirmed fixed by reverting it.

Tearing the DMA down from thread context also introduces an **unprotected RMW on the shared pacer `TIMx->DIER`**: `bbTIM_DMACmd()` is called from thread context while `bbDMAIrqHandler()` (prio 2,1) does the same read-modify-write on the *same* DIER for the other port group. Port groups on GPIOA and GPIOB share one pacer timer, so this is a live race.

## Fix

Restore the bounded wait, but size the timeout from the capture window instead of the fixed 2000 µs it replaces:

```c
bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
```

≈78 µs at DShot600, ≈155 µs at DShot300.

This keeps what #15332 was after. The old 2000 µs bound was ~30× longer than any legitimate capture, which is what let the overrun cascade compound into the 10–20 ms TASK_RX starvation bursts that PR reported; capping at the window length caps the cascade at one window. Because the window is timer-paced and always runs to completion, the loop normally exits as soon as the DMA completion IRQ clears `telemetryPending`, and the ESC is never cut off mid-reply.

The timeout is now a backstop for a stalled DMA only, and on that path the DMA is **left alone** — the still-pending ports are flagged so `bbDecodeTelemetry()` skips a torn buffer rather than decoding a bad-but-valid GCR frame, and `bbUpdateComplete()` reinitialises the stream as it does on every cycle. That also removes the DIER race.

### What this PR does *not* fix

Thanks to @coderabbitai for catching that my first draft overclaimed here. There is a second hazard: `xDMA_Cmd(DISABLE)` is just `CR &= ~EN` and does not wait for `EN` to read 0, while `bbSwitchToOutput()` → `bbLoadDMARegs()` blind-writes CR/FCR/NDTR/PAR/M0AR immediately after — forbidden by RM0090 (DMA_SxCR: *"It is forbidden to write these registers when the EN bit is read as 1"*).

Not aborting does **not** avoid this, because `bbUpdateComplete()` reprograms the stream every cycle regardless of how `bbTelemetryWait()` exited. It is pre-existing on the stall path (the pre-#15332 timeout `break` did the same) and deliberately left alone here to keep this PR to the regression. Worth a separate look.

`telemetryAborted` and the AT32 `telemetryPending` IRQ-handler fix from #15332 are both retained. Applied to the STM32, APM32 and AT32 copies, matching #15332's scope.

## Testing

Builds clean on STM32F405, APM32F405 and AT32F435M. No unit tests cover `dshot_bitbang.c` (platform code, excluded from the host test build).

**Not yet confirmed on hardware.** The reasoning above is sound on its own terms — aborting mid-frame into a push-pull driver is wrong regardless — but nobody has yet verified that the abort path is what breaks the baro on the affected boards.

The direct check runs on an **unpatched build** (master, with #15332), where `set debug_mode = DSHOT_TELEMETRY_COUNTS` makes **debug[2] the abort count** — there, every pending port is aborted, so the counter tracks exactly the events under suspicion. If it climbs at the moment the altitude goes bad on an affected board, the chain is confirmed. If it stays at zero, the baro fault is something else and this PR will not fix #15533.

Thanks to @blckmn for catching that debug[2] does not mean the same thing once this PR lands. Restoring the wait loop initially kept its pre-#15332 placement, which bumped the counter whenever the loop spun at all — and spinning is normal, since the capture window legitimately overlaps the next update at high loop rates, so it would have read nonzero in healthy flight. Fixed in a5887cee9 by bumping it in the timeout branch instead, next to where `telemetryAborted` is set. On a patched build debug[2] is therefore a **stalled-DMA count** and is expected to stay at zero.

Flight testing on FLYWOOF405S_AIO / SpeedyBee F405 AIO would be very welcome, as would a check that RC jitter on 8 kHz F7 bidirDShot setups is still improved relative to pre-#15332.

If 2026.6 needs a patch before that testing lands, a straight revert of #15332 on the maintenance branch is the lower-risk call there, and this can go to master.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry capture reliability by waiting for transfers to complete within a bounded timeout.
  * Prevented incomplete telemetry captures from being decoded.
  * Improved recovery after telemetry capture timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
