### PR TITLE
feat: Two tap arm

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1133,7 +1133,7 @@ const clivalue_t valueTable[] = {
     { "auto_disarm_delay",          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 60 }, PG_ARMING_CONFIG, offsetof(armingConfig_t, auto_disarm_delay) },
     { PARAM_NAME_GYRO_CAL_ON_FIRST_ARM, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, gyro_cal_on_first_arm) },
     { PARAM_NAME_PREARM_ALLOW_REARM, VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, prearm_allow_rearm) },
-    { PARAM_NAME_TWO_TAP_ARMING,    VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, two_tap_arming) },
+    { PARAM_NAME_TWO_TAP_ARMING,    VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 }, PG_ARMING_CONFIG, offsetof(armingConfig_t, two_tap_arming) },
 // PG_GPS_CONFIG
 #ifdef USE_GPS
     { PARAM_NAME_GPS_PROVIDER,               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_PROVIDER },   PG_GPS_CONFIG, offsetof(gpsConfig_t, provider) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1133,6 +1133,7 @@ const clivalue_t valueTable[] = {
     { "auto_disarm_delay",          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 60 }, PG_ARMING_CONFIG, offsetof(armingConfig_t, auto_disarm_delay) },
     { PARAM_NAME_GYRO_CAL_ON_FIRST_ARM, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, gyro_cal_on_first_arm) },
     { PARAM_NAME_PREARM_ALLOW_REARM, VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, prearm_allow_rearm) },
+    { PARAM_NAME_TWO_TAP_ARMING,    VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, two_tap_arming) },
 // PG_GPS_CONFIG
 #ifdef USE_GPS
     { PARAM_NAME_GPS_PROVIDER,               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_PROVIDER },   PG_GPS_CONFIG, offsetof(gpsConfig_t, provider) },

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -92,6 +92,7 @@
 #define PARAM_NAME_THROTTLE_LIMIT_PERCENT "throttle_limit_percent"
 #define PARAM_NAME_GYRO_CAL_ON_FIRST_ARM "gyro_cal_on_first_arm"
 #define PARAM_NAME_PREARM_ALLOW_REARM "prearm_allow_rearm"
+#define PARAM_NAME_TWO_TAP_ARMING "two_tap_arming"
 #define PARAM_NAME_DEADBAND "deadband"
 #define PARAM_NAME_YAW_DEADBAND "yaw_deadband"
 #define PARAM_NAME_PID_PROCESS_DENOM "pid_process_denom"

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -82,12 +82,13 @@ PG_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig,
     .yaw_control_reversed = false,
 );
 
-PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 2);
+PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 3);
 
 PG_RESET_TEMPLATE(armingConfig_t, armingConfig,
     .gyro_cal_on_first_arm = 0,
     .auto_disarm_delay = 5,
     .prearm_allow_rearm = 0,
+    .two_tap_arming = 0,
 );
 
 PG_REGISTER_WITH_RESET_TEMPLATE(flight3DConfig_t, flight3DConfig, PG_MOTOR_3D_CONFIG, 0);
@@ -427,5 +428,6 @@ void processRcStickPositions(void)
 void rcControlsInit(void)
 {
     analyzeModeActivationConditions();
+    rcModeSetTwoTapArming(armingConfig()->two_tap_arming);
     isUsingSticksToArm = !isModeActivationConditionPresent(BOXARM) && systemConfig()->enableStickArming;
 }

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -151,6 +151,7 @@ void processRcStickPositions(void)
     static uint8_t rcSticks;
     // an extra guard for disarming through switch to prevent that one frame can disarm it
     static uint8_t rcDisarmTicks;
+    static bool armSwitchWasActive;
     static bool doNotRepeat;
     static bool pendingApplyRollAndPitchTrimDeltaSave = false;
 
