### PR TITLE
fix(build): scope SRC_MANIFEST per-target to fix parallel-build race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ SRC_DIR         := $(ROOT)/src/main
 LIB_MAIN_DIR    := $(ROOT)/lib/main
 LIB_MODULES_DIR := $(ROOT)/lib/modules
 OBJECT_DIR      := $(ROOT)/obj/main
-SRC_MANIFEST    := $(OBJECT_DIR)/.src_manifest
 BIN_DIR         := $(ROOT)/obj
 CMSIS_DIR       := $(ROOT)/lib/main/CMSIS
 INCLUDE_DIRS    := $(SRC_DIR)
@@ -467,6 +466,11 @@ TARGET_EXE      := $(BIN_DIR)/$(TARGET_FULLNAME)
 TARGET_DFU      := $(BIN_DIR)/$(TARGET_FULLNAME).dfu
 TARGET_ZIP      := $(BIN_DIR)/$(TARGET_FULLNAME).zip
 TARGET_OBJ_DIR  := $(OBJECT_DIR)/$(TARGET_NAME)
+# Scoped under TARGET_OBJ_DIR, not the shared OBJECT_DIR: concurrent
+# `make TARGET=X` invocations (e.g. `make -jN all_configs`) each run their
+# own validate-deps, and a manifest shared across targets races on the
+# mv below when multiple targets build in parallel.
+SRC_MANIFEST    := $(TARGET_OBJ_DIR)/.src_manifest
 TARGET_ELF      := $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME).elf
 TARGET_EXST_ELF := $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME)_EXST.elf
 TARGET_UNPATCHED_BIN := $(OBJECT_DIR)/$(FORKNAME)_$(TARGET_NAME)_UNPATCHED.bin
@@ -754,12 +758,12 @@ $(AUTOHYDRATE_STAMPS):
 # the cost is a single cmp call.
 .PHONY: validate-deps
 validate-deps:
-	$(V1) mkdir -p "$(OBJECT_DIR)"; \
+	$(V1) mkdir -p "$(TARGET_OBJ_DIR)"; \
 	printf '%s\n' $(SRC) | sort > "$(SRC_MANIFEST).new"; \
 	if [ -f "$(SRC_MANIFEST)" ] && ! cmp -s "$(SRC_MANIFEST)" "$(SRC_MANIFEST).new"; then \
 	    if comm -23 "$(SRC_MANIFEST)" "$(SRC_MANIFEST).new" | grep -q .; then \
 	        echo "Sources removed — clearing stale dependency files"; \
-	        find "$(OBJECT_DIR)" -name '*.d' -delete 2>/dev/null; \
+	        find "$(TARGET_OBJ_DIR)" -name '*.d' -delete 2>/dev/null; \
 	    fi; \
 	fi; \
 	mv -f "$(SRC_MANIFEST).new" "$(SRC_MANIFEST)"

--- a/Makefile
+++ b/Makefile
@@ -760,7 +760,9 @@ $(AUTOHYDRATE_STAMPS):
 validate-deps:
 	$(V1) mkdir -p "$(TARGET_OBJ_DIR)"; \
 	printf '%s\n' $(SRC) | sort > "$(SRC_MANIFEST).new"; \
-	if [ -f "$(SRC_MANIFEST)" ] && ! cmp -s "$(SRC_MANIFEST)" "$(SRC_MANIFEST).new"; then \
+	if [ ! -f "$(SRC_MANIFEST)" ]; then \
+	    find "$(TARGET_OBJ_DIR)" -name '*.d' -delete 2>/dev/null; \
+	elif ! cmp -s "$(SRC_MANIFEST)" "$(SRC_MANIFEST).new"; then \
 	    if comm -23 "$(SRC_MANIFEST)" "$(SRC_MANIFEST).new" | grep -q .; then \
 	        echo "Sources removed — clearing stale dependency files"; \
 	        find "$(TARGET_OBJ_DIR)" -name '*.d' -delete 2>/dev/null; \


### PR DESCRIPTION
AI Generated pull-request

## Summary

`validate-deps` wrote its source manifest to a single path shared across every target
(`obj/main/.src_manifest`). `make -jN all_configs` / `make -jN all` build many targets via
independent recursive `$(MAKE)` sub-processes (`mk/config.mk:119`), and every one of them runs
`validate-deps` against that same shared file — concurrent processes race on the temp-file-then-`mv`
at the end of the recipe.

