### PR TITLE
Bug fix velocity in gps rescue

### DIFF
--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -757,7 +757,14 @@ bool positionControl(void)
             ap.iPolicy = I_FREEZE;   // retain the integral, do not wind it up while manoeuvring
         } else {
             // No stick input
-            if (!FLIGHT_MODE(GPS_RESCUE_MODE)){
+            if (!FLIGHT_MODE(GPS_RESCUE_MODE)) {
+                // If in GPS Rescue, we have both velocity and acceleration
+                // otherwise hold position at zero velocity and acceleration
+                targetVelocity.v[EF_EAST]  = 0.0f;
+                targetVelocity.v[EF_NORTH] = 0.0f;
+                targetAcceleration.v[EF_EAST]  = 0.0f;
+                targetAcceleration.v[EF_NORTH] = 0.0f;
+            }
             // If in GPS Recue, we have both velocity and acceleration
             // otherwise hold position at zero velocity and acceleration
             targetVelocity.v[EF_EAST]  = 0.0f;

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -757,14 +757,19 @@ bool positionControl(void)
             ap.iPolicy = I_FREEZE;   // retain the integral, do not wind it up while manoeuvring
         } else {
             // No stick input
+
+#ifdef USE_GPS_RESCUE
             if (!FLIGHT_MODE(GPS_RESCUE_MODE)){
-            // If in GPS Recue, we have both velocity and acceleration
+#endif
+            // If in GPS Rescue, we have both velocity and acceleration
             // otherwise hold position at zero velocity and acceleration
             targetVelocity.v[EF_EAST]  = 0.0f;
             targetVelocity.v[EF_NORTH] = 0.0f;
             targetAcceleration.v[EF_EAST]  = 0.0f;
             targetAcceleration.v[EF_NORTH] = 0.0f;
+#ifdef USE_GPS_RESCUE
             }
+#endif
             if (ap.wasSticksActive) {
                 // Sticks just released: capture the current point and decide
                 // whether to brake, based on the speed being carried.

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -756,11 +756,15 @@ bool positionControl(void)
             ap.anchor = ANCHOR_OFF;  // fly the commanded velocity via the virtual distance error
             ap.iPolicy = I_FREEZE;   // retain the integral, do not wind it up while manoeuvring
         } else {
-            // No stick input: commanded velocity and its feedforward are zero.
+            // No stick input
+            if (!FLIGHT_MODE(GPS_RESCUE_MODE)){
+            // If in GPS Recue, we have both velocity and acceleration
+            // otherwise hold position at zero velocity and acceleration
             targetVelocity.v[EF_EAST]  = 0.0f;
             targetVelocity.v[EF_NORTH] = 0.0f;
             targetAcceleration.v[EF_EAST]  = 0.0f;
             targetAcceleration.v[EF_NORTH] = 0.0f;
+            }
             if (ap.wasSticksActive) {
                 // Sticks just released: capture the current point and decide
                 // whether to brake, based on the speed being carried.

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -757,16 +757,15 @@ bool positionControl(void)
             ap.iPolicy = I_FREEZE;   // retain the integral, do not wind it up while manoeuvring
         } else {
             // No stick input
-
 #ifdef USE_GPS_RESCUE
             if (!FLIGHT_MODE(GPS_RESCUE_MODE)){
 #endif
-            // If in GPS Rescue, we have both velocity and acceleration
-            // otherwise hold position at zero velocity and acceleration
-            targetVelocity.v[EF_EAST]  = 0.0f;
-            targetVelocity.v[EF_NORTH] = 0.0f;
-            targetAcceleration.v[EF_EAST]  = 0.0f;
-            targetAcceleration.v[EF_NORTH] = 0.0f;
+                // If in GPS Rescue, we have both velocity and acceleration
+                // otherwise hold position at zero velocity and acceleration
+                targetVelocity.v[EF_EAST]  = 0.0f;
+                targetVelocity.v[EF_NORTH] = 0.0f;
+                targetAcceleration.v[EF_EAST]  = 0.0f;
+                targetAcceleration.v[EF_NORTH] = 0.0f;
 #ifdef USE_GPS_RESCUE
             }
 #endif

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -153,14 +153,11 @@ void gpsRescueInit(void)
     rescueState.isAvailable = true;
     rescueState.sensor.isHeadingOK = true;
     rescueState.isOK = true;
-    rescueState.positionHoldWasActive = false; // tracks whether positionHold is active before starting GPS Rescue
 }
 
 #if !ENABLE_RESCUE_PLAN
 static void rescueStart(void)
 {
-    initPositionHold(); // initialise position hold at current location
-
     rescueState.phase = RESCUE_INITIALIZE;
 }
 
@@ -307,13 +304,6 @@ bool oneSecondPassed(timeUs_t currentTimeUs, timeUs_t *lastTimeUs) {
     }
     return false;
 }
-
-#ifdef USE_POSITION_HOLD
-void gpsRescueCapturePositionHoldState(void)
-{
-    rescueState.positionHoldWasActive = isAutopilotInControl();
-}
-#endif // USE_POSITION_HOLD
 
 static void rescueDisarmNow(void)
 {
@@ -563,11 +553,6 @@ void initRescueValues(void)
     rescueState.intent.xyAttenuator = 0.0f;        // For a slower start to gaining velocity
 
     resetAltitudeControl(); // Initialise altitude in autopilot multirotor
-#ifdef USE_POSITION_HOLD
-    if (rescueState.positionHoldWasActive) {
-        initPositionHold(); // if already active, init positionHold to ensure that the braking is performed when GPS Rescue starts and positionHold is already active.
-    }
-#endif // USE_POSITION_HOLD
 }
 #endif // !ENABLE_RESCUE_PLAN
 
@@ -596,10 +581,6 @@ void gpsRescueUpdate(void) // called from core.c at TASK_GPS_RESCUE_RATE_HZ
     switch (rescueState.phase) {
     case RESCUE_IDLE:
         updateMaxAltitude();
-#ifdef USE_POSITION_HOLD
-        gpsRescueCapturePositionHoldState();
-#endif // USE_POSITION_HOLD
-         
         break;
 
     case RESCUE_INITIALIZE:
@@ -610,7 +591,7 @@ void gpsRescueUpdate(void) // called from core.c at TASK_GPS_RESCUE_RATE_HZ
             if (rescueState.sensor.distanceToHomeCm < GPS_RESCUE_ACCEPT_RADIUS && isBelowLandingAltitude()) {
                 rescueState.phase = RESCUE_DO_NOTHING;
             } else {
-                initRescueValues(); // fix the target location
+                initRescueValues(); // configure the descent distances and return altitudes
                 returnAltitudeLow = rescueState.sensor.currentAltitudeCm < rescueState.intent.returnAltitudeCm;
                 rescueState.phase = RESCUE_ATTAIN_ALT;
             }

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -554,7 +554,10 @@ void initRescueValues(void)
     rescueState.intent.xyAttenuator = 0.0f;        // For a slower start to gaining velocity
 
     resetAltitudeControl(); // Initialise altitude in autopilot multirotor
-initPositionHold(); // Initialise position hold at current location 
+    if (isAutopilotInControl()) { // do we need to check if a nav process is active here?
+        initPositionHold(); // Initialise position hold at current location and set braking mode 
+        }
+    }
 }
 #endif // !ENABLE_RESCUE_PLAN
 

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -554,8 +554,7 @@ void initRescueValues(void)
     rescueState.intent.xyAttenuator = 0.0f;        // For a slower start to gaining velocity
 
     resetAltitudeControl(); // Initialise altitude in autopilot multirotor
-    resetPositionControl(TASK_GPS_RESCUE_RATE_HZ); // Initialise position control in autopilot multirotor
-
+initPositionHold(); // Initialise position hold at current location 
 }
 #endif // !ENABLE_RESCUE_PLAN
 

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -43,7 +43,6 @@
 #include "flight/failsafe.h"
 #include "flight/imu.h"
 #include "flight/pid.h"
