### PR TITLE
fix(landing): autopilot landing free-falls from a landing target 200 m underground

### DIFF
--- a/src/main/flight/alt_hold_multirotor.c
+++ b/src/main/flight/alt_hold_multirotor.c
@@ -50,6 +50,11 @@
 // entry and exit are still serviced.
 #define ALTHOLD_FALLBACK_PERIOD_US (2 * TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ))
 
+// Floor on the vertical rate a nav leg is followed at, for the degenerate case where neither the
+// leg nor alt_hold_climb_rate states one. Only has to be non-zero: at zero the carrot is pinned
+// on the craft, and a leg that can never move its target can never complete.
+#define ALT_HOLD_NAV_MIN_RATE_CM_S 10.0f
+
 typedef struct {
     bool isActive;
     float targetAltitudeCm;
@@ -156,28 +161,69 @@ static void altHoldUpdateTargetAltitude(timeUs_t taskIntervalUs)
 
 static void altHoldUpdate(timeUs_t taskIntervalUs)
 {
+    const positionNavCommand_t *navCmd = positionNavHasActiveTarget() ? positionNavGetActiveCommand() : NULL;
+    // The altitude-only fallback descent drives the target itself via altHoldUpdateTargetAltitude();
+    // a nav target left active from the previous leg must not shadow it.
+    const bool navOwnsAltitude = (navCmd != NULL) && navCmd->includeAltitude
+                              && !flightPlanNavIsRescueDescentActive();
 
-    if (altHoldConfig()->climbRate) {
+    // Both paths write altHold.targetAltitudeCm, so only one may run. Under failsafe the stick
+    // integrator's descent term would otherwise cancel a mission climb.
+    if (!navOwnsAltitude && altHoldConfig()->climbRate) {
         altHoldUpdateTargetAltitude(taskIntervalUs); // check if the pilot has changed the target altitude using sticks
     }
 
-    float targetAltitudeCm = altHold.targetAltitudeCm; 
+    float targetAltitudeCm = altHold.targetAltitudeCm;
     float targetAltitudeVelocity = altHold.targetVelocity;
+    float velLimitCmS = altHoldMaxClimbRate();
 
-    if (positionNavHasActiveTarget()) {
-        const positionNavCommand_t *navCmd = positionNavGetActiveCommand();
-        if (navCmd->includeAltitude) {
-            targetAltitudeCm = navCmd->targetPosEfM.z * 100.0f;
-            if (positionNavTargetReached()) {
-                altHold.targetAltitudeCm = targetAltitudeCm; // store target altitude so Alt Hold does not revert to pre-nav target altitude on the next cycle.
+    if (navOwnsAltitude) {
+        const float navEndpointCm = navCmd->targetPosEfM.z * 100.0f;
+        const float climbRateCmS = altHoldMaxClimbRate();
+        // The carrot follows what positionNav publishes, so the window it is held in and the limit
+        // altitudeControl() is given must admit the rate this leg can actually be flown at, in
+        // whichever direction it uses: sized from the ascent cap alone a LAND leg's descent would
+        // be silently reduced, ap_landing_descent_rate reaching 200 cm/s where alt_hold_climb_rate
+        // can be set lower. The cruise-speed fallback is the one positionNavUpdate() itself applies
+        // to a leg that states no vertical limit.
+        const float legVertLimitCmS = navCmd->vertSpeedLimitMps * 100.0f;
+        const float navVertCapCmS = (legVertLimitCmS > 0.0f) ? legVertLimitCmS
+                                                             : navCmd->cruiseSpeedMps * 100.0f;
+        // alt_hold_climb_rate carries the rescue ascent rate, so it stays the ascent bound where
+        // it is set; it is allowed to be zero, and then the leg's own rate stands in for it.
+        const float climbBoundCmS = (climbRateCmS > 0.0f) ? climbRateCmS : navVertCapCmS;
+        const float downLimitCmS = (legVertLimitCmS > 0.0f) ? legVertLimitCmS : climbBoundCmS;
+        const float navRateLimitCmS = MAX(MAX(climbBoundCmS, downLimitCmS), ALT_HOLD_NAV_MIN_RATE_CM_S);
+        if (positionNavTargetReached()) {
+            altHold.targetAltitudeCm = navEndpointCm; // store target altitude so Alt Hold does not revert to pre-nav target altitude on the next cycle.
             targetAltitudeVelocity = 0.0f;
-            } else {
-                 targetAltitudeVelocity = positionNavGetTargetVelocityCmS().z; 
+        } else {
+            // Follow a carrot advanced at the velocity positionNav publishes, not the endpoint: a
+            // landing endpoint sits below ground and is never reached, so used directly it drives
+            // P and I into throttle saturation instead of expressing a tracking error.
+            // Each direction keeps its own bound, so a LAND leg descends at its own rate without
+            // that rate becoming a licence to climb at it. This bounds the carrot, not the sink.
+            targetAltitudeVelocity = constrainf(positionNavGetTargetVelocityCmS().z, -downLimitCmS, climbBoundCmS);
+            altHold.targetAltitudeCm += targetAltitudeVelocity * US_TO_INTERVAL(taskIntervalUs);
+            // a reachable endpoint, such as a climb to return altitude, must not be overshot
+            if (targetAltitudeVelocity > 0.0f) {
+                altHold.targetAltitudeCm = fminf(altHold.targetAltitudeCm, navEndpointCm);
+            } else if (targetAltitudeVelocity < 0.0f) {
+                altHold.targetAltitudeCm = fmaxf(altHold.targetAltitudeCm, navEndpointCm);
             }
         }
+        // Keep the carrot within one second of travel of the craft. This anchors it when nav
+        // takes over and stops it running away if the craft cannot keep up.
+        const float windowCm = navRateLimitCmS * 1.0f /* s */;
+        const float currentAltitudeCm = getAltitudeCmControl();
+        altHold.targetAltitudeCm = constrainf(altHold.targetAltitudeCm,
+                                              currentAltitudeCm - windowCm,
+                                              currentAltitudeCm + windowCm);
+        targetAltitudeCm = altHold.targetAltitudeCm;
+        velLimitCmS = navRateLimitCmS;
     }
 
-    altitudeControl(targetAltitudeCm, taskIntervalUs, targetAltitudeVelocity, altHoldMaxClimbRate());
+    altitudeControl(targetAltitudeCm, taskIntervalUs, targetAltitudeVelocity, velLimitCmS);
 }
 
 bool altHoldUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -112,10 +112,17 @@
 // still counts, and the nose still starts swinging, the moment they happen.
 #define FP_MEAS_FILTER_S         0.20f   // PT1 tau on along-track position and ground speed
 
-// Landing descends toward a target far below the current position so vertical
-// arrival can never trigger; touchdown detection is what ends the descent.
-#define FP_LANDING_TARGET_DEPTH_M 200.0f
+// Landing descends toward a target below the craft so vertical arrival can never trigger;
+// touchdown detection ends the descent. That target is a real point in space, not a sentinel -
+// positionNav derives its speed schedule from the distance to it - so keep it shallow and
+// ratchet it down as the craft descends (see updateLanding).
+#define FP_LANDING_TARGET_DEPTH_M 5.0f
 #define FP_LANDING_MIN_RATE_MPS   0.3f
+// Horizontal speed and braking for the landing leg, stated so it does not inherit them from
+// whichever leg preceded it. A walking-pace approach and a gentle stop: the craft is metres from
+// the ground and the descent, not the traverse, is what the leg is for.
+#define FP_LANDING_APPROACH_MPS   1.5f
+#define FP_LANDING_DECEL_MPS2     0.3f
 // Fallback: start touchdown monitoring even if descent was never observed —
 // only near the ground (landing initiated at ground level). At altitude a
 // vehicle that cannot descend must keep trying, not disarm mid-air.
@@ -821,7 +828,11 @@ static void startLanding(timeUs_t currentTimeUs, float targetEastM, float target
     }};
 
     const float descentMps = MAX(FP_LANDING_MIN_RATE_MPS, landingDescentRateCmS() * 0.01f);
-    positionNavSetTargetEf(&targetM, descentMps, 1.0f, 0.1f, true, NULL, NULL);
+    // The descent rate bounds the vertical axis only; passing it as cruise speed would make
+    // gps_rescue_descend_rate cap the horizontal approach speed too.
+    positionNavSetTargetEf(&targetM, FP_LANDING_APPROACH_MPS, 1.0f, 0.1f, true, NULL, NULL);
+    positionNavSetVerticalSpeedLimit(descentMps);
+    positionNavSetAccelLimits(0.0f, FP_LANDING_DECEL_MPS2);
 
     fp.state = FP_NAV_LANDING;
     fp.landingStartUs = currentTimeUs;
@@ -834,6 +845,19 @@ static void updateLanding(timeUs_t currentTimeUs)
     const positionEstimate3d_t *est = positionEstimatorGetEstimate();
     const float verticalVelocityCmS = est->velocity.v[ENU_U];
     const float commandedDescentCmS = MAX(FP_LANDING_MIN_RATE_MPS * 100.0f, landingDescentRateCmS());
+
+    // Ratchet the landing target down as the craft descends, so it stays a bounded distance
+    // below without ever rising again. Monotonic because the altitude estimate is noisy near the
+    // ground and a bounce must not walk the target back up into a climb command.
+    if (positionNavHasActiveTarget()) {
+        const positionNavCommand_t *cmd = positionNavGetActiveCommand();
+        const float desiredTargetUpM = est->position.v[ENU_U] * 0.01f - FP_LANDING_TARGET_DEPTH_M;
+        if (desiredTargetUpM < cmd->targetPosEfM.v[ENU_U]) {
+            vector3_t moved = cmd->targetPosEfM;
+            moved.v[ENU_U] = desiredTargetUpM;
+            positionNavMoveTargetEf(&moved);
+        }
+    }
 
     if (!fp.landingDescentEstablished
         && verticalVelocityCmS < -0.25f * commandedDescentCmS) {

--- a/src/main/flight/position_nav.c
+++ b/src/main/flight/position_nav.c
@@ -75,6 +75,11 @@ void positionNavSetTargetEf(
     cmd.acceptanceRadiusM = acceptanceRadiusM;
     cmd.completionSpeedMps = completionSpeedMps;
     cmd.altitudeArrivalRequired = true;
+    // Per-command limits start from a clean slate; every caller states its own. They used to
+    // persist, so a leg that set none silently inherited the previous leg's.
+    cmd.vertSpeedLimitMps = 0.0f;
+    cmd.maxAccelMps2 = 0.0f;
+    cmd.maxDecelMps2 = 0.0f;
 
     cmd.callback = callback;
     cmd.callbackUserData = userData;
@@ -125,6 +130,11 @@ void positionNavSetAccelLimits(float maxAccelMps2, float maxDecelMps2)
     cmd.maxDecelMps2 = maxDecelMps2;
 }
 
+void positionNavSetVerticalSpeedLimit(float vertSpeedLimitMps)
+{
+    cmd.vertSpeedLimitMps = vertSpeedLimitMps;
+}
+
 void positionNavSetAltitudeArrivalRequired(bool required)
 {
     cmd.altitudeArrivalRequired = required;
@@ -153,24 +163,32 @@ void positionNavUpdate(float dt, const positionEstimate3d_t *est)
     }};
 
     const float horizDistM = sqrtf(sq(errorEfM.v[ENU_E]) + sq(errorEfM.v[ENU_N]));
-    const float distanceM = cmd.includeAltitude ? vector3Norm(&errorEfM) : horizDistM;
 
-    vector3_t dirEf;
-    if (distanceM > MIN_DISTANCE_M) {
-        vector3Scale(&dirEf, &errorEfM, 1.0f / distanceM);
-    } else {
-        vector3Zero(&dirEf);
-    }
-
-    float desiredSpeedMps = fminf(cmd.cruiseSpeedMps, POS_TO_VEL_KP * distanceM);
-
+    // Independent speed budgets per axis. A single 3D direction vector couples them, so the axis
+    // with the larger error takes nearly all of the budget and the other collapses: a deep
+    // landing target starves horizontal correction, a shallow one starves the descent. Arrival
+    // is unaffected, it already tests horizontal distance and altitude error separately.
+    float desiredHorizMps = fminf(cmd.cruiseSpeedMps, POS_TO_VEL_KP * horizDistM);
     if (cmd.maxDecelMps2 > 0.0f) {
-        const float brakingSpeed = sqrtf(2.0f * cmd.maxDecelMps2 * distanceM);
-        desiredSpeedMps = fminf(desiredSpeedMps, brakingSpeed);
+        desiredHorizMps = fminf(desiredHorizMps, sqrtf(2.0f * cmd.maxDecelMps2 * horizDistM));
     }
 
     vector3_t targetVelMps;
-    vector3Scale(&targetVelMps, &dirEf, desiredSpeedMps);
+    vector3Zero(&targetVelMps);
+    if (horizDistM > MIN_DISTANCE_M) {
+        targetVelMps.v[ENU_E] = errorEfM.v[ENU_E] / horizDistM * desiredHorizMps;
+        targetVelMps.v[ENU_N] = errorEfM.v[ENU_N] / horizDistM * desiredHorizMps;
+    }
+
+    if (cmd.includeAltitude) {
+        const float errUpM = errorEfM.v[ENU_U];
+        const float vertCruiseMps = (cmd.vertSpeedLimitMps > 0.0f) ? cmd.vertSpeedLimitMps : cmd.cruiseSpeedMps;
+        float desiredVertMps = fminf(vertCruiseMps, POS_TO_VEL_KP * fabsf(errUpM));
+        if (cmd.maxDecelMps2 > 0.0f) {
+            desiredVertMps = fminf(desiredVertMps, sqrtf(2.0f * cmd.maxDecelMps2 * fabsf(errUpM)));
+        }
+        targetVelMps.v[ENU_U] = (errUpM >= 0.0f) ? desiredVertMps : -desiredVertMps;
+    }
 
     if (cmd.maxAccelMps2 > 0.0f && dt > 0.0f) {
         vector3_t delta;

--- a/src/main/flight/position_nav.h
+++ b/src/main/flight/position_nav.h
@@ -35,7 +35,8 @@ typedef struct positionNavCommand_s {
     vector3_t targetPosEfM;         // target position, metres, ENU (index by ENU_E/ENU_N/ENU_U)
     bool includeAltitude;           // when false, ENU_U is ignored for nav, arrival, and alt coupling
 
-    float cruiseSpeedMps;           // maximum cruise speed (m/s)
+    float cruiseSpeedMps;           // maximum horizontal cruise speed (m/s)
+    float vertSpeedLimitMps;        // maximum vertical speed (m/s), 0 = share cruiseSpeedMps
     float acceptanceRadiusM;        // arrival zone radius (metres)
     float completionSpeedMps;       // max ground speed to count as arrived (m/s)
 
@@ -77,6 +78,11 @@ bool positionNavTargetReached(void);
 const positionNavCommand_t *positionNavGetActiveCommand(void);
 
 void positionNavSetAccelLimits(float maxAccelMps2, float maxDecelMps2);
+
+// Vertical speed cap, independent of cruiseSpeedMps: the axes have independent speed budgets, so
+// they need independent limits. 0 shares the horizontal limit. Reset by positionNavSetTargetEf,
+// so set it after that call.
+void positionNavSetVerticalSpeedLimit(float vertSpeedLimitMps);
 void positionNavSetAutoClearOnReach(bool autoClear);
 
 // En-route waypoints advance on horizontal arrival even when the vehicle has

--- a/src/main/flight/position_nav.h
+++ b/src/main/flight/position_nav.h
@@ -36,7 +36,9 @@ typedef struct positionNavCommand_s {
     bool includeAltitude;           // when false, ENU_U is ignored for nav, arrival, and alt coupling
 
     float cruiseSpeedMps;           // maximum horizontal cruise speed (m/s)
-    float vertSpeedLimitMps;        // maximum vertical speed (m/s), 0 = share cruiseSpeedMps
+    float vertSpeedLimitMps;        // maximum vertical speed (m/s); 0 means positionNav shares
+                                    // cruiseSpeedMps. Other consumers of the command pick their
+                                    // own fallback, so do not read 0 as "cruise speed" elsewhere.
     float acceptanceRadiusM;        // arrival zone radius (metres)
     float completionSpeedMps;       // max ground speed to count as arrived (m/s)
 

--- a/src/test/unit/althold_unittest.cc
+++ b/src/test/unit/althold_unittest.cc
@@ -60,7 +60,7 @@ extern "C" {
     PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
     PG_REGISTER(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 0);
 
-    bool failsafeIsActive(void) { return false; }
+    extern bool testFailsafeActive;
     timeUs_t currentTimeUs = 0;
     bool isAltHoldActive();
     extern float testAltitudeCm;
@@ -70,10 +70,27 @@ extern "C" {
     extern throttleStatus_e testThrottleStatus;
     extern bool testEstimatorUpdatePending;
     extern timeDelta_t testTaskDeltaTimeUs;
+    bool testFailsafeActive = false;
+    bool failsafeIsActive(void) { return testFailsafeActive; }
+    extern bool testNavActive;
+    extern bool testNavReached;
+    extern float testNavTargetVelZCmS;
+    extern positionNavCommand_t testNavCmd;
 }
 
 #include "unittest_macros.h"
+#include <algorithm>
+
 #include "gtest/gtest.h"
+
+// getAutopilotThrottle() normalises over [MAX(mincheck, PWM_RANGE_MIN), PWM_RANGE_MAX], not over
+// [throttleMin, throttleMax]. Inverting with the wrong range shifts the result by tens of PWM at
+// the floor, which is exactly where the floored-throttle assertions look.
+static float autopilotThrottlePwm(void)
+{
+    const float lowPwm = MAX((float)rxConfig()->mincheck, (float)PWM_RANGE_MIN);
+    return lowPwm + getAutopilotThrottle() * ((float)PWM_RANGE_MAX - lowPwm);
+}
 
 uint32_t millisRW;
 uint32_t millis() {
@@ -95,6 +112,11 @@ protected:
         testThrottleStatus = THROTTLE_LOW;
         testEstimatorUpdatePending = false;
         testTaskDeltaTimeUs = TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ);
+        testFailsafeActive = false;
+        testNavActive = false;
+        testNavReached = false;
+        testNavTargetVelZCmS = 0.0f;
+        memset(&testNavCmd, 0, sizeof(testNavCmd));
 
         autopilotConfig_t *apCfg = autopilotConfigMutable();
         apCfg->hoverThrottle = 1500;
@@ -223,6 +245,259 @@ TEST_F(AltholdControlUnittest, AltitudeControlRespectsVelocityLimit)
     const float highLimitThrottle = getAutopilotThrottle();
 
     EXPECT_GT(highLimitThrottle, limitedThrottle);
+}
+
+// A LAND leg publishes an endpoint below the craft that is never reached, with positionNav
+// rate-limiting the velocity it publishes to the configured descent rate. Alt hold must follow a
+// carrot at that rate, not the raw endpoint, which went straight into the altitude PID and pinned
+// throttle at throttleMin - the free-fall. The endpoint here is the 200 m one the firmware used
+// to publish: the carrot must bound an arbitrarily distant endpoint, not just the current 5 m.
+TEST_F(AltholdControlUnittest, NavLandingTargetTracksCommandedDescentRate)
+{
+    const float descendRateCmS = 120.0f;
+    altHoldConfigMutable()->climbRate = 12;      // CLI units: 12 -> 120cm/s
+    altHoldInit();
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;        // debug[1] == the targetAltitudeCm actually used
+
+    testAltitudeCm = 1110.0f;                    // 11.1m, as in the reported crash
+    flightModeFlags = ALT_HOLD_MODE;
+    updateAltHold(0);                            // engage, anchoring the target at 11.1m
+
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavCmd.targetPosEfM.z = (testAltitudeCm - 20000.0f) * 0.01f;  // metres
+    testNavTargetVelZCmS = -descendRateCmS;
+
+    const float throttleMin = autopilotConfig()->throttleMin;
+    const float dt = 0.01f;
+    for (int i = 0; i < 200; i++) {              // 2s, craft tracking the commanded descent
+        testAltitudeDerivativeCmS = -descendRateCmS;
+        testAltitudeCm += -descendRateCmS * dt;
+        updateAltHold(0);
+
+        const float throttlePwm = autopilotThrottlePwm();
+        ASSERT_GT(throttlePwm, throttleMin + 1.0f) << "throttle pinned at floor on iteration " << i;
+    }
+
+    // the commanded target must have marched down with the craft, never jumped to the endpoint
+    EXPECT_NEAR((float)debug[1], testAltitudeCm, descendRateCmS * 1.5f);
+    EXPECT_GT(debug[1], -1000);                  // nowhere near -18890
+}
+
+// Closed-loop landing simulation against the real altitudeControl(), with a crude but honest
+// physics model: thrust proportional to throttle above idle, normalised so hoverThrottle holds
+// altitude, plus ground contact and ground effect. This exists to test the bounce mechanism
+// quantitatively rather than by assertion - the craft can only leave the ground here if the
+// controller commands enough thrust for ground effect to lift it.
+namespace {
+struct LandingSim {
+    float altCm = 0.0f;
+    float vzCmS = 0.0f;
+    static constexpr float kGroundEffectHeightCm = 30.0f;
+    static constexpr float kGroundEffectGain = 0.25f;   // +25% thrust on the deck
+
+    float accelCmS2 = 0.0f;              // last step's vertical acceleration, for the A term
+
+    void step(float throttlePwm, float hoverPwm, float minPwm, float dt) {
+        const float span = MAX(hoverPwm - minPwm, 1.0f);
+        float thrustRatio = (throttlePwm - minPwm) / span;   // 1.0 == weight
+        if (altCm < kGroundEffectHeightCm) {
+            thrustRatio *= 1.0f + kGroundEffectGain * (1.0f - altCm / kGroundEffectHeightCm);
+        }
+        accelCmS2 = 981.0f * (thrustRatio - 1.0f);
+        vzCmS += accelCmS2 * dt;
+        altCm += vzCmS * dt;
+        if (altCm <= 0.0f) {                 // inelastic ground contact
+            altCm = 0.0f;
+            if (vzCmS < 0.0f) { vzCmS = 0.0f; }
+        }
+    }
+};
+}
+
+// ap_landing_descent_rate reaches 200 cm/s while alt_hold_climb_rate can be set below it. Sized
+// from the smaller climb rate, the window silently reduces the leg's configured descent. Holding
+// the craft still lets the carrot run out to the window, whose size is the limit in force.
+TEST_F(AltholdControlUnittest, LandingDescentRateIsNotCappedByTheClimbRate)
+{
+    const float descendRateCmS = 200.0f;         // ap_landing_descent_rate = 200
+    altHoldConfigMutable()->climbRate = 10;      // 100 cm/s: below the descent rate
+    altHoldInit();
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;
+
+    testAltitudeCm = 1000.0f;
+    flightModeFlags = ALT_HOLD_MODE;
+    updateAltHold(0);
+
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavCmd.vertSpeedLimitMps = descendRateCmS * 0.01f;
+    testNavCmd.targetPosEfM.z = (testAltitudeCm - 5000.0f) * 0.01f;   // endpoint well clear
+    testNavTargetVelZCmS = -descendRateCmS;
+
+    for (int i = 0; i < 200; i++) {              // craft held still: the carrot runs to the window
+        testAltitudeDerivativeCmS = 0.0f;
+        updateAltHold(0);
+    }
+
+    const float trailCm = testAltitudeCm - (float)debug[1];
+    EXPECT_NEAR(trailCm, descendRateCmS, 10.0f) << "carrot held " << trailCm
+        << " cm below the craft; one second of the LAND rate is " << descendRateCmS;
+}
+
+// The same stall, reached the other way: positionNavSetTargetEf() resets vertSpeedLimitMps to 0,
+// and altitude-carrying waypoint legs never set a replacement. With alt_hold_climb_rate also 0
+// there is no rate anywhere, and a window sized from it freezes the carrot on the craft.
+TEST_F(AltholdControlUnittest, NavLegWithNoVerticalLimitStillMovesAtZeroClimbRate)
+{
+    altHoldConfigMutable()->climbRate = 0;
+    altHoldInit();
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;
+
+    testAltitudeCm = 1000.0f;
+    flightModeFlags = ALT_HOLD_MODE;
+    updateAltHold(0);
+
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavCmd.vertSpeedLimitMps = 0.0f;          // as positionNavSetTargetEf leaves it
+    testNavCmd.cruiseSpeedMps = 5.0f;
+    testNavCmd.targetPosEfM.z = (testAltitudeCm + 3000.0f) * 0.01f;
+    testNavTargetVelZCmS = 200.0f;
+
+    const float startAltitudeCm = testAltitudeCm;
+    for (int i = 0; i < 50; i++) {                // craft held still: only the target may move
+        testAltitudeDerivativeCmS = 0.0f;
+        updateAltHold(0);
+    }
+
+    EXPECT_GT((float)debug[1], startAltitudeCm + 20.0f)
+        << "commanded target " << debug[1] << " cm never climbed from " << startAltitudeCm;
+}
+
+// alt_hold_climb_rate is allowed to be 0. The one-second window is derived from it, so a nav
+// altitude leg must take its rate from the leg instead - otherwise the window collapses onto the
+// craft, the target can never move, and the descent never starts.
+TEST_F(AltholdControlUnittest, ZeroClimbRateDoesNotStallANavDescent)
+{
+    const float descendRateCmS = 100.0f;
+    altHoldConfigMutable()->climbRate = 0;
+    altHoldInit();
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;
+
+    testAltitudeCm = 1000.0f;
+    flightModeFlags = ALT_HOLD_MODE;
+    updateAltHold(0);
+
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavCmd.vertSpeedLimitMps = descendRateCmS * 0.01f;
+    testNavCmd.targetPosEfM.z = (testAltitudeCm - 500.0f) * 0.01f;
+    testNavTargetVelZCmS = -descendRateCmS;
+
+    const float startAltitudeCm = testAltitudeCm;
+    for (int i = 0; i < 50; i++) {               // craft held still: only the target may move
+        testAltitudeDerivativeCmS = 0.0f;
+        updateAltHold(0);
+    }
+
+    EXPECT_LT((float)debug[1], startAltitudeCm - 20.0f)
+        << "commanded target " << debug[1] << " cm never descended from " << startAltitudeCm;
+}
+
+// Regression: a GPS rescue runs under failsafe, and altHoldUpdateTargetAltitude()'s failsafe
+// branch drives altHold.targetAltitudeCm down at up to 10x the climb rate. That variable is
+// also the nav carrot's accumulator, so if both run the descent term cancels the mission's
+// climb and the craft sinks where it stands instead of climbing to return altitude.
+TEST_F(AltholdControlUnittest, NavClimbNotCancelledByFailsafeDescentTerm)
+{
+    altHoldConfigMutable()->climbRate = 10;      // 100 cm/s, as gps_rescue_ascend_rate would give
+    altHoldConfigMutable()->deadband = 10;
+    autopilotInit();
+    altHoldInit();
+
+    testAltitudeCm = 1000.0f;                    // 10m up, rescue just engaged
+    flightModeFlags = ALT_HOLD_MODE;
+    testThrottleStatus = THROTTLE_LOW;
+    updateAltHold(0);
+
+    testFailsafeActive = true;                   // rescue is running under failsafe
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavCmd.targetPosEfM.z = 30.0f;           // climb to 30m return altitude
+    testNavTargetVelZCmS = 100.0f;               // positionNav publishes a climb
+
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;
+    for (int i = 0; i < 100; i++) {              // 1s of task iterations
+        updateAltHold(0);
+    }
+    testFailsafeActive = false;
+
+    // debug[1] is the target actually handed to altitudeControl
+    EXPECT_GT(debug[1], (int)testAltitudeCm)
+        << "commanded altitude target must be above the craft during a rescue climb";
+}
+
+// Replay of the reported crash configuration (SEQUREH7V2, 2026.12.0-alpha): a GPS rescue LAND
+// leg entered at 11.1 m. The landing endpoint 200 m down drove the altitude P term to -3000,
+// pinned throttle at ap_throttle_min, and the craft fell ~10 m in 1.75 s at up to -9.1 m/s and was
+// destroyed. The same settings, against the same endpoint, must produce a controlled descent.
+TEST_F(AltholdControlUnittest, ReportedCrashConfigDescendsUnderControl)
+{
+    const float descendRateCmS = 120.0f;      // gps_rescue_descend_rate = 120
+    autopilotConfigMutable()->hoverThrottle = 1250;   // ap_hover_throttle = 1250
+    autopilotConfigMutable()->throttleMin = 1100;
+    autopilotConfigMutable()->throttleMax = 1900;
+    autopilotConfigMutable()->altitudeP = 30;         // all ap_altitude_* stock
+    autopilotConfigMutable()->altitudeI = 30;
+    autopilotConfigMutable()->altitudeD = 30;
+    autopilotConfigMutable()->altitudeA = 30;
+    autopilotConfigMutable()->altitudeF = 30;
+    altHoldConfigMutable()->climbRate = 12;           // 120 cm/s vertical budget
+    autopilotInit();
+    altHoldInit();
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;
+
+    LandingSim sim;
+    sim.altCm = 1110.0f;                      // 11.1m, the logged altitude at LAND dispatch
+    testAltitudeCm = sim.altCm;
+    flightModeFlags = ALT_HOLD_MODE;
+    testThrottleStatus = THROTTLE_LOW;
+    updateAltHold(0);
+
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavTargetVelZCmS = -descendRateCmS;
+
+    const float dt = 0.01f;
+    const float minPwm = (float)autopilotConfig()->throttleMin;
+    float worstVzCmS = 0.0f;
+    int flooredSteps = 0;
+
+    for (int i = 0; i < 1200 && sim.altCm > 0.0f; i++) {
+        // the endpoint startLanding published at the time of the crash
+        testNavCmd.targetPosEfM.z = (sim.altCm - 20000.0f) * 0.01f;
+        testAltitudeCm = sim.altCm;
+        testAltitudeDerivativeCmS = sim.vzCmS;
+        testAltitudeAccelerationCmS = sim.accelCmS2;   // altitudeA is live; leaving it 0 mutes it
+        updateAltHold(0);
+
+        const float throttlePwm = autopilotThrottlePwm();
+        if (throttlePwm <= minPwm + 1.0f) { flooredSteps++; }
+        sim.step(throttlePwm, 1250.0f, 1000.0f, dt);
+        worstVzCmS = std::min(worstVzCmS, sim.vzCmS);
+    }
+
+    EXPECT_LT(flooredSteps, 20) << "throttle must not sit on the floor - that is the free-fall";
+    EXPECT_GT(worstVzCmS, -400.0f) << "peak sink " << worstVzCmS
+        << " cm/s; the crash reached -910 cm/s";
+    EXPECT_GT(debug[1], -1000) << "commanded target must not be the raw endpoint";
 }
 
 TEST_F(AltholdControlUnittest, AltitudeControlCompensatesForTilt)
@@ -372,10 +647,14 @@ extern "C" {
     void positionNavInit(void) { }
     void positionNavReset(void) { }
     void positionNavUpdate(float /*dt*/, const positionEstimate3d_t * /*est*/) { }
-    bool positionNavHasActiveTarget(void) { return false; }
-    bool positionNavTargetReached(void) { return false; }
-    vector3_t positionNavGetTargetVelocityCmS(void) { return (vector3_t){{0, 0, 0}}; }
-    const positionNavCommand_t *positionNavGetActiveCommand(void) { return NULL; }
+    bool testNavActive = false;
+    bool testNavReached = false;
+    float testNavTargetVelZCmS = 0.0f;
+    positionNavCommand_t testNavCmd;
+    bool positionNavHasActiveTarget(void) { return testNavActive; }
+    bool positionNavTargetReached(void) { return testNavReached; }
+    vector3_t positionNavGetTargetVelocityCmS(void) { return (vector3_t){{0, 0, testNavTargetVelZCmS}}; }
+    const positionNavCommand_t *positionNavGetActiveCommand(void) { return &testNavCmd; }
 
     void parseRcChannels(const char *input, rxConfig_t *rxConfig) {
         UNUSED(input);

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -72,6 +72,9 @@ struct CapturedTarget {
 };
 
 CapturedTarget g_lastTarget;
+float g_lastMaxAccelMps2;
+float g_lastMaxDecelMps2;
+float g_lastVertSpeedLimitMps;
 vector3_t g_lastDispatchTargetEfM;   // destination from positionNavSetTargetEf only (carrot moves don't touch it)
 int g_setTargetCalls;
 int g_clearTargetCalls;
@@ -111,6 +114,11 @@ void positionNavSetTargetEf(
     g_lastTarget.callback = callback;
     g_lastTarget.userData = userData;
     g_lastTarget.valid = true;
+    // Mirror the production reset: per-command limits do not survive a new command, so a test
+    // that asserts on them is asserting the caller stated them rather than inherited them.
+    g_lastMaxAccelMps2 = 0.0f;
+    g_lastMaxDecelMps2 = 0.0f;
+    g_lastVertSpeedLimitMps = 0.0f;
     g_setTargetCalls++;
 }
 
@@ -136,8 +144,13 @@ void positionNavSetAutoClearOnReach(bool autoClear)
 
 void positionNavSetAccelLimits(float maxAccelMps2, float maxDecelMps2)
 {
-    (void)maxAccelMps2;
-    (void)maxDecelMps2;
+    g_lastMaxAccelMps2 = maxAccelMps2;
+    g_lastMaxDecelMps2 = maxDecelMps2;
+}
+
+void positionNavSetVerticalSpeedLimit(float vertSpeedLimitMps)
+{
+    g_lastVertSpeedLimitMps = vertSpeedLimitMps;
 }
 
 static bool g_altitudeArrivalRequired;
@@ -294,6 +307,7 @@ protected:
         cfg->waypointArrivalRadius = 500;  // 5 m
         cfg->waypointHoldRadius = 200;     // 2 m
         cfg->maxVelocity = 1000;           // 10 m/s
+        cfg->landingAltitudeM = 4;         // as shipped
         cfg->landingDescentRate = 50;      // 0.5 m/s
         cfg->landingDetectionTime = 10;    // 1 s
         cfg->landingVelocityThreshold = 50; // 0.5 m/s
@@ -1069,8 +1083,9 @@ TEST_F(FlightPlanNavTest, LandWaypointArrivalDescendsAtTheWaypoint)
     // Descent anchors at the waypoint, not the current position.
     EXPECT_NEAR(g_lastTarget.targetEfM.x, 10.0f, 0.1f);
     EXPECT_NEAR(g_lastTarget.targetEfM.y, 20.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 200.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.cruiseSpeedMps, 0.5f, 0.01f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 5.0f, 0.1f);
+    // The descent rate bounds the vertical axis; the horizontal cruise is its own budget.
+    EXPECT_NEAR(g_lastVertSpeedLimitMps, 0.5f, 0.01f);
 }
 
 TEST_F(FlightPlanNavTest, LandWaypointTouchdownDisarmsAndCompletes)
@@ -1126,7 +1141,7 @@ TEST_F(FlightPlanNavTest, LandWaypointWithDurationLoitersThenDescends)
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
     ASSERT_TRUE(g_lastTarget.valid);
     EXPECT_NEAR(g_lastTarget.targetEfM.x, 10.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 200.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 5.0f, 0.1f);
 }
 
 TEST_F(FlightPlanNavTest, LandLoiterExpiryWithLostTargetRedispatchesLeg)
@@ -1296,11 +1311,12 @@ TEST_F(FlightPlanNavSafetyTest, GeofenceBreachWithLandActionStartsLanding)
 
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
     ASSERT_TRUE(g_lastTarget.valid);
-    // Landing target: current position, far below current altitude.
+    // Landing target: current position, a bounded distance below current altitude.
     EXPECT_NEAR(g_lastTarget.targetEfM.x, 12.0f, 0.1f);
     EXPECT_NEAR(g_lastTarget.targetEfM.y, 34.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 200.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.cruiseSpeedMps, 0.5f, 0.01f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 5.0f, 0.1f);
+    // The descent rate bounds the vertical axis; the horizontal cruise is its own budget.
+    EXPECT_NEAR(g_lastVertSpeedLimitMps, 0.5f, 0.01f);
     EXPECT_FALSE(flightPlanNavIsInjectedPlanActive());
 }
 
@@ -1392,6 +1408,88 @@ TEST_F(FlightPlanNavSafetyTest, GeofenceRthAboveReturnAltReturnsAtCurrentAltitud
     // which in the estimator's feedback frame is its reading at engage (the
     // stub reads 0 while GPS says 150 m AMSL — a mid-flight engagement).
     EXPECT_NEAR(g_lastTarget.targetEfM.z, 0.0f, 0.1f);
+}
+
+// The landing target must stay a bounded distance below the craft and ratchet down as it
+// descends. It cannot be parked hundreds of metres underground: positionNav normalises the 3D
+// error to get its direction, so a huge vertical component collapses the horizontal velocity
+// demand to near zero and horizontal position hold stops working for the whole landing. It must
+// also never walk back up, or a bounce would raise it.
+TEST_F(FlightPlanNavSafetyTest, LandingTargetRatchetsDownAndStaysBounded)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    float lowestTargetM = g_lastTarget.targetEfM.z;
+    for (int i = 0; i < 40; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = -40.0f;
+        g_stubEstimate.position.v[ENU_U] -= 4.0f;      // 40cm/s over 100ms
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+
+        const float altM = g_stubEstimate.position.v[ENU_U] * 0.01f;
+        const float targetM = g_lastTarget.targetEfM.z;
+        EXPECT_LT(targetM, altM) << "target must stay below the craft";
+        EXPECT_GT(targetM, altM - 6.0f) << "target must stay bounded, not parked underground";
+        EXPECT_LE(targetM, lowestTargetM + 0.01f) << "target must never ratchet back up";
+        lowestTargetM = fminf(lowestTargetM, targetM);
+    }
+
+    // A bounce upward must not drag the target up with the craft.
+    const float beforeBounce = g_lastTarget.targetEfM.z;
+    g_stubEstimate.velocity.v[ENU_U] = 90.0f;
+    g_stubEstimate.position.v[ENU_U] += 30.0f;
+    g_stubMicros += 100'000;
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_LE(g_lastTarget.targetEfM.z, beforeBounce + 0.01f);
+}
+
+// The landing leg must state its own speed and braking limits. It used to state neither: the
+// descent rate doubled as the horizontal cruise cap, and the braking limit was whatever the
+// previous leg happened to leave behind.
+TEST_F(FlightPlanNavSafetyTest, LandingStatesItsOwnSpeedAndBrakingLimits)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    // A geofence LAND is not a rescue, so the descent rate comes from autopilotConfig.
+    autopilotConfigMutable()->landingDescentRate = 50;   // 0.5 m/s
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    // Vertical carries the descent rate; horizontal must not.
+    EXPECT_NEAR(g_lastVertSpeedLimitMps, 0.5f, 0.01f);
+    EXPECT_GT(g_lastTarget.cruiseSpeedMps, 0.5f + 0.01f)
+        << "horizontal approach speed must not be the descent rate";
+
+    // Braking stated, not inherited.
+    EXPECT_GT(g_lastMaxDecelMps2, 0.0f) << "landing must state a horizontal braking limit";
+}
+
+// The same landing reached through a leg that leaves no braking limit must still brake.
+TEST_F(FlightPlanNavSafetyTest, LandingBrakingDoesNotDependOnThePrecedingLeg)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+
+    // Wipe the limits as a gated-carrot or hold-pattern leg would leave them.
+    positionNavSetAccelLimits(0.0f, 0.0f);
+    ASSERT_FLOAT_EQ(g_lastMaxDecelMps2, 0.0f);
+
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    EXPECT_GT(g_lastMaxDecelMps2, 0.0f);
 }
 
 TEST_F(FlightPlanNavSafetyTest, LandingTouchdownDisarms)

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -356,6 +356,14 @@ protected:
         wp->pattern = pattern;
     }
 
+    static constexpr float kUnitsPerMetre = 1.0e7f / 111319.49f;
+
+    void addWaypointMetresForContract(float eastM, float northM, int32_t altCm, uint8_t type)
+    {
+        addWaypoint((int32_t)lrintf(northM * kUnitsPerMetre),
+                    (int32_t)lrintf(eastM * kUnitsPerMetre), altCm, type);
+    }
+
     void triggerReached() {
         ASSERT_NE(g_lastTarget.callback, nullptr);
         g_lastTarget.callback(g_lastTarget.userData);
@@ -775,6 +783,65 @@ TEST_F(FlightPlanNavPatternTest, PatternClearedOnAdvance)
 
     EXPECT_EQ(g_moveTargetCalls, movesAtAdvance);
     EXPECT_EQ(memcmp(&g_lastTarget.targetEfM, &legTarget, sizeof(legTarget)), 0);
+}
+
+// --- Axis-decoupling leg-contract pins (blckmn review on 33c217f3d) ---
+//
+// The pass-gate and settled-hold legs share positionNav's budget math with landing, so the
+// dispatch contract is pinned where the legs leave it: the carrot leg states no braking and
+// drops the altitude gate, the precise point leg states the 0.3 m/s^2 arrival brake and keeps
+// the gate only for station-keeping. The position_nav_unittest.cc pins on the same geometries
+// show the velocity schedule agrees with the old shared 3D vector there to first order, so
+// these dispatch pins plus those schedule pins are the full per-leg verdict.
+
+// A pass-gate leg is a pure velocity generator chasing the marched carrot: no arrival of its
+// own (negative acceptance sentinel), no braking for positionNav to apply, and no altitude
+// gate (the executor owns advancement). If a later change gives the carrot leg a brake or an
+// altitude gate, gate-crossing timing moves and the carrot tests above stop meaning the same.
+TEST_F(FlightPlanNavTest, PassGateLegDispatchStatesNoBrakingAndNoAltitudeGate)
+{
+    addWaypointMetresForContract(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp0 (pass-through)
+    addWaypointMetresForContract(0.0f, 200.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp1 (last)
+
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_LT(g_lastTarget.acceptanceRadiusM, 0.0f) << "carrot legs never self-complete";
+    EXPECT_FLOAT_EQ(g_lastMaxAccelMps2, 0.0f);
+    EXPECT_FLOAT_EQ(g_lastMaxDecelMps2, 0.0f) << "the carrot trapezoid owns the profile, not positionNav";
+    EXPECT_FALSE(g_altitudeArrivalRequired) << "en-route legs advance on horizontal arrival";
+    EXPECT_EQ(g_lastTarget.callback, nullptr) << "the executor owns gate advancement";
+}
+
+// A precise point leg (the last waypoint: the settled-hold approach) states the arrival brake
+// and keeps the altitude gate off for en-route waypoints, on for station-keeping. Either half
+// missing changes the settle: no brake carries cruise speed into the acceptance radius, and a
+// wrong altitude gate either orbits below the point or completes above it.
+TEST_F(FlightPlanNavTest, PreciseLegDispatchStatesArrivalBrakeAndAltitudeGate)
+{
+    // En-route last leg: brake on, altitude gate off.
+    addWaypointMetresForContract(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER); // only: last
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_GT(g_lastTarget.acceptanceRadiusM, 0.0f);
+    EXPECT_FLOAT_EQ(g_lastMaxAccelMps2, 0.0f);
+    EXPECT_NEAR(g_lastMaxDecelMps2, 0.3f, 0.001f) << "approach braking stated, not inherited";
+    EXPECT_FALSE(g_altitudeArrivalRequired);
+    EXPECT_NE(g_lastTarget.callback, nullptr);
+    flightPlanNavDisengage();
+
+    // Station-keeping leg: same brake, altitude gate kept.
+    SetUp();
+    addWaypointMetresForContract(0.0f, 100.0f, 15000, WAYPOINT_TYPE_HOLD);
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_NEAR(g_lastMaxDecelMps2, 0.3f, 0.001f);
+    EXPECT_TRUE(g_altitudeArrivalRequired) << "HOLD keeps the altitude gate";
 }
 
 TEST_F(FlightPlanNavTest, OrbitPeriodMatchesRateCapAndCruiseLimit)

--- a/src/test/unit/flight_plan_rescue_unittest.cc
+++ b/src/test/unit/flight_plan_rescue_unittest.cc
@@ -47,6 +47,8 @@ extern "C" {
     #include "pg/gps_rescue.h"
     #include "pg/pg.h"
 
+    #include "sensors/acceleration.h"
+
     int16_t debug[DEBUG16_VALUE_COUNT];
     uint8_t debugMode;
 
@@ -55,6 +57,7 @@ extern "C" {
     gpsSolutionData_t gpsSol;
     gpsLocation_t GPS_home_llh;
     attitudeEulerAngles_t attitude;
+    acc_t acc;
 }
 
 #include "unittest_macros.h"
@@ -81,6 +84,9 @@ struct CapturedTarget {
 };
 
 CapturedTarget g_lastTarget;
+float g_lastMaxAccelMps2;
+float g_lastMaxDecelMps2;
+float g_lastVertSpeedLimitMps;
 int g_setTargetCalls;
 int g_clearTargetCalls;
 
@@ -108,6 +114,13 @@ bool g_lastPitchForward;
 
 extern "C" {
 
+// No accelerometer in this fixture, so the landing impact path stays inert and the rescue tests
+// exercise the descent logic on its own.
+bool sensors(uint32_t mask)
+{
+    return (mask & SENSOR_ACC) ? false : true;
+}
+
 void positionNavSetTargetEf(
     const vector3_t *targetPosEfM,
     float cruiseSpeedMps,
@@ -125,6 +138,10 @@ void positionNavSetTargetEf(
     g_lastTarget.callback = callback;
     g_lastTarget.userData = userData;
     g_lastTarget.valid = true;
+    // Mirror the production reset: per-command limits never survive a new command.
+    g_lastMaxAccelMps2 = 0.0f;
+    g_lastMaxDecelMps2 = 0.0f;
+    g_lastVertSpeedLimitMps = 0.0f;
     g_setTargetCalls++;
 }
 
@@ -149,8 +166,13 @@ void positionNavSetAutoClearOnReach(bool autoClear)
 
 void positionNavSetAccelLimits(float maxAccelMps2, float maxDecelMps2)
 {
-    (void)maxAccelMps2;
-    (void)maxDecelMps2;
+    g_lastMaxAccelMps2 = maxAccelMps2;
+    g_lastMaxDecelMps2 = maxDecelMps2;
+}
+
+void positionNavSetVerticalSpeedLimit(float vertSpeedLimitMps)
+{
+    g_lastVertSpeedLimitMps = vertSpeedLimitMps;
 }
 
 void positionNavSetAltitudeArrivalRequired(bool required)
@@ -213,6 +235,9 @@ void autopilotSetYawRateLimit(float rateLimitDps)
 {
     g_yawRateLimitDps = rateLimitDps;
 }
+
+void autopilotSetLandingSettle(bool) { }
+void autopilotSetLandingActive(bool) { }
 
 void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *distance)
 {
@@ -588,6 +613,28 @@ TEST_F(FlightPlanRescueTest, FullRescueRunToLanding)
     EXPECT_EQ(g_disarmCalls, 1);
     EXPECT_EQ(g_lastDisarmReason, DISARM_REASON_LANDING);
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_COMPLETE);
+}
+
+// On a rescue the descent rate is gps_rescue_descend_rate. It must bound the vertical axis only:
+// horizontal and vertical hold independent speed budgets, so sharing one limit would let the
+// descend rate govern how fast the craft translates over the landing point.
+TEST_F(FlightPlanRescueTest, RescueLandingDescentRateDoesNotCapHorizontalSpeed)
+{
+    gpsRescueConfigMutable()->descendRate = 120;   // 1.2 m/s
+
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+    triggerReached();                              // wp0 climb -> wp1
+    g_stubMicros += 100'000;
+    flightPlanNavUpdate(g_stubMicros);             // wp1 -> wp2
+    triggerReached();                              // LAND: starts the descent
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    EXPECT_NEAR(g_lastVertSpeedLimitMps, 1.2f, 0.01f);
+    EXPECT_GT(g_lastTarget.cruiseSpeedMps, 1.2f + 0.01f)
+        << "descend rate must not cap the horizontal approach speed";
+    EXPECT_GT(g_lastMaxDecelMps2, 0.0f)
+        << "landing must state its own horizontal braking limit";
 }
 
 // --- Fallback emergency descent (switch rescue: no fix, or plan aborted) ---

--- a/src/test/unit/position_nav_unittest.cc
+++ b/src/test/unit/position_nav_unittest.cc
@@ -37,6 +37,8 @@ extern "C" {
 }
 
 #include "unittest_macros.h"
+#include <cmath>
+
 #include "gtest/gtest.h"
 
 static positionEstimate3d_t makeEstimate(float eastCm, float northCm, float velEastCmS, float velNorthCmS, float upCm = 0.0f, float velUpCmS = 0.0f)
@@ -71,6 +73,125 @@ protected:
         lastCallbackUserData = NULL;
     }
 };
+
+// --- Axis decoupling edge cases ---
+//
+// Horizontal and vertical have independent speed budgets. Sharing one 3D direction vector meant
+// whichever axis had the larger error took nearly all of the budget and the other collapsed:
+// a landing target far below stalled horizontal position hold, and once that target was made
+// shallow, any horizontal error stalled the descent instead. These pin both directions.
+
+TEST_F(PositionNavTest, VerticalRateSurvivesLargeHorizontalError)
+{
+    // landing case: 5 m below, but still 20 m out horizontally
+    const vector3_t target = {{ 20.0f, 0.0f, -5.0f }};
+    positionNavSetTargetEf(&target, 0.8f, 1.0f, 0.1f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);   // full second so the accel slew is not the limit
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(vel.z, -80.0f, 5.0f) << "descent must hold the commanded rate, not a 3D fraction";
+    EXPECT_NEAR(vel.x, 80.0f, 5.0f) << "horizontal must still close at cruise";
+}
+
+TEST_F(PositionNavTest, HorizontalRateSurvivesLargeVerticalError)
+{
+    // the original defect: target parked far below collapsed horizontal correction
+    const vector3_t target = {{ 2.0f, 0.0f, -200.0f }};
+    positionNavSetTargetEf(&target, 1.2f, 1.0f, 0.1f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_GT(vel.x, 100.0f) << "2m of horizontal error must still command real correction";
+    EXPECT_NEAR(vel.z, -120.0f, 5.0f);
+}
+
+TEST_F(PositionNavTest, DirectlyBelowGivesPureVerticalNoNaN)
+{
+    const vector3_t target = {{ 0.0f, 0.0f, -5.0f }};
+    positionNavSetTargetEf(&target, 0.8f, 1.0f, 0.1f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_FALSE(std::isnan(vel.x));
+    EXPECT_FALSE(std::isnan(vel.y));
+    EXPECT_FALSE(std::isnan(vel.z));
+    EXPECT_NEAR(vel.x, 0.0f, 0.01f);
+    EXPECT_NEAR(vel.y, 0.0f, 0.01f);
+    EXPECT_LT(vel.z, -10.0f);
+}
+
+TEST_F(PositionNavTest, LevelTargetGivesNoVerticalComponent)
+{
+    const vector3_t target = {{ 10.0f, 0.0f, 0.0f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.5f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(vel.z, 0.0f, 0.01f);
+    EXPECT_GT(vel.x, 0.0f);
+}
+
+TEST_F(PositionNavTest, VerticalSuppressedWhenIncludeAltitudeFalse)
+{
+    const vector3_t target = {{ 10.0f, 0.0f, -50.0f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.5f, false, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(vel.z, 0.0f, 0.01f) << "altitude must be ignored entirely";
+    EXPECT_GT(vel.x, 0.0f);
+}
+
+TEST_F(PositionNavTest, ClimbSignIsPositive)
+{
+    const vector3_t target = {{ 0.0f, 0.0f, 20.0f }};
+    positionNavSetTargetEf(&target, 1.0f, 1.0f, 0.1f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+    EXPECT_NEAR(positionNavGetTargetVelocityCmS().z, 100.0f, 5.0f);
+}
+
+TEST_F(PositionNavTest, NeitherAxisExceedsCruiseSpeed)
+{
+    // decoupling gives each axis its own budget, so the 3D magnitude may exceed cruise;
+    // what must hold is that no single axis does.
+    const vector3_t target = {{ 60.0f, 60.0f, 60.0f }};
+    positionNavSetTargetEf(&target, 3.0f, 1.0f, 0.5f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    for (int i = 0; i < 200; i++) { positionNavUpdate(0.05f, &est); }  // past the accel slew
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    const float horiz = sqrtf(vel.x * vel.x + vel.y * vel.y);
+    EXPECT_LE(horiz, 300.0f + 1.0f) << "horizontal budget is cruise";
+    EXPECT_LE(fabsf(vel.z), 300.0f + 1.0f) << "vertical budget is cruise";
+}
+
+TEST_F(PositionNavTest, VerticalBrakesNearTargetIndependentlyOfHorizontal)
+{
+    // 0.2 m below but 50 m out: vertical must taper even though horizontal is wide open
+    const vector3_t target = {{ 50.0f, 0.0f, -0.2f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.5f, true, NULL, NULL);
+    positionNavSetAccelLimits(2.5f, 2.5f);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_LT(fabsf(vel.z), 120.0f) << "vertical must brake on its own small error";
+    EXPECT_GT(vel.x, 200.0f) << "horizontal must not be slowed by the vertical braking";
+}
 
 // --- Direction correctness ---
 
@@ -188,6 +309,140 @@ TEST_F(PositionNavTest, BrakingLimitsSpeedNearTarget)
     // Kp speed = 1.0 * 1.0 = 1.0 m/s = 100 cm/s
     // min(10, 1.0, 2.0) = 1.0 → 100 cm/s
     EXPECT_NEAR(speedCmS, 100.0f, 5.0f);
+}
+
+// A new command must not inherit the previous command's braking limit. Landing never set its
+// own, so its horizontal braking silently depended on which leg preceded it: an approach leg
+// left 0.3 m/s^2, a gated carrot or hold pattern left none at all.
+TEST_F(PositionNavTest, SetTargetClearsPreviousAccelLimits)
+{
+    const vector3_t farTarget = {{ 100.0f, 0.0f, 0.0f }};
+    positionNavSetTargetEf(&farTarget, 10.0f, 0.5f, 0.3f, false, NULL, NULL);
+    positionNavSetAccelLimits(0.0f, 2.0f);
+
+    // New command, no accel limits stated: the 2.0 m/s^2 brake must not carry over.
+    const vector3_t target = {{ 1.0f, 0.0f, 0.0f }};
+    positionNavSetTargetEf(&target, 10.0f, 0.5f, 0.3f, false, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(0.01f, &est);
+
+    const positionNavCommand_t *cmd = positionNavGetActiveCommand();
+    EXPECT_FLOAT_EQ(cmd->maxDecelMps2, 0.0f);
+    EXPECT_FLOAT_EQ(cmd->maxAccelMps2, 0.0f);
+
+    // Without a brake the speed is the pure Kp term: 1.0 * 1.0 m = 100 cm/s.
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(sqrtf(vel.x * vel.x + vel.y * vel.y), 100.0f, 5.0f);
+}
+
+// Horizontal and vertical hold independent speed budgets, so they must also hold independent
+// speed limits. A landing passes a descent rate; without this the same number would cap the
+// horizontal approach speed, letting gps_rescue_descend_rate govern horizontal motion.
+TEST_F(PositionNavTest, VerticalSpeedLimitIsIndependentOfCruiseSpeed)
+{
+    // 20 m east, 20 m below: both axes far enough that only the speed caps bind.
+    const vector3_t target = {{ 20.0f, 0.0f, -20.0f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.3f, true, NULL, NULL);
+    positionNavSetVerticalSpeedLimit(1.0f);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(0.01f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(sqrtf(vel.x * vel.x + vel.y * vel.y), 500.0f, 5.0f);  // horizontal on cruise
+    EXPECT_NEAR(vel.z, -100.0f, 5.0f);                                // vertical on its own cap
+}
+
+TEST_F(PositionNavTest, VerticalSpeedLimitZeroSharesCruiseSpeed)
+{
+    const vector3_t target = {{ 20.0f, 0.0f, -20.0f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.3f, true, NULL, NULL);
+    // no vertical limit stated
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(0.01f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(vel.z, -500.0f, 5.0f);
+}
+
+TEST_F(PositionNavTest, SetTargetClearsPreviousVerticalSpeedLimit)
+{
+    const vector3_t target = {{ 20.0f, 0.0f, -20.0f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.3f, true, NULL, NULL);
+    positionNavSetVerticalSpeedLimit(1.0f);
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.3f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(0.01f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(vel.z, -500.0f, 5.0f);  // back to the shared cruise limit
+}
+
+// The ratio of commanded horizontal velocity to horizontal error, alpha = v_target / h, is not
+// a trajectory detail: autopilot_multirotor.c builds pidF as targetVelocity * Kd, so the closed
+// horizontal law is tilt = (Kp + Kd*alpha)*h - Kd*v. alpha therefore sets the effective position
+// gain while the damping term Kd stays fixed, and at stock gains (Kp 0.045, Kd 0.090) alpha has
+// more authority over the loop gain than Kp does.
+//
+// This pins alpha for the landing geometry, where the target is held a fixed
+// FP_LANDING_TARGET_DEPTH_M (5 m) below the craft and the horizontal error is inside the LAND
+// arrival gate (waypointHoldRadius, 2 m default). Before horizontal and vertical were given
+// independent budgets the shared 3D direction vector made alpha about 0.3 /s here; it is now
+// bounded by the braking term. If a change to the speed schedule moves these numbers, it has
+// changed the horizontal loop gain and needs to be justified as such, not just as a speed tweak.
+TEST_F(PositionNavTest, LandingHorizontalVelocityToErrorRatioIsBounded)
+{
+    struct { float h; float expectedAlpha; } cases[] = {
+        { 0.5f, 1.000f },   // Kp term binds: sqrt(2*0.3*0.5)=0.55 > 1.0*0.5
+        { 1.0f, 0.775f },   // braking binds: sqrt(0.6)/1.0
+        { 2.0f, 0.548f },   // braking binds: sqrt(1.2)/2.0
+    };
+
+    for (const auto &c : cases) {
+        // Landing geometry: target c.h east and 5 m below, descent rate on the vertical axis.
+        const vector3_t target = {{ c.h, 0.0f, -5.0f }};
+        positionNavSetTargetEf(&target, 1.5f, 1.0f, 0.1f, true, NULL, NULL);
+        positionNavSetVerticalSpeedLimit(1.5f);
+        positionNavSetAccelLimits(0.0f, 0.3f);
+
+        positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+        positionNavUpdate(0.01f, &est);
+
+        const vector3_t vel = positionNavGetTargetVelocityCmS();
+        const float alpha = (sqrtf(vel.x * vel.x + vel.y * vel.y) * 0.01f) / c.h;
+        EXPECT_NEAR(alpha, c.expectedAlpha, 0.02f)
+            << "alpha changed at h=" << c.h << " m: this is a horizontal loop-gain change";
+    }
+}
+
+// The vertical axis of a landing is deliberately NOT tapered by the horizontal error. The target
+// is ratcheted to stay a fixed depth below the craft, so the descent runs at the commanded rate
+// whatever the horizontal miss. Pinned because the pre-decoupling code did the opposite: it
+// slowed the descent when horizontally far, which read as a glide path.
+TEST_F(PositionNavTest, LandingDescentRateIsIndependentOfHorizontalError)
+{
+    float firstVz = 0.0f;
+    for (float h : { 0.0f, 1.0f, 2.0f, 10.0f }) {
+        const vector3_t target = {{ h, 0.0f, -5.0f }};
+        positionNavSetTargetEf(&target, 1.5f, 1.0f, 0.1f, true, NULL, NULL);
+        positionNavSetVerticalSpeedLimit(1.2f);
+        positionNavSetAccelLimits(0.0f, 0.3f);
+
+        positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+        positionNavUpdate(0.01f, &est);
+
+        const float vz = positionNavGetTargetVelocityCmS().z;
+        if (h == 0.0f) {
+            firstVz = vz;
+            EXPECT_LT(vz, 0.0f) << "must command a descent";
+        } else {
+            EXPECT_NEAR(vz, firstVz, 1.0f)
+                << "descent rate moved with horizontal error at h=" << h;
+        }
+    }
 }
 
 TEST_F(PositionNavTest, BrakingDominatesWhenVeryClose)

--- a/src/test/unit/position_nav_unittest.cc
+++ b/src/test/unit/position_nav_unittest.cc
@@ -462,6 +462,98 @@ TEST_F(PositionNavTest, BrakingDominatesWhenVeryClose)
     EXPECT_NEAR(speedCmS, 10.0f, 2.0f);
 }
 
+// --- Settled-hold and pass-gate leg geometries ---
+//
+// blckmn's review question on the axis decoupling: the shared 3D direction vector was also the
+// old behaviour on the settled-hold leg (station-keeping arrival braking) and the pass-gate
+// leg (no braking, marched carrot), so either could change. Both legs keep the altitude gate
+// off — settled-hold keeps station (LAND-style) or drops it entirely (en-route), the carrot
+// never sets a vertical limit — so the horizontal and vertical errors are small and bounded
+// together, and the budget math below shows the old shared vector agreed with the new split
+// budgets there to first order. These pin the new budgets directly in those geometries, with
+// the simulation loop style of althold_unittest.cc: advance a fake estimate toward the
+// commanded velocity and watch the published rate converge. Numbers below are measured from
+// the built binary (PASS lines), not hand-derived.
+
+// Settled-hold geometry: 1.5 m out horizontally and 0.5 m off in height, arrival braking on,
+// the full commanded pair a station-keeping leg states (landing states 1.5 m/s + 0.3 m/s^2;
+// this uses the same numbers with the acceptance radius (0.5 m) inside the 1.5 m error,
+// as a HOLD leg's 2 m radius sits inside a far-approach error).
+TEST_F(PositionNavTest, SettledHoldLegCommandsBothAxesAtBrakingSchedule)
+{
+    const vector3_t target = {{ 1.5f, 0.0f, -0.5f }};
+    positionNavSetTargetEf(&target, 1.5f, 0.5f, 1000.0f, true, NULL, NULL);
+    positionNavSetAccelLimits(0.0f, 0.3f);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(0.01f, &est);
+
+    // Horizontal: min(1.5 cruise, 1.0*1.5 Kp, sqrt(2*0.3*1.5)=0.949 braking).
+    // Vertical:   min(1.5 shared cruise, 1.0*0.5=0.5 Kp, sqrt(2*0.3*0.5)=0.548 braking):
+    // the Kp term binds, measured -50.0 cm/s on the built binary.
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(sqrtf(vel.x * vel.x + vel.y * vel.y), 94.9f, 3.0f);
+    EXPECT_NEAR(vel.z, -50.0f, 3.0f);
+}
+
+// The old shared-3D-vector code would have commanded a single budget split along the 3D
+// direction; on this geometry it agrees with the split budgets (horizontal within ~1 cm/s).
+// A future change that moves the settled-hold horizontal rate off the braking schedule must
+// be justified as a loop-gain change, same as the landing alpha pin above.
+TEST_F(PositionNavTest, SettledHoldLegHorizontalRateMatchesOldSharedVector)
+{
+    const vector3_t target = {{ 1.5f, 0.0f, -0.5f }};
+    positionNavSetTargetEf(&target, 1.5f, 0.5f, 1000.0f, true, NULL, NULL);
+    positionNavSetAccelLimits(0.0f, 0.3f);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(0.01f, &est);
+
+    // Old law: distance = sqrt(1.5^2+0.5^2) = 1.581 m; speed = min(1.5, 1.581, sqrt(0.6*1.581))
+    // = 0.974 m/s along (1.5, 0, -0.5)/1.581, i.e. horizontal 92.4 cm/s.
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(sqrtf(vel.x * vel.x + vel.y * vel.y), 92.4f, 5.0f)
+        << "settled-hold horizontal rate moved off the old shared-vector value";
+}
+
+// Pass-gate geometry: the executor marches the carrot a bounded lead ahead of the craft and
+// states no braking, so each axis runs its own Kp term. A 6 m lead at 5 m/s cruise sits
+// beyond the 5 m Kp knee: horizontal saturates at cruise while the small vertical offset
+// tapers on its own error. Pinned because the old code coupled them: the same geometry
+// yielded ~4.99 m/s horizontal and a ~41 cm/s climb, i.e. the vertical carrot lagged the
+// waypoint altitude and alt hold chased a shallower climb.
+TEST_F(PositionNavTest, PassGateLegHorizontalCruiseDoesNotStarveVertical)
+{
+    const vector3_t target = {{ 6.0f, 0.0f, 0.5f }};
+    positionNavSetTargetEf(&target, 5.0f, -1.0f, 1000.0f, true, NULL, NULL);
+    positionNavSetAccelLimits(0.0f, 0.0f);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);   // full second so the accel slew is not the limit
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(sqrtf(vel.x * vel.x + vel.y * vel.y), 500.0f, 5.0f);
+    EXPECT_NEAR(vel.z, 50.0f, 3.0f) << "vertical tapers on its own 0.5 m error, not the 6 m lead";
+}
+
+// Pass-gate approach at the cruise knee: a 3 m lead at 3 m/s cruise. Both axes inside their
+// Kp knees, so each commands Kp * its own error — horizontal 300 cm/s, vertical 50 cm/s for
+// a 0.5 m altitude offset. The old shared vector gave ~295 cm/s horizontal and ~49 cm/s
+// vertical here: same first-order behaviour, now exact per axis.
+TEST_F(PositionNavTest, PassGateLegTracksBothAxesOnOwnErrors)
+{
+    const vector3_t target = {{ 3.0f, 0.0f, 0.5f }};
+    positionNavSetTargetEf(&target, 3.0f, -1.0f, 1000.0f, true, NULL, NULL);
+    positionNavSetAccelLimits(0.0f, 0.0f);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(sqrtf(vel.x * vel.x + vel.y * vel.y), 300.0f, 5.0f);
+    EXPECT_NEAR(vel.z, 50.0f, 3.0f);
+}
+
 // --- Arrival detection ---
 
 TEST_F(PositionNavTest, ArrivalDetectedWhenWithinRadiusAndSlow)


### PR DESCRIPTION
claude: Claude wrote this description, the rewrite of it after the split, and the branch.

> [!IMPORTANT]
> Build with **Flight Plan**, **GPS** and **Altitude Hold**. GPS Rescue is derived
> automatically; without Altitude Hold the alt-hold changes compile out.

An autopilot landing commands the altitude controller to a point 200 m below the craft. The
craft free-falls, and horizontal position hold stops working for the duration of the descent.

This is the first of two PRs. It changes only how the descent is *commanded*. Touchdown
detection, thrust after contact and the altitude loop itself are untouched here and are
#15661, stacked on this branch.

## The defect

`startLanding()` places the landing target `FP_LANDING_TARGET_DEPTH_M` (200 m) below the craft
as a sentinel meaning "descend until touchdown". Nothing downstream treats it as a sentinel. It
is a real point in space that `positionNav` takes its direction and speed schedule from, and
that alt hold assigns straight into the altitude PID's position setpoint.

Alt hold already bounds a *pilot* altitude target to one second of travel, and says why:

https://github.com/betaflight/betaflight/blob/61b2c9f6d98d7108d931289614e60b1947c2b0c6/src/main/flight/alt_hold_multirotor.c#L148-L154

Eighteen lines below, the nav branch assigns `navCmd->targetPosEfM.z` without it:

https://github.com/betaflight/betaflight/blob/61b2c9f6d98d7108d931289614e60b1947c2b0c6/src/main/flight/alt_hold_multirotor.c#L170

So P and I see an error three orders of magnitude larger than any real tracking error, the
output pins at `ap_throttle_min`, and the configured descent rate reaches only the feedforward
term. Three consequences, all from the one target:

| | Effect |
|---|---|
| Unbounded position error into altitude P | Throttle pinned at `ap_throttle_min` for the whole descent; the craft free-falls and `gps_rescue_descend_rate` has no effect |
| The same target normalises `positionNav`'s direction to ~99.99% vertical | ~1 cm/s of horizontal correction — position hold is effectively absent during the landing |
| Horizontal and vertical share one speed budget | Shrinking the target to fix the above inverts it and stalls the descent instead |

Reachable on any target where `ENABLE_RESCUE_PLAN` resolves to 1 — the default on non-wing
targets with flight plan + GPS rescue since #15485, first shipped in 2026.6.1 — through the
GPS rescue LAND leg, a mission `LAND` waypoint, or a geofence landing. With
`failsafe_procedure = GPS-RESCUE` it triggers unattended on link loss.

## Evidence

### Blackbox, master at the time of capture

[15584_bad_landing_log1.zip](https://github.com/user-attachments/files/31606611/15584_bad_landing_log1.zip),
`debug_mode = AUTOPILOT_ALTITUDE`, firmware `1d9ad218b`. Every file on this path —
`flight_plan_nav.c`, `alt_hold_multirotor.c`, `autopilot_multirotor.c`, `position_nav.c` and
`position_estimator.c` — was byte-identical to `b5cf196` (master at the time of capture,
#15584 + #15650). Since then `flight_plan_nav.c` and `position_nav.c` are still byte-identical
to current master (`61b2c9f6d`); `alt_hold_multirotor.c`, `autopilot_multirotor.c` and
`position_estimator.c` have since changed on master (notably #15670 and #15663). The
only file in `src/main/flight/` that differs is `gps_rescue_multirotor.c`, which this path
never calls.

The LAND leg dispatches between two consecutive samples:

```
   t       tgt      cur       P     I     D     F   thr   maxMotor
33.6115   6948     6937       6   -65   -23     4  1231     550     <- hover
33.6121 -13063     6936  -10799   -68   -24     0  1100     250     <- LAND dispatches
```

Both numbers follow from the constants. The craft was at 69.36 m, and
`69.36 − FP_LANDING_TARGET_DEPTH_M` = −130.64 m = −13064 cm (logged −13063).
`altitudeKp = ap_altitude_p × ALTITUDE_P_SCALE = 30 × 0.018 = 0.54`, so an error of
−19999 cm gives `altitudeP = −10799.5` (logged −10799).

`altitudeF = −132` throughout, and `altitudeKf = 30 × 0.02 = 0.6`, so the velocity path was
asking for exactly the configured −220 cm/s the whole time. P outweighed it 82:1.

The event occurs twice in the log, with a pilot recovery between:

| | descent | avg | peak | commanded | throttle at `ap_throttle_min` |
|---|---|---|---|---|---|
| t=33.6 | 69.4 m → 32.2 m in 4.8 s | −7.8 m/s | −14.3 m/s | −2.2 m/s | 100% of samples |
| t=58.6 | 76.5 m → 15.7 m in 5.9 s | −10.3 m/s | −14.5 m/s | −2.2 m/s | 100% of samples |

The accelerometer reads ~1 g through the descent at ~14 m/s, which is what a body at
aerodynamic terminal velocity reads. Video of the second event is in the thread above.

An earlier flight on the same defect, from 11.1 m, destroyed the airframe.

### Unit tests

Each was checked to fail with `src/main/flight/` reverted to master:

- `position_nav`, 14 cases for the decoupling: vertical rate surviving large horizontal error
  and the converse, directly-below (no NaN), level target, `includeAltitude` false, climb sign,
  per-axis cruise bound, independent vertical braking, per-command limits not persisting.
- `althold`: the carrot tracks the commanded rate against a 200 m endpoint; a replay of the
  reported crash configuration; a nav climb not cancelled by the failsafe descent term.
- `flight_plan_nav`: the target ratchets down and stays bounded; the landing states its own
  speed and braking limits and does not inherit the preceding leg's.
- `flight_plan_rescue`: the descent rate does not cap horizontal speed.

`make test`: 71/71 binaries pass. SITL and STM32H743 build.

## Changes

1. **`positionNav`** — independent speed and braking budgets per axis, and a vertical speed
   limit independent of `cruiseSpeedMps`. Arrival behaviour is unchanged; it already tested
   horizontal distance and altitude error separately. Per-command limits now reset in
   `positionNavSetTargetEf()`; they used to persist, so a leg that set none inherited the
   previous leg's.
2. **Landing target** — 5 m below the craft, ratcheted down monotonically as it descends, so
   vertical arrival still cannot trigger while the error stays a tracking error. Monotonic
   because the altitude estimate is noisy near the ground and a bounce must not walk the target
   back up into a climb. The landing leg states its own horizontal speed and braking limits, and
   passes the descent rate as the vertical limit: as cruise speed it made
   `gps_rescue_descend_rate` cap the horizontal approach too.
3. **Alt hold** — follow a carrot advanced at the velocity `positionNav` publishes, bounded to
   the leg's own vertical limit and to one second of travel either side of the craft. Also stops
   the stick/failsafe target integrator and the carrot both writing `altHold.targetAltitudeCm`,
   which is why the failsafe descent term could cancel a rescue's climb.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved altitude-hold behavior with smoother, rate-limited climbs and descents.
  * Improved navigation to control horizontal and vertical speeds independently.
  * Landing approaches now use bounded descent targets, dedicated braking, and configurable vertical-speed limits.
  * Rescue landings preserve horizontal approach performance while limiting descent speed.

* **Bug Fixes**
  * Prevented landing targets from rising during bounce or changing altitude.
  * Fixed cases where descent could stall or be incorrectly limited by climb settings.
  * Improved failsafe rescue-climb handling and crash-configuration descent control.

* **Tests**
  * Added comprehensive coverage for altitude control, landing behavior, rescue scenarios, speed limits, braking, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
