### PR TITLE
Build: allow ESC sensor support without DSHOT

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -306,10 +306,6 @@
 #define USE_VTX_RTC6705
 #endif
 
-#ifndef USE_DSHOT
-#undef USE_ESC_SENSOR
-#endif
-
 #ifndef USE_ESC_SENSOR
 #undef USE_ESC_SENSOR_TELEMETRY
 #endif

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -366,7 +366,13 @@
 #define USE_MSP_OVER_TELEMETRY
 
 #define USE_VIRTUAL_CURRENT_METER
+
+// DSHOT builds include ESC sensor support by default. Targets with another
+// telemetry transport may enable USE_ESC_SENSOR explicitly in target.h.
+#ifdef USE_DSHOT
 #define USE_ESC_SENSOR
+#endif
+
 #define USE_SERIAL_4WAY_BLHELI_BOOTLOADER
 #define USE_RCDEVICE
 


### PR DESCRIPTION
## Summary

  Allow targets to enable ESC sensor support without requiring DSHOT.

  This change:

  - Enables `USE_ESC_SENSOR` by default when `USE_DSHOT` is enabled.
  - Allows non-DSHOT targets to enable `USE_ESC_SENSOR` explicitly in `target.h`.
  - Preserves the existing dependency between `USE_ESC_SENSOR_TELEMETRY` and `USE_ESC_SENSOR`.

  ## Motivation

  ESC telemetry is not inherently tied to DSHOT. ModalAI uses it with their custom UART connected ESCs. Perhaps DroneCAN is another possibility.

  Previously, `common_post.h` unconditionally removed `USE_ESC_SENSOR` whenever DSHOT was disabled. This prevented targets using another
  telemetry transport from opting into the shared ESC sensor functionality.

  ## Compatibility

DSHOT targets retain ESC sensor support by default, while targets that explicitly undefine USE_ESC_SENSOR remain unchanged.

  Non-DSHOT targets remain unchanged unless they explicitly define `USE_ESC_SENSOR`. `USE_ESC_SENSOR_TELEMETRY` is still disabled when ESC
  sensor support is not enabled.

  ## Testing

  - The change applies cleanly to the current `master` branch.
  - `git diff --check` passes.
  - Was built and tested for the custom Hexagon platform on ModalAI's branch. (See https://github.com/modalai/betaflight/commits/voxl3-dev for more details)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved ESC sensor configuration across supported targets.
- ESC sensor support is now enabled only when explicitly configured or supported by the selected telemetry transport.
- ESC sensor telemetry remains available only when ESC sensor support is enabled.
- Prevented unrelated DShot settings from unexpectedly enabling or disabling ESC sensor functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->