### PR TITLE
PICO: Enable ESC Passthrough and Serial Passthrough.

### DIFF
--- a/src/main/drivers/motor.c
+++ b/src/main/drivers/motor.c
@@ -405,6 +405,26 @@ IO_t motorGetIo(unsigned index)
     return motorDevice.vTable->getMotorIO ? motorDevice.vTable->getMotorIO(index) : IO_NONE;
 }
 
+void motorReleaseIo(unsigned index)
+{
+    if (index < motorDevice.count && motorDevice.vTable->releaseMotorIO) {
+        motorDevice.vTable->releaseMotorIO(index);
+    }
+}
+
+bool motorReinstateIo(unsigned index)
+{
+    if (index >= motorDevice.count) {
+        return false;
+    }
+
+    if (motorDevice.vTable->reinstateMotorIO) {
+        return motorDevice.vTable->reinstateMotorIO(index);
+    }
+
+    return true; // return "ok" if no reinstate function on this device.
+}
+
 /* functions below for empty methods and no active motors */
 void motorPostInitNull(void)
 {
@@ -477,6 +497,8 @@ static const motorVTable_t motorNullVTable = {
     .requestTelemetry = NULL,
     .isMotorIdle = NULL,
     .getMotorIO = NULL,
+    .releaseMotorIO = NULL,
+    .reinstateMotorIO = NULL,
 };
 
 void motorNullDevInit(motorDevice_t *device)

--- a/src/main/drivers/motor.h
+++ b/src/main/drivers/motor.h
@@ -56,6 +56,8 @@ bool motorIsEnabled(void);
 bool motorIsMotorEnabled(unsigned index);
 bool motorIsMotorIdle(unsigned index);
 IO_t motorGetIo(unsigned index);
+void motorReleaseIo(unsigned index);
+bool motorReinstateIo(unsigned index);
 
 timeMs_t motorGetMotorEnableTimeMs(void);
 void motorShutdown(void); // Replaces stopPwmAllMotors

--- a/src/main/drivers/motor_types.h
+++ b/src/main/drivers/motor_types.h
@@ -82,6 +82,8 @@ typedef struct motorVTable_s {
     void (*shutdown)(void);
     bool (*isMotorIdle)(unsigned index);
     IO_t (*getMotorIO)(unsigned index);
+    void (*releaseMotorIO)(unsigned index);
+    bool (*reinstateMotorIO)(unsigned index);
 
     // Digital commands
     void (*requestTelemetry)(unsigned index);

--- a/src/main/io/serial_4way.c
+++ b/src/main/io/serial_4way.c
@@ -110,6 +110,7 @@ inline bool isEscHi(uint8_t selEsc)
 {
     return (IORead(escHardware[selEsc].io) != GPIO_PIN_RESET);
 }
+
 inline bool isEscLo(uint8_t selEsc)
 {
     return (IORead(escHardware[selEsc].io) == GPIO_PIN_RESET);
@@ -144,6 +145,7 @@ uint8_t esc4wayInit(void)
         if (motorIsMotorEnabled(i)) {
             const IO_t io = motorGetIo(i);
             if (io != IO_NONE) {
+                motorReleaseIo(i);
                 escHardware[escIndex].io = io;
                 setEscInput(escIndex);
                 setEscHi(escIndex);
@@ -151,6 +153,7 @@ uint8_t esc4wayInit(void)
             }
         }
     }
+
     escCount = escIndex;
     return escCount;
 }
@@ -162,7 +165,20 @@ void esc4wayRelease(void)
         IOConfigGPIO(escHardware[escCount].io, IOCFG_AF_PP);
         setEscLo(escCount);
     }
-    motorEnable();
+
+    bool ok = true;
+    for (uint8_t i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
+        if (motorIsMotorEnabled(i)) {
+            const IO_t io = motorGetIo(i);
+            if (io != IO_NONE) {
+                ok = motorReinstateIo(i) && ok;
+            }
+        }
+    }
+
+    if (ok) {
+        motorEnable();
+    }
 }
 
 #define SET_DISCONNECTED DeviceInfo.words[0] = 0