@@ -177,10 +178,19 @@ void processRcStickPositions(void)
 
     // perform actions
     if (!isUsingSticksToArm) {
-        if (IS_RC_MODE_ACTIVE(BOXARM)) {
+        const bool armSwitchActive = IS_RC_MODE_ACTIVE(BOXARM);
+        const bool armSwitchReady = rcModeIsTwoTapArmReady();
+        if (armSwitchActive && !armSwitchWasActive && !ARMING_FLAG(ARMED) && !armSwitchReady) {
+            beeperConfirmationBeeps(1);
+        }
+        armSwitchWasActive = armSwitchActive;
+
+        if (armSwitchActive) {
             rcDisarmTicks = 0;
             // Arming via ARM BOX
-            tryArm();
+            if (ARMING_FLAG(ARMED) || armSwitchReady) {
+                tryArm();
+            }
         } else {
             resetTryingToArm();
             // Disarming via ARM BOX

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -126,6 +126,7 @@ typedef struct armingConfig_s {
     uint8_t gyro_cal_on_first_arm;          // calibrate the gyro right before the first arm
     uint8_t auto_disarm_delay;              // allow automatically disarming multicopters after auto_disarm_delay seconds of zero throttle. Disabled when 0
     uint8_t prearm_allow_rearm;
+    uint8_t two_tap_arming;                 // require two quick arming switch taps to arm
 } armingConfig_t;
 
 PG_DECLARE(armingConfig_t, armingConfig);

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -126,7 +126,7 @@ typedef struct armingConfig_s {
     uint8_t gyro_cal_on_first_arm;          // calibrate the gyro right before the first arm
     uint8_t auto_disarm_delay;              // allow automatically disarming multicopters after auto_disarm_delay seconds of zero throttle. Disabled when 0
     uint8_t prearm_allow_rearm;
-    uint8_t two_tap_arming;                 // require two quick arming switch taps to arm
+    uint8_t two_tap_arming;                 // maximum time between arming switch taps, in 10ms units; disabled when 0
 } armingConfig_t;
 
 PG_DECLARE(armingConfig_t, armingConfig);

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -68,9 +68,9 @@ static struct {
     timeUs_t firstTapAt;
     twoTapState_e state;
 } twoTapArm;
-static timeUs_t twoTapTimeoutUs;
+static timeDelta_t twoTapTimeoutUs;
 
-#define TWO_TAP_TIMEOUT_UNIT_US 10000U
+#define TWO_TAP_TIMEOUT_UNIT_US 10000
 
 PG_REGISTER_ARRAY(modeActivationCondition_t, MAX_MODE_ACTIVATION_CONDITION_COUNT, modeActivationConditions, PG_MODE_ACTIVATION_PROFILE, 5);
 
@@ -90,11 +90,21 @@ void rcModeUpdate(const boxBitmask_t *newState)
 
 void rcModeSetTwoTapArming(uint8_t timeoutCentiseconds)
 {
-    twoTapTimeoutUs = timeoutCentiseconds * TWO_TAP_TIMEOUT_UNIT_US;
+    twoTapTimeoutUs = (timeDelta_t)timeoutCentiseconds * TWO_TAP_TIMEOUT_UNIT_US;
     twoTapArm.state = TWO_TAP_IDLE;
 }
 
-static bool processTwoTapArm(timeUs_t currentTimeUs, bool armSwitchActive)
+bool rcModeIsTwoTapArmReady(void)
+{
+    return !twoTapTimeoutUs || twoTapArm.state == TWO_TAP_READY;
+}
+
+bool rcModeIsTwoTapArmWaiting(void)
+{
+    return twoTapArm.state == TWO_TAP_FIRST_TAP || twoTapArm.state == TWO_TAP_WAITING_FOR_SECOND_TAP;
+}
+
+static void processTwoTapArm(timeUs_t currentTimeUs, bool armSwitchActive)
 {
     switch (twoTapArm.state) {
     case TWO_TAP_IDLE:
@@ -108,7 +118,7 @@ static bool processTwoTapArm(timeUs_t currentTimeUs, bool armSwitchActive)
         if (!armSwitchActive) {
             twoTapArm.state = TWO_TAP_WAITING_FOR_SECOND_TAP;
         }
-        if (cmpTimeUs(currentTimeUs, twoTapArm.firstTapAt) > (timeDelta_t)twoTapTimeoutUs) {
+        if (cmpTimeUs(currentTimeUs, twoTapArm.firstTapAt) > twoTapTimeoutUs) {
             twoTapArm.state = armSwitchActive ? TWO_TAP_TIMEOUT : TWO_TAP_IDLE;
         }
         break;
@@ -117,7 +127,7 @@ static bool processTwoTapArm(timeUs_t currentTimeUs, bool armSwitchActive)
         if (armSwitchActive) {
             twoTapArm.state = TWO_TAP_READY;
         }
-        if (cmpTimeUs(currentTimeUs, twoTapArm.firstTapAt) > (timeDelta_t)twoTapTimeoutUs) {
+        if (cmpTimeUs(currentTimeUs, twoTapArm.firstTapAt) > twoTapTimeoutUs) {
             twoTapArm.state = armSwitchActive ? TWO_TAP_TIMEOUT : TWO_TAP_IDLE;
         }
         break;
@@ -134,8 +144,6 @@ static bool processTwoTapArm(timeUs_t currentTimeUs, bool armSwitchActive)
         }
         break;
     }
-
-    return twoTapArm.state == TWO_TAP_READY;
 }
 
 #if ENABLE_TELEMETRY_MAVLINK_COMMANDS
@@ -266,8 +274,8 @@ void updateActivatedModes(void)
 
     rcModeUpdate(&newMask);
 
-    if (twoTapTimeoutUs && !processTwoTapArm(micros(), IS_RC_MODE_ACTIVE(BOXARM))) {
-        bitArrayClr(&rcModeActivationMask, BOXARM);
+    if (twoTapTimeoutUs) {
+        processTwoTapArm(micros(), IS_RC_MODE_ACTIVE(BOXARM));
     }
 
     airmodeEnabled = featureIsEnabled(FEATURE_AIRMODE) || IS_RC_MODE_ACTIVE(BOXAIRMODE);

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -68,9 +68,9 @@ static struct {
     timeUs_t firstTapAt;
     twoTapState_e state;
 } twoTapArm;
-static bool twoTapArmingEnabled;
+static timeUs_t twoTapTimeoutUs;
 
-#define TWO_TAP_TIMEOUT_US 500000
+#define TWO_TAP_TIMEOUT_UNIT_US 10000U
 
 PG_REGISTER_ARRAY(modeActivationCondition_t, MAX_MODE_ACTIVATION_CONDITION_COUNT, modeActivationConditions, PG_MODE_ACTIVATION_PROFILE, 5);
 
@@ -88,9 +88,9 @@ void rcModeUpdate(const boxBitmask_t *newState)
     rcModeActivationMask = *newState;
 }
 
-void rcModeSetTwoTapArming(bool enabled)
+void rcModeSetTwoTapArming(uint8_t timeoutCentiseconds)
 {
-    twoTapArmingEnabled = enabled;
+    twoTapTimeoutUs = timeoutCentiseconds * TWO_TAP_TIMEOUT_UNIT_US;
     twoTapArm.state = TWO_TAP_IDLE;
 }
 
@@ -108,7 +108,7 @@ static bool processTwoTapArm(timeUs_t currentTimeUs, bool armSwitchActive)
         if (!armSwitchActive) {
             twoTapArm.state = TWO_TAP_WAITING_FOR_SECOND_TAP;
         }
-        if (cmpTimeUs(currentTimeUs, twoTapArm.firstTapAt) > TWO_TAP_TIMEOUT_US) {
+        if (cmpTimeUs(currentTimeUs, twoTapArm.firstTapAt) > (timeDelta_t)twoTapTimeoutUs) {
             twoTapArm.state = armSwitchActive ? TWO_TAP_TIMEOUT : TWO_TAP_IDLE;
         }
         break;
@@ -117,7 +117,7 @@ static bool processTwoTapArm(timeUs_t currentTimeUs, bool armSwitchActive)
         if (armSwitchActive) {
             twoTapArm.state = TWO_TAP_READY;
         }
-        if (cmpTimeUs(currentTimeUs, twoTapArm.firstTapAt) > TWO_TAP_TIMEOUT_US) {
+        if (cmpTimeUs(currentTimeUs, twoTapArm.firstTapAt) > (timeDelta_t)twoTapTimeoutUs) {
             twoTapArm.state = armSwitchActive ? TWO_TAP_TIMEOUT : TWO_TAP_IDLE;
         }
         break;
@@ -266,7 +266,7 @@ void updateActivatedModes(void)
 
     rcModeUpdate(&newMask);
 
-    if (twoTapArmingEnabled && !processTwoTapArm(micros(), IS_RC_MODE_ACTIVE(BOXARM))) {
+    if (twoTapTimeoutUs && !processTwoTapArm(micros(), IS_RC_MODE_ACTIVE(BOXARM))) {
         bitArrayClr(&rcModeActivationMask, BOXARM);
     }
 

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -56,6 +56,22 @@ static uint8_t activeMacArray[MAX_MODE_ACTIVATION_CONDITION_COUNT];
 static int activeLinkedMacCount = 0;
 static uint8_t activeLinkedMacArray[MAX_MODE_ACTIVATION_CONDITION_COUNT];
 
+typedef enum {
+    TWO_TAP_IDLE,
+    TWO_TAP_FIRST_TAP,
+    TWO_TAP_WAITING_FOR_SECOND_TAP,
+    TWO_TAP_READY,
+    TWO_TAP_TIMEOUT,
+} twoTapState_e;
+
+static struct {
+    timeUs_t firstTapAt;
+    twoTapState_e state;
+} twoTapArm;
+static bool twoTapArmingEnabled;
+
+#define TWO_TAP_TIMEOUT_US 500000
+
 PG_REGISTER_ARRAY(modeActivationCondition_t, MAX_MODE_ACTIVATION_CONDITION_COUNT, modeActivationConditions, PG_MODE_ACTIVATION_PROFILE, 5);
 
 #if defined(USE_CUSTOM_BOX_NAMES)
@@ -70,6 +86,56 @@ bool IS_RC_MODE_ACTIVE(boxId_e boxId)
 void rcModeUpdate(const boxBitmask_t *newState)
 {
     rcModeActivationMask = *newState;
+}
+
+void rcModeSetTwoTapArming(bool enabled)
+{
+    twoTapArmingEnabled = enabled;
+    twoTapArm.state = TWO_TAP_IDLE;
+}
+
+static bool processTwoTapArm(timeUs_t currentTimeUs, bool armSwitchActive)
+{
+    switch (twoTapArm.state) {
+    case TWO_TAP_IDLE:
+        if (armSwitchActive) {
+            twoTapArm.state = TWO_TAP_FIRST_TAP;
+            twoTapArm.firstTapAt = currentTimeUs;
+        }
+        break;
+
+    case TWO_TAP_FIRST_TAP:
+        if (!armSwitchActive) {
+            twoTapArm.state = TWO_TAP_WAITING_FOR_SECOND_TAP;
+        }
+        if (cmpTimeUs(currentTimeUs, twoTapArm.firstTapAt) > TWO_TAP_TIMEOUT_US) {
+            twoTapArm.state = armSwitchActive ? TWO_TAP_TIMEOUT : TWO_TAP_IDLE;
+        }
+        break;
+
+    case TWO_TAP_WAITING_FOR_SECOND_TAP:
+        if (armSwitchActive) {
+            twoTapArm.state = TWO_TAP_READY;
+        }
+        if (cmpTimeUs(currentTimeUs, twoTapArm.firstTapAt) > TWO_TAP_TIMEOUT_US) {
+            twoTapArm.state = armSwitchActive ? TWO_TAP_TIMEOUT : TWO_TAP_IDLE;
+        }
+        break;
+
+    case TWO_TAP_READY:
+        if (!armSwitchActive) {
+            twoTapArm.state = TWO_TAP_IDLE;
+        }
+        break;
+
+    case TWO_TAP_TIMEOUT:
+        if (!armSwitchActive) {
+            twoTapArm.state = TWO_TAP_IDLE;
+        }
+        break;
+    }
+
+    return twoTapArm.state == TWO_TAP_READY;
 }
 
 #if ENABLE_TELEMETRY_MAVLINK_COMMANDS
@@ -199,6 +265,10 @@ void updateActivatedModes(void)
 #endif
 
     rcModeUpdate(&newMask);
+
+    if (twoTapArmingEnabled && !processTwoTapArm(micros(), IS_RC_MODE_ACTIVE(BOXARM))) {
+        bitArrayClr(&rcModeActivationMask, BOXARM);
+    }
 
     airmodeEnabled = featureIsEnabled(FEATURE_AIRMODE) || IS_RC_MODE_ACTIVE(BOXAIRMODE);
 }

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -147,7 +147,7 @@ typedef struct modeActivationProfile_s {
 
 bool IS_RC_MODE_ACTIVE(boxId_e boxId);
 void rcModeUpdate(const boxBitmask_t *newState);
-void rcModeSetTwoTapArming(bool enabled);
+void rcModeSetTwoTapArming(uint8_t timeoutCentiseconds);
 
 // External (MAVLink command) flight-mode override. Forces the selected box modes
 // active on top of the RC-derived mask each loop, so a MAVLink DO_SET_MODE / RTL

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -147,6 +147,7 @@ typedef struct modeActivationProfile_s {
 
 bool IS_RC_MODE_ACTIVE(boxId_e boxId);
 void rcModeUpdate(const boxBitmask_t *newState);
+void rcModeSetTwoTapArming(bool enabled);
 
 // External (MAVLink command) flight-mode override. Forces the selected box modes
 // active on top of the RC-derived mask each loop, so a MAVLink DO_SET_MODE / RTL

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -148,6 +148,8 @@ typedef struct modeActivationProfile_s {
 bool IS_RC_MODE_ACTIVE(boxId_e boxId);
 void rcModeUpdate(const boxBitmask_t *newState);
 void rcModeSetTwoTapArming(uint8_t timeoutCentiseconds);
+bool rcModeIsTwoTapArmReady(void);
+bool rcModeIsTwoTapArmWaiting(void);
 
 // External (MAVLink command) flight-mode override. Forces the selected box modes
 // active on top of the RC-derived mask each loop, so a MAVLink DO_SET_MODE / RTL

--- a/src/main/osd/osd_warnings.c
+++ b/src/main/osd/osd_warnings.c
@@ -230,6 +230,14 @@ void renderOsdWarning(char *warningText, bool *blinking, uint8_t *displayAttr)
         }
     }
 
+    if (osdWarnGetState(OSD_WARNING_ARMING_DISABLE)
+        && !ARMING_FLAG(ARMED)
+        && rcModeIsTwoTapArmWaiting()) {
+        tfp_sprintf(warningText, "TAP AGAIN");
+        *displayAttr = DISPLAYPORT_SEVERITY_INFO;
+        return;
+    }
+
 #ifdef USE_DSHOT
     if (isTryingToArm() && !ARMING_FLAG(ARMED)) {
         const int beaconGuard = cmpTimeUs(currentTimeUs, getLastDshotBeaconCommandTimeUs());

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -111,6 +111,7 @@ extern "C" {
     int32_t simulationVerticalSpeed;
     uint16_t simulationCoreTemperature;
     bool simulationGpsHealthy;
+    bool simulationTwoTapArmWaiting;
 }
 
 uint32_t simulationFeatureFlags = FEATURE_GPS;
@@ -145,6 +146,7 @@ void setDefaultSimulationState()
     simulationVerticalSpeed = 0;
     simulationCoreTemperature = 0;
     simulationGpsHealthy = false;
+    simulationTwoTapArmWaiting = false;
 
     rcData[PITCH] = 1500;
 
@@ -1080,6 +1082,31 @@ TEST_F(OsdTest, TestElementCoreTemperature)
     displayPortTestBufferSubstring(1, 8, "C%c 91%c", SYM_TEMPERATURE, SYM_F);
 }
 
+TEST_F(OsdTest, TestElementWarningsTwoTapArming)
+{
+    osdConfigMutable()->enabledWarnings = 0;
+    osdWarnSetState(OSD_WARNING_ARMING_DISABLE, true);
+
+    char warningText[OSD_WARNINGS_MAX_SIZE + 1];
+    bool blinking;
+    uint8_t displayAttr;
+
+    simulationTwoTapArmWaiting = true;
+    renderOsdWarning(warningText, &blinking, &displayAttr);
+    EXPECT_STREQ("TAP AGAIN", warningText);
+    EXPECT_FALSE(blinking);
+    EXPECT_EQ(DISPLAYPORT_SEVERITY_INFO, displayAttr);
+
+    ENABLE_ARMING_FLAG(ARMED);
+    renderOsdWarning(warningText, &blinking, &displayAttr);
+    EXPECT_STREQ("", warningText);
+
+    DISABLE_ARMING_FLAG(ARMED);
+    osdWarnSetState(OSD_WARNING_ARMING_DISABLE, false);
+    renderOsdWarning(warningText, &blinking, &displayAttr);
+    EXPECT_STREQ("", warningText);
+}
+
 /*
  * Tests the battery notifications shown on the warnings OSD element.
  */
@@ -1518,6 +1545,10 @@ extern "C" {
 
     bool IS_RC_MODE_ACTIVE(boxId_e) {
         return false;
+    }
+
+    bool rcModeIsTwoTapArmWaiting(void) {
+        return simulationTwoTapArmWaiting;
     }
 
     uint32_t micros() {

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -195,6 +195,65 @@ TEST_F(RcControlsModesTest, updateActivatedModesUsingValidAuxConfigurationAndRXV
     }
 }
 
+uint32_t fixedMillis;
+
+TEST_F(RcControlsModesTest, twoTapArming)
+{
+    modeActivationConditionsMutable(0)->modeId = BOXARM;
+    modeActivationConditionsMutable(0)->auxChannelIndex = AUX1 - NON_AUX_CHANNEL_COUNT;
+    modeActivationConditionsMutable(0)->range.startStep = CHANNEL_VALUE_TO_STEP(1700);
+    modeActivationConditionsMutable(0)->range.endStep = CHANNEL_VALUE_TO_STEP(2100);
+
+    memset(&rxRuntimeState, 0, sizeof(rxRuntimeState));
+    rxRuntimeState.channelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT - NON_AUX_CHANNEL_COUNT;
+    rcData[AUX1] = PWM_RANGE_MIDDLE;
+    analyzeModeActivationConditions();
+
+    PG_RESET(armingConfig);
+    EXPECT_EQ(0, armingConfig()->two_tap_arming);
+
+    armingConfigMutable()->two_tap_arming = 1;
+    rcModeSetTwoTapArming(true);
+    fixedMillis = 0;
+    updateActivatedModes();
+
+    rcData[AUX1] = PWM_RANGE_MAX;
+    updateActivatedModes();
+    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXARM));
+
+    fixedMillis = 100;
+    rcData[AUX1] = PWM_RANGE_MIDDLE;
+    updateActivatedModes();
+    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXARM));
+
+    fixedMillis = 200;
+    rcData[AUX1] = PWM_RANGE_MAX;
+    updateActivatedModes();
+    EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXARM));
+
+    rcData[AUX1] = PWM_RANGE_MIDDLE;
+    updateActivatedModes();
+    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXARM));
+
+    fixedMillis = 300;
+    rcData[AUX1] = PWM_RANGE_MAX;
+    updateActivatedModes();
+    fixedMillis = 801;
+    updateActivatedModes();
+    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXARM));
+
+    rcData[AUX1] = PWM_RANGE_MIDDLE;
+    updateActivatedModes();
+
+    armingConfigMutable()->two_tap_arming = 0;
+    rcModeSetTwoTapArming(false);
+    rcData[AUX1] = PWM_RANGE_MAX;
+    updateActivatedModes();
+    EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXARM));
+
+    memset(modeActivationConditionsMutable(0), 0, sizeof(modeActivationCondition_t));
+}
+
 enum {
     COUNTER_QUEUE_CONFIRMATION_BEEP,
     COUNTER_CHANGE_CONTROL_RATE_PROFILE
@@ -227,8 +286,6 @@ void resetCallCounters(void)
 {
     memset(&callCounts, 0, sizeof(callCounts));
 }
-
-uint32_t fixedMillis;
 
 extern "C" {
 uint32_t millis(void)

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -212,8 +212,8 @@ TEST_F(RcControlsModesTest, twoTapArming)
     PG_RESET(armingConfig);
     EXPECT_EQ(0, armingConfig()->two_tap_arming);
 
-    armingConfigMutable()->two_tap_arming = 1;
-    rcModeSetTwoTapArming(true);
+    armingConfigMutable()->two_tap_arming = 100;
+    rcModeSetTwoTapArming(armingConfig()->two_tap_arming);
     fixedMillis = 0;
     updateActivatedModes();
 
@@ -221,12 +221,12 @@ TEST_F(RcControlsModesTest, twoTapArming)
     updateActivatedModes();
     EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXARM));
 
