### PR TITLE
Dynamic Notch: Fix tracking bug at low frequencies

### DIFF
--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -87,6 +87,7 @@
 #define DYN_NOTCH_CALC_TICKS       (XYZ_AXIS_COUNT * STEP_COUNT) // 3 axes and 4 steps per axis
 #define DYN_NOTCH_OSD_MIN_THROTTLE 20
 #define DYN_NOTCH_UPDATE_MIN_HZ    2000
+#define DYN_NOTCH_FLOOR_MIN_HZ     60  // exclude freq range which contains quad motion from noise estimate
 
 typedef enum {
 
@@ -150,8 +151,12 @@ static FAST_DATA_ZERO_INIT float   sdftSampleRateHz;
 static FAST_DATA_ZERO_INIT float   sdftResolutionHz;
 static FAST_DATA_ZERO_INIT int     sdftStartBin;
 static FAST_DATA_ZERO_INIT int     sdftEndBin;
+static FAST_DATA_ZERO_INIT int     sdftFloorStartBin;
 static FAST_DATA_ZERO_INIT float   sdftNoiseThreshold;
 static FAST_DATA_ZERO_INIT float   pt1LooptimeS;
+
+// Reset the sampling buffers and the state machine
+static void resetState(void);
 
 void dynNotchInit(const dynNotchConfig_t *config, const float dt)
 {
@@ -188,7 +193,17 @@ void dynNotchInit(const dynNotchConfig_t *config, const float dt)
     sdftResolutionHz = sdftSampleRateHz / SDFT_SAMPLE_SIZE; // 18.5hz per bin at 8k and 600Hz maxHz
     sdftStartBin = MAX(1, lrintf(dynNotch.minHz / sdftResolutionHz)); // can't use bin 0 because it is DC.
     sdftEndBin = MIN(SDFT_BIN_COUNT - 1, lrintf(dynNotch.maxHz / sdftResolutionHz)); // can't use more than SDFT_BIN_COUNT bins.
+
+    // The noise floor is averaged over [sdftFloorStartBin, sdftEndBin] to exclude the motion region
+    // Fall back to the whole range if excluding it would leave too few bins to average
+    sdftFloorStartBin = MAX(sdftStartBin, lrintf(DYN_NOTCH_FLOOR_MIN_HZ / sdftResolutionHz));
+    if (sdftFloorStartBin > sdftEndBin - 3) {
+        sdftFloorStartBin = sdftStartBin;
+    }
+
     pt1LooptimeS = DYN_NOTCH_CALC_TICKS / looprateHz;
+
+    resetState();
 
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         sdftInit(&sdft[axis], sdftStartBin, sdftEndBin, sampleCount);
@@ -200,6 +215,24 @@ void dynNotchInit(const dynNotchConfig_t *config, const float dt)
             dynNotch.centerFreq[axis][p] = (p + 0.5f) * (dynNotch.maxHz - dynNotch.minHz) / (float)dynNotch.count + dynNotch.minHz;
             svfNotchInit(&dynNotch.notch[axis][p], dynNotch.centerFreq[axis][p], dt, dynNotch.q);
         }
+    }
+}
+
+static void resetState(void)
+{
+    sampleIndex = 0;
+    state.tick = 0;
+    state.step = 0;
+    state.axis = 0;
+
+    for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
+        sampleAccumulator[axis] = 0.0f;
+        sampleAvg[axis] = 0.0f;
+    }
+
+    for (int p = 0; p < DYN_NOTCH_COUNT_MAX; p++) {
+        peaks[p].bin = 0;
+        peaks[p].value = 0.0f;
     }
 }
 
