### PR TITLE
[2026.6] backport: Guard I2C busdev accessors against an unset bus

### DIFF
--- a/src/main/drivers/bus_i2c_busdev.c
+++ b/src/main/drivers/bus_i2c_busdev.c
@@ -34,6 +34,9 @@ static uint8_t i2cRegisteredDeviceCount = 0;
 
 bool i2cBusWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data)
 {
+    if (!dev->bus) {
+        return false;
+    }
     return i2cWrite(dev->bus->busType_u.i2c.device, dev->busType_u.i2c.address, reg, data);
 }
 
@@ -41,6 +44,10 @@ bool i2cBusWriteRegisterStart(const extDevice_t *dev, uint8_t reg, uint8_t data)
 {
     // Need a static value, not on the stack
     static uint8_t byte;
+
+    if (!dev->bus) {
+        return false;
+    }
 
     if (i2cBusy(dev->bus->busType_u.i2c.device, NULL)) {
         return false;
@@ -53,23 +60,37 @@ bool i2cBusWriteRegisterStart(const extDevice_t *dev, uint8_t reg, uint8_t data)
 
 bool i2cBusReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length)
 {
+    if (!dev->bus) {
+        return false;
+    }
     return i2cRead(dev->bus->busType_u.i2c.device, dev->busType_u.i2c.address, reg, length, data);
 }
 
 uint8_t i2cBusReadRegister(const extDevice_t *dev, uint8_t reg)
 {
-    uint8_t data;
-    i2cRead(dev->bus->busType_u.i2c.device, dev->busType_u.i2c.address, reg, 1, &data);
+    uint8_t data = 0xFF;
+    if (dev->bus) {
+        i2cRead(dev->bus->busType_u.i2c.device, dev->busType_u.i2c.address, reg, 1, &data);
+    }
     return data;
 }
 
 bool i2cBusReadRegisterBufferStart(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length)
 {
+    if (!dev->bus) {
+        return false;
+    }
     return i2cReadBuffer(dev->bus->busType_u.i2c.device, dev->busType_u.i2c.address, reg, length, data);
 }
 
 bool i2cBusBusy(const extDevice_t *dev, bool *error)
 {
+    if (!dev->bus) {
+        if (error) {
+            *error = true;
+        }
+        return true;
+    }
     return i2cBusy(dev->bus->busType_u.i2c.device, error);
 }
 

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -202,7 +202,9 @@ static bool baroDetect(baroDev_t *baroDev, baroSensor_e baroHardwareToUse)
     switch (barometerConfig()->baro_busType) {
 #ifdef USE_I2C
     case BUS_TYPE_I2C:
-        i2cBusSetInstance(dev, barometerConfig()->baro_i2c_device);
+        if (!i2cBusSetInstance(dev, barometerConfig()->baro_i2c_device)) {
+            return false;
+        }
         dev->busType_u.i2c.address = barometerConfig()->baro_i2c_address;
         break;
 #endif

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -258,7 +258,9 @@ static bool compassDetect(magDev_t *magDev, uint8_t *alignment)
     switch (compassConfig()->mag_busType) {
 #ifdef USE_I2C
     case BUS_TYPE_I2C:
-        i2cBusSetInstance(dev, compassConfig()->mag_i2c_device);
+        if (!i2cBusSetInstance(dev, compassConfig()->mag_i2c_device)) {
+            return false;
+        }
         dev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         break;
 #endif


### PR DESCRIPTION
Backport of #15604 to 2026.6-maintenance. Checks the result of `i2cBusSetInstance()` during barometer and compass detection and guards the `i2cBus*` accessors against a NULL bus to avoid a hard fault. The pitot change from the master fix is omitted as pitot support is not present on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved I2C safety when devices are not connected to a bus.
  * Prevented invalid bus operations and reported busy status appropriately when no bus is available.
  * Improved barometer and compass detection by stopping cleanly when I2C bus setup fails.
  * Single-register reads now return a safe default value when no bus is assigned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->