-    fixedMillis = 100;
+    fixedMillis = 500;
     rcData[AUX1] = PWM_RANGE_MIDDLE;
     updateActivatedModes();
     EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXARM));
 
-    fixedMillis = 200;
+    fixedMillis = 1000;
     rcData[AUX1] = PWM_RANGE_MAX;
     updateActivatedModes();
     EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXARM));
@@ -235,18 +235,34 @@ TEST_F(RcControlsModesTest, twoTapArming)
     updateActivatedModes();
     EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXARM));
 
-    fixedMillis = 300;
+    fixedMillis = 1100;
     rcData[AUX1] = PWM_RANGE_MAX;
     updateActivatedModes();
-    fixedMillis = 801;
+    fixedMillis = 2101;
     updateActivatedModes();
     EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXARM));
 
     rcData[AUX1] = PWM_RANGE_MIDDLE;
     updateActivatedModes();
 
+    armingConfigMutable()->two_tap_arming = 200;
+    rcModeSetTwoTapArming(armingConfig()->two_tap_arming);
+    fixedMillis = 3000;
+    rcData[AUX1] = PWM_RANGE_MAX;
+    updateActivatedModes();
+    fixedMillis = 4000;
+    rcData[AUX1] = PWM_RANGE_MIDDLE;
+    updateActivatedModes();
+    fixedMillis = 5000;
+    rcData[AUX1] = PWM_RANGE_MAX;
+    updateActivatedModes();
+    EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXARM));
+
+    rcData[AUX1] = PWM_RANGE_MIDDLE;
+    updateActivatedModes();
+
     armingConfigMutable()->two_tap_arming = 0;
