### PR TITLE
Add a filter to thrust linear

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1812,6 +1812,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_THROTTLE_BOOST, "%d",            currentPidProfile->throttle_boost);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_THROTTLE_BOOST_CUTOFF, "%d",     currentPidProfile->throttle_boost_cutoff);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_THRUST_LINEARIZATION,  "%d",     currentPidProfile->thrustLinearization);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_THRUST_LINEARIZATION_CUTOFF, "%d", currentPidProfile->thrustLinearizationCutoff);
 
 #ifdef USE_GPS
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GPS_PROVIDER, "%d",               gpsConfig()->provider);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1327,6 +1327,7 @@ const clivalue_t valueTable[] = {
 
 #ifdef USE_THRUST_LINEARIZATION
     { "thrust_linear",              VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 150 }, PG_PID_PROFILE, offsetof(pidProfile_t, thrustLinearization) },
+    { PARAM_NAME_THRUST_LINEARIZATION_CUTOFF, VAR_UINT8 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, thrustLinearizationCutoff) },
 #endif
 
 #ifdef USE_FEEDFORWARD

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -616,7 +616,6 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
     UNUSED(self);
 
     pidProfile_t *pidProfile = pidProfilesMutable(pidProfileIndex);
-    pidInitConfig(currentPidProfile);
 
     pidProfile->pid[PID_LEVEL].P = cmsx_angleP;
     pidProfile->pid[PID_LEVEL].F = cmsx_angleFF;
@@ -667,6 +666,7 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
     pidProfile->tpa_low_always = cmsx_tpa_low_always;
     pidProfile->landing_disarm_threshold = cmsx_landing_disarm_threshold;
 
+    pidInitConfig(currentPidProfile);
     initEscEndpoints();
     return NULL;
 }

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -517,6 +517,7 @@ static uint8_t  cmsx_horizonLimitDegrees;
 
 static uint8_t  cmsx_throttleBoost;
 static uint8_t  cmsx_thrustLinearization;
+static uint8_t  cmsx_thrustLinearizationCutoff;
 static uint8_t  cmsx_antiGravityGain;
 static uint8_t  cmsx_motorOutputLimit;
 static int8_t   cmsx_autoProfileCellCount;
@@ -571,6 +572,7 @@ static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
 
     cmsx_throttleBoost = pidProfile->throttle_boost;
     cmsx_thrustLinearization = pidProfile->thrustLinearization;
+    cmsx_thrustLinearizationCutoff = pidProfile->thrustLinearizationCutoff;
     cmsx_motorOutputLimit = pidProfile->motor_output_limit;
     cmsx_autoProfileCellCount = pidProfile->auto_profile_cell_count;
 
@@ -629,6 +631,7 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
 
     pidProfile->throttle_boost = cmsx_throttleBoost;
     pidProfile->thrustLinearization = cmsx_thrustLinearization;
+    pidProfile->thrustLinearizationCutoff = cmsx_thrustLinearizationCutoff;
     pidProfile->motor_output_limit = cmsx_motorOutputLimit;
     pidProfile->auto_profile_cell_count = cmsx_autoProfileCellCount;
 
@@ -693,6 +696,7 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
 #endif
 #ifdef USE_THRUST_LINEARIZATION
     { "THR LINEAR",  OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_thrustLinearization,    0,    150,   1  }    },
+    { "THR LIN CUT", OME_UINT8,  NULL, &(OSD_UINT8_t)  { &cmsx_thrustLinearizationCutoff, 0, 250, 1 }    },
 #endif
 #ifdef USE_ITERM_RELAX
     { "I_RELAX",         OME_TAB,    NULL, &(OSD_TAB_t)     { &cmsx_iterm_relax,        ITERM_RELAX_COUNT - 1,      lookupTableItermRelax       } },

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -118,6 +118,7 @@
 #define PARAM_NAME_THROTTLE_BOOST "throttle_boost"
 #define PARAM_NAME_THROTTLE_BOOST_CUTOFF "throttle_boost_cutoff"
 #define PARAM_NAME_THRUST_LINEARIZATION "thrust_linear"
