### PR TITLE
cli: guard msp_uart_N/msp_baud_N settings against MAX_MSP_PORT_COUNT < 3

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -2014,12 +2014,18 @@ const clivalue_t valueTable[] = {
 #endif
 
     { "serialmsp_halfduplex", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MSP_CONFIG, offsetof(mspConfig_t, halfDuplex) },
+#if MAX_MSP_PORT_COUNT > 0
     { "msp_uart_1", VAR_INT8   | MASTER_VALUE | MODE_LOOKUP_IDENTIFIER, .config.identifier = { IDENTIFIER_LOOKUP_SERIAL_PORT }, PG_MSP_CONFIG, offsetof(mspConfig_t, msp_uart[0]) },
     { "msp_baud_1", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BAUD_RATE }, PG_MSP_CONFIG, offsetof(mspConfig_t, msp_baud[0]) },
+#endif
+#if MAX_MSP_PORT_COUNT > 1
     { "msp_uart_2", VAR_INT8   | MASTER_VALUE | MODE_LOOKUP_IDENTIFIER, .config.identifier = { IDENTIFIER_LOOKUP_SERIAL_PORT }, PG_MSP_CONFIG, offsetof(mspConfig_t, msp_uart[1]) },
     { "msp_baud_2", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BAUD_RATE }, PG_MSP_CONFIG, offsetof(mspConfig_t, msp_baud[1]) },
+#endif
+#if MAX_MSP_PORT_COUNT > 2
     { "msp_uart_3", VAR_INT8   | MASTER_VALUE | MODE_LOOKUP_IDENTIFIER, .config.identifier = { IDENTIFIER_LOOKUP_SERIAL_PORT }, PG_MSP_CONFIG, offsetof(mspConfig_t, msp_uart[2]) },
     { "msp_baud_3", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BAUD_RATE }, PG_MSP_CONFIG, offsetof(mspConfig_t, msp_baud[2]) },
+#endif
 
 // PG_TIMECONFIG
 #ifdef USE_RTC_TIME
@@ -2177,6 +2183,10 @@ const clivalue_t valueTable[] = {
 const uint16_t valueTableEntryCount = ARRAYLEN(valueTable);
 
 STATIC_ASSERT(LOOKUP_TABLE_COUNT == ARRAYLEN(lookupTables), LOOKUP_TABLE_COUNT_incorrect);
+
+// The msp_uart_N/msp_baud_N entries above are written out one slot at a time,
+// so raising MAX_MSP_PORT_COUNT past 3 means adding a slot's worth of them.
+STATIC_ASSERT(MAX_MSP_PORT_COUNT <= 3, msp_port_settings_incomplete);
 
 #ifdef USE_TELEMETRY
 // The telemetry_N_ entries above are written out one slot at a time, so adding


### PR DESCRIPTION
## Summary
. `msp_uart_1..3`/`msp_baud_1..3` were registered unconditionally in `valueTable[]` (`src/main/cli/settings.c`) via `offsetof(mspConfig_t, msp_uart[N])`/`msp_baud[N])`, while `mspConfig_t`'s backing arrays are sized by `MAX_MSP_PORT_COUNT` (default 3, `#ifndef`-overridable in `msp_serial.h`). If a target ever defined `MAX_MSP_PORT_COUNT` below 3, the higher-numbered CLI entries would reference bytes past the end of the actual array — and the CLI get/set path (`cliGetValuePointer`/`cliSetVar` in `cli.c`) performs no bounds check against the parameter group's real size, so this was a genuine out-of-bounds write, not just a theoretical concern. I confirmed this by compiling a standalone reproduction with the real struct layout: at `MAX_MSP_PORT_COUNT=2`, `msp_uart_3`'s offset collides with `msp_baud_1`, and `msp_baud_3`'s offset lands one byte past the struct — a real memory-safety bug (currently dormant since no shipped target overrides the macro below 3).

- Wraps each `msp_uart_N`/`msp_baud_N` pair in `#if MAX_MSP_PORT_COUNT > N` guards, mirroring the existing `telemetry_N_*` pattern in the same file (added in the same commit, 301d01a, that introduced this gap).
- Adds `STATIC_ASSERT(MAX_MSP_PORT_COUNT <= 3, msp_port_settings_incomplete);` next to the file's other table-completeness asserts, so raising the macro above 3 in the future fails the build instead of silently leaving new ports unconfigurable via CLI.

No behavior change at the current default of `MAX_MSP_PORT_COUNT == 3` — verified byte-for-byte identical compiled offsets before/after.

## Test plan

- [x] Standalone reproduction (real struct layout + real `#if`/`STATIC_ASSERT` text from this diff, compiled and run with a real C compiler) confirms: out-of-bounds writes occur pre-fix at `MAX_MSP_PORT_COUNT` = 1 and 2; post-fix, no corruption at 1/2/3 and a compile-time failure at 4.
- [x] `git diff --check` clean; only `src/main/cli/settings.c` touched.
- [ ] Full firmware build across targets (not run — no ARM toolchain available in the environment this fix was prepared in; needs CI/maintainer verification).
- [ ] Betaflight's existing unit test suite does not compile `settings.c` (confirmed via `src/test/Makefile`), so it provides no additional coverage for this change either way.