-    rcModeSetTwoTapArming(false);
+    rcModeSetTwoTapArming(armingConfig()->two_tap_arming);
     rcData[AUX1] = PWM_RANGE_MAX;
     updateActivatedModes();
     EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXARM));

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -195,10 +195,21 @@ TEST_F(RcControlsModesTest, updateActivatedModesUsingValidAuxConfigurationAndRXV
     }
 }
 
+enum {
+    COUNTER_QUEUE_CONFIRMATION_BEEP,
+    COUNTER_CHANGE_CONTROL_RATE_PROFILE,
+    COUNTER_TRY_ARM,
+};
+#define CALL_COUNT_ITEM_COUNT 3
+
+static int callCounts[CALL_COUNT_ITEM_COUNT];
+
 uint32_t fixedMillis;
 
 TEST_F(RcControlsModesTest, twoTapArming)
 {
+    memset(callCounts, 0, sizeof(callCounts));
+
     modeActivationConditionsMutable(0)->modeId = BOXARM;
     modeActivationConditionsMutable(0)->auxChannelIndex = AUX1 - NON_AUX_CHANNEL_COUNT;
     modeActivationConditionsMutable(0)->range.startStep = CHANNEL_VALUE_TO_STEP(1700);
@@ -207,32 +218,63 @@ TEST_F(RcControlsModesTest, twoTapArming)
     memset(&rxRuntimeState, 0, sizeof(rxRuntimeState));
     rxRuntimeState.channelCount = MAX_SUPPORTED_RC_CHANNEL_COUNT - NON_AUX_CHANNEL_COUNT;
     rcData[AUX1] = PWM_RANGE_MIDDLE;
-    analyzeModeActivationConditions();
 
     PG_RESET(armingConfig);
     EXPECT_EQ(0, armingConfig()->two_tap_arming);
 
     armingConfigMutable()->two_tap_arming = 100;
-    rcModeSetTwoTapArming(armingConfig()->two_tap_arming);
+    rcControlsInit();
     fixedMillis = 0;
     updateActivatedModes();
 
     rcData[AUX1] = PWM_RANGE_MAX;
     updateActivatedModes();
-    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXARM));
+    EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXARM));
+    EXPECT_FALSE(rcModeIsTwoTapArmReady());
+    EXPECT_TRUE(rcModeIsTwoTapArmWaiting());
+    processRcStickPositions();
+    EXPECT_EQ(1, callCounts[COUNTER_QUEUE_CONFIRMATION_BEEP]);
+    EXPECT_EQ(0, callCounts[COUNTER_TRY_ARM]);
 
     fixedMillis = 500;
     rcData[AUX1] = PWM_RANGE_MIDDLE;
     updateActivatedModes();
     EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXARM));
