### PR TITLE
PICO: Faster lrintf function

### DIFF
--- a/src/platform/PICO/math_pico.S
+++ b/src/platform/PICO/math_pico.S
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "pico/asm_helper.S"
+
+.section .text.mathfunctions, "ax"
+
+// Wrapped lrintf function, because gcc arm (13.3) / newlib is
+// pulling in a long slow function that unpacks floats by hand.
+// Round to nearest integer ("bankers' round", n + 0.5 -> nearest even integer).
+wrapper_func lrintf
+    vmov s0, r0
+    vcvtn.s32.f32 s0, s0
+    vmov  r0, s0
+    bx lr

--- a/src/platform/PICO/math_pico.S
+++ b/src/platform/PICO/math_pico.S
@@ -21,6 +21,8 @@
 
 #include "pico/asm_helper.S"
 
+pico_default_asm_setup
+
 .section .text.mathfunctions, "ax"
 
 // Wrapped lrintf function, because gcc arm (13.3) / newlib is

--- a/src/platform/PICO/memfunctions.S
+++ b/src/platform/PICO/memfunctions.S
@@ -6,6 +6,10 @@
 
 #include "pico/asm_helper.S"
 
+// Don't invoke pico_default_asm_setup
+// The instructions below were written in the old "divided" syntax, and would behave differently
+// if assembled assuming "unified" syntax.
+
 .section .text.memfunctions, "ax"
 
 // Wrapped memset and memcpy functions, code copied from rp2040 bootrom source

--- a/src/platform/PICO/mk/RP2350.mk
+++ b/src/platform/PICO/mk/RP2350.mk
@@ -423,7 +423,16 @@ PICO_MEM_WRAP_FNS = \
 
 PICO_MEM_LD_FLAGS = $(foreach fn, $(PICO_MEM_WRAP_FNS), -Wl,--wrap=$(fn))
 
-EXTRA_LD_FLAGS += $(PICO_STDIO_LD_FLAGS) $(PICO_TRACE_LD_FLAGS) $(PICO_FLOAT_LD_FLAGS) $(PICO_DOUBLE_LD_FLAGS) $(PICO_BIT_OPS_LD_FLAGS) $(PICO_MEM_LD_FLAGS)
+PICO_LIB_SRC += \
+            PICO/math_pico.S
+
+# Wrapped version of lrintf (nearest integer to float) for vcvtn instruction instead of slow library function
+PICO_MATH_WRAP_FNS = \
+            lrintf
+
+PICO_MATH_WRAP_FLAGS = $(foreach fn, $(PICO_MATH_WRAP_FNS), -Wl,--wrap=$(fn))
+
+EXTRA_LD_FLAGS += $(PICO_STDIO_LD_FLAGS) $(PICO_TRACE_LD_FLAGS) $(PICO_FLOAT_LD_FLAGS) $(PICO_DOUBLE_LD_FLAGS) $(PICO_BIT_OPS_LD_FLAGS) $(PICO_MEM_LD_FLAGS) $(PICO_MATH_WRAP_FLAGS)
 
 ifdef RP2350_TARGET
 


### PR DESCRIPTION
PICO: Faster lrintf function

On RP2350, lrintf is compiled to a slow library function. This has a noticeable effect when running Blackbox. 
PICO / RP2350 has the VCVTN instruction to round a float to the nearest integer, so use that (via function wrapping).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved floating-point rounding performance on RP2350 platforms.
  - Integer rounding now uses native processor support for faster results and consistent nearest-even rounding behavior.
- **Compatibility**
  - Added support for the `lrintf` floating-point conversion routine on RP2350.
  - Applications using this routine can now rely on platform-integrated behavior without requiring additional configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->