+#define PARAM_NAME_THRUST_LINEARIZATION_CUTOFF "thrust_linear_cut"
 #define PARAM_NAME_D_MAX_GAIN "d_max_gain"
 #define PARAM_NAME_D_MAX_ADVANCE "d_max_advance"
 #define PARAM_NAME_MOTOR_OUTPUT_LIMIT "motor_output_limit"

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -459,7 +459,7 @@ static void applyMixToMotors(const float motorMix[MAX_SUPPORTED_MOTORS], motorMi
     for (int i = 0; i < mixerRuntime.motorCount; i++) {
         float motorOutput = motorOutputMixSign * motorMix[i] + throttle * activeMixer[i].throttle;
 #ifdef USE_THRUST_LINEARIZATION
-        motorOutput = pidApplyThrustLinearization(motorOutput);
+        motorOutput = pidApplyThrustLinearization(motorOutput, i);
 #endif
         motorOutput = motorOutputMin + motorOutputRange * motorOutput;
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -120,7 +120,7 @@ PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
 #define IS_AXIS_IN_ANGLE_MODE(i) false
 #endif // USE_ACC
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 12);
+PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 13);
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {
@@ -182,6 +182,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .launchControlGain = 40,
         .launchControlAllowTriggerReset = true,
         .thrustLinearization = 0,
+        .thrustLinearizationCutoff = 75,
         .d_max = D_MAX_DEFAULT,
         .d_max_gain = 0,
         .d_max_advance = 35,
@@ -504,12 +505,13 @@ void pidAcroTrainerInit(void)
 // steepening near the top of the throttle range.
 //
 // Cost: 4 mults, 2 adds, 2 subs per motor (no sqrt). Called per-motor per loop.
-float pidApplyThrustLinearization(float motorOutput)
+float pidApplyThrustLinearization(float motorOutput, unsigned motorIndex)
 {
     const float e = pidRuntime.thrustLinearization;
     const float inv = 1.0f - motorOutput;
-    motorOutput *= 1.0f + e * inv * (1.0f + e * (inv - motorOutput));
-    return motorOutput;
+    const float linearizedOutput = motorOutput * (1.0f + e * inv * (1.0f + e * (inv - motorOutput)));
+    const float linearizationChange = linearizedOutput - motorOutput;
+    return motorOutput + pt1FilterApply(&pidRuntime.thrustLinearizationMotorFilter[motorIndex], linearizationChange);
 }
 
 // Inverse of the curve above, applied to base throttle so hover throttle is
@@ -520,11 +522,13 @@ float pidApplyThrustLinearization(float motorOutput)
 // by the full forward multiplier.
 float pidCompensateThrustLinearization(float throttle)
 {
+    const float uncompensatedThrottle = throttle;
     if (pidRuntime.thrustLinearization != 0.0f) {
         const float e = pidRuntime.thrustLinearization;
         throttle *= 1.0f - e * (1.0f - throttle);
     }
-    return throttle;
+    const float linearizationChange = throttle - uncompensatedThrottle;
+    return uncompensatedThrottle + pt1FilterApply(&pidRuntime.thrustLinearizationThrottleFilter, linearizationChange);
 }
 #endif
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -511,7 +511,7 @@ float pidApplyThrustLinearization(float motorOutput, unsigned motorIndex)
     const float inv = 1.0f - motorOutput;
     const float linearizedOutput = motorOutput * (1.0f + e * inv * (1.0f + e * (inv - motorOutput)));
     const float linearizationChange = linearizedOutput - motorOutput;
-    return motorOutput + pt1FilterApply(&pidRuntime.thrustLinearizationMotorFilter[motorIndex], linearizationChange);
+    return constrainf(motorOutput + pt1FilterApply(&pidRuntime.thrustLinearizationMotorFilter[motorIndex], linearizationChange), 0.0f, 1.0f);
 }
 
 // Inverse of the curve above, applied to base throttle so hover throttle is
@@ -528,7 +528,7 @@ float pidCompensateThrustLinearization(float throttle)
         throttle *= 1.0f - e * (1.0f - throttle);
     }
     const float linearizationChange = throttle - uncompensatedThrottle;