+    EXPECT_FALSE(rcModeIsTwoTapArmReady());
+    EXPECT_TRUE(rcModeIsTwoTapArmWaiting());
+    processRcStickPositions();
 
     fixedMillis = 1000;
     rcData[AUX1] = PWM_RANGE_MAX;
     updateActivatedModes();
     EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXARM));
+    EXPECT_TRUE(rcModeIsTwoTapArmReady());
+    EXPECT_FALSE(rcModeIsTwoTapArmWaiting());
+    processRcStickPositions();
+    EXPECT_EQ(1, callCounts[COUNTER_TRY_ARM]);
+
+    fixedMillis = 1001;
+    updateActivatedModes();
+    EXPECT_TRUE(rcModeIsTwoTapArmReady());
+    processRcStickPositions();
+    EXPECT_EQ(2, callCounts[COUNTER_TRY_ARM]);
+
+    ENABLE_ARMING_FLAG(ARMED);
+    rcData[AUX1] = PWM_RANGE_MIDDLE;
+    updateActivatedModes();
+    processRcStickPositions();
+    rcData[AUX1] = PWM_RANGE_MAX;
+    updateActivatedModes();
+    EXPECT_FALSE(rcModeIsTwoTapArmReady());
+    processRcStickPositions();
+    EXPECT_TRUE(ARMING_FLAG(ARMED));
+    EXPECT_EQ(3, callCounts[COUNTER_TRY_ARM]);
+    DISABLE_ARMING_FLAG(ARMED);
+    rcModeSetTwoTapArming(100);
 
     rcData[AUX1] = PWM_RANGE_MIDDLE;
     updateActivatedModes();
