### PR TITLE
List detected DroneCAN nodes in CLI status

### DIFF
--- a/mk/dronecan.mk
+++ b/mk/dronecan.mk
@@ -19,6 +19,7 @@ MCU_COMMON_SRC += \
             io/dronecan/dronecan_mag.c \
             io/dronecan/dronecan_airspeed.c \
             io/dronecan/dronecan_node.c \
+            io/dronecan/dronecan_nodes.c \
             io/dronecan/dronecan_esc.c \
             io/dronecan/dronecan_dna.c \
             dronecan/libcanard/canard.c

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -115,6 +115,8 @@ bool cliMode = false;
 #include "io/asyncfatfs/asyncfatfs.h"
 #include "io/beeper.h"
 #include "io/dronecan/dronecan.h"
+#include "io/dronecan/dronecan_msg.h"
+#include "io/dronecan/dronecan_nodes.h"
 #include "io/flashfs.h"
 #include "io/gimbal.h"
 #include "io/gps.h"
@@ -6209,6 +6211,36 @@ RAM_CODE static void cliStatus(const char *cmdName, char *cmdline)
     if (dronecanConfig()->enabled) {
         if (dronecanIsInitialised()) {
             cliPrintLinef("DroneCAN: node %d, device %d", dronecanConfig()->node_id, dronecanConfig()->device);
+
+            static const char * const nodeHealthNames[] = { "OK", "WARNING", "ERROR", "CRITICAL" };
+            static const char * const nodeModeNames[] = { "OPERATIONAL", "INITIALISING", "MAINTENANCE", "UPDATING", "?", "?", "?", "OFFLINE" };
+            for (uint8_t i = 0; i < dronecanNodesCount(); i++) {
+                const dronecanNodeEntry_t *node = dronecanNodesGet(i);
+                cliPrintf("  node %d: %s (%s", node->nodeId,
+                          node->infoValid && node->name[0] ? node->name : "no info",
+                          nodeHealthNames[node->health & 0x03]);
+                if (node->mode != UAVCAN_NODE_MODE_OPERATIONAL) {
+                    cliPrintf(", %s", nodeModeNames[node->mode & 0x07]);
+                }
+                const timeDelta_t sinceHeardUs = cmpTimeUs(micros(), node->lastHeardUs);
+                if (sinceHeardUs > 3000000) {
+                    cliPrintf(", last seen %ds ago", (int)(sinceHeardUs / 1000000));
+                }
+                cliPrint(")");
+                if (node->sensorFlags & DRONECAN_NODE_SENSOR_GPS) {
+                    cliPrint(" GPS");
+                }
+                if (node->sensorFlags & DRONECAN_NODE_SENSOR_MAG) {
+                    cliPrint(" MAG");
+                }
+                if (node->sensorFlags & DRONECAN_NODE_SENSOR_AIRSPEED) {
+                    cliPrint(" AIRSPEED");
+                }
+                if (node->sensorFlags & DRONECAN_NODE_SENSOR_ESC) {
+                    cliPrint(" ESC");
+                }
+                cliPrintLinefeed();
+            }
         } else {
             cliPrintLine("DroneCAN: NOT RUNNING (check dronecan_node_id and dronecan_device)");
         }

--- a/src/main/io/dronecan/dronecan.c
+++ b/src/main/io/dronecan/dronecan.c
@@ -40,6 +40,7 @@
 #include "scheduler/scheduler.h"
 
 #include "io/dronecan/dronecan.h"
+#include "io/dronecan/dronecan_nodes.h"
 
 #include "pg/dronecan.h"
 
@@ -145,9 +146,11 @@ static void dronecanOnTransferReception(CanardInstance *ins,
         if (sub->dataTypeId == transfer->data_type_id
                 && sub->transferType == transfer->transfer_type) {
             if (sub->handler) {
+                // Keep scanning after a match — independent modules may
+                // subscribe to the same data type (node tracking and DNA
+                // both consume NodeStatus).
                 sub->handler(ins, transfer);
             }
-            return;
         }
     }
 }
@@ -273,6 +276,9 @@ void dronecanInit(void)
     // Wire the node-level publishers/responders (registers the GetNodeInfo
     // subscriber against our table before the first frame can arrive).
     dronecanNodeInit();
+    // Track remote nodes from their NodeStatus broadcasts and fetch their
+    // names via GetNodeInfo, for the CLI's detected-device listing.
+    dronecanNodesInit();
     // Install the GNSS Fix2 subscriber so a DroneCAN GPS module's broadcasts
     // land in our cache as soon as the transport is live.
 #ifdef USE_GPS
@@ -345,6 +351,7 @@ void dronecanUpdate(timeUs_t currentTimeUs)
     if (cmpTimeUs(currentTimeUs, dronecanLastSecondUs) >= 1000000) {
         dronecanLastSecondUs = currentTimeUs;
         dronecanNodeUpdate(currentTimeUs);
+        dronecanNodesUpdate(currentTimeUs);
         canardCleanupStaleTransfers(&dronecanInstance, (uint64_t)currentTimeUs);
     }
 