-    return uncompensatedThrottle + pt1FilterApply(&pidRuntime.thrustLinearizationThrottleFilter, linearizationChange);
+    return constrainf(uncompensatedThrottle + pt1FilterApply(&pidRuntime.thrustLinearizationThrottleFilter, linearizationChange), 0.0f, 1.0f);
 }
 #endif
 

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -241,6 +241,7 @@ typedef struct pidProfile_s {
     uint8_t launchControlGain;              // Iterm gain used while launch control is active
     uint8_t launchControlAllowTriggerReset; // Controls trigger behavior and whether the trigger can be reset
     uint8_t thrustLinearization;            // Thrust curve compensation, ≈ ArduPilot MOT_THST_EXPO * 100 (0..150, default 0)
+    uint8_t thrustLinearizationCutoff;      // PT1 cutoff for changes introduced by thrust linearization; below 5 disables filtering
     uint8_t d_max[XYZ_AXIS_COUNT];          // Maximum D value on each axis
     uint8_t d_max_gain;                     // Gain factor for amount of gyro / setpoint activity required to boost D
     uint8_t d_max_advance;                  // Percentage multiplier for setpoint input to boost algorithm
@@ -470,6 +471,8 @@ typedef struct pidRuntime_s {
 
 #ifdef USE_THRUST_LINEARIZATION
     float thrustLinearization;
+    pt1Filter_t thrustLinearizationThrottleFilter;
+    pt1Filter_t thrustLinearizationMotorFilter[MAX_SUPPORTED_MOTORS];
 #endif
 
 #ifdef USE_FEEDFORWARD
@@ -548,7 +551,7 @@ void pidSetAntiGravityState(bool newState);
 bool pidAntiGravityEnabled(void);
 
 #ifdef USE_THRUST_LINEARIZATION
-float pidApplyThrustLinearization(float motorValue);
+float pidApplyThrustLinearization(float motorValue, unsigned motorIndex);
 float pidCompensateThrustLinearization(float throttle);
 #endif
 

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -481,6 +481,13 @@ void pidInitConfig(const pidProfile_t *pidProfile)
 
 #ifdef USE_THRUST_LINEARIZATION
     pidRuntime.thrustLinearization = pidProfile->thrustLinearization / 100.0f;
+    const float thrustLinearizationFilterGain = pidProfile->thrustLinearizationCutoff < 5
+        ? 1.0f
+        : pt1FilterGain(pidProfile->thrustLinearizationCutoff, pidRuntime.dT);
+    pt1FilterInit(&pidRuntime.thrustLinearizationThrottleFilter, thrustLinearizationFilterGain);
+    for (unsigned i = 0; i < MAX_SUPPORTED_MOTORS; i++) {
+        pt1FilterInit(&pidRuntime.thrustLinearizationMotorFilter[i], thrustLinearizationFilterGain);
+    }
 #endif
 
 #ifdef USE_D_MAX

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -600,6 +600,7 @@ pid_unittest_DEFINES := \
 		USE_RC_SMOOTHING_FILTER= \
 		USE_LAUNCH_CONTROL= \
 		USE_FEEDFORWARD= \
+		USE_THRUST_LINEARIZATION= \
 		USE_ADVANCED_TPA= \
 
 position_rescue_geometry_unittest_SRC := \

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -258,6 +258,22 @@ TEST(pidControllerTest, testThrustLinearizationFiltering)
     EXPECT_NEAR(0.625f, pidApplyThrustLinearization(0.5f, 0), 1e-6f);
     EXPECT_NEAR(0.375f, pidCompensateThrustLinearization(0.5f), 1e-6f);
 
+    pidProfile->thrustLinearizationCutoff = 4;
+    pidInit(pidProfile);
+
+    EXPECT_NEAR(0.625f, pidApplyThrustLinearization(0.5f, 0), 1e-6f);
+    EXPECT_NEAR(0.375f, pidCompensateThrustLinearization(0.5f), 1e-6f);
+
+    pidProfile->thrustLinearizationCutoff = 5;
+    pidInit(pidProfile);
+
+    const float thresholdMotor = pidApplyThrustLinearization(0.5f, 0);
+    EXPECT_GT(thresholdMotor, 0.5f);
+    EXPECT_LT(thresholdMotor, 0.625f);
+    const float thresholdThrottle = pidCompensateThrustLinearization(0.5f);
+    EXPECT_GT(thresholdThrottle, 0.375f);
+    EXPECT_LT(thresholdThrottle, 0.5f);
+
     pidProfile->thrustLinearizationCutoff = 75;
     pidInit(pidProfile);
 
@@ -281,6 +297,10 @@ TEST(pidControllerTest, testThrustLinearizationFiltering)
     }
     EXPECT_NEAR(0.625f, motorOutput, 1e-5f);
     EXPECT_NEAR(0.375f, throttle, 1e-5f);
+
+    // Retained filter state must not push normalized outputs beyond their valid range.
+    EXPECT_FLOAT_EQ(1.0f, pidApplyThrustLinearization(1.0f, 0));
+    EXPECT_FLOAT_EQ(0.0f, pidCompensateThrustLinearization(0.0f));
 }
 
 TEST(pidControllerTest, testStabilisationDisabled)

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -248,6 +248,41 @@ TEST(pidControllerTest, testInitialisation)
     }
 }
 