-#include "flight/pos_hold_multirotor.h"
 #include "flight/position.h"
 #include "flight/position_estimator.h"
 
@@ -123,7 +122,6 @@ typedef struct {
     rescueSensorData_s sensor;
     rescueIntent_s intent;
     bool isAvailable;
-    bool positionHoldWasActive;
     bool isOK;
 } rescueState_s;
 rescueState_s rescueState;

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -123,6 +123,7 @@ typedef struct {
     rescueSensorData_s sensor;
     rescueIntent_s intent;
     bool isAvailable;
+    bool positionHoldWasActive;
     bool isOK;
 } rescueState_s;
 rescueState_s rescueState;
@@ -152,7 +153,7 @@ void gpsRescueInit(void)
     rescueState.isAvailable = true;
     rescueState.sensor.isHeadingOK = true;
     rescueState.isOK = true;
-
+    rescueState.positionHoldWasActive = false; // tracks whether positionHold is active before starting GPS Rescue
 }
 
 #if !ENABLE_RESCUE_PLAN
@@ -306,6 +307,13 @@ bool oneSecondPassed(timeUs_t currentTimeUs, timeUs_t *lastTimeUs) {
     }
     return false;
 }
+
+#ifdef USE_POSITION_HOLD
+void gpsRescueCapturePositionHoldState(void)
+{
+    rescueState.positionHoldWasActive = isAutopilotInControl();
+}
+#endif // USE_POSITION_HOLD
 
 static void rescueDisarmNow(void)
 {
@@ -556,8 +564,8 @@ void initRescueValues(void)
 
     resetAltitudeControl(); // Initialise altitude in autopilot multirotor
 #ifdef USE_POSITION_HOLD
-    if (isAutopilotInControl()) {
-        initPositionHold();
+    if (rescueState.positionHoldWasActive) {
+        initPositionHold(); // if already active, init positionHold to ensure that the braking is performed when GPS Rescue starts and positionHold is already active.
     }
 #endif // USE_POSITION_HOLD
 }
@@ -588,6 +596,10 @@ void gpsRescueUpdate(void) // called from core.c at TASK_GPS_RESCUE_RATE_HZ
     switch (rescueState.phase) {
     case RESCUE_IDLE:
         updateMaxAltitude();
+#ifdef USE_POSITION_HOLD
+        gpsRescueCapturePositionHoldState();
+#endif // USE_POSITION_HOLD
+         
         break;
 
     case RESCUE_INITIALIZE:

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -43,6 +43,7 @@
 #include "flight/failsafe.h"
 #include "flight/imu.h"
 #include "flight/pid.h"
+#include "flight/pos_hold_multirotor.h"
 #include "flight/position.h"
 #include "flight/position_estimator.h"
 

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -555,9 +555,11 @@ void initRescueValues(void)
     rescueState.intent.xyAttenuator = 0.0f;        // For a slower start to gaining velocity
 
     resetAltitudeControl(); // Initialise altitude in autopilot multirotor
-    if (isAutopilotInControl()) { // do we need to check if a nav process is active here?
-        initPositionHold(); // Initialise position hold at current location and set braking mode 
+#ifdef USE_POSITION_HOLD
+    if (isAutopilotInControl()) {
+        initPositionHold();
     }
+#endif // USE_POSITION_HOLD
 }
 #endif // !ENABLE_RESCUE_PLAN
 

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -556,7 +556,6 @@ void initRescueValues(void)
     resetAltitudeControl(); // Initialise altitude in autopilot multirotor
     if (isAutopilotInControl()) { // do we need to check if a nav process is active here?
         initPositionHold(); // Initialise position hold at current location and set braking mode 
-        }
     }
 }
 #endif // !ENABLE_RESCUE_PLAN