--- a/src/main/io/dronecan/dronecan.h
+++ b/src/main/io/dronecan/dronecan.h
@@ -32,11 +32,11 @@
 
 #include "common/time.h"
 
-// Maximum number of subscribers a single stack instance accepts. NodeStatus
-// + GetNodeInfo use two slots out of the box; consumers added in follow-up
-// PRs (GPS, ESC telemetry, etc.) register into the remainder. Bump if a
-// target needs more — each slot is ~16 bytes of .bss.
-#define DRONECAN_MAX_SUBSCRIBERS    8
+// Maximum number of subscribers a single stack instance accepts. A full
+// build registers 11 (GetNodeInfo server + client, NodeStatus x2, GPS x2,
+// mag x2, airspeed, ESC status, DNA allocation). Bump if a target needs
+// more — each slot is ~16 bytes of .bss.
+#define DRONECAN_MAX_SUBSCRIBERS    12
 
 typedef void (*dronecanRxHandler)(CanardInstance *ins, CanardRxTransfer *transfer);
 

--- a/src/main/io/dronecan/dronecan_airspeed.c
+++ b/src/main/io/dronecan/dronecan_airspeed.c
@@ -35,6 +35,7 @@
 
 #include "io/dronecan/dronecan.h"
 #include "io/dronecan/dronecan_airspeed.h"
+#include "io/dronecan/dronecan_nodes.h"
 #include "io/dronecan/dronecan_msg.h"
 
 // Seqlock publication (same discipline as dronecan_mag.c): the handler runs on