+    processRcStickPositions();
     EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXARM));
 
     fixedMillis = 1100;
@@ -240,7 +282,9 @@ TEST_F(RcControlsModesTest, twoTapArming)
     updateActivatedModes();
     fixedMillis = 2101;
     updateActivatedModes();
-    EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXARM));
+    EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXARM));
+    EXPECT_FALSE(rcModeIsTwoTapArmReady());
+    EXPECT_FALSE(rcModeIsTwoTapArmWaiting());
 
     rcData[AUX1] = PWM_RANGE_MIDDLE;
     updateActivatedModes();
@@ -257,6 +301,22 @@ TEST_F(RcControlsModesTest, twoTapArming)
     rcData[AUX1] = PWM_RANGE_MAX;
     updateActivatedModes();
     EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXARM));
+    EXPECT_TRUE(rcModeIsTwoTapArmReady());
+
+    rcData[AUX1] = PWM_RANGE_MIDDLE;
+    updateActivatedModes();
+
+    rcModeSetTwoTapArming(100);
+    fixedMillis = 4294500U;
+    rcData[AUX1] = PWM_RANGE_MAX;
+    updateActivatedModes();
+    fixedMillis += 200;
+    rcData[AUX1] = PWM_RANGE_MIDDLE;
+    updateActivatedModes();
+    fixedMillis += 400;
+    rcData[AUX1] = PWM_RANGE_MAX;
+    updateActivatedModes();
+    EXPECT_TRUE(rcModeIsTwoTapArmReady());
 
     rcData[AUX1] = PWM_RANGE_MIDDLE;
     updateActivatedModes();