--- a/src/platform/PICO/dshot_pico.c
+++ b/src/platform/PICO/dshot_pico.c
@@ -79,12 +79,16 @@ static bool dshot_program_init(PIO pio, uint sm, int offset, uint pin)
     return PICO_OK == pio_sm_init(pio, sm, offset, &config);
 }
 
-
-static void dshotUpdateInit(void)
+static void resetOutgoingPackets(void)
 {
     for (int motorIndex = 0; motorIndex < dshotMotorCount; ++motorIndex) {
         outgoingPacket[motorIndex] = -1;
     }
+}
+    
+static void dshotUpdateInit(void)
+{
+    resetOutgoingPackets();
 }
 
 // Prepare packet for sending on .updateComplete (dshotUpdateComplete)
@@ -247,39 +251,69 @@ static void dshotUpdateComplete(void)
         cucm = 0; cucrts = 0; cucwait = 0; cucother = 0;
     }
 #endif
+
+    resetOutgoingPackets();
+}
+
+static void dshotReleaseMotorIO(unsigned motorIndex)
+{
+    bprintf("dshotReleaseMotorIO %d", motorIndex);
+    // Disable the state machine and reclaim the motor pin for SIO
+    // (so that e.g. the ESC 4-way passthrough can drive them as plain GPIOs)
+    const motorOutput_t *motor = &dshotMotors[motorIndex];
+    if (motor->configured) {
+        pio_sm_set_enabled(motor->pio, motor->pio_sm, false);
+        gpio_init(motor->pinIndex);
+    }
+}
+
+static bool dshotReinstateMotorIO(unsigned motorIndex)
+{
+    bprintf("dshotReinstateMotorIO %d", motorIndex);
+    // Reclaim the motor pins for the PIO and reset the pulls and the state machines.
+    const motorOutput_t *motor = &dshotMotors[motorIndex];
+    bool ok = false;
+    if (motor->configured) {
+        if (useDshotTelemetry) {
+            ok = dshot_program_bidir_init(motor->pio, motor->pio_sm, motor->offset, motor->pinIndex);
+        } else {
+            ok = dshot_program_init(motor->pio, motor->pio_sm, motor->offset, motor->pinIndex);
+        }
+    }
+
+    return ok;
 }
 
 static bool dshotEnableMotors(void)
 {
-    bprintf("pico dshotEnableMotors (useDshotTelemetry = %d)", useDshotTelemetry);
-    // No special processing required
+    // No special processing required    
     return true;
 }
 
 static void dshotDisableMotors(void)
 {
-    bprintf("pico dshotDisableMotors");
     // No special processing required
-    return;
 }
 
 static void dshotShutdown(void)
 {
-    // TODO: implement?
-    bprintf("pico dshotShutdown");
+    // DShot signal is only generated if write to motors happen, which is guarded by "enabled" on motorDevice
+    // Hence there's no special processing required here.
     return;
 }
 
 static bool dshotIsMotorEnabled(unsigned index)
 {
-    return dshotMotors[index].enabled;
+    return dshotMotors[index].configured;
 }
 
-static void dshotPostInit(void)
+static IO_t dshotGetMotorIO(unsigned index)
 {
-    for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < dshotMotorCount; motorIndex++) {
-        dshotMotors[motorIndex].enabled = true;
+    if (index >= (unsigned)dshotMotorCount) {
+        return IO_NONE;
     }
+
+    return dshotMotors[index].io;
 }
 
 static bool dshotIsMotorIdle(unsigned motorIndex)
