### PR TITLE
Preserve 'defaults' arguments when rewriting config file lines

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -8762,15 +8762,20 @@ void cliProcessConfigFile(const char *filename)
             if (cp) {
                 *cp = '\0';
             }
-            // Tokenize the comment-stripped line and look for 'nosave' as a discrete token
+            // Tokenize the comment-stripped line and look for 'nosave' as a discrete token.
+            // strtok writes NULs over the delimiters, so run it on a scratch copy: 'stripped'
+            // is reused below to rebuild the line and must keep its arguments intact.
+            char scratch[CLI_IN_BUFFER_SIZE];
+            strcpy(scratch, stripped);
             bool hasNosave = false;
-            char *tok = strtok(stripped, " \t\r\n");
+            char *saveptr;
+            char *tok = strtok_r(scratch, " \t\r\n", &saveptr);
             while (tok) {
                 if (strcasecmp(tok, "nosave") == 0) {
                     hasNosave = true;
                     break;
                 }
-                tok = strtok(NULL, " \t\r\n");
+                tok = strtok_r(NULL, " \t\r\n", &saveptr);
             }
             if (!hasNosave) {
                 // Append 'nosave' to the original line (minus any trailing comment/whitespace)

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -8526,7 +8526,7 @@ static void processCharacter(const char c)
             cliPrompt();
         }
 
-    } else if (bufferIndex < sizeof(cliBuffer) && c >= 32 && c <= 126) {
+    } else if (bufferIndex < sizeof(cliBuffer) - 1 && c >= 32 && c <= 126) {
         if (!bufferIndex && c == ' ') {
             return; // Ignore leading spaces
         }
@@ -8766,7 +8766,8 @@ void cliProcessConfigFile(const char *filename)
             // strtok writes NULs over the delimiters, so run it on a scratch copy: 'stripped'
             // is reused below to rebuild the line and must keep its arguments intact.
             char scratch[CLI_IN_BUFFER_SIZE];
-            strcpy(scratch, stripped);
+            strncpy(scratch, stripped, sizeof(scratch) - 1);
+            scratch[sizeof(scratch) - 1] = '\0';
             bool hasNosave = false;
             char *saveptr;
             char *tok = strtok_r(scratch, " \t\r\n", &saveptr);
@@ -8791,6 +8792,13 @@ void cliProcessConfigFile(const char *filename)
                     nosaveLine[--len] = '\0';
                 }
                 strcat(nosaveLine, " nosave\n");
+                // processCharacter() stops buffering at CLI_IN_BUFFER_SIZE characters but still
+                // null terminates at bufferIndex when the newline arrives, so a rewritten line
+                // that no longer fits would both run truncated and write one past cliBuffer.
+                if (strlen(nosaveLine) > CLI_IN_BUFFER_SIZE) {
+                    printf("[CONFIG] Line too long to rewrite, skipped: %s\n", stripped);
+                    continue;
+                }
                 for (size_t i = 0; nosaveLine[i]; i++) {
                     processCharacter(nosaveLine[i]);
                 }


### PR DESCRIPTION
`strtok` writes NULs over the delimiters it finds, and the tokenised buffer was then reused to rebuild the rewritten line, so everything after the first token had already been cut off. A config file containing `defaults group_id 5` was rewritten as `defaults nosave` and silently reset every parameter group instead of just group 5.

Tokenising a scratch copy leaves the stripped line intact. Also swapped `strtok` for `strtok_r` to match `cliDefaults` and avoid the shared static state.

Confirmed against SITL with `--config`. `defaults group_id 5` and `defaults group_id 5 # comment` now emit `defaults group_id 5 nosave` and print `# resetting group 5 to defaults`, where both previously emitted `defaults nosave` and did a full reset. The `defaults`, `defaults nosave` and `defaults # nosave` cases are unchanged.

No unit test: `cli_unittest` doesn't compile `CONFIG_IN_FILE`, which is SITL only and reads from a file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processing of configuration defaults to preserve command text and arguments.
  * Prevented unintended changes when applying `nosave` settings.
  * Preserved existing `nosave` detection behavior during command reconstruction.
  * Added a diagnostic when a rewritten configuration command exceeds the available buffer, and safely skips that command.
  * Improved command-line input handling to prevent truncation or memory-boundary issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->