--- a/src/main/flight/gps_rescue_multirotor.h
+++ b/src/main/flight/gps_rescue_multirotor.h
@@ -49,6 +49,5 @@ bool gpsRescueIsConfigured(void);
 bool gpsRescueIsAvailable(void);
 bool gpsRescueIsHeadingOK(void);
 bool gpsRescueIsOK(void);
-void gpsRescueCapturePositionHoldState(void);
 
 #endif // !USE_WING

--- a/src/main/flight/gps_rescue_multirotor.h
+++ b/src/main/flight/gps_rescue_multirotor.h
@@ -49,5 +49,6 @@ bool gpsRescueIsConfigured(void);
 bool gpsRescueIsAvailable(void);
 bool gpsRescueIsHeadingOK(void);
 bool gpsRescueIsOK(void);
+void gpsRescueCapturePositionHoldState(void);
 
 #endif // !USE_WING

--- a/src/main/flight/pos_hold_multirotor.c
+++ b/src/main/flight/pos_hold_multirotor.c
@@ -55,7 +55,7 @@ void posHoldInit(void)
 
 static void posHoldCheckSticks(void)
 {
-    if (failsafeIsActive()|| FLIGHT_MODE(GPS_RESCUE_MODE)) {
+    if (failsafeIsActive() || FLIGHT_MODE(GPS_RESCUE_MODE)) {
         setSticksActiveStatus(false);
         return;
     }

--- a/src/main/flight/pos_hold_multirotor.c
+++ b/src/main/flight/pos_hold_multirotor.c
@@ -43,7 +43,6 @@ typedef struct posHoldState_s {
     bool isEnabled;
     bool isControlOk;
     bool areSensorsOk;
-    bool gpsRescueWasActive;
     float deadband;
 } posHoldState_t;
 
@@ -86,10 +85,14 @@ static bool sensorsOk(void)
 }
 
 
-void updatePosHold(timeUs_t currentTimeUs) {
+void updatePosHold(timeUs_t currentTimeUs)
+{
     UNUSED(currentTimeUs);
+
+    static bool gpsRescueWasActive = false;
+
     const bool gpsRescueActive = FLIGHT_MODE(GPS_RESCUE_MODE);
-    const bool gpsRescueStarting = gpsRescueActive && !posHold.gpsRescueWasActive;
+    const bool gpsRescueStarting = gpsRescueActive && !gpsRescueWasActive;
 
     if (gpsRescueStarting && posHold.isEnabled) {
         initPositionHold();
@@ -104,10 +107,10 @@ void updatePosHold(timeUs_t currentTimeUs) {
     } else {
         if (posHold.isEnabled) {
             setSticksActiveStatus(false);
-            posHold.gpsRescueWasActive = gpsRescueActive;
         }
         posHold.isEnabled = false;
     }
+    gpsRescueWasActive = gpsRescueActive;
 
     if (posHold.isEnabled) {
         posHoldCheckSticks();

--- a/src/main/flight/pos_hold_multirotor.c
+++ b/src/main/flight/pos_hold_multirotor.c
@@ -55,7 +55,7 @@ void posHoldInit(void)
 
 static void posHoldCheckSticks(void)
 {
-    if (failsafeIsActive()) {
+    if (failsafeIsActive()|| FLIGHT_MODE(GPS_RESCUE_MODE)) {
         setSticksActiveStatus(false);
         return;
     }

--- a/src/main/flight/pos_hold_multirotor.c
+++ b/src/main/flight/pos_hold_multirotor.c
@@ -32,9 +32,7 @@
 #include "flight/autopilot.h"
 #include "flight/failsafe.h"
 #include "flight/imu.h"
-#include "flight/pos_hold_multirotor.h"
 #include "flight/position.h"
-
 #include "flight/position_estimator.h"
 #include "rx/rx.h"
 

--- a/src/main/flight/pos_hold_multirotor.c
+++ b/src/main/flight/pos_hold_multirotor.c
@@ -43,6 +43,7 @@ typedef struct posHoldState_s {
     bool isEnabled;
     bool isControlOk;
     bool areSensorsOk;
+    bool gpsRescueWasActive;
     float deadband;
 } posHoldState_t;
 
@@ -84,9 +85,17 @@ static bool sensorsOk(void)
     }
 }
 
+
 void updatePosHold(timeUs_t currentTimeUs) {
     UNUSED(currentTimeUs);
-    if (FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(GPS_RESCUE_MODE)) {
+    const bool gpsRescueActive = FLIGHT_MODE(GPS_RESCUE_MODE);
+    const bool gpsRescueStarting = gpsRescueActive && !posHold.gpsRescueWasActive;
+
+    if (gpsRescueStarting && posHold.isEnabled) {
+        initPositionHold();
+    }
+
+    if (FLIGHT_MODE(POS_HOLD_MODE) || gpsRescueActive) {
         if (!posHold.isEnabled) {
             resetPositionControl(POSHOLD_TASK_RATE_HZ);
             posHold.isControlOk = true;
@@ -95,6 +104,7 @@ void updatePosHold(timeUs_t currentTimeUs) {
     } else {
         if (posHold.isEnabled) {
             setSticksActiveStatus(false);
+            posHold.gpsRescueWasActive = gpsRescueActive;
         }
         posHold.isEnabled = false;
     }

--- a/src/main/flight/pos_hold_multirotor.c
+++ b/src/main/flight/pos_hold_multirotor.c
@@ -32,7 +32,9 @@
 #include "flight/autopilot.h"
 #include "flight/failsafe.h"
 #include "flight/imu.h"
+#include "flight/pos_hold_multirotor.h"
 #include "flight/position.h"
+
 #include "flight/position_estimator.h"
 #include "rx/rx.h"
 


### PR DESCRIPTION
 FIxes an issue in legacy  GPS Rescue implementation where the velocity and acceleration information were not used, because positionHold assumed that we were in a fixed hold and they should be zero. 
  This improves velocity control and stops iTerm and P from winding up to deal with the loss of the target velocity, leading to an overshooting of the landing point.
  
  Also raises discussion about duplicate iterations of `initPositionHold` or `resetPositionHold` when GPS Rescue starts, and indeed whenever positionHold starts.
  
  I noticed in some logs that when entering GPS Rescue at speeds exceeding the BRAKING_MODE_THRESHOLD, sometimes, positionHold's braking mode was not activated, leading to an overshoot of the stopping point, and the associated P factor then pushed velocity towards home up a bit too high.  I wasn't sure why this would happen, but noticed that we request the initPositionHold function  both from resetPositionControl in pos_hold_multirotor.c and again within autopilot_multirotor.c should the boolean `ispositionHeld` is false.
  
  Additionally we were sending resetPositionControl from gps_rescue_multirotor when it started, even though the same reset was being sent in pos_hold_multirotor.c in the case when positionHold was not already active, and potentially this meant sending the init function three times during a clean GPS rescue start.
  
  I've made a suggestion to improve the init behaviour but I think more needs to be done there.
  
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPS Rescue behavior by preserving its supplied velocity and acceleration targets when no pilot input is detected.
  * Prevented normal position-hold commands from overriding GPS Rescue control targets.
  * Improved rescue initialization to retain appropriate position-hold state when the autopilot is in control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->