+TEST(pidControllerTest, testThrustLinearizationFiltering)
+{
+    setDefaultTestSettings();
+    pidProfile->thrustLinearization = 50;
+    pidProfile->thrustLinearizationCutoff = 0;
+    pidInit(pidProfile);
+
+    EXPECT_NEAR(0.625f, pidApplyThrustLinearization(0.5f, 0), 1e-6f);
+    EXPECT_NEAR(0.375f, pidCompensateThrustLinearization(0.5f), 1e-6f);
+
+    pidProfile->thrustLinearizationCutoff = 75;
+    pidInit(pidProfile);
+
+    const float firstMotor0 = pidApplyThrustLinearization(0.5f, 0);
+    const float firstMotor1 = pidApplyThrustLinearization(0.5f, 1);
+    EXPECT_GT(firstMotor0, 0.5f);
+    EXPECT_LT(firstMotor0, 0.625f);
+    EXPECT_FLOAT_EQ(firstMotor0, firstMotor1);
+    EXPECT_GT(pidApplyThrustLinearization(0.5f, 0), firstMotor0);
+
+    const float firstThrottle = pidCompensateThrustLinearization(0.5f);
+    EXPECT_GT(firstThrottle, 0.375f);
+    EXPECT_LT(firstThrottle, 0.5f);
+    EXPECT_LT(pidCompensateThrustLinearization(0.5f), firstThrottle);
+
+    float motorOutput = 0.0f;
+    float throttle = 0.0f;
+    for (int i = 0; i < 100; i++) {
+        motorOutput = pidApplyThrustLinearization(0.5f, 0);
+        throttle = pidCompensateThrustLinearization(0.5f);
+    }
+    EXPECT_NEAR(0.625f, motorOutput, 1e-5f);
+    EXPECT_NEAR(0.375f, throttle, 1e-5f);
+}
+
 TEST(pidControllerTest, testStabilisationDisabled)
 {
     ENABLE_ARMING_FLAG(ARMED);


### PR DESCRIPTION
Thrust linear is pretty good at increasing the noise motors near low throttles, this is due to us inversing a quadratic curve. By adding a lowpass filter to the output of thrust linear we can reduce the effect of this added noise without impacting performance much (if at all). This has often allowed me to run a higher (more accurate) thrust linear value which I was unable to reach previously without adding some extra noise/propwash to my flights.

This introduces the thrust_linear_cut parameter, and setting it to anything lower than 5hz disables the filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an adjustable thrust-linearization cutoff setting in CLI and configuration menus.
  * Added per-motor and throttle filtering for smoother thrust linearization and compensation.
  * Included the cutoff value in system information and parameter reporting.
  * Applied a default cutoff value of 75.

* **Bug Fixes**
  * Improved consistency and gradual convergence of thrust linearization across motors.
  * Kept filtered motor and throttle outputs within their valid ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->