### PR TITLE
Link camera control on STM32C5 and STM32N6

### DIFF
--- a/src/platform/STM32/mk/STM32C5.mk
+++ b/src/platform/STM32/mk/STM32C5.mk
@@ -149,6 +149,7 @@ MCU_COMMON_SRC = \
             STM32/bus_i2c_i3c.c \
             STM32/spa06_i3c_probe.c \
             STM32/can_stm32c5xx.c \
+            STM32/camera_control_stm32.c \
             drivers/bus_i2c_timing.c \
             STM32/serial_uart_ll.c \
             STM32/serial_uart_stm32c5xx.c \

--- a/src/platform/STM32/mk/STM32N6.mk
+++ b/src/platform/STM32/mk/STM32N6.mk
@@ -186,6 +186,7 @@ MCU_COMMON_SRC = \
             STM32/debug_uart_stm32n6xx.c \
             STM32/timer_hal.c \
             STM32/timer_stm32n6xx.c \
+            STM32/camera_control_stm32.c \
             drivers/adc.c \
             drivers/serial_escserial.c \
             STM32/startup/system_stm32n6xx_s.c


### PR DESCRIPTION
## Summary

`STM32_COMMON.mk` builds `common/stm32/camera_control.c` for every STM32 family, and that file calls `cameraControlHardwarePwmInit()`. The function lives in `STM32/camera_control_stm32.c`, which **F4, F7, G4, H5 and H7 each list in their own mk file — C5 and N6 do not.**

The result is a link failure on those two families:

```
undefined reference to `cameraControlHardwarePwmInit'
```

## Why it went unnoticed

`common_post.h` only enables the feature when the config asks for it:

```c
#if defined(CAMERA_CONTROL_PIN) && defined(USE_OSD_SD) && !defined(USE_CAMERA_CONTROL)
#define USE_CAMERA_CONTROL
#endif
```

So a C5 or N6 build links fine until some config defines `CAMERA_CONTROL_PIN`. No config in tree does for either family yet, which is why CI is green.

## Verification

- An `STM32C562` config defining `CAMERA_CONTROL_PIN` fails to link before this change and links after it.
- `STM32N657` builds, with `camera_control_stm32.o` now in the object list.
- `ACROBO_C562V1` (the existing C562 config, no camera control) is unaffected and still builds.

Found while generating a target for a C562 flight controller whose schematic wires a camera-control line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added camera-control support to STM32 C5 and N6 platform builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->