### PR TITLE
PICO: dshot enable 150 300

### DIFF
--- a/src/platform/PICO/dshot.pio
+++ b/src/platform/PICO/dshot.pio
@@ -10,13 +10,14 @@
 ; For >4 motors, could configure pin with disable, config set, enable, [but run out of time in gyro loop? might need another PIO for more SMs]
 ;
 
-; presumably BF writes dshot async, at max of ~10k/sec or so (typical aiming for 8k loop for gyro)
-; dshot frame takes approx. 0.1ms dshot150 or dshot300_bidir
-; so hopefully never going to be overflowing the tx fifo (but could happen with 150bidir and be close with 150, 300bidir)
+; Betaflight is cautious and automatically reduces the PID rate to ensure that
+; the DSHOT exchange fits into the PID rate period, so we should never be overflowing the tx fifo.
 
 ; DSHOT 600 (non-bidirectional)
 ; 1 bit ~ 1.667us = 40 PIO cycles
 ; Min delay between frames of 2us = 48 cycles, allow 56 cycles
+; This program also serves for DSHOT 300 and DSHOT 150, by dividing the PIO clock appropriately,
+; with min delay ~ 4.5us, ~9us respectively (not going to cause any TX buffer overflow at the respective PID rates)
 .program dshot_600
 start:
     set    pins, 0                [31]      ; Set pin low [assumed pin already set for output]
@@ -37,7 +38,7 @@ outzero:
 
 
 ; DSHOT 600 bidirectional with edge detection receive (integer clock divider)
-; Uses 'wait' instructions for precise edge detection (jmp pin is broken on RP2350)
+; Uses 'wait' instructions for precise edge detection
 ;
 ; INTEGER CLOCK DIVIDER: PIO runs at 75 MHz (150 MHz / 2) for clean timing.
 ; This gives exactly 125 cycles per DShot bit and 100 cycles per telemetry bit.
@@ -61,6 +62,11 @@ outzero:
 ;       5.56x oversampling loop (4 outer x 32 inner = 128 samples)
 ;       switch back to output, drive HIGH
 ; Total: 27 instructions
+;
+; This program also serves for DSHOT 300 and DSHOT 150, by dividing the PIO clock appropriately, with
+; delays (of fixed number of PIO cycles) verified to be in spec. Betaflight automatically reduces the
+; PID rate as required for slower DSHOT rates: the DSHOT exchange should fit into a PID cycle
+; up to and including DSHOT 600 bidir at 8K PID rate.
 
 .program dshot_600_bidir
 
@@ -108,7 +114,6 @@ PUBLIC wait_zero:
     ; Telemetry bit = 100 cycles, so 100/18 = 5.56x oversampling
     ; 21 bits × 5.56 = 117 samples needed, fits in 128 with margin (actually only +20 bit periods until final edge)
 
-
 outer_loop:
     set    y, 31                            ; 32 inner loop iterations
 inner_loop:
@@ -126,5 +131,5 @@ PUBLIC complete:
     set    pins, 1                          ; Set pin HIGH (idle state)
     set    y, 4                             ;
 delay_next_output:
-    jmp    !y, delay_next_output [29]       ; TODO how much min delay here? 2us seen somewhere?? 5*30/75 = 2 us
+    jmp    y--, delay_next_output [29]      ; Abundance of caution delay of 2us/4us/8us (at DSHOT 600/300/150) before next transmit
 .wrap

--- a/src/platform/PICO/dshot_bidir_pico.c
+++ b/src/platform/PICO/dshot_bidir_pico.c
@@ -78,9 +78,9 @@ bool dshot_program_bidir_init(PIO pio, uint sm, int offset, uint pin)
 
     float clocks_per_us = clock_get_hz(clk_sys) / 1000000;
 #ifdef TEST_DSHOT_SLOW
-    sm_config_set_clkdiv(&config, (1.0e4f + dshotGetPeriodTiming()) / DSHOT_BIDIR_BIT_PERIOD * clocks_per_us);
+    sm_config_set_clkdiv(&config, (1.0e4f + dshotBitPeriodUs) / DSHOT_BIDIR_BIT_PERIOD * clocks_per_us);
 #else
-    sm_config_set_clkdiv(&config, dshotGetPeriodTiming() / DSHOT_BIDIR_BIT_PERIOD * clocks_per_us);
+    sm_config_set_clkdiv(&config, dshotBitPeriodUs / DSHOT_BIDIR_BIT_PERIOD * clocks_per_us);
 #endif
 
     bool ok = PICO_OK == pio_sm_init(pio, sm, offset, &config);

--- a/src/platform/PICO/dshot_pico.c
+++ b/src/platform/PICO/dshot_pico.c
@@ -32,30 +32,30 @@
 #include "common/maths.h"
 
 
-static int32_t outgoingPacket[MAX_SUPPORTED_MOTORS]; // 16-bit packet or -1 for none pending.
-const PIO dshotPio = PIO_INSTANCE(PIO_DSHOT_INDEX); // currently only single pio supported => 4 motors.
+#define DSHOT_BIT_PERIOD 40
 
-motorProtocolTypes_e dshotMotorProtocol;
 motorOutput_t dshotMotors[MAX_SUPPORTED_MOTORS];
-
+float dshotBitPeriodUs = 1.666667f;
 bool useDshotTelemetry = false;
 