@@ -292,6 +326,7 @@ static bool dshotIsMotorIdle(unsigned motorIndex)
 
 static void dshotRequestTelemetry(unsigned index)
 {
+    bprintf("dshotRequestTelemetry, usedst=%d, index=%d", useDshotTelemetry, index);
     if (useDshotTelemetry) {
         if (index < dshotMotorCount) {
             dshotMotors[index].protocolControl.requestTelemetry = true;
@@ -300,7 +335,7 @@ static void dshotRequestTelemetry(unsigned index)
 }
 
 static motorVTable_t dshotVTable = {
-    .postInit = dshotPostInit,
+    .postInit = NULL,
     .enable = dshotEnableMotors,
     .disable = dshotDisableMotors,
     .isMotorEnabled = dshotIsMotorEnabled,
@@ -319,6 +354,9 @@ static motorVTable_t dshotVTable = {
     .convertMotorToExternal = dshotConvertToExternal,
     .shutdown = dshotShutdown,
     .isMotorIdle = dshotIsMotorIdle,
+    .getMotorIO = dshotGetMotorIO,
+    .releaseMotorIO = dshotReleaseMotorIO,
+    .reinstateMotorIO = dshotReinstateMotorIO,
     .requestTelemetry = dshotRequestTelemetry,
 };
 
@@ -328,8 +366,8 @@ bool dshotPwmDevInit(motorDevice_t *device, const motorDevConfig_t *motorConfig)
     dbgPinLo(0);
     dbgPinLo(1);
 
-    device->vTable = NULL; // Only set vTable if initialisation is succesful (TODO: check)
-    dshotMotorCount = 0;   // Only set dshotMotorCount ble if initialisation is succesful (TODO: check)
+    device->vTable = NULL; // Only set vTable if initialisation is succesful
+    dshotMotorCount = 0;   // Only set dshotMotorCount if initialisation is succesful
 
     uint8_t motorCountProvisional = device->count;
     if (motorCountProvisional > 4) {
@@ -354,7 +392,8 @@ bool dshotPwmDevInit(motorDevice_t *device, const motorDevConfig_t *motorConfig)
     int pinIndexMin = 48;
     int pinIndexMax = -1;
     for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < motorCountProvisional; motorIndex++) {
-        int pinIndex = DEFIO_TAG_PIN(motorConfig->ioTags[motorIndex]);
+        const unsigned reorderedMotorIndex = motorConfig->motorOutputReordering[motorIndex];
+        int pinIndex = DEFIO_TAG_PIN(motorConfig->ioTags[reorderedMotorIndex]);
         pinIndexMin = pinIndex < pinIndexMin ? pinIndex : pinIndexMin;
         pinIndexMax = pinIndex > pinIndexMax ? pinIndex : pinIndexMax;
     }
@@ -391,9 +430,10 @@ bool dshotPwmDevInit(motorDevice_t *device, const motorDevConfig_t *motorConfig)
 
     for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < motorCountProvisional; motorIndex++) {
         outgoingPacket[motorIndex] = -1;
-        int pinIndex = DEFIO_TAG_PIN(motorConfig->ioTags[motorIndex]);
-        IO_t io = IOGetByTag(motorConfig->ioTags[motorIndex]);
-        bprintf("dshot motor index %d on pin %d",motorIndex, IO_Pin(io));
+        const unsigned reorderedMotorIndex = motorConfig->motorOutputReordering[motorIndex];
+        int pinIndex = DEFIO_TAG_PIN(motorConfig->ioTags[reorderedMotorIndex]);
+        IO_t io = IOGetByTag(motorConfig->ioTags[reorderedMotorIndex]);
+        bprintf("dshot reordered motor index %d (from %d) on pin %d", reorderedMotorIndex, motorIndex, IO_Pin(io));
         if (!IOIsFreeOrPreinit(io)) {
             bprintf("io pin not free");
             return false;
@@ -408,10 +448,8 @@ bool dshotPwmDevInit(motorDevice_t *device, const motorDevConfig_t *motorConfig)
             return false;
         }
 
-        IOInit(io, OWNER_MOTOR, RESOURCE_INDEX(motorIndex));
+        IOInit(io, OWNER_MOTOR, RESOURCE_INDEX(reorderedMotorIndex));
 
-        // TODO: take account of motor reordering,
-        // cf. versions of  pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t motorIndex, uint8_t reorderedMotorIndex, motorProtocolTypes_e pwmProtocolType, uint8_t output)
         dshotMotors[motorIndex].pinIndex = pinIndex;
         dshotMotors[motorIndex].io = io;
         dshotMotors[motorIndex].pio = dshotPio;

--- a/src/platform/PICO/dshot_pico.c
+++ b/src/platform/PICO/dshot_pico.c
@@ -85,7 +85,7 @@ static void resetOutgoingPackets(void)
         outgoingPacket[motorIndex] = -1;
     }
 }
-    
+
 static void dshotUpdateInit(void)
 {
     resetOutgoingPackets();
@@ -286,7 +286,7 @@ static bool dshotReinstateMotorIO(unsigned motorIndex)
 
 static bool dshotEnableMotors(void)
 {
-    // No special processing required    
+    // No special processing required
     return true;
 }
 

--- a/src/platform/PICO/dshot_pico.c
+++ b/src/platform/PICO/dshot_pico.c
@@ -393,7 +393,14 @@ bool dshotPwmDevInit(motorDevice_t *device, const motorDevConfig_t *motorConfig)
     int pinIndexMax = -1;
     for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < motorCountProvisional; motorIndex++) {
         const unsigned reorderedMotorIndex = motorConfig->motorOutputReordering[motorIndex];
-        int pinIndex = DEFIO_TAG_PIN(motorConfig->ioTags[reorderedMotorIndex]);
+        const ioTag_t tag = motorConfig->ioTags[reorderedMotorIndex];
+        const IO_t io = IOGetByTag(tag);
+        if (!tag || !io) {
+            bprintf("Invalid motor tag %d from reordered index %d (original index %d)",
+                    tag, reorderedMotorIndex, motorIndex);
+            return false;
+        }
+        int pinIndex = DEFIO_TAG_PIN(tag);
         pinIndexMin = pinIndex < pinIndexMin ? pinIndex : pinIndexMin;
         pinIndexMax = pinIndex > pinIndexMax ? pinIndex : pinIndexMax;
     }

--- a/src/platform/PICO/dshot_pico.h
+++ b/src/platform/PICO/dshot_pico.h
@@ -45,7 +45,6 @@ typedef struct motorOutput_s {
     int pinIndex;            // pinIndex of this motor output
     IO_t io;                 // IO_t for this output
     bool configured;
-    bool enabled;
     PIO pio;
     uint16_t pio_sm;
 } motorOutput_t;

--- a/src/platform/PICO/include/platform/platform.h
+++ b/src/platform/PICO/include/platform/platform.h
@@ -100,6 +100,10 @@ struct quadSpiResource_s
 
 #define SCHEDULER_DELAY_LIMIT           10
 
+// GPIO_PIN_ definitions for ease of compatibility with stm32 targets
+#define GPIO_PIN_RESET (0)
+#define GPIO_PIN_SET   (1)
+
 // There is no library definition for pupd, so define one here
 #define GPIO_PULLUP     1
 #define GPIO_PULLDOWN   2
@@ -112,8 +116,8 @@ struct quadSpiResource_s
 #define IOCFG_OUT_OD          IO_CONFIG(GPIO_OUT, 0, 0)
 #define IOCFG_AF_PP           0
 #define IOCFG_AF_OD           0
-#define IOCFG_IPD             IO_CONFIG(GPIO_IN, 0, 0)
-#define IOCFG_IPU             IO_CONFIG(GPIO_IN, 0, 0)
+#define IOCFG_IPD             IO_CONFIG(GPIO_IN, 0, GPIO_PULLDOWN)
+#define IOCFG_IPU             IO_CONFIG(GPIO_IN, 0, GPIO_PULLUP)
 #define IOCFG_IN_FLOATING     IO_CONFIG(GPIO_IN, 0, 0)
 
 // TODO update these and IOConfigGPIO

--- a/src/platform/PICO/pwm_motor_pico.c
+++ b/src/platform/PICO/pwm_motor_pico.c
@@ -61,7 +61,29 @@ void pwmShutdownPulsesForAllMotors(void)
     }
 }
 