**Before** (running `make -j48 -k all_configs` on a 48-core machine):
```
mv: cannot stat './obj/main/.src_manifest.new': No such file or directory
make[2]: *** [Makefile:757: validate-deps] Error 1
make[2]: Target 'hex' not remade because of errors.
make[1]: *** [Makefile:793: fwo] Error 2
make: *** [mk/config.mk:119: BLADE_F7] Error 2
```
The specific failing target is arbitrary — whichever process lost the race that run; re-running
with different `-j` values or target subsets fails a different target each time, which is itself
evidence this is a race rather than a per-target defect.

**After** (same command, same machine): no manifest-related failures. 30 randomly-selected config
targets built concurrently under `-j10` locally (16 fully linked before the verification run was
time-boxed; zero manifest-race errors across the full log) and the reporter's original 48-core
`all_configs` run no longer hits this failure mode.

Moved `SRC_MANIFEST` under `TARGET_OBJ_DIR`, matching the existing convention for per-target
artifacts with a *fixed* (non-target-embedded) filename — the same bucket `TARGET_OBJS`/
`TARGET_DEPS`/`TARGET_EF_HASH_FILE` already live in, as opposed to artifacts like `TARGET_ELF`
whose *filename itself* embeds `$(TARGET_NAME)` and can safely share the flat `OBJECT_DIR`.

**Second bug fixed in the same recipe**: the "clear stale `.d` files on source removal" step
recursively removed every `.d` file under the entire shared object tree via a `find` call, not
just the building target's own subdirectory — a source-removal event on one concurrently-building
target would have wiped every *other* target's dependency files too. Rescoped that cleanup step to
`TARGET_OBJ_DIR` alongside the manifest fix, since it's the same underlying shared-directory
mistake.

Bonus: `make TARGET=X clean` already recursively removes `TARGET_OBJ_DIR` — the manifest now gets
cleaned up by a normal single-target clean too, which it never did living outside any per-target
directory.

## Test plan

- [x] `make TARGET=STM32F405 -j10` — single-target sanity build, unaffected by the relocation
- [x] 30 randomly-selected config targets (`shuf` sample of the 626-entry `BASE_CONFIGS` list)
      built in one `make -j10 -k <targets>` invocation — 16 fully linked before time-boxing the
      run (expected on 10 cores for 30 from-scratch full builds), zero `cannot stat`/
      `validate-deps`/`Error` occurrences anywhere in the ~11,000-line combined log
- [x] `make clean_test && make test` — 67/67 test binaries PASS, 0 FAIL
- [x] Confirmed via `git diff --stat` this touches only `Makefile` (2 hunks, +7/-3 lines), no other
      file — this is a from-`master` branch, unrelated to any other in-flight work
- [x] **Full-scale confirmation on the original reporting machine**: the exact command that
      originally hit the race, `time nice make -j48 -k all_configs`, run to completion on the
      48-core server — `36m0s` wall , `613` `.hex` files produced,
      zero manifest-race failures anywhere in the run

## Follow-up — explicitly out of scope for this PR

Output from concurrent target builds interleaves under `-jN` (each per-target sub-`make` writes
`%% file.c`-style progress lines to the same stdout with nothing serializing them — confirmed zero
`--output-sync`/`-O` anywhere in `Makefile` or CI workflows). Not a correctness issue, just a
readability one; not addressed here. If pursued: GNU Make's `--output-sync=recurse` is the
applicable mode for this codebase's structure specifically (not `target`/`line` — the per-target
build here is a genuine recursive `$(MAKE)` call via `mk/config.mk:119`, and only `recurse` groups
a full nested make's output). Expect an ergonomics side-effect worth flagging to whoever picks this
up: output for a target only flushes once its entire recursive build finishes, so with `-k` running
many targets in parallel there can be long stretches of apparent silence followed by large delayed
per-target dumps in completion order rather than submission order — not a hang.

CI and default thread counts are intentionally untouched by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency validation now keeps source manifests and related files in the appropriate target-specific build directory.
  * Improved dependency comparison, updating, and cleanup behavior for target-specific builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
