### PR TITLE
fix(vtx): follow the OSD's port for an MSP VTX

### DIFF
--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -581,15 +581,24 @@ static void validateAndFixConfig(void)
     }
 
 #ifdef USE_MSP_DISPLAYPORT
-    // Find the first serial port on which MSP Displayport is enabled
+    // Find the serial port the MSP display port is drawn over.  The OSD's own
+    // assignment names it; an MSP VTX with no OSD port set is the legacy way of
+    // saying the same thing, so its UART stands in when the OSD names none.
     displayPortMspSetSerial(SERIAL_PORT_NONE);
 
-    for (unsigned i = 0; i < ARRAYLEN(serialPortIdentifiers); i++) {
-        const serialPortIdentifier_e identifier = serialPortIdentifiers[i];
-        if ((identifier != SERIAL_PORT_USB_VCP)
-            && ((serialSynthesizeFunctionMask(identifier) & (FUNCTION_VTX_MSP | FUNCTION_MSP)) == (FUNCTION_VTX_MSP | FUNCTION_MSP))) {
-            displayPortMspSetSerial(identifier);
-            break;
+#ifdef USE_OSD
+    if (osdConfig()->displayPortDevice == OSD_DISPLAYPORT_DEVICE_MSP && osdConfig()->osd_uart != SERIAL_PORT_NONE) {
+        displayPortMspSetSerial(osdConfig()->osd_uart);
+    } else
+#endif
+    {
+        for (unsigned i = 0; i < ARRAYLEN(serialPortIdentifiers); i++) {
+            const serialPortIdentifier_e identifier = serialPortIdentifiers[i];
+            if ((identifier != SERIAL_PORT_USB_VCP)
+                && (serialSynthesizeFunctionMask(identifier) & FUNCTION_VTX_MSP)) {
+                displayPortMspSetSerial(identifier);
+                break;
+            }
         }
     }
 #endif

--- a/src/main/io/vtx.c
+++ b/src/main/io/vtx.c
@@ -74,9 +74,6 @@ void pgResetFn_vtxSettingsConfig(vtxSettingsConfig_t *vtxSettingsConfig)
 #elif defined(USE_VTX_MSP) && defined(VTX_MSP_UART)
     vtxSettingsConfig->vtx_type = VTXDEV_MSP;
     vtxSettingsConfig->vtx_uart = VTX_MSP_UART;
-#elif defined(USE_VTX_MSP) && defined(MSP_DISPLAYPORT_UART)
-    vtxSettingsConfig->vtx_type = VTXDEV_MSP;
-    vtxSettingsConfig->vtx_uart = MSP_DISPLAYPORT_UART;
 #else
     vtxSettingsConfig->vtx_type = VTXDEV_UNSUPPORTED;
     vtxSettingsConfig->vtx_uart = SERIAL_PORT_NONE;

--- a/src/main/io/vtx_msp.c
+++ b/src/main/io/vtx_msp.c
@@ -50,6 +50,8 @@
 #include "msp/msp_protocol.h"
 #include "msp/msp_serial.h"
 
+#include "osd/osd.h"
+
 #include "pg/vtx_table.h"
 
 #include "rx/crsf.h"
@@ -76,6 +78,22 @@ STATIC_UNIT_TESTED mspVtxStatus_e mspVtxStatus = MSP_VTX_STATUS_OFFLINE;
 static uint8_t mspVtxPortIdentifier = 255;
 
 #define MSP_VTX_REQUEST_PERIOD_US (200 * 1000) // 200ms
+
+// The port is never opened here, it only names the MSP link the VTX answers on.  A goggle
+// system speaks both the display port and the VTX over that one link, so an unassigned VTX
+// port follows the OSD's rather than making the user name the same UART twice.
+static serialPortIdentifier_e mspVtxPort(void)
+{
+    const serialPortIdentifier_e port = vtxSettingsConfig()->vtx_uart;
+
+#if defined(USE_OSD) && defined(USE_MSP_DISPLAYPORT)
+    if (port == SERIAL_PORT_NONE && osdConfig()->displayPortDevice == OSD_DISPLAYPORT_DEVICE_MSP) {
+        return osdConfig()->osd_uart;
+    }
+#endif
+
+    return port;
+}
 
 static bool isCrsfPort(serialPortIdentifier_e port)
 {
@@ -175,7 +193,7 @@ static void vtxMspProcess(vtxDevice_t *vtxDevice, timeUs_t currentTimeUs)
 {
     UNUSED(vtxDevice);
 
-    const serialPortIdentifier_e port = vtxSettingsConfig()->vtx_uart;
+    const serialPortIdentifier_e port = mspVtxPort();
     uint8_t frame[15];
 
     switch (mspVtxStatus) {
@@ -371,8 +389,12 @@ static const vtxVTable_t mspVTable = {
 bool vtxMspInit(void)
 {
     // don't bother setting up this device if we don't have MSP vtx enabled
-    const serialPortIdentifier_e port = vtxSettingsConfig()->vtx_uart;
-    if (port == SERIAL_PORT_NONE || vtxSettingsConfig()->vtx_type != VTXDEV_MSP) {
+    if (vtxSettingsConfig()->vtx_type != VTXDEV_MSP) {
+        return false;
+    }
+
+    const serialPortIdentifier_e port = mspVtxPort();
+    if (port == SERIAL_PORT_NONE) {
         return false;
     }
 

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -685,6 +685,13 @@ bool mspSerialIsConfiguratorActive(void)
             continue;
         }
 
+#ifdef USE_MSP_DISPLAYPORT
+        // The goggles polling on the display port UART are a peripheral too.
+        if (mspPort->port->identifier == displayPortMspGetSerial()) {
+            continue;
+        }
+#endif
+
         if (cmp32(now, mspPort->lastActivityMs) < (int32_t)MSP_ACTIVITY_DEFAULT_TIMEOUT_MS) {
             return true;
         }

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -584,6 +584,21 @@ static void mspProcessPacket(mspPort_t *mspPort, mspProcessCommandFnPtr mspProce
  *
  * Called periodically by the scheduler.
  */
+// A peripheral MSP port has a device streaming on it — the goggles on the
+// display port UART, an MSP VTX, an MSP-transport sensor.  Its bytes are never
+// configurator input, so they must not read as CLI entry, a reboot request, or
+// configurator activity.
+static bool mspPortIsPeripheral(serialPortIdentifier_e identifier)
+{
+#ifdef USE_MSP_DISPLAYPORT
+    if (identifier == displayPortMspGetSerial()) {
+        return true;
+    }
+#endif
+
+    return serialSynthesizeFunctionMask(identifier) & (FUNCTION_VTX_MSP | FUNCTION_LIDAR);
+}
+
 void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessCommandFnPtr mspProcessCommandFn, mspProcessReplyFnPtr mspProcessReplyFn)
 {
     for (mspPort_t *mspPort = mspPorts; mspPort < ARRAYEND(mspPorts); mspPort++) {
@@ -603,11 +618,7 @@ void mspSerialProcess(mspEvaluateNonMspData_e evaluateNonMspData, mspProcessComm
                 mspPort->portState = PORT_MSP_PACKET;
                 mspPort->packetState = MSP_HEADER_START;
             } else if ((evaluateNonMspData == MSP_EVALUATE_NON_MSP_DATA)
-#ifdef USE_MSP_DISPLAYPORT
-                       // Don't evaluate non-MSP commands on VTX MSP port
-                       && (mspPort->port->identifier != displayPortMspGetSerial())
-#endif
-                       ) {
+                       && !mspPortIsPeripheral(mspPort->port->identifier)) {
                 // evaluate the non-MSP data
                 if (c == serialConfig()->reboot_character) {
                     mspPort->pendingRequest = MSP_PENDING_BOOTLOADER_ROM;
@@ -678,19 +689,9 @@ bool mspSerialIsConfiguratorActive(void)
             continue;
         }
 
-        // Skip ports shared with a VTX or an MSP-transport sensor — those are
-        // peripherals, not configurators, and a sensor streaming for the whole
-        // flight would otherwise report a configurator permanently attached.
-        if (serialSynthesizeFunctionMask(mspPort->port->identifier) & (FUNCTION_VTX_MSP | FUNCTION_LIDAR)) {
+        if (mspPortIsPeripheral(mspPort->port->identifier)) {
             continue;
         }
-
-#ifdef USE_MSP_DISPLAYPORT
-        // The goggles polling on the display port UART are a peripheral too.
-        if (mspPort->port->identifier == displayPortMspGetSerial()) {
-            continue;
-        }
-#endif
 
         if (cmp32(now, mspPort->lastActivityMs) < (int32_t)MSP_ACTIVITY_DEFAULT_TIMEOUT_MS) {
             return true;

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -435,7 +435,14 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->osd_show_spec_prearm = true;
 #endif // USE_RACE_PRO
 
+#ifdef MSP_DISPLAYPORT_UART
+    // A board naming a display port UART is wired to goggles, which are drawn
+    // over MSP.  That is the OSD's port, not a VTX's.
+    osdConfig->osd_uart = MSP_DISPLAYPORT_UART;
+    osdConfig->displayPortDevice = OSD_DISPLAYPORT_DEVICE_MSP;
+#else
     osdConfig->osd_uart = SERIAL_PORT_NONE;
+#endif
     osdConfig->osd_custom_text_uart = SERIAL_PORT_NONE;
     osdConfig->osd_custom_text_baud = BAUD_115200;
 }


### PR DESCRIPTION
Follow-up to #15620.

vtx_uart never opens a port for VTXDEV_MSP, it only names the MSP link the VTX answers on, and on a goggle system that link is the display port's own UART. An unassigned vtx_uart now falls back to osd_uart when the display port device is MSP, so DJI, HDZero and Walksnail are set up without naming the same UART twice. A backpack carrying VTX control on the RX UART still names it explicitly, which is what isCrsfPort() needs.

Configurator side: betaflight/betaflight-configurator#5467, where the VTX tab's port row goes read-only for an MSP VTX and shows the OSD's UART.

![VTX tab](https://raw.githubusercontent.com/blckmn/betaflight-configurator/screenshots/osd-protocol-vtx.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic UART selection for MSP VTX communication when using an OSD DisplayPort connection.
  * Added default OSD configuration for builds with MSP DisplayPort support.
  * Improved VTX initialization to operate only when MSP VTX is configured.

* **Bug Fixes**
  * Corrected default UART assignment for MSP-based VTX configurations.
  * Improved serial-port selection and prevented DisplayPort, VTX, and lidar connections from being treated as configurators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->