-void pwmDisableMotors(void)
+static void pwmReleaseMotorIO(unsigned motorIndex)
+{
+    // Disable the pwm and reclaim the motor pin for SIO
+    // (so that e.g. the ESC 4-way passthrough can drive them as plain GPIOs)
+    if (picoPwmMotors[motorIndex].initialised) {
+        gpio_init(IO_Pin(pwmMotors[motorIndex].io));
+    }
+}
+
+static bool pwmReinstateMotorIO(unsigned motorIndex)
+{
+    bprintf("pwmReinstateMotorIO %d", motorIndex);
+    // Reclaim the motor pins for the PIO and reset the pulls and the state machines.
+    bool ok = false;
+    if (picoPwmMotors[motorIndex].initialised) {
+        gpio_set_function(IO_Pin(pwmMotors[motorIndex].io), GPIO_FUNC_PWM);
+        ok = true;
+    }
+
+    return ok;
+}
+
+static void pwmDisableMotors(void)
 {
     pwmShutdownPulsesForAllMotors();
 }
@@ -134,6 +156,8 @@ static motorVTable_t motorPwmVTable = {
     .write = pwmWriteStandard,
     .decodeTelemetry = NULL,
     .updateComplete = pwmCompleteMotorUpdate,
+    .releaseMotorIO = pwmReleaseMotorIO,
+    .reinstateMotorIO = pwmReinstateMotorIO,
     .requestTelemetry = NULL,
     .isMotorIdle = NULL,
     .getMotorIO = pwmGetMotorIO,

--- a/src/platform/PICO/pwm_motor_pico.c
+++ b/src/platform/PICO/pwm_motor_pico.c
@@ -66,7 +66,10 @@ static void pwmReleaseMotorIO(unsigned motorIndex)
     // Disable the pwm and reclaim the motor pin for SIO
     // (so that e.g. the ESC 4-way passthrough can drive them as plain GPIOs)
     if (picoPwmMotors[motorIndex].initialised) {
-        gpio_init(IO_Pin(pwmMotors[motorIndex].io));
+        int pinIndex = IO_GPIOPinIdx(pwmMotors[motorIndex].io);
+        if (pinIndex >= 0) {
+            gpio_init(pinIndex);
+        }
     }
 }
 