@@ -59,6 +60,8 @@ static float decodeFloat32(const CanardRxTransfer *t, uint32_t bitOffset)
 static void handleRawAirData(CanardInstance *ins, CanardRxTransfer *t)
 {
     UNUSED(ins);
+
+    dronecanNodesNoteSensor(t->source_node_id, DRONECAN_NODE_SENSOR_AIRSPEED);
 
     const float diffPa = decodeFloat32(t, RAWAIRDATA_OFFSET_DIFF_P);
     const float staticPa = decodeFloat32(t, RAWAIRDATA_OFFSET_STATIC_P);

--- a/src/main/io/dronecan/dronecan_esc.c
+++ b/src/main/io/dronecan/dronecan_esc.c
@@ -53,6 +53,7 @@
 #include "io/dronecan/dronecan.h"
 #include "io/dronecan/dronecan_esc.h"
 #include "io/dronecan/dronecan_msg.h"
+#include "io/dronecan/dronecan_nodes.h"
 
 //-----------------------------------------------------------------------------
 // Command out: esc.RawCommand
@@ -172,6 +173,8 @@ static timeUs_t escStatusLastUs[MAX_SUPPORTED_MOTORS];
 static void handleEscStatus(CanardInstance *ins, CanardRxTransfer *t)
 {
     UNUSED(ins);
+
+    dronecanNodesNoteSensor(t->source_node_id, DRONECAN_NODE_SENSOR_ESC);
 
     uint32_t errorCount = 0;
     uint16_t voltageF16 = 0;

--- a/src/main/io/dronecan/dronecan_gnss.c
+++ b/src/main/io/dronecan/dronecan_gnss.c
@@ -37,6 +37,7 @@
 #include "drivers/time.h"
 
 #include "io/dronecan/dronecan.h"
+#include "io/dronecan/dronecan_nodes.h"
 #include "io/dronecan/dronecan_gnss.h"
 #include "io/dronecan/dronecan_msg.h"
 
@@ -78,6 +79,8 @@ static bool auxReceived = false;
 static void handleFix2(CanardInstance *ins, CanardRxTransfer *t)
 {
     UNUSED(ins);
+
+    dronecanNodesNoteSensor(t->source_node_id, DRONECAN_NODE_SENSOR_GPS);
 
     uint64_t gnssTimeUsec = 0;
     uint8_t timeStandard = 0;

--- a/src/main/io/dronecan/dronecan_mag.c
+++ b/src/main/io/dronecan/dronecan_mag.c
@@ -38,6 +38,7 @@
 
 #include "io/dronecan/dronecan.h"
 #include "io/dronecan/dronecan_mag.h"
+#include "io/dronecan/dronecan_nodes.h"
 #include "io/dronecan/dronecan_msg.h"
 
 // Bit offsets into the MagneticFieldStrength2 payload. sensor_id then the
@@ -101,6 +102,8 @@ static void handleMag2(CanardInstance *ins, CanardRxTransfer *t)
 {
     UNUSED(ins);
 
+    dronecanNodesNoteSensor(t->source_node_id, DRONECAN_NODE_SENSOR_MAG);
+
     uint8_t sensorId = 0;
     canardDecodeScalar(t, MAG2_OFFSET_SENSOR_ID, 8, false, &sensorId);
 
@@ -117,6 +120,8 @@ static void handleMag2(CanardInstance *ins, CanardRxTransfer *t)
 static void handleMagLegacy(CanardInstance *ins, CanardRxTransfer *t)
 {
     UNUSED(ins);
+
+    dronecanNodesNoteSensor(t->source_node_id, DRONECAN_NODE_SENSOR_MAG);
 
     publishField(t, MAG_OFFSET_FIELD_X);
 }

--- a/src/main/io/dronecan/dronecan_nodes.c
+++ b/src/main/io/dronecan/dronecan_nodes.c
@@ -1,0 +1,226 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platform.h"
+
+#if ENABLE_DRONECAN
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "canard.h"
+
+#include "common/time.h"
+#include "common/utils.h"
+
+#include "drivers/time.h"
+
+#include "io/dronecan/dronecan.h"
+#include "io/dronecan/dronecan_msg.h"
+#include "io/dronecan/dronecan_nodes.h"
+
+#define DRONECAN_MAX_NODES          16U
+#define NODES_INFO_RETRY_MAX        3U
+#define NODES_INFO_TIMEOUT_US       2000000
+
+static dronecanNodeEntry_t nodes[DRONECAN_MAX_NODES];
+static uint8_t nodeCount;
+
+// GetNodeInfo client state. The 1 KiB libcanard pool only has headroom for
+// one multi-frame response in flight, so requests are strictly serialised:
+// pendingNodeId != 0 blocks the scheduler until the response lands or the
+// timeout passes.
+static uint8_t infoTransferId;
+static uint8_t pendingNodeId;
+static timeUs_t pendingSentUs;
+
+static dronecanNodeEntry_t *findNode(uint8_t nodeId)
+{
+    for (uint8_t i = 0; i < nodeCount; i++) {
+        if (nodes[i].nodeId == nodeId) {
+            return &nodes[i];
+        }
+    }
+    return NULL;
+}
+
+static dronecanNodeEntry_t *findOrAddNode(uint8_t nodeId)
+{
+    dronecanNodeEntry_t *node = findNode(nodeId);
+    if (node) {
+        return node;
+    }
+    if (nodeId < CANARD_MIN_NODE_ID || nodeId > CANARD_MAX_NODE_ID
+            || nodeCount >= DRONECAN_MAX_NODES) {
+        return NULL;
+    }
+    node = &nodes[nodeCount++];
+    memset(node, 0, sizeof(*node));
+    node->nodeId = nodeId;
+    return node;
+}
+
+static void handleNodeStatus(CanardInstance *ins, CanardRxTransfer *t)
+{
+    UNUSED(ins);
+
+    dronecanNodeEntry_t *node = findOrAddNode(t->source_node_id);
+    if (!node) {
+        return;
+    }
+
+    uint32_t uptimeSec = 0;
+    uint8_t health = 0;
+    uint8_t mode = 0;
+    canardDecodeScalar(t, 0, 32, false, &uptimeSec);
+    canardDecodeScalar(t, 32, 2, false, &health);
+    canardDecodeScalar(t, 34, 3, false, &mode);
+
+    node->uptimeSec = uptimeSec;
+    node->health = health;
+    node->mode = mode;
+    node->lastHeardUs = micros();
+}
+
+static void handleNodeInfoResponse(CanardInstance *ins, CanardRxTransfer *t)
+{
+    UNUSED(ins);
+
+    dronecanNodeEntry_t *node = findNode(t->source_node_id);
+    if (!node) {
+        return;
+    }
+    if (t->source_node_id == pendingNodeId) {
+        pendingNodeId = 0;
+    }
+
+    // Response layout (see the responder in dronecan_node.c): NodeStatus (7)
+    // + SoftwareVersion (15) + HardwareVersion (18 + COA length byte). The
+    // certificate_of_authenticity is a length-prefixed array, so the name's
+    // start moves with it; name itself is TAO — it runs to the payload end.
+    if (t->payload_len < 41U) {
+        return;
+    }
+    uint8_t coaLen = 0;
+    canardDecodeScalar(t, 40U * 8U, 8, false, &coaLen);
+
+    const uint32_t nameOffset = 41U + coaLen;
+    uint8_t nameLen = 0;
+    if (t->payload_len > nameOffset) {
+        nameLen = (uint8_t)(t->payload_len - nameOffset);
+        if (nameLen > DRONECAN_NODE_NAME_MAX) {
+            nameLen = DRONECAN_NODE_NAME_MAX;
+        }
+    }
+    for (uint8_t i = 0; i < nameLen; i++) {
+        uint8_t c = 0;
+        canardDecodeScalar(t, (nameOffset + i) * 8U, 8, false, &c);
+        node->name[i] = (c >= 0x20U && c < 0x7FU) ? (char)c : '?';
+    }
+    node->name[nameLen] = '\0';
+    node->infoValid = true;
+}
+
+static void sendNodeInfoRequest(dronecanNodeEntry_t *node, timeUs_t currentTimeUs)
+{
+    // GetNodeInfo requests carry an empty payload; give libcanard a valid
+    // pointer anyway so the zero-length copy is well defined.
+    static const uint8_t emptyPayload[1] = { 0 };
+
+    CanardTxTransfer tx;
+    canardInitTxTransfer(&tx);
+    tx.transfer_type       = CanardTransferTypeRequest;
+    tx.data_type_signature = UAVCAN_GET_NODE_INFO_SIGNATURE;
+    tx.data_type_id        = UAVCAN_GET_NODE_INFO_ID;
+    tx.inout_transfer_id   = &infoTransferId;
+    tx.priority            = CANARD_TRANSFER_PRIORITY_LOW;
+    tx.payload             = emptyPayload;
+    tx.payload_len         = 0;
+
+    node->infoRetries++;
+    if (canardRequestOrRespondObj(dronecanGetInstance(), node->nodeId, &tx) >= 0) {
+        pendingNodeId = node->nodeId;
+        pendingSentUs = currentTimeUs;
+    }
+}
+
+void dronecanNodesInit(void)
+{
+    memset(nodes, 0, sizeof(nodes));
+    nodeCount = 0;
+    infoTransferId = 0;
+    pendingNodeId = 0;
+    pendingSentUs = 0;
+
+    const dronecanSubscriber_t nodeStatusSub = {
+        .signature    = UAVCAN_NODE_STATUS_SIGNATURE,
+        .dataTypeId   = UAVCAN_NODE_STATUS_ID,
+        .transferType = CanardTransferTypeBroadcast,
+        .handler      = handleNodeStatus,
+    };
+    (void)dronecanRegisterSubscriber(&nodeStatusSub);
+
+    const dronecanSubscriber_t nodeInfoSub = {
+        .signature    = UAVCAN_GET_NODE_INFO_SIGNATURE,
+        .dataTypeId   = UAVCAN_GET_NODE_INFO_ID,
+        .transferType = CanardTransferTypeResponse,
+        .handler      = handleNodeInfoResponse,
+    };
+    (void)dronecanRegisterSubscriber(&nodeInfoSub);
+}
+
+void dronecanNodesUpdate(timeUs_t currentTimeUs)
+{
+    if (pendingNodeId != 0U
+            && cmpTimeUs(currentTimeUs, pendingSentUs) < NODES_INFO_TIMEOUT_US) {
+        return;
+    }
+    pendingNodeId = 0;
+
+    for (uint8_t i = 0; i < nodeCount; i++) {
+        dronecanNodeEntry_t *node = &nodes[i];
+        if (!node->infoValid && node->infoRetries < NODES_INFO_RETRY_MAX) {
+            sendNodeInfoRequest(node, currentTimeUs);
+            return;
+        }
+    }
+}
+
+void dronecanNodesNoteSensor(uint8_t nodeId, uint8_t sensorFlag)
+{
+    dronecanNodeEntry_t *node = findOrAddNode(nodeId);
+    if (node) {
+        node->sensorFlags |= sensorFlag;
+    }
+}
+
+uint8_t dronecanNodesCount(void)
+{
+    return nodeCount;
+}
+
+const dronecanNodeEntry_t *dronecanNodesGet(uint8_t index)
+{
+    return (index < nodeCount) ? &nodes[index] : NULL;
+}
+
+#endif // ENABLE_DRONECAN

--- a/src/main/io/dronecan/dronecan_nodes.c
+++ b/src/main/io/dronecan/dronecan_nodes.c
@@ -156,8 +156,8 @@ static void sendNodeInfoRequest(dronecanNodeEntry_t *node, timeUs_t currentTimeU
     tx.payload             = emptyPayload;
     tx.payload_len         = 0;
 
-    node->infoRetries++;
     if (canardRequestOrRespondObj(dronecanGetInstance(), node->nodeId, &tx) >= 0) {
+        node->infoRetries++;
         pendingNodeId = node->nodeId;
         pendingSentUs = currentTimeUs;
     }
@@ -210,6 +210,7 @@ void dronecanNodesNoteSensor(uint8_t nodeId, uint8_t sensorFlag)
     dronecanNodeEntry_t *node = findOrAddNode(nodeId);
     if (node) {
         node->sensorFlags |= sensorFlag;
+        node->lastHeardUs = micros();
     }
 }
 

--- a/src/main/io/dronecan/dronecan_nodes.h
+++ b/src/main/io/dronecan/dronecan_nodes.h
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "platform.h"
+
+#if ENABLE_DRONECAN
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "common/time.h"
+
+// Data classes observed from a remote node, so the CLI can show what each
+// device on the bus is actually delivering (a GPS+compass module sets two).
+#define DRONECAN_NODE_SENSOR_GPS        (1U << 0)
+#define DRONECAN_NODE_SENSOR_MAG        (1U << 1)
+#define DRONECAN_NODE_SENSOR_AIRSPEED   (1U << 2)
+#define DRONECAN_NODE_SENSOR_ESC        (1U << 3)
+
+// DSDL allows 80 bytes; reverse-DNS style names in the wild fit well inside
+// this, and the table is per-node RAM.
+#define DRONECAN_NODE_NAME_MAX          32U
+
+typedef struct dronecanNodeEntry_s {
+    uint8_t  nodeId;
+    uint8_t  health;                    // UAVCAN_NODE_HEALTH_*
+    uint8_t  mode;                      // UAVCAN_NODE_MODE_*
+    uint8_t  sensorFlags;               // DRONECAN_NODE_SENSOR_*
+    uint8_t  infoRetries;
+    bool     infoValid;
+    uint32_t uptimeSec;
+    timeUs_t lastHeardUs;
+    char     name[DRONECAN_NODE_NAME_MAX + 1];
+} dronecanNodeEntry_t;
+
+void dronecanNodesInit(void);
+void dronecanNodesUpdate(timeUs_t currentTimeUs);
+
+// Called by the sensor RX handlers to attribute a data class to its source
+// node. Safe before the node's first NodeStatus — the entry is created on
+// demand.
+void dronecanNodesNoteSensor(uint8_t nodeId, uint8_t sensorFlag);
+
+uint8_t dronecanNodesCount(void);
+const dronecanNodeEntry_t *dronecanNodesGet(uint8_t index);
+
+#endif // ENABLE_DRONECAN

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -545,6 +545,21 @@ $(OBJECT_DIR)/dronecan_mag_unittest/io/dronecan/dronecan_mag.c.o \
 $(OBJECT_DIR)/dronecan_mag_unittest/dronecan_mag_unittest.o: $(DRONECAN_LIBCANARD_DIR)/canard.c
 
 
+dronecan_nodes_unittest_SRC := \
+		$(USER_DIR)/io/dronecan/dronecan_nodes.c \
+		$(TEST_DIR)/dronecan_nodes_canard.c
+
+dronecan_nodes_unittest_DEFINES := \
+		ENABLE_DRONECAN=1
+
+dronecan_nodes_unittest_INCLUDE_DIRS := \
+		$(DRONECAN_LIBCANARD_DIR)
+
+$(OBJECT_DIR)/dronecan_nodes_unittest/dronecan_nodes_canard.c.o \
+$(OBJECT_DIR)/dronecan_nodes_unittest/io/dronecan/dronecan_nodes.c.o \
+$(OBJECT_DIR)/dronecan_nodes_unittest/dronecan_nodes_unittest.o: $(DRONECAN_LIBCANARD_DIR)/canard.c
+
+
 .PHONY: check-pg-ids
 check-pg-ids:
 	@pg=$(USER_DIR)/pg/pg_ids.h; \

--- a/src/test/unit/dronecan_gnss_unittest.cc
+++ b/src/test/unit/dronecan_gnss_unittest.cc
@@ -54,6 +54,12 @@ extern "C" {
         return true;
     }
 
+    void dronecanNodesNoteSensor(uint8_t nodeId, uint8_t sensorFlag)
+    {
+        (void)nodeId;
+        (void)sensorFlag;
+    }
+
     static timeUs_t mockMicros = 0;
 
     timeUs_t micros(void) { return mockMicros; }

--- a/src/test/unit/dronecan_mag_unittest.cc
+++ b/src/test/unit/dronecan_mag_unittest.cc
@@ -49,6 +49,12 @@ extern "C" {
         return true;
     }
 
+    void dronecanNodesNoteSensor(uint8_t nodeId, uint8_t sensorFlag)
+    {
+        (void)nodeId;
+        (void)sensorFlag;
+    }
+
     // Controllable clock; the module timestamps each accepted frame with it.
     static timeUs_t mockMicros = 0;
 

--- a/src/test/unit/dronecan_nodes_canard.c
+++ b/src/test/unit/dronecan_nodes_canard.c
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Compile libcanard's implementation into the test binary. The submodule path
+// is added to this test's INCLUDE_DIRS so both this shim and the code under
+// test resolve canard.h against the same source.
+#if !__has_include("canard.c")
+#error "libcanard missing; run: git submodule update --init lib/modules/dronecan/libcanard"
+#endif
+#include "canard.c"

--- a/src/test/unit/dronecan_nodes_unittest.cc
+++ b/src/test/unit/dronecan_nodes_unittest.cc
@@ -205,6 +205,7 @@ TEST_F(DronecanNodesTest, AnonymousNodeStatusIgnored)
 
 TEST_F(DronecanNodesTest, NoteSensorCreatesEntryAndMergesWithStatus)
 {
+    mockMicros = 2000000;
     dronecanNodesNoteSensor(50, DRONECAN_NODE_SENSOR_GPS);
     dronecanNodesNoteSensor(50, DRONECAN_NODE_SENSOR_MAG);
 
@@ -212,6 +213,7 @@ TEST_F(DronecanNodesTest, NoteSensorCreatesEntryAndMergesWithStatus)
     const dronecanNodeEntry_t *node = findEntry(50);
     ASSERT_NE(nullptr, node);
     EXPECT_EQ(DRONECAN_NODE_SENSOR_GPS | DRONECAN_NODE_SENSOR_MAG, node->sensorFlags);
+    EXPECT_EQ(2000000U, node->lastHeardUs);
 
     feedNodeStatus(50, 7, UAVCAN_NODE_HEALTH_OK, UAVCAN_NODE_MODE_OPERATIONAL);
     EXPECT_EQ(1, dronecanNodesCount());

--- a/src/test/unit/dronecan_nodes_unittest.cc
+++ b/src/test/unit/dronecan_nodes_unittest.cc
@@ -1,0 +1,303 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdint>
+#include <cstring>
+
+extern "C" {
+    #include "platform.h"
+
+    #include "canard.h"
+
+    #include "io/dronecan/dronecan.h"
+    #include "io/dronecan/dronecan_msg.h"
+    #include "io/dronecan/dronecan_nodes.h"
+
+    // dronecanRegisterSubscriber() lives in dronecan.c, which is not linked
+    // into this test. Capture the handlers the module registers so the tests
+    // can feed hand-built transfers directly.
+    static dronecanRxHandler capturedStatusHandler = nullptr;
+    static dronecanRxHandler capturedInfoHandler = nullptr;
+
+    bool dronecanRegisterSubscriber(const dronecanSubscriber_t *subscriber)
+    {
+        if (subscriber->dataTypeId == UAVCAN_NODE_STATUS_ID
+                && subscriber->transferType == CanardTransferTypeBroadcast) {
+            capturedStatusHandler = subscriber->handler;
+        } else if (subscriber->dataTypeId == UAVCAN_GET_NODE_INFO_ID
+                && subscriber->transferType == CanardTransferTypeResponse) {
+            capturedInfoHandler = subscriber->handler;
+        }
+        return true;
+    }
+
+    // Real libcanard instance so the module's canardRequestOrRespondObj()
+    // calls enqueue genuine frames the tests can count and inspect.
+    static CanardInstance testInstance;
+    static uint8_t testPool[2048];
+
+    static bool testShouldAccept(const CanardInstance *, uint64_t *, uint16_t,
+                                 CanardTransferType, uint8_t)
+    {
+        return false;
+    }
+
+    static void testOnReception(CanardInstance *, CanardRxTransfer *)
+    {
+    }
+
+    CanardInstance *dronecanGetInstance(void)
+    {
+        return &testInstance;
+    }
+
+    // Controllable clock; the module timestamps NodeStatus receptions with it.
+    static timeUs_t mockMicros = 0;
+
+    timeUs_t micros(void)
+    {
+        return mockMicros;
+    }
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+static void feedNodeStatus(uint8_t sourceNodeId, uint32_t uptimeSec,
+                           uint8_t health, uint8_t mode)
+{
+    static uint8_t payload[UAVCAN_NODE_STATUS_PAYLOAD_LEN];
+    const uint8_t subMode = 0;
+    const uint16_t vendorCode = 0;
+    memset(payload, 0, sizeof(payload));
+    canardEncodeScalar(payload, 0, 32, &uptimeSec);
+    canardEncodeScalar(payload, 32, 2, &health);
+    canardEncodeScalar(payload, 34, 3, &mode);
+    canardEncodeScalar(payload, 37, 3, &subMode);
+    canardEncodeScalar(payload, 40, 16, &vendorCode);
+
+    CanardRxTransfer transfer;
+    memset(&transfer, 0, sizeof(transfer));
+    transfer.transfer_type = CanardTransferTypeBroadcast;
+    transfer.data_type_id = UAVCAN_NODE_STATUS_ID;
+    transfer.source_node_id = sourceNodeId;
+    transfer.payload_head = payload;
+    transfer.payload_len = sizeof(payload);
+
+    capturedStatusHandler(nullptr, &transfer);
+}
+
+// GetNodeInfo.Response: NodeStatus (7) + SoftwareVersion (15) +
+// HardwareVersion (18 + COA length byte + COA) + TAO name to payload end.
+static void feedNodeInfoResponse(uint8_t sourceNodeId, uint8_t coaLen,
+                                 const char *name)
+{
+    static uint8_t payload[160];
+    memset(payload, 0, sizeof(payload));
+    payload[40] = coaLen;
+    const size_t nameLen = strlen(name);
+    memcpy(&payload[41 + coaLen], name, nameLen);
+
+    CanardRxTransfer transfer;
+    memset(&transfer, 0, sizeof(transfer));
+    transfer.transfer_type = CanardTransferTypeResponse;
+    transfer.data_type_id = UAVCAN_GET_NODE_INFO_ID;
+    transfer.source_node_id = sourceNodeId;
+    transfer.payload_head = payload;
+    transfer.payload_len = (uint16_t)(41 + coaLen + nameLen);
+
+    capturedInfoHandler(nullptr, &transfer);
+}
+
+// Drain the instance's TX queue, returning how many frames were queued and
+// the destination node id of the first one (service frames carry it in CAN
+// id bits 8..14).
+static int drainTxQueue(uint8_t *firstDestination = nullptr)
+{
+    int frames = 0;
+    for (const CanardCANFrame *frame = canardPeekTxQueue(&testInstance);
+         frame != NULL;
+         frame = canardPeekTxQueue(&testInstance)) {
+        if (frames == 0 && firstDestination) {
+            *firstDestination = (uint8_t)((frame->id >> 8) & 0x7FU);
+        }
+        frames++;
+        canardPopTxQueue(&testInstance);
+    }
+    return frames;
+}
+
+static const dronecanNodeEntry_t *findEntry(uint8_t nodeId)
+{
+    for (uint8_t i = 0; i < dronecanNodesCount(); i++) {
+        const dronecanNodeEntry_t *node = dronecanNodesGet(i);
+        if (node->nodeId == nodeId) {
+            return node;
+        }
+    }
+    return nullptr;
+}
+
+class DronecanNodesTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        mockMicros = 0;
+        capturedStatusHandler = nullptr;
+        capturedInfoHandler = nullptr;
+        canardInit(&testInstance, testPool, sizeof(testPool),
+                   testOnReception, testShouldAccept, NULL);
+        canardSetLocalNodeID(&testInstance, 10);
+        dronecanNodesInit();
+        ASSERT_NE(capturedStatusHandler, nullptr);
+        ASSERT_NE(capturedInfoHandler, nullptr);
+    }
+};
+
+TEST_F(DronecanNodesTest, EmptyUntilFirstFrame)
+{
+    EXPECT_EQ(0, dronecanNodesCount());
+    EXPECT_EQ(nullptr, dronecanNodesGet(0));
+
+    dronecanNodesUpdate(1000000);
+    EXPECT_EQ(0, drainTxQueue());
+}
+
+TEST_F(DronecanNodesTest, NodeStatusCreatesAndDecodes)
+{
+    mockMicros = 5000000;
+    feedNodeStatus(42, 123, UAVCAN_NODE_HEALTH_WARNING, UAVCAN_NODE_MODE_INITIALIZATION);
+
+    ASSERT_EQ(1, dronecanNodesCount());
+    const dronecanNodeEntry_t *node = findEntry(42);
+    ASSERT_NE(nullptr, node);
+    EXPECT_EQ(123U, node->uptimeSec);
+    EXPECT_EQ(UAVCAN_NODE_HEALTH_WARNING, node->health);
+    EXPECT_EQ(UAVCAN_NODE_MODE_INITIALIZATION, node->mode);
+    EXPECT_EQ(5000000U, node->lastHeardUs);
+    EXPECT_FALSE(node->infoValid);
+}
+
+TEST_F(DronecanNodesTest, AnonymousNodeStatusIgnored)
+{
+    feedNodeStatus(0, 1, UAVCAN_NODE_HEALTH_OK, UAVCAN_NODE_MODE_OPERATIONAL);
+    EXPECT_EQ(0, dronecanNodesCount());
+}
+
+TEST_F(DronecanNodesTest, NoteSensorCreatesEntryAndMergesWithStatus)
+{
+    dronecanNodesNoteSensor(50, DRONECAN_NODE_SENSOR_GPS);
+    dronecanNodesNoteSensor(50, DRONECAN_NODE_SENSOR_MAG);
+
+    ASSERT_EQ(1, dronecanNodesCount());
+    const dronecanNodeEntry_t *node = findEntry(50);
+    ASSERT_NE(nullptr, node);
+    EXPECT_EQ(DRONECAN_NODE_SENSOR_GPS | DRONECAN_NODE_SENSOR_MAG, node->sensorFlags);
+
+    feedNodeStatus(50, 7, UAVCAN_NODE_HEALTH_OK, UAVCAN_NODE_MODE_OPERATIONAL);
+    EXPECT_EQ(1, dronecanNodesCount());
+    EXPECT_EQ(7U, node->uptimeSec);
+}
+
+TEST_F(DronecanNodesTest, SingleOutstandingInfoRequest)
+{
+    feedNodeStatus(20, 1, UAVCAN_NODE_HEALTH_OK, UAVCAN_NODE_MODE_OPERATIONAL);
+    feedNodeStatus(21, 1, UAVCAN_NODE_HEALTH_OK, UAVCAN_NODE_MODE_OPERATIONAL);
+
+    uint8_t destination = 0;
+    dronecanNodesUpdate(1000000);
+    EXPECT_EQ(1, drainTxQueue(&destination));
+    EXPECT_EQ(20, destination);
+
+    // Within the 2 s response window no further request goes out.
+    dronecanNodesUpdate(2000000);
+    EXPECT_EQ(0, drainTxQueue());
+
+    // After the timeout the scheduler moves on (same node retried first).
+    dronecanNodesUpdate(3100000);
+    EXPECT_EQ(1, drainTxQueue(&destination));
+    EXPECT_EQ(20, destination);
+}
+
+TEST_F(DronecanNodesTest, ResponseStoresNameAndFreesScheduler)
+{
+    feedNodeStatus(20, 1, UAVCAN_NODE_HEALTH_OK, UAVCAN_NODE_MODE_OPERATIONAL);
+    feedNodeStatus(21, 1, UAVCAN_NODE_HEALTH_OK, UAVCAN_NODE_MODE_OPERATIONAL);
+
+    dronecanNodesUpdate(1000000);
+    EXPECT_EQ(1, drainTxQueue());
+
+    feedNodeInfoResponse(20, 0, "org.test.device");
+    const dronecanNodeEntry_t *node = findEntry(20);
+    ASSERT_NE(nullptr, node);
+    EXPECT_TRUE(node->infoValid);
+    EXPECT_STREQ("org.test.device", node->name);
+
+    // The pending slot is free, so the next update queries the other node
+    // without waiting for the timeout.
+    uint8_t destination = 0;
+    dronecanNodesUpdate(2000000);
+    EXPECT_EQ(1, drainTxQueue(&destination));
+    EXPECT_EQ(21, destination);
+}
+
+TEST_F(DronecanNodesTest, ResponseNameFollowsCertificateOfAuthenticity)
+{
+    feedNodeStatus(20, 1, UAVCAN_NODE_HEALTH_OK, UAVCAN_NODE_MODE_OPERATIONAL);
+    feedNodeInfoResponse(20, 4, "org.coa.device");
+
+    const dronecanNodeEntry_t *node = findEntry(20);
+    ASSERT_NE(nullptr, node);
+    EXPECT_TRUE(node->infoValid);
+    EXPECT_STREQ("org.coa.device", node->name);
+}
+
+TEST_F(DronecanNodesTest, LongNameTruncated)
+{
+    feedNodeStatus(20, 1, UAVCAN_NODE_HEALTH_OK, UAVCAN_NODE_MODE_OPERATIONAL);
+    feedNodeInfoResponse(20, 0,
+        "org.example.a-very-long-node-name-that-exceeds-the-cli-limit");
+
+    const dronecanNodeEntry_t *node = findEntry(20);
+    ASSERT_NE(nullptr, node);
+    EXPECT_TRUE(node->infoValid);
+    EXPECT_EQ(DRONECAN_NODE_NAME_MAX, strlen(node->name));
+    EXPECT_STREQ("org.example.a-very-long-node-nam", node->name);
+}
+
+TEST_F(DronecanNodesTest, InfoRequestsStopAfterRetryLimit)
+{
+    feedNodeStatus(20, 1, UAVCAN_NODE_HEALTH_OK, UAVCAN_NODE_MODE_OPERATIONAL);
+
+    timeUs_t now = 1000000;
+    int requests = 0;
+    for (int i = 0; i < 6; i++) {
+        dronecanNodesUpdate(now);
+        requests += drainTxQueue();
+        now += 2500000;
+    }
+    EXPECT_EQ(3, requests);
+
+    const dronecanNodeEntry_t *node = findEntry(20);
+    ASSERT_NE(nullptr, node);
+    EXPECT_FALSE(node->infoValid);
+}


### PR DESCRIPTION
Tracks remote DroneCAN nodes from their NodeStatus broadcasts, fetches their names with a GetNodeInfo client (one request in flight at a time, three retries), and attributes GPS/mag/airspeed/ESC data to the source node. `status` then lists what is actually on the bus:

```
DroneCAN: node 10, device 1
  node 123: org.ardupilot.MatekG474-GPS (OK) GPS MAG
  node 124: org.ardupilot.MatekL431-GPS (OK) MAG
  node 125: org.ardupilot.TBS-L431-Airspeed (OK) AIRSPEED
```

Nodes that go quiet are marked with `last seen Ns ago`, so a dead or wedged bus is visible at a glance. Transfer dispatch now delivers to every matching subscriber (node tracking and DNA both consume NodeStatus), and the subscriber table grows to 12: a full build already needed 9 of the previous 8 slots, with the extra registrations failing silently. Verified on a MATEKH743 with the three modules above; unit tests cover NodeStatus/GetNodeInfo decoding and the request scheduler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DroneCAN node discovery and tracking.
  * CLI status output now lists discovered nodes, health, operating mode, last-seen time, names, and detected sensors.
  * Identifies GPS, magnetometer, airspeed, and ESC sensors by their DroneCAN source nodes.
  * Supports tracking up to 16 nodes and up to 12 message subscribers.

* **Bug Fixes**
  * DroneCAN transfers are now delivered to all matching subscribers instead of only the first.

* **Tests**
  * Added comprehensive coverage for node discovery, status updates, sensor detection, responses, retries, and name handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->