### PR TITLE
Enable FDCAN on STM32C562 and give it its own pin table

### DIFF
--- a/src/main/drivers/can/can_impl.h
+++ b/src/main/drivers/can/can_impl.h
@@ -33,11 +33,15 @@
 #include "platform/rcc_types.h"
 #endif
 
-// Maximum number of alternate pin options per TX/RX line.
+// Maximum number of alternate pin options per TX/RX line. The bound is set by
+// whichever family lists the most: STM32C562 routes FDCAN1_TX to nine pins of
+// the ports Betaflight compiles in, which is the widest set here. Rows that
+// list fewer simply leave the tail zeroed, and canPinConfigure() never matches
+// a zero because it tests the configured ioTag for non-zero first.
 #if defined(X32M7)
 #define CAN_MAX_PIN_SEL 5
 #else
-#define CAN_MAX_PIN_SEL 3
+#define CAN_MAX_PIN_SEL 9
 #endif
 
 // Software TX ring depth (power of two so the index can be masked). Sized to

--- a/src/platform/STM32/can_stm32c5xx.c
+++ b/src/platform/STM32/can_stm32c5xx.c
@@ -33,7 +33,7 @@
 
 // C5 FDCAN specifics:
 //  - C591 has no FDCAN peripheral; hardware-table rows only exist when a
-//    variant with FDCAN (C562, C593) is selected.
+//    variant with FDCAN (C562, C593, C5A3) is selected.
 //  - Silicon exposes at most FDCAN1 and FDCAN2. The CANDEV_3 row is emitted as
 //    a zero-initialised placeholder so the fixed-length canHardware[] array
 //    still has CANDEV_COUNT entries; canPinConfigure() skips rows whose reg
@@ -51,12 +51,14 @@
 //  - The C562 list is DS14927's complete AF9 set restricted to the ports
 //    Betaflight compiles in for this part (A-E; C562 has no GPIOF and no
 //    GPIOH, so the datasheet's PH2 FDCAN1_RX option is not reachable).
