### PR TITLE
build: support platform-specific ELF linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,10 @@ READELF      = $(ARM_SDK_PREFIX)readelf
 SIZE         = $(ARM_SDK_PREFIX)size
 DFUSE-PACK  := src/utils/dfuse-pack.py
 
+# Command used to link the final ELF. Platform makefiles can override this
+# when linking requires a dedicated linker instead of the C compiler driver.
+ELF_LINK_CMD = $(CROSS_CC) -o $@ $(filter-out %.ld,$^) $(LD_FLAGS)
+
 # Preprocessor helpers (generic .h parsing)
 include $(MAKE_SCRIPT_DIR)/preprocess.mk
 
@@ -564,7 +568,7 @@ endif
 
 $(TARGET_ELF): $(TARGET_OBJS) $(LD_SCRIPT) $(LD_SCRIPTS)
 	@echo "Linking $(TARGET_NAME)" "$(STDOUT)"
-	$(V1) $(CROSS_CC) -o $@ $(filter-out %.ld,$^) $(LD_FLAGS)
+	$(V1) $(ELF_LINK_CMD)
 	$(V1) $(SIZE) $(TARGET_ELF)
 
 $(TARGET_UF2): $(TARGET_ELF)
@@ -780,11 +784,17 @@ uf2: $(PLATFORM_SDK_STAMP) $(AUTOHYDRATE_STAMPS) validate-deps
 exe: $(AUTOHYDRATE_STAMPS) validate-deps
 	$(V1) $(MAKE) $(MAKE_PARALLEL) $(TARGET_EXE)
 
+.PHONY: elf
+elf: $(PLATFORM_SDK_STAMP) $(AUTOHYDRATE_STAMPS) validate-deps
+	$(V1) $(MAKE) $(MAKE_PARALLEL) $(TARGET_ELF)
+
 # FWO (Firmware Output) is the default output for building the firmware
 .PHONY: fwo
 fwo:
 ifeq ($(DEFAULT_OUTPUT),exe)
 	$(V1) $(MAKE) exe
+else ifeq ($(DEFAULT_OUTPUT),elf)
+	$(V1) $(MAKE) elf
 else ifeq ($(DEFAULT_OUTPUT),uf2)
 	$(V1) $(MAKE) uf2
 else ifeq ($(DEFAULT_OUTPUT),bin)


### PR DESCRIPTION
 ## Summary

  Allow platform makefiles to customize ELF linking and select the linked ELF as their final firmware output.

  This change:

  - Introduces `ELF_LINK_CMD`, whose default value is identical to the existing inline link command.
  - Adds a public `elf` build target.
  - Allows platforms to select it with `DEFAULT_OUTPUT := elf`.

  A platform that requires a dedicated linker can now configure:

```make
  ELF_LINK_CMD = platform-linker $(LD_FLAGS) -o $@ $(TARGET_OBJS)
  DEFAULT_OUTPUT := elf
```

  without adding platform-specific conditions to the top-level Makefile.

  ## Motivation

  Some platforms use a dedicated linker rather than the compiler driver and deploy the resulting ELF directly. Previously, supporting such a platform required
  modifying the top-level link recipe and generating a dummy converted artifact to satisfy the default firmware-output path.

  These extension points allow that build configuration to remain entirely within the platform directory, consistent with the goal of adding new platforms
  without platform-specific top-level build logic.

  ## Compatibility

  Existing platforms retain the same link command and firmware-output selection:

  - ELF_LINK_CMD defaults to the command previously embedded directly in the ELF rule.
  - The existing hex, bin, uf2, and exe output paths are unchanged.
  - The new behavior is only selected by platforms that explicitly set DEFAULT_OUTPUT := elf or override ELF_LINK_CMD.

  ## Testing

  Validated with a downstream platform (ModalAI HEXAGON for VOXL3) that:

  - Compiles with a non-GCC toolchain.
  - Links through a dedicated ELF linker.
  - Selects ELF as its final firmware output.

  A clean build completed successfully, including the platform-specific link and size steps, and the resulting firmware was deployed and tested on target.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an ELF build target for generating final executable output.
  * Added support for selecting ELF output through the default build dispatcher.

* **Improvements**
  * Enabled platform-specific customization of the ELF linking command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->