### PR TITLE
build: make DroneCAN a build option, and stop reporting flight plan twice

### DIFF
--- a/src/main/msp/msp_build_info.c
+++ b/src/main/msp/msp_build_info.c
@@ -174,9 +174,6 @@ static const uint16_t buildOptions[] = {
 #ifdef USE_WING
         BUILD_OPTION_WING,
 #endif
-#if ENABLE_FLIGHT_PLAN
-        BUILD_OPTION_FLIGHT_PLAN,
-#endif
 #ifdef USE_BRUSHED
         BUILD_OPTION_BRUSHED,
 #endif

--- a/src/main/msp/msp_build_info.c
+++ b/src/main/msp/msp_build_info.c
@@ -23,8 +23,8 @@
  * WARNING: This is an auto-generated file, please do not edit directly!
  *
  * Generator    : `src/utils/make-build-info.py`
- * Source       : https://build.betaflight.com/api/options/2026.6
- * Input hash   : 7078aa17160739f81692eed6cf885e85
+ * Source       : https://build.betaflight.com/api/options/2026.12
+ * Input hash   : 305e9e75314878377cbadd2550bf4802
  */
 
 #include <stdint.h>
@@ -117,6 +117,9 @@ static const uint16_t buildOptions[] = {
 #ifdef USE_DASHBOARD
         BUILD_OPTION_DASHBOARD,
 #endif
+#ifdef USE_DRONECAN
+        BUILD_OPTION_DRONECAN,
+#endif
 #ifdef USE_EMFAT_TOOLS
         BUILD_OPTION_EMFAT_TOOLS,
 #endif
@@ -176,6 +179,9 @@ static const uint16_t buildOptions[] = {
 #endif
 #ifdef USE_BRUSHED
         BUILD_OPTION_BRUSHED,
+#endif
+#ifdef USE_DRONECAN_ESC
+        BUILD_OPTION_DRONECAN_ESC,
 #endif
 #ifdef USE_DSHOT
         BUILD_OPTION_DSHOT,

--- a/src/main/msp/msp_build_info.h
+++ b/src/main/msp/msp_build_info.h
@@ -23,8 +23,8 @@
  * WARNING: This is an auto-generated file, please do not edit directly!
  *
  * Generator    : `src/utils/make-build-info.py`
- * Source       : https://build.betaflight.com/api/options/2026.6
- * Input hash   : 7078aa17160739f81692eed6cf885e85
+ * Source       : https://build.betaflight.com/api/options/2026.12
+ * Input hash   : 305e9e75314878377cbadd2550bf4802
  */
 
 #pragma once
@@ -61,6 +61,7 @@
 #define BUILD_OPTION_CAMERA_CONTROL             16407
 #define BUILD_OPTION_CHIRP                      16426
 #define BUILD_OPTION_DASHBOARD                  16408
+#define BUILD_OPTION_DRONECAN                   16430
 #define BUILD_OPTION_EMFAT_TOOLS                16409
 #define BUILD_OPTION_ESCSERIAL_SIMONK           16410
 #define BUILD_OPTION_FLIGHT_PLAN                16427
@@ -80,9 +81,9 @@
 #define BUILD_OPTION_SERVOS                     16420
 #define BUILD_OPTION_VTX                        16421
 #define BUILD_OPTION_WING                       16424
-
 // Motor Protocols
 #define BUILD_OPTION_BRUSHED                    8230
+#define BUILD_OPTION_DRONECAN_ESC               8236
 #define BUILD_OPTION_DSHOT                      8231
 #define BUILD_OPTION_MULTISHOT                  8232
 #define BUILD_OPTION_ONESHOT                    8233

--- a/src/main/msp/msp_build_info.h
+++ b/src/main/msp/msp_build_info.h
@@ -81,8 +81,6 @@
 #define BUILD_OPTION_VTX                        16421
 #define BUILD_OPTION_WING                       16424
 
-#define BUILD_OPTION_FLIGHT_PLAN                16427
-
 // Motor Protocols
 #define BUILD_OPTION_BRUSHED                    8230
 #define BUILD_OPTION_DSHOT                      8231

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -961,8 +961,15 @@ extern struct linker_symbol __fontdata_end;
 // `#ifdef USE_DRONECAN`, and leaving it set would advertise a stack that was
 // never compiled. The runtime PG flag (dronecan_enabled) still decides whether
 // the task is started.
+// The ESC protocol is its own build option, and it speaks over the stack, so
+// picking it brings the stack with it.
+#if defined(USE_DRONECAN_ESC) && !defined(USE_DRONECAN)
+#define USE_DRONECAN
+#endif
+
 #if defined(USE_DRONECAN) && !ENABLE_CAN
 #undef USE_DRONECAN
+#undef USE_DRONECAN_ESC
 #endif
 
 #if defined(USE_DRONECAN) && !defined(ENABLE_DRONECAN)
@@ -972,10 +979,12 @@ extern struct linker_symbol __fontdata_end;
 #endif
 
 // DroneCAN ESC: command ESCs over CAN (uavcan.equipment.esc.RawCommand) and
-// ingest their telemetry (uavcan.equipment.esc.Status). Built in wherever the
-// DroneCAN stack is, gated at runtime by selecting the DRONECAN motor protocol.
-#if !defined(ENABLE_DRONECAN_ESC)
-#define ENABLE_DRONECAN_ESC ENABLE_DRONECAN
+// ingest their telemetry (uavcan.equipment.esc.Status), gated at runtime by
+// selecting the DRONECAN motor protocol.
+#if defined(USE_DRONECAN_ESC) && !defined(ENABLE_DRONECAN_ESC)
+#define ENABLE_DRONECAN_ESC 1
+#elif !defined(ENABLE_DRONECAN_ESC)
+#define ENABLE_DRONECAN_ESC 0
 #endif
 
 // DroneCAN dynamic node-ID allocation: the FC acts as the centralised allocator,

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -954,12 +954,21 @@ extern struct linker_symbol __fontdata_end;
 #define ENABLE_CAN 0
 #endif
 
-// DroneCAN piggy-backs on the same hardware gate as the raw CAN driver: the
-// stack is meaningless without a CAN peripheral to drive. Platforms that
-// compile CAN in also compile DroneCAN in by default, with the runtime PG
-// flag (dronecan_enabled) deciding whether the task is actually started.
-#if !defined(ENABLE_DRONECAN)
-#define ENABLE_DRONECAN ENABLE_CAN
+// DroneCAN is picked as a build option, the same way the flight plan is. The
+// stack is meaningless without a CAN peripheral to drive, so the option is
+// dropped rather than honoured on a platform that has none. Dropping it, rather
+// than just ignoring it, keeps the build info honest: it reports on
+// `#ifdef USE_DRONECAN`, and leaving it set would advertise a stack that was
+// never compiled. The runtime PG flag (dronecan_enabled) still decides whether
+// the task is started.
+#if defined(USE_DRONECAN) && !ENABLE_CAN
+#undef USE_DRONECAN
+#endif
+
+#if defined(USE_DRONECAN) && !defined(ENABLE_DRONECAN)
+#define ENABLE_DRONECAN 1
+#elif !defined(ENABLE_DRONECAN)
+#define ENABLE_DRONECAN 0
 #endif
 
 // DroneCAN ESC: command ESCs over CAN (uavcan.equipment.esc.RawCommand) and


### PR DESCRIPTION
DroneCAN was compiled into every H7, G4 and C593 board because `ENABLE_DRONECAN` followed `ENABLE_CAN`, which those platforms turn on for the raw CAN driver. It now follows `USE_DRONECAN`, the same way the flight plan follows `USE_FLIGHT_PLAN`, so it is picked rather than assumed. On an H743 that does not want it: 12016 bytes of flash and 2592 of RAM.

The API serves two options, so `ENABLE_DRONECAN_ESC` gets the same treatment instead of following the stack. Picking the ESC protocol brings the stack with it, since it speaks over it. A platform with no CAN peripheral drops both rather than advertising what it could not compile, which matters because the build info reports on `#ifdef USE_DRONECAN`.

Options read back out of the compiled binaries:

| build | reports |
|---|---|
| H743 | neither |
| H743 `-DUSE_DRONECAN` | DRONECAN |
| H743 `-DUSE_DRONECAN_ESC` | DRONECAN, DRONECAN_ESC |
| F405 `-DUSE_DRONECAN_ESC` | neither |

Regenerated against `api/options/2026.12`, the version this firmware line is on; the file had been left pointing at 2026.6.

Separately, the generated build info carried a hand-added `#if ENABLE_FLIGHT_PLAN` block beside the generated `#ifdef USE_FLIGHT_PLAN` one, plus a duplicate define. Nothing defines `ENABLE_FLIGHT_PLAN` except `USE_FLIGHT_PLAN`, so both always fired and the option went out twice. Measured on SITL over MSP_BUILD_INFO: 7 options with 16427 twice before, 6 with it once after. Regenerating confirmed the removal matches what the generator produces, so the edits are gone rather than waiting to be silently dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent build options for DroneCAN and DroneCAN ESC support.
  * DroneCAN ESC selection now automatically enables DroneCAN.
  * Improved configuration handling when DroneCAN is selected without CAN hardware support.

* **Refactor**
  * Updated build metadata and option tracking for the latest source configuration.
  * Removed the obsolete flight-plan build option entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->