-//  - The C593 list is its datasheet's complete AF9 set as well (DS15136, the
-//    STM32C59xxx datasheet, covers C591 and C593 together). Every pin the original commit listed is in it;
-//    what is added is the rest. PH2 is left out for the same reason as on C562
-//    - Betaflight compiles no GPIOH for any C5 - so FDCAN1_RX on PH2 is not
-//    reachable. No C593 target exists yet, so this table is read from the
-//    datasheet rather than proved by a build.
+//  - The second row serves both C593 and C5A3, whose FDCAN AF maps are
+//    identical: DS15136 (STM32C59xxx, covering C591 and C593) and DS15137
+//    (STM32C5Axxx) list the same seven TX and six RX pins for FDCAN1 and the
+//    same three each for FDCAN2. Every pin the original commit listed is in
+//    that set; what is added is the rest. PH2 is left out for the same reason
+//    as on C562 - Betaflight compiles no GPIOH for any C5 - so FDCAN1_RX on
+//    PH2 is not reachable. No C593 target exists yet, so that half is read
+//    from the datasheet rather than proved by a build; C5A3 does build.
 const canHardware_t canHardware[CANDEV_COUNT] = {
     {
         .device = CANDEV_1,

--- a/src/platform/STM32/can_stm32c5xx.c
+++ b/src/platform/STM32/can_stm32c5xx.c
@@ -48,11 +48,11 @@
 //    a C593 (PB5/PB6/PB12/PB13) are FDCAN1 lines there. Listing one set for
 //    the family would hand those four pins to the wrong instance, so C562 has
 //    its own row below.
-//  - The C562 list is its datasheet's complete AF9 set restricted to the ports
+//  - The C562 list is DS14927's complete AF9 set restricted to the ports
 //    Betaflight compiles in for this part (A-E; C562 has no GPIOF and no
 //    GPIOH, so the datasheet's PH2 FDCAN1_RX option is not reachable).
-//  - The C593 list is its datasheet's complete AF9 set as well (DS15154 covers
-//    C591 and C593 together). Every pin the original commit listed is in it;
+//  - The C593 list is its datasheet's complete AF9 set as well (DS15136, the
+//    STM32C59xxx datasheet, covers C591 and C593 together). Every pin the original commit listed is in it;
 //    what is added is the rest. PH2 is left out for the same reason as on C562
 //    - Betaflight compiles no GPIOH for any C5 - so FDCAN1_RX on PH2 is not
 //    reachable. No C593 target exists yet, so this table is read from the

--- a/src/platform/STM32/can_stm32c5xx.c
+++ b/src/platform/STM32/can_stm32c5xx.c
@@ -51,9 +51,12 @@
 //  - The C562 list is its datasheet's complete AF9 set restricted to the ports
 //    Betaflight compiles in for this part (A-E; C562 has no GPIOF and no
 //    GPIOH, so the datasheet's PH2 FDCAN1_RX option is not reachable).
-//  - The C593 list is unchanged and still the partial set the original commit
-//    introduced; no C593 target exists yet, and no C593 datasheet was consulted
-//    here, so it is left exactly as it was rather than guessed at.
+//  - The C593 list is its datasheet's complete AF9 set as well (DS15154 covers
+//    C591 and C593 together). Every pin the original commit listed is in it;
+//    what is added is the rest. PH2 is left out for the same reason as on C562
+//    - Betaflight compiles no GPIOH for any C5 - so FDCAN1_RX on PH2 is not
+//    reachable. No C593 target exists yet, so this table is read from the
+//    datasheet rather than proved by a build.
 const canHardware_t canHardware[CANDEV_COUNT] = {
     {
         .device = CANDEV_1,
@@ -82,13 +85,19 @@ const canHardware_t canHardware[CANDEV_COUNT] = {
 #else
         .txPins = {
             { DEFIO_TAG_E(PA12), HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB7),  HAL_GPIO_AF9_FDCAN1 },
             { DEFIO_TAG_E(PB9),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PC13), HAL_GPIO_AF9_FDCAN1 },
             { DEFIO_TAG_E(PD1),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PD5),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PE1),  HAL_GPIO_AF9_FDCAN1 },
         },
         .rxPins = {
             { DEFIO_TAG_E(PA11), HAL_GPIO_AF9_FDCAN1 },
             { DEFIO_TAG_E(PB8),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PC14), HAL_GPIO_AF9_FDCAN1 },
             { DEFIO_TAG_E(PD0),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PE0),  HAL_GPIO_AF9_FDCAN1 },
         },
 #endif
         .rcc = RCC_APB1H(FDCAN),