@@ -76,8 +79,11 @@ static bool pwmReinstateMotorIO(unsigned motorIndex)
     // Reclaim the motor pins for the PIO and reset the pulls and the state machines.
     bool ok = false;
     if (picoPwmMotors[motorIndex].initialised) {
-        gpio_set_function(IO_Pin(pwmMotors[motorIndex].io), GPIO_FUNC_PWM);
-        ok = true;
+        int pinIndex = IO_GPIOPinIdx(pwmMotors[motorIndex].io);
+        if (pinIndex >= 0) {
+            gpio_set_function(pinIndex, GPIO_FUNC_PWM);
+            ok = true;
+        }
     }
 
     return ok;

--- a/src/platform/PICO/target/common/target_RP2350.h
+++ b/src/platform/PICO/target/common/target_RP2350.h
@@ -137,9 +137,11 @@
 #undef USE_TELEMETRY_SMARTPORT
 #undef USE_TELEMETRY_SRXL
 
-#undef USE_SERIAL_4WAY_BLHELI_INTERFACE
-#undef USE_SERIAL_4WAY_BLHELI_BOOTLOADER
+// USE_SERIAL_4WAY_BLHELI_BOOTLOADER (BLHeli_S / AM32 configurator passthrough over the motor
+// pins) is supported.
+// SimonK STK500v2 support is not enabled (legacy, and unverified on this platform).
 #undef USE_SERIAL_4WAY_SK_BOOTLOADER
+
 #undef USE_MULTI_GYRO
 
 #undef USE_RANGEFINDER_HCSR04
@@ -148,7 +150,5 @@
 #undef USE_SRXL
 #undef USE_SPEKTRUM
 #undef USE_SPEKTRUM_BIND
-
-#undef USE_SERIAL_PASSTHROUGH
 
 #undef USE_RPM_LIMIT


### PR DESCRIPTION
PICO: Enable ESC Passthrough and Serial Passthrough.

Remove #undef USE_SERIAL_PASSTHROUGH
Remove #undef USE_SERIAL_4WAY_BLHELI_INTERFACE, _BOOTLOADER 
Add new motor device vTable functions for targeted use by esc4wayInit/Release, to perform platform and device-specific
  setup and restore for GPIOs entering and leaving ESC passthrough mode.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Motor I/O can now be temporarily released and reinstated by motor index.
  * Serial 4-way ESC mode now safely reclaims motor I/O and restores it afterward.
  * PWM and DShot motor outputs support temporary GPIO access and reliable restoration.
  * RP2350 targets now support BLHeli_S/AM32 serial 4-way bootloader passthrough.
* **Improvements**
  * Motor output configuration and pin ordering are applied more consistently.
  * GPIO pull-up and pull-down configurations are now correctly represented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->