-float dshotGetPeriodTiming(void)
+const PIO dshotPio = PIO_INSTANCE(PIO_DSHOT_INDEX); // currently only single pio supported => 4 motors.
+
+static int32_t outgoingPacket[MAX_SUPPORTED_MOTORS]; // 16-bit packet or -1 for none pending.
+
+static float dshotGetPeriodTiming(motorProtocolTypes_e dshotMotorProtocol)
 {
     switch(dshotMotorProtocol) {
-        case MOTOR_PROTOCOL_DSHOT600:
-            return 1.666667f;
-        case MOTOR_PROTOCOL_DSHOT300:
-            return 3.333333f;
-        default:
         case MOTOR_PROTOCOL_DSHOT150:
             return 6.666667f;
+        case MOTOR_PROTOCOL_DSHOT300:
+            return 3.333333f;
+        case MOTOR_PROTOCOL_DSHOT600:
+            return 1.666667f;
+        default:
+            return -1.0f;
     }
 }
 
-#define DSHOT_BIT_PERIOD 40
-
-// TODO DSHOT150, 300
 static bool dshot_program_init(PIO pio, uint sm, int offset, uint pin)
 {
     bprintf("dshot_program_init on pin %d", pin);
@@ -71,9 +71,9 @@ static bool dshot_program_init(PIO pio, uint sm, int offset, uint pin)
 
     float clocks_per_us = clock_get_hz(clk_sys) / 1000000;
 #ifdef TEST_DSHOT_SLOW
-    sm_config_set_clkdiv(&config, (1.0e4f + dshotGetPeriodTiming()) / DSHOT_BIT_PERIOD * clocks_per_us);
+    sm_config_set_clkdiv(&config, (1.0e4f + dshotBitPeriodUs) / DSHOT_BIT_PERIOD * clocks_per_us);
 #else
-    sm_config_set_clkdiv(&config, dshotGetPeriodTiming() / DSHOT_BIT_PERIOD * clocks_per_us);
+    sm_config_set_clkdiv(&config, dshotBitPeriodUs / DSHOT_BIT_PERIOD * clocks_per_us);
 #endif
 
     return PICO_OK == pio_sm_init(pio, sm, offset, &config);
@@ -340,12 +340,14 @@ bool dshotPwmDevInit(motorDevice_t *device, const motorDevConfig_t *motorConfig)
         return false;
     }
 
-    dshotMotorProtocol = motorConfig->motorProtocol;
-    if (dshotMotorProtocol != MOTOR_PROTOCOL_DSHOT600) {
-        bprintf("\n*** DSHOT motor protocol [%d] not currently supported", dshotMotorProtocol);
+    motorProtocolTypes_e motorProtocol = motorConfig->motorProtocol;
+    dshotBitPeriodUs = dshotGetPeriodTiming(motorProtocol);
+    if (dshotBitPeriodUs < 0) {
+        bprintf("\n*** DSHOT motor protocol [%d] not currently supported", motorProtocol);
         return false;
-        // TODO support DSHOT300, DSHOT150
     }
+
+    bprintf("dshot protocol [%d] bit period %.3f us", motorProtocol, (double)dshotBitPeriodUs);
 
 #ifdef USE_DSHOT_TELEMETRY
     useDshotTelemetry = motorConfig->useDshotTelemetry; // as per config set dshotBidir ON/OFF, or from Bidirectional Dshot toggle on motor page in Configurator.

--- a/src/platform/PICO/dshot_pico.c
+++ b/src/platform/PICO/dshot_pico.c
@@ -31,7 +31,7 @@
 #include "dshot_pico.h"
 #include "common/maths.h"
 
-
+// (non-bidir) bit period in PIO clocks
 #define DSHOT_BIT_PERIOD 40
 
 motorOutput_t dshotMotors[MAX_SUPPORTED_MOTORS];

--- a/src/platform/PICO/dshot_pico.h
+++ b/src/platform/PICO/dshot_pico.h
@@ -52,11 +52,9 @@ typedef struct motorOutput_s {
 
 extern const PIO dshotPio; // currently only single pio supported => 4 motors.
 
-extern motorProtocolTypes_e dshotMotorProtocol;
-
 extern motorOutput_t dshotMotors[MAX_SUPPORTED_MOTORS];
 
-float dshotGetPeriodTiming(void);
+extern float dshotBitPeriodUs;
 
 bool dshot_program_bidir_init(PIO pio, uint sm, int offset, uint pin);
 bool dshotTelemetryWait(void);

--- a/src/platform/PICO/dshot_pio_programs.h
+++ b/src/platform/PICO/dshot_pio_programs.h
@@ -97,7 +97,7 @@ static const uint16_t dshot_600_bidir_program_instructions[] = {
     0xe081, // 25: set    pindirs, 1
     0xe001, // 26: set    pins, 1
     0xe044, // 27: set    y, 4
-    0x1d7c, // 28: jmp    !y, 28                 [29]
+    0x1d9c, // 28: jmp    y--, 28                [29]
             //     .wrap
 };
 


### PR DESCRIPTION
PICO: dshot enable 150 300

Enable DSHOT 150, DSHOT 300 on PICO.
Fix PIO instruction for final delay loop on DSHOT bidir. 
Update comments (delay loops are within sensible range for 150, 300, 600).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected bidirectional DSHOT post-telemetry timing and delay behavior.
  * Improved DSHOT communication reliability by preventing transmit-buffer overflow during exchanges.

* **Enhancements**
  * Added support for DSHOT150, DSHOT300, and DSHOT600 on PICO targets.
  * Updated timing support for different DSHOT protocols, including slower test configurations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->