@@ -100,12 +109,14 @@ const canHardware_t canHardware[CANDEV_COUNT] = {
         .device = CANDEV_2,
         .reg = (canResource_t *)FDCAN2,
         .txPins = {
+            { DEFIO_TAG_E(PA10), HAL_GPIO_AF9_FDCAN2 },
             { DEFIO_TAG_E(PB6),  HAL_GPIO_AF9_FDCAN2 },
             { DEFIO_TAG_E(PB13), HAL_GPIO_AF9_FDCAN2 },
         },
         .rxPins = {
             { DEFIO_TAG_E(PB5),  HAL_GPIO_AF9_FDCAN2 },
             { DEFIO_TAG_E(PB12), HAL_GPIO_AF9_FDCAN2 },
+            { DEFIO_TAG_E(PD9),  HAL_GPIO_AF9_FDCAN2 },
         },
         .rcc = RCC_APB1H(FDCAN),
         .irq0 = FDCAN2_IT0_IRQn,

--- a/src/platform/STM32/can_stm32c5xx.c
+++ b/src/platform/STM32/can_stm32c5xx.c
@@ -33,8 +33,8 @@
 
 // C5 FDCAN specifics:
 //  - C591 has no FDCAN peripheral; hardware-table rows only exist when a
-//    variant with FDCAN (e.g. C593) is selected.
-//  - Silicon exposes only FDCAN1 and FDCAN2. The CANDEV_3 row is emitted as
+//    variant with FDCAN (C562, C593) is selected.
+//  - Silicon exposes at most FDCAN1 and FDCAN2. The CANDEV_3 row is emitted as
 //    a zero-initialised placeholder so the fixed-length canHardware[] array
 //    still has CANDEV_COUNT entries; canPinConfigure() skips rows whose reg
 //    pointer is NULL.
@@ -43,13 +43,43 @@
 //  - Pin AF values use the HAL2 naming (HAL_GPIO_AF9_FDCANx); the numeric
 //    value is still 9 as on G4/H7, but the symbol name is HAL_-prefixed on
 //    this SDK.
-//  - Pin options listed here are the silicon-advertised FDCAN TX/RX lines
-//    for C593 (AF9). An actual C593 target will be added in a separate PR;
-//    the pin list can be extended then as needed.
+//  - The pin options are per *variant*, not per family, and the two differ in
+//    a way that matters: C562 has one FDCAN, so pins that are FDCAN2 lines on
+//    a C593 (PB5/PB6/PB12/PB13) are FDCAN1 lines there. Listing one set for
+//    the family would hand those four pins to the wrong instance, so C562 has
+//    its own row below.
+//  - The C562 list is its datasheet's complete AF9 set restricted to the ports
+//    Betaflight compiles in for this part (A-E; C562 has no GPIOF and no
+//    GPIOH, so the datasheet's PH2 FDCAN1_RX option is not reachable).
+//  - The C593 list is unchanged and still the partial set the original commit
+//    introduced; no C593 target exists yet, and no C593 datasheet was consulted
+//    here, so it is left exactly as it was rather than guessed at.
 const canHardware_t canHardware[CANDEV_COUNT] = {
     {
         .device = CANDEV_1,
         .reg = (canResource_t *)FDCAN1,
+#if defined(STM32C562xx)
+        .txPins = {
+            { DEFIO_TAG_E(PA12), HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB6),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB7),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB9),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB13), HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PC13), HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PD1),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PD5),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PE1),  HAL_GPIO_AF9_FDCAN1 },
+        },
+        .rxPins = {
+            { DEFIO_TAG_E(PA11), HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB5),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB8),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PB12), HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PC14), HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PD0),  HAL_GPIO_AF9_FDCAN1 },
+            { DEFIO_TAG_E(PE0),  HAL_GPIO_AF9_FDCAN1 },
+        },
+#else
         .txPins = {
             { DEFIO_TAG_E(PA12), HAL_GPIO_AF9_FDCAN1 },
             { DEFIO_TAG_E(PB9),  HAL_GPIO_AF9_FDCAN1 },
@@ -60,6 +90,7 @@ const canHardware_t canHardware[CANDEV_COUNT] = {
             { DEFIO_TAG_E(PB8),  HAL_GPIO_AF9_FDCAN1 },
             { DEFIO_TAG_E(PD0),  HAL_GPIO_AF9_FDCAN1 },
         },
+#endif
         .rcc = RCC_APB1H(FDCAN),
         .irq0 = FDCAN1_IT0_IRQn,
         .irq1 = FDCAN1_IT1_IRQn,

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -382,8 +382,9 @@
 #define USE_DMA_SPEC
 #define USE_PERSISTENT_OBJECTS
 #define USE_LATE_TASK_STATISTICS
-// C591 has no FDCAN hardware; enable CAN only on variants that do (e.g. C593).
-#if defined(STM32C593xx) && !defined(ENABLE_CAN)
+// Not every C5 carries FDCAN: C591 has none, while C562 has a single FDCAN1
+// and C593 has FDCAN1 + FDCAN2. Enable CAN only on the variants that have it.
+#if (defined(STM32C562xx) || defined(STM32C593xx)) && !defined(ENABLE_CAN)
 #define ENABLE_CAN 1
 #endif
 #endif

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -383,8 +383,10 @@
 #define USE_PERSISTENT_OBJECTS
 #define USE_LATE_TASK_STATISTICS
 // Not every C5 carries FDCAN: C591 has none, while C562 has a single FDCAN1
-// and C593 has FDCAN1 + FDCAN2. Enable CAN only on the variants that have it.
-#if (defined(STM32C562xx) || defined(STM32C593xx)) && !defined(ENABLE_CAN)
+// and C593 and C5A3 have FDCAN1 + FDCAN2. Enable CAN only on the variants that
+// have it.
+#if (defined(STM32C562xx) || defined(STM32C593xx) || defined(STM32C5A3xx)) \
+    && !defined(ENABLE_CAN)
 #define ENABLE_CAN 1
 #endif
 // C591 has no FDCAN at all (DS15136: "FDCAN 0 (on STM32C591xx)"), so the

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -387,6 +387,14 @@
 #if (defined(STM32C562xx) || defined(STM32C593xx)) && !defined(ENABLE_CAN)
 #define ENABLE_CAN 1
 #endif
+// C591 has no FDCAN at all (DS15154: "FDCAN 0 (on STM32C591xx)"), so the
+// hardware table would fall through to the C593 mapping and hand it register
+// addresses and IRQs that do not exist on the part. Nothing in tree sets this,
+// but a -DENABLE_CAN=1 on the command line would reach it, so fail the build
+// rather than the flight.
+#if defined(STM32C591xx) && ENABLE_CAN
+#error "STM32C591 has no FDCAN peripheral; ENABLE_CAN cannot be set for it"
+#endif
 #endif
 
 #ifdef STM32N6

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -387,7 +387,7 @@
 #if (defined(STM32C562xx) || defined(STM32C593xx)) && !defined(ENABLE_CAN)
 #define ENABLE_CAN 1
 #endif
-// C591 has no FDCAN at all (DS15154: "FDCAN 0 (on STM32C591xx)"), so the
+// C591 has no FDCAN at all (DS15136: "FDCAN 0 (on STM32C591xx)"), so the
 // hardware table would fall through to the C593 mapping and hand it register
 // addresses and IRQs that do not exist on the part. Nothing in tree sets this,
 // but a -DENABLE_CAN=1 on the command line would reach it, so fail the build


### PR DESCRIPTION
## Summary

`STM32C562` carries a single FDCAN1, but `ENABLE_CAN` was gated on `STM32C593xx` alone, so it stayed `0` on every C562 build — as it did on `STM32C5A3`, which has two. Since no C593 target exists yet, the C5 CAN driver was unreachable in practice — `can_stm32c5xx.c` compiled to nothing on both C5 targets in the tree.

This enables it for C562 and gives that part its own pin table.

## Why the pin list has to be per variant

C593 has two FDCAN instances; C562 has one. `PB5`/`PB6`/`PB12`/`PB13` are listed as the **FDCAN2** lines for C593, and on a C562 those same pins are **FDCAN1** lines. A single family-wide list would bind all four to the wrong instance, so C562 gets its own `CANDEV_1` row.

The C562 row is the complete AF9 set from its datasheet, restricted to the ports Betaflight compiles in for the part (A–E):

| line | pins |
|---|---|
| `FDCAN1_TX` | `PA12` `PB6` `PB7` `PB9` `PB13` `PC13` `PD1` `PD5` `PE1` |
| `FDCAN1_RX` | `PA11` `PB5` `PB8` `PB12` `PC14` `PD0` `PE0` |

C562 has no GPIOF and no GPIOH, so the datasheet's `PH2` `FDCAN1_RX` option is not reachable and is left out.

The C593 list is now that datasheet's complete AF9 set too — DS15136, the combined STM32C59xxx datasheet, covers C591 and C593 together. Every pin the original commit listed is confirmed present; the rest are added:

| line | pins |
|---|---|
| `FDCAN1_TX` | `PA12` `PB7` `PB9` `PC13` `PD1` `PD5` `PE1` |
| `FDCAN1_RX` | `PA11` `PB8` `PC14` `PD0` `PE0` |
| `FDCAN2_TX` | `PA10` `PB6` `PB13` |
| `FDCAN2_RX` | `PB5` `PB12` `PD9` |

`PH2` is excluded there for the same reason as on C562: Betaflight compiles no GPIOH for any C5. No C593 target exists yet, so that table is read from the datasheet rather than proved by a build.

## `CAN_MAX_PIN_SEL`

Raised from 3 to 9 to fit the widest list. Rows listing fewer leave the tail zeroed, which `canPinConfigure()` cannot match — it tests the configured ioTag for non-zero before comparing. Cost is a few dozen bytes of `const` table.

## Verification

Rather than trust a green build, `canHardware` was decoded out of a linked `STM32C562` image. The TX row holds the nine expected ioTags and the RX row the seven, each with AF `9`, and the `CANDEV_2`/`CANDEV_3` rows are zeroed as a single-instance part requires:

```
txPins: 1c09 2609 2709 2909 2d09 3d09 4109 4509 5109   (PA12 PB6 PB7 PB9 PB13 PC13 PD1 PD5 PE1)
rxPins: 1b09 2509 2809 2c09 3e09 4009 5009 0000 0000   (PA11 PB5 PB8 PB12 PC14 PD0 PE0)
```

`can_hw.o`, `can_pinconfig.o`, `can_stm32c5xx.o` and `canard.o` are all in the C562 build, confirming the gate actually opened.

## How this came up

A C562 flight controller schematic wires its CAN transceiver to `PC13` (TX), `PC14` (RX) and `PC15` (standby) — all datasheet-legal, none of them selectable in firmware, and CAN disabled on the part regardless. Config generation for that board is blocked on this.

Not runtime-tested on hardware yet; a C562 board with a transceiver populated is what that needs.

## C591 cannot get here

The same datasheet (DS15136) states `FDCAN: 0 (on STM32C591xx)`. The C562 pin list above is from DS14927. If `ENABLE_CAN` ever reached a C591 build, the hardware table would fall through to the C593 mapping and hand it register addresses and IRQs the silicon has not got — so that invariant is now enforced at compile time:

```c
#if defined(STM32C591xx) && ENABLE_CAN
#error "STM32C591 has no FDCAN peripheral; ENABLE_CAN cannot be set for it"
#endif
```

Nothing in tree sets it, but `-DENABLE_CAN=1` on the command line would. Verified by forcing the flag: the build stops on the `#error` rather than producing an image.

## STM32C5A3

Also enabled, and also gated off before this. `STM32C5A3` is a target in tree with two FDCANs, and DS15137 (STM32C5Axxx) gives it the same AF9 map as the C593 — the same seven TX and six RX pins on FDCAN1, the same three each on FDCAN2 — so the second table row serves both and only the gate had to change.

That identity is checked, not assumed. It is the exact thing this PR is careful about elsewhere: C562 and C593 disagree about which instance owns `PB5`/`PB6`/`PB12`/`PB13`, so "same family" is not an argument. C5A3 and C593 agree pin for pin; C562 is the odd one out.

Unlike C593, C5A3 is a real target, so this half is proved by a build. `canHardware` decoded out of a linked `STM32C5A3` image:

```
CANDEV_1 tx: 1c09 2709 2909 3d09 4109 4509 5109   (PA12 PB7 PB9 PC13 PD1 PD5 PE1)
CANDEV_1 rx: 1b09 2809 3e09 4009 5009             (PA11 PB8 PC14 PD0 PE0)
CANDEV_2 tx: 1a09 2609 2d09                       (PA10 PB6 PB13)
CANDEV_2 rx: 2509 2c09 4909                       (PB5 PB12 PD9)
```

`PH2` is absent throughout because no C5 compiles a GPIOH.

## Datasheets used

| part | document |
|---|---|
| STM32C562 | DS14927 |
| STM32C591 / STM32C593 | DS15136 (STM32C59xxx) |
| STM32C5A3 | DS15137 (STM32C5Axxx) |

Builds: `STM32C562`, `STM32C591`, `STM32C5A3`, `STM32G474`, `STM32H743`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded CAN pin-selection support on compatible STM32 platforms.
  - Added broader FDCAN1 and FDCAN2 pin options for STM32C562, STM32C593, and STM32C5A3 devices.
  - Enabled CAN support for STM32C562, STM32C593, and STM32C5A3 targets.

- **Bug Fixes**
  - Prevented CAN-enabled builds for STM32C591, which lacks FDCAN hardware.
  - Improved alternate CAN pin handling across supported STM32C5 silicon variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->