### PR TITLE
Use an arguments file when linking.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ DFUSE-PACK  := src/utils/dfuse-pack.py
 
 # Command used to link the final ELF. Platform makefiles can override this
 # when linking requires a dedicated linker instead of the C compiler driver.
-ELF_LINK_CMD = $(CROSS_CC) -o $@ $(filter-out %.ld,$^) $(LD_FLAGS)
+ELF_LINK_CMD = $(file > $@.args,$(filter-out %.ld,$^)) $(CROSS_CC) -o $@ @$@.args $(LD_FLAGS)
 
 # Preprocessor helpers (generic .h parsing)
 include $(MAKE_SCRIPT_DIR)/preprocess.mk


### PR DESCRIPTION
* without this, builds fail due to argument length limits as follows:

```
arm-none-eabi-gcc.exe: fatal error: cannot execute 'D:/Programs/Dev/GNUArmTools/active/bin/../libexec/gcc/arm-none-eabi/13.3.1/collect2.exe': CreateProcess: No such file or directory
compilation terminated
```

Tested on Windows 11 msys2/ucrt64, make 4.4.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application linking reliability when projects include many dependencies.
  * Prevented command-line length issues during builds by handling linker inputs more efficiently.

* **Chores**
  * Updated the build process to support more robust compilation and linking across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->