@@ -265,9 +298,9 @@ static FAST_CODE_NOINLINE_CRITICAL void dynNotchProcess(void)
         {
             sdftWinSq(&sdft[state.axis], sdftData);
 
-            // Get total vibrational power in dyn notch range for noise floor estimate in STEP_CALC_FREQUENCIES
+            // Get total vibrational power for the noise floor estimate in STEP_CALC_FREQUENCIES
             sdftNoiseThreshold = 0.0f;
-            for (int bin = sdftStartBin; bin <= sdftEndBin; bin++) {
+            for (int bin = sdftFloorStartBin; bin <= sdftEndBin; bin++) {
                 sdftNoiseThreshold += sdftData[bin];  // sdftData contains power spectral density
             }
 
@@ -325,14 +358,14 @@ static FAST_CODE_NOINLINE_CRITICAL void dynNotchProcess(void)
             // Approximate noise floor (= average power spectral density in dyn notch range, excluding peaks)
             int peakCount = 0;
             for (int p = 0; p < dynNotch.count; p++) {
-                if (peaks[p].bin != 0) {
+                if (peaks[p].bin > sdftFloorStartBin) {
                     sdftNoiseThreshold -= 0.75f * sdftData[peaks[p].bin - 1];
                     sdftNoiseThreshold -= sdftData[peaks[p].bin];
                     sdftNoiseThreshold -= 0.75f * sdftData[peaks[p].bin + 1];
                     peakCount++;
                 }
             }
-            sdftNoiseThreshold /= sdftEndBin - sdftStartBin - peakCount + 1;
+            sdftNoiseThreshold /= sdftEndBin - sdftFloorStartBin - peakCount + 1;
 
             // A noise threshold 2 times the noise floor prevents peak tracking being too sensitive to noise
             sdftNoiseThreshold *= 2.0f;

--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -358,7 +358,7 @@ static FAST_CODE_NOINLINE_CRITICAL void dynNotchProcess(void)
             // Approximate noise floor (= average power spectral density in dyn notch range, excluding peaks)
             int peakCount = 0;
             for (int p = 0; p < dynNotch.count; p++) {
-                if (peaks[p].bin > sdftFloorStartBin) {
+                if (peaks[p].bin >= sdftFloorStartBin) {
                     sdftNoiseThreshold -= 0.75f * sdftData[peaks[p].bin - 1];
                     sdftNoiseThreshold -= sdftData[peaks[p].bin];
                     sdftNoiseThreshold -= 0.75f * sdftData[peaks[p].bin + 1];


### PR DESCRIPTION
## Symptom

Reported by @bw1129: with `dyn_notch_min_hz` set low, the notch centers can get stuck for seconds — visible as flat lines in the PID Toolbox spectrogram, and a steppy staircase cumulative distribution instead of a smooth one.

He also found the boundary: `min_hz` 20 and 25 are broken, 30 and 60 are fine, and `min_hz` 25 becomes fine again if `max_hz` is reduced from 600 to 400.

## Cause

A peak qualifies on its power against `sdftNoiseThreshold`, the mean power of the whole search band. Below ~60 Hz that band contains rigid-body quad motion and its harmonics, which is far louder than any resonance. Once the search region reaches into it, `sdftNoiseThreshold` is inflated until it is bigger than any peak. Valid peaks get drowned out by the faulty noise estimation and are no longer visible. As a result, notches stop moving and freeze in place.

The boundary he found is exactly where the lowest SDFT bin enters the search range:

| min_hz | max_hz | resolution | sdftStartBin | reported |
|---|---|---|---|---|
| 20 | 600 | 18.52 Hz | **1** (18.5 Hz) | bad |
| 25 | 400 | 11.11 Hz | 2 (22.2 Hz) | ok |
| 25 | 600 | 18.52 Hz | **1** (18.5 Hz) | bad |
| 30 | 600 | 18.52 Hz | 2 (37.0 Hz) | ok |
| 60 | 600 | 18.52 Hz | 3 (55.6 Hz) | ok |

Bin 1 holds the motion. Lowering `max_hz` raises the SDFT resolution, which moves `min_hz` 25 off bin 1 — which is why constraining `max_hz` also made it go away.

## Fix

Cap the noise floor estimate at 60 Hz, if the lower search limit `dyn_notch_min_hz` reaches lower. The **search** range is unchanged: a resonance below 60 Hz is still found, it just no longer inflates the noise threshold.

## Result

Red lines are the notch centers. `dyn_notch_min_hz = 20` to demonstrate the bug and the fix and `dyn_notch_q = 200` for better visibility. Master holds flat lines while the noise bands move underneath; the fix actually detects and tracks them.

<img width="3434" height="1468" alt="pr1_rpmOff_min20_q200_10s" src="https://github.com/user-attachments/assets/61be3863-271f-4adf-a4b4-c179d4e12f72" />

<img width="3434" height="1465" alt="pr1_rpmOn_min20_q200_10s" src="https://github.com/user-attachments/assets/5f3947a0-57bb-4918-9041-525aefa55f77" />

## Also included

While testing I ran into another bug. Re-initialising with a smaller `sampleCount` leaves `sampleIndex` above it, `dynNotchUpdate()`'s refill test never fires again, and `sdftPushBatch()` indexes past the end of `sdft->data` (= index out of bounds error).

`dynNotchInit()` now resets the sampling state, fixing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic noise filtering by applying a minimum frequency boundary during noise estimation.
  * Enhanced filter initialization and reset behavior for more consistent performance.
  * Improved noise-floor calculations by excluding detected peaks from the estimation range.
  * Increased filtering reliability in challenging signal conditions by providing fallback behavior when the usable frequency range is limited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->