@@ -266,17 +326,10 @@ TEST_F(RcControlsModesTest, twoTapArming)
     rcData[AUX1] = PWM_RANGE_MAX;
     updateActivatedModes();
     EXPECT_TRUE(IS_RC_MODE_ACTIVE(BOXARM));
+    EXPECT_TRUE(rcModeIsTwoTapArmReady());
 
     memset(modeActivationConditionsMutable(0), 0, sizeof(modeActivationCondition_t));
 }
-
-enum {
-    COUNTER_QUEUE_CONFIRMATION_BEEP,
-    COUNTER_CHANGE_CONTROL_RATE_PROFILE
-};
-#define CALL_COUNT_ITEM_COUNT 2
-
-static int callCounts[CALL_COUNT_ITEM_COUNT];
 
 #define CALL_COUNTER(item) (callCounts[item])
 
@@ -815,7 +868,7 @@ void applyAccelerometerTrimsDelta(rollAndPitchTrims_t*) {}
 void handleInflightCalibrationStickPosition(void) {}
 bool featureIsEnabled(uint32_t) { return false;}
 bool sensors(uint32_t) { return false;}
-void tryArm(void) {}
+void tryArm(void) { callCounts[COUNTER_TRY_ARM]++; }
 void disarm(flightLogDisarmReason_e) {}
 void dashboardDisablePageCycling() {}
 void dashboardEnablePageCycling() {}


### PR DESCRIPTION
Allow for FlightOne style arming. This is the arming style where you have to flip your arming switch twice within a short window. For many pilots that don't want to set a pre-arm switch for whatever reason this provides additional arming safety.

This is enabled by setting the two_tap_arming setting to the time you want it to take for you to flip your arm switch twice in units of 1/100 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional two-tap arming for switch-based arming.
  * Configurable timeout determines how quickly the second tap must occur.
  * The feature is disabled by default and can be configured through CLI settings.
  * Added a confirmation beep and “TAP AGAIN” on-screen message while waiting for the second tap.

* **Bug Fixes**
  * Improved handling of expired or incomplete tap sequences so arming remains unavailable until a valid sequence is completed.
  * Preserved normal arming behavior when two-tap arming is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->