### PR TITLE
fix(sitl): stop calling uartPinConfigure where there is no pin config

### DIFF
--- a/src/main/fc/init.c
+++ b/src/main/fc/init.c
@@ -547,7 +547,7 @@ void initPhase2(void)
     busSwitchInit();
 #endif
 
-#if defined(USE_UART)
+#if defined(USE_UART) && SERIAL_TRAIT_PIN_CONFIG
     uartPinConfigure(serialPinConfig());
 #endif
 


### PR DESCRIPTION
SITL does not boot on master. It dies with SIGFPE in `tasksInit`, and a non-LTO build does not link at all.

SIMULATOR sets `SERIAL_TRAIT_PIN_CONFIG` to 0, so it has neither the `serialPinConfig` parameter group nor a `uartPinConfigure` implementation, but `initPhase2` gated the call on `USE_UART`, which SITL does define through `USE_UART1..6`.

`make TARGET=SITL DEBUG=GDB` fails with `undefined reference to serialPinConfig_System`. The LTO build hides that and produces a binary that reads a parameter group which was never defined, so `serialConfig()->serial_update_rate_hz` comes back as 0 and the `TASK_PERIOD_HZ` division in `tasksInit` traps on the first scheduler setup.

Gates on the platform trait rather than the UART count, since both the group and the function belong to platforms that carry a serial pin config.

With this applied SITL boots, binds 5761 and serves MSP. Verified by connecting the Configurator to it over a WebSocket bridge and round-tripping settings over the MSP CLI. `make test` passes.

The mismatch is not new: the `SERIAL_TRAIT_PIN_CONFIG` guard in `serial_pinconfig.c` dates to #14202 and #15573 did not touch either file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * UART pin configuration is now enabled only when both UART support and serial pin configuration are enabled, preventing unintended configuration in unsupported setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->