### PR TITLE
Driver for the Analog Devices ADIS16607 accel/gyro.

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -316,6 +316,7 @@ COMMON_SRC += \
             drivers/accgyro/accgyro_mpu6050.c \
             drivers/accgyro/accgyro_mpu6500.c \
             drivers/accgyro/accgyro_mpu.c \
+            drivers/accgyro/accgyro_spi_adis16607.c \
             drivers/accgyro/accgyro_spi_bmi160.c \
             drivers/accgyro/accgyro_spi_bmi270.c \
             drivers/accgyro/accgyro_spi_icm20649.c \

--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -71,6 +71,7 @@ typedef enum {
     GYRO_ICM42686P,
     GYRO_ICM56686,
     GYRO_VIRTUAL,
+    GYRO_ADIS16607,
     GYRO_HARDWARE_COUNT
 } gyroHardware_e;
 
@@ -88,6 +89,7 @@ typedef enum {
     GYRO_RATE_1_kHz,
     GYRO_RATE_1100_Hz,
     GYRO_RATE_3200_Hz,
+    GYRO_RATE_4780_Hz,
     GYRO_RATE_6400_Hz,
     GYRO_RATE_6664_Hz,
     GYRO_RATE_8_kHz,

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -57,6 +57,7 @@
 #include "drivers/accgyro/accgyro_spi_mpu6500.h"
 #include "drivers/accgyro/accgyro_spi_mpu9250.h"
 #include "drivers/accgyro/accgyro_spi_l3gd20.h"
+#include "drivers/accgyro/accgyro_spi_adis16607.h"
 #include "drivers/accgyro/accgyro_spi_lsm6dsv16x.h"
 #include "drivers/accgyro/accgyro_mpu.h"
 #include "drivers/accgyro/accgyro_spi_icm40609.h"
@@ -397,6 +398,13 @@ static gyroSpiDetectFn_t gyroSpiDetectFnTable[] = {
 #endif
 #ifdef USE_ACCGYRO_ICM40609D
     icm40609SpiDetect,
+#endif
+#ifdef USE_ACCGYRO_ADIS16607
+    // Deliberately last on two counts: this part has no WHO_AM_I so the probe
+    // matches DEV_ID (0x00), an address every other part here also answers, and
+    // the probe has to write the half-duplex mode key before it can read at all.
+    // Running it last means a known part has already claimed the bus by then.
+    adis16607SpiDetect,
 #endif
     NULL // Avoid an empty array
 };

--- a/src/main/drivers/accgyro/accgyro_mpu.h
+++ b/src/main/drivers/accgyro/accgyro_mpu.h
@@ -54,6 +54,8 @@
 #define IIM42653_WHO_AM_I_CONST             (0x56)
 #define LSM6DSV16X_WHO_AM_I_CONST           (0x70)
 #define LSM6DSK320X_WHO_AM_I_CONST          (0x75)
+// ADIS16607 has no WHO_AM_I; DEV_ID (0x00) is the equivalent and reads 0x6000.
+#define ADIS16607_DEV_ID_CONST              (0x6000)
 #define ICM40609_WHO_AM_I_CONST             (0x3B)
 
 // RA = Register Address
@@ -225,7 +227,8 @@ typedef enum {
     ICM_45605_SPI,
     ICM_45686_SPI,
     ICM_56686_SPI,
-    ICM_40609_SPI
+    ICM_40609_SPI,
+    ADIS16607_SPI,
 } mpuSensor_e;
 
 typedef enum {

--- a/src/main/drivers/accgyro/accgyro_spi_adis16607.c
+++ b/src/main/drivers/accgyro/accgyro_spi_adis16607.c
@@ -64,6 +64,8 @@
 #define ADIS16607_WRITE_RETRIES         8
 #define ADIS16607_CONFIG_RETRIES        3
 
+static bool adis16607ConfigOk;
+
 // Half duplex: the response arrives in the same 32-bit frame as the command.
 static uint16_t adis16607ReadReg(const extDevice_t *dev, uint8_t reg)
 {
@@ -233,9 +235,11 @@ static void adis16607GyroInit(gyroDev_t *gyro)
      * fail their checksum or their data counter rather than publish a
      * misinterpreted frame.
      */
+    adis16607ConfigOk = false;
     for (int tries = 0; tries < ADIS16607_CONFIG_RETRIES; tries++) {
         adis16607Unlock(dev);
         if (adis16607Configure(dev, filterBandwidthOptions[gyroConfig()->gyro_hardware_lpf])) {
+            adis16607ConfigOk = true;
             break;
         }
     }

--- a/src/main/drivers/accgyro/accgyro_spi_adis16607.c
+++ b/src/main/drivers/accgyro/accgyro_spi_adis16607.c
@@ -1,0 +1,460 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "platform.h"
+
+#if defined(USE_ACCGYRO_ADIS16607)
+
+#include "common/axis.h"
+#include "common/maths.h"
+#include "common/utils.h"
+
+#include "drivers/accgyro/accgyro.h"
+#include "drivers/accgyro/accgyro_mpu.h"
+#include "drivers/accgyro/accgyro_spi_adis16607.h"
+#include "drivers/bus_spi.h"
+#include "drivers/exti.h"
+#include "drivers/io.h"
+#include "drivers/nvic.h"
+#include "drivers/time.h"
+
+#include "pg/gyrodev.h"
+
+#include "sensors/gyro.h"
+
+/*
+ * Analog Devices ADIS16607 precision MEMS IMU, gyro and accelerometer.
+ *
+ * Driven in the 16-bit output format, so readFn gets one int16_t per channel
+ * and the LOW registers never cross the bus. The FIFO is disabled, so the burst
+ * reads the live output registers and one data-ready pulse gives exactly one
+ * fresh sample.
+ */
+
+#define ADIS16607_DEC_RATE_SETTING      ADIS16607_DEC_RATE_4780HZ
+
+#define GYRO_EXTI_DETECT_THRESHOLD      1000
+
+#define ADIS16607_RESET_DELAY_MS        200
+#define ADIS16607_STATUS_RETRIES        20
+#define ADIS16607_STATUS_DELAY_MS       10
+#define ADIS16607_DEV_ID_RETRIES        5
+#define ADIS16607_WRITE_RETRIES         8
+#define ADIS16607_CONFIG_RETRIES        3
+
+// Half duplex: the response arrives in the same 32-bit frame as the command.
+static uint16_t adis16607ReadReg(const extDevice_t *dev, uint8_t reg)
+{
+    uint8_t txBuf[4] = { reg | ADIS16607_READ_BIT, 0, 0, 0 };
+    uint8_t rxBuf[4] = { 0 };
+
+    spiReadWriteBuf(dev, txBuf, rxBuf, sizeof(txBuf));
+
+    return (rxBuf[2] << 8) | rxBuf[3];
+}
+
+static void adis16607WriteReg(const extDevice_t *dev, uint8_t reg, uint16_t value)
+{
+    uint8_t txBuf[3] = { reg, value >> 8, value & 0xff };
+
+    spiReadWriteBuf(dev, txBuf, NULL, sizeof(txBuf));
+}
+
+// The part silently drops writes while locked or while the bootloader runs.
+static bool adis16607WriteRegVerify(const extDevice_t *dev, uint8_t reg, uint16_t value)
+{
+    for (int i = 0; i < ADIS16607_WRITE_RETRIES; i++) {
+        adis16607WriteReg(dev, reg, value);
+        if (adis16607ReadReg(dev, reg) == value) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void adis16607Unlock(const extDevice_t *dev)
+{
+    adis16607WriteReg(dev, ADIS16607_REG_WRITE_LOCK, ADIS16607_WRITE_LOCK_KEY_A);
+    adis16607WriteReg(dev, ADIS16607_REG_WRITE_LOCK, ADIS16607_WRITE_LOCK_KEY_B);
+}
+
+static void adis16607Lock(const extDevice_t *dev)
+{
+    adis16607WriteReg(dev, ADIS16607_REG_WRITE_LOCK, ADIS16607_WRITE_LOCK_KEY_B);
+    adis16607WriteReg(dev, ADIS16607_REG_WRITE_LOCK, ADIS16607_WRITE_LOCK_KEY_A);
+}
+
+uint8_t adis16607SpiDetect(const extDevice_t *dev)
+{
+    /* This probe must write before it can read. Out of reset the part tells full
+     * from half duplex by frame length, and a read is 32 bits either way, so it
+     * resolves a bare read as full duplex and answers with a CRC error. The
+     * 24-bit key write is the only unambiguously half-duplex frame. With no ADIS
+     * fitted it writes 0xB4B4 to register 0x32 of whatever else is on the bus,
+     * so this probe is deliberately last in gyroSpiDetectFnTable[].
+     */
+    for (int tries = 0; tries < ADIS16607_DEV_ID_RETRIES; tries++) {
+        adis16607WriteReg(dev, ADIS16607_REG_SPI_HALFDUPLEX_KEY, ADIS16607_SPI_HALFDUPLEX_KEY_VAL);
+
+        if (adis16607ReadReg(dev, ADIS16607_REG_DEV_ID) == ADIS16607_DEV_ID_CONST) {
+            return ADIS16607_SPI;
+        }
+    }
+
+    return MPU_NONE;
+}
+
+/*
+ * The data counter is the only thing in a burst that separates a fresh sample
+ * from a re-read of output registers the part has not rewritten yet: the
+ * checksum matches either way. Held per device, since two of these can share a
+ * build.
+ */
+typedef struct {
+    const gyroDev_t *gyro;
+    uint16_t dataCntr;
+    bool valid;
+} adis16607FrameState_t;
+
+static adis16607FrameState_t frameStates[MAX_GYRODEV_COUNT];
+
+static adis16607FrameState_t *adis16607FrameState(const gyroDev_t *gyro)
+{
+    for (unsigned i = 0; i < ARRAYLEN(frameStates); i++) {
+        if (frameStates[i].gyro == gyro) {
+            return &frameStates[i];
+        }
+    }
+
+    for (unsigned i = 0; i < ARRAYLEN(frameStates); i++) {
+        if (!frameStates[i].gyro) {
+            frameStates[i].gyro = gyro;
+            return &frameStates[i];
+        }
+    }
+
+    return NULL;
+}
+
+// Every write here changes how the burst is laid out or how fast it arrives, so
+// each one is verified and the caller retries the whole block on failure.
+static bool adis16607Configure(const extDevice_t *dev, uint16_t filterBandwidth)
+{
+    bool ok = true;
+
+    // Data ready on GPIO3, the pin wired to GYRO_1_EXTI_PIN.
+    ok = adis16607WriteRegVerify(dev, ADIS16607_REG_USER_GPIO_CFG1, ADIS16607_GPIO_CFG1_GPIO3_DATA_RDY) && ok;
+
+    ok = adis16607WriteRegVerify(dev, ADIS16607_REG_USER_DATA_CFG, ADIS16607_USER_DATA_CFG) && ok;
+
+    ok = adis16607WriteRegVerify(dev, ADIS16607_REG_MSC_CTRL, filterBandwidth) && ok;
+
+    // Zero DEC_RATE first so the decimation accumulator resets.
+    ok = adis16607WriteRegVerify(dev, ADIS16607_REG_DEC_RATE, ADIS16607_DEC_RATE_9560HZ) && ok;
+    ok = adis16607WriteRegVerify(dev, ADIS16607_REG_DEC_RATE, ADIS16607_DEC_RATE_SETTING) && ok;
+
+    ok = adis16607WriteRegVerify(dev, ADIS16607_REG_USER_FIFO_CFG, ADIS16607_FIFO_CFG_DISABLED) && ok;
+
+    return ok;
+}
+
+static void adis16607GyroInit(gyroDev_t *gyro)
+{
+    const extDevice_t *dev = &gyro->dev;
+
+    // Default off: the filter's phase lag is unquantified, which is not
+    // acceptable in a 4kHz PID loop.
+    static const uint16_t filterBandwidthOptions[GYRO_HARDWARE_LPF_COUNT] = {
+        [GYRO_HARDWARE_LPF_NORMAL] = ADIS16607_MSC_CTRL_FILT_BW_OFF,
+        [GYRO_HARDWARE_LPF_OPTION_1] = ADIS16607_MSC_CTRL_FILT_BW_500HZ,
+        [GYRO_HARDWARE_LPF_OPTION_2] = ADIS16607_MSC_CTRL_FILT_BW_100HZ,
+#ifdef USE_GYRO_DLPF_EXPERIMENTAL
+        [GYRO_HARDWARE_LPF_EXPERIMENTAL] = ADIS16607_MSC_CTRL_FILT_BW_20HZ,
+#endif
+    };
+
+    spiSetClkDivisor(dev, spiCalculateDivider(ADIS16607_MAX_SPI_CLK_HZ));
+
+    // SOFT_RESET restores register defaults, which forgets the SPI mode key.
+    for (int tries = 0; tries < ADIS16607_DEV_ID_RETRIES; tries++) {
+        adis16607Unlock(dev);
+        adis16607WriteReg(dev, ADIS16607_REG_SOFT_RESET, ADIS16607_SOFT_RESET_REG_RESET);
+        delay(ADIS16607_RESET_DELAY_MS);
+        adis16607WriteReg(dev, ADIS16607_REG_SPI_HALFDUPLEX_KEY, ADIS16607_SPI_HALFDUPLEX_KEY_VAL);
+
+        if (adis16607ReadReg(dev, ADIS16607_REG_DEV_ID) == ADIS16607_DEV_ID_CONST) {
+            break;
+        }
+    }
+
+    for (int tries = 0; tries < ADIS16607_STATUS_RETRIES; tries++) {
+        if (!(adis16607ReadReg(dev, ADIS16607_REG_DIGITAL_STATUS) & ADIS16607_DIGITAL_STATUS_BOOTLOAD_BUSY)) {
+            break;
+        }
+        delay(ADIS16607_STATUS_DELAY_MS);
+    }
+
+    // Let the startup errors settle. These reads may not clear the flags, so do
+    // not rely on them to.
+    for (int tries = 0; tries < ADIS16607_STATUS_RETRIES; tries++) {
+        if (adis16607ReadReg(dev, ADIS16607_REG_DIAG_STAT) == 0) {
+            break;
+        }
+        delay(ADIS16607_STATUS_DELAY_MS);
+    }
+
+    /* A configuration write the part drops is not cosmetic: the wrong
+     * USER_DATA_CFG shifts every word of the burst, and the wrong DEC_RATE runs
+     * the part at an ODR the scheduler was not told about. Unlock and retry the
+     * block until it reads back. If it never does, the reads that follow will
+     * fail their checksum or their data counter rather than publish a
+     * misinterpreted frame.
+     */
+    for (int tries = 0; tries < ADIS16607_CONFIG_RETRIES; tries++) {
+        adis16607Unlock(dev);
+        if (adis16607Configure(dev, filterBandwidthOptions[gyroConfig()->gyro_hardware_lpf])) {
+            break;
+        }
+    }
+
+    // Locking is what leaves the initialisation state and starts data-ready.
+    adis16607Lock(dev);
+
+    adis16607FrameState_t *state = adis16607FrameState(gyro);
+    if (state) {
+        state->valid = false;
+    }
+
+    gyro->scale = ADIS16607_GYRO_SCALE;
+    gyro->tempScale = ADIS16607_TEMP_SCALE;
+    gyro->tempZero = ADIS16607_TEMP_ZERO;
+
+    mpuGyroInit(gyro);
+
+    // Replace the MPU-style defaults mpuGyroInit() left behind.
+    gyro->gyroDataReg = ADIS16607_REG_X_GYRO_HIGH;
+    gyro->accDataReg = ADIS16607_REG_X_ACCEL_HIGH;
+    gyro->tempDataReg = ADIS16607_REG_TEMPERATURE;
+    gyro->dmaReadRegStart = ADIS16607_BURST_CMD;
+
+    /* mpuIntExtiInit() arms a rising edge, but the output registers are still
+     * updating then and a burst can tear across a sample boundary, so sample on
+     * the falling edge. Only where mpuIntExtiInit() claimed the pin and installed
+     * the handler, since it returns early otherwise.
+     */
+    const IO_t mpuIntIO = IOGetByTag(gyro->mpuIntExtiTag);
+#ifdef ENSURE_MPU_DATA_READY_IS_LOW
+    if (mpuIntIO && !IORead(mpuIntIO)) {
+#else
+    if (mpuIntIO) {
+#endif
+        EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING,
+                   BETAFLIGHT_EXTI_TRIGGER_FALLING);
+        EXTIEnable(mpuIntIO);
+    }
+}
+
+static void adis16607AccInit(accDev_t *acc)
+{
+    acc->acc_1G = ADIS16607_ACC_1G;
+}
+
+// Byte-wise so the frame needs no alignment guarantee on gyro->dev.rxBuf, which
+// is a plain uint8_t DMA buffer.
+static uint16_t adis16607Word(const uint8_t *frame, int word)
+{
+    return (frame[word * 2] << 8) | frame[word * 2 + 1];
+}
+
+static bool adis16607BurstChecksumValid(const uint8_t *frame)
+{
+    uint16_t sum = 0;
+    uint16_t orBits = 0;
+    uint16_t andBits = 0xffff;
+
+    for (int i = ADIS16607_BURST_CHECKSUM_FIRST_WORD; i < ADIS16607_BURST_WORD_CHECKSUM; i++) {
+        const uint16_t word = adis16607Word(frame, i);
+        sum += word;
+        orBits |= word;
+        andBits &= word;
+    }
+
+    /* A truncated sum has fixed points at both rails, so an all-zero and an
+     * all-ones frame both validate - and those are exactly what a bus with MISO
+     * stuck low or high returns. Neither is a real sample: the accel cannot read
+     * zero on all three axes, and 0xffff on every word would need DIAG_STAT to
+     * report every fault at once.
+     */
+    if (orBits == 0 || andBits == 0xffff) {
+        return false;
+    }
+
+    return sum == adis16607Word(frame, ADIS16607_BURST_WORD_CHECKSUM);
+}
+
+static bool adis16607UnpackGyro(gyroDev_t *gyro)
+{
+    const uint8_t *frame = gyro->dev.rxBuf;
+
+    if (!adis16607BurstChecksumValid(frame)) {
+        return false;
+    }
+
+    /* An unchanged data counter means the output registers were read twice
+     * between two of the part's updates, so this frame repeats the last one. The
+     * polled path hits that whenever the gyro task and the 4780Hz ODR drift out
+     * of phase, and the DMA path hits it when a transfer completes before the
+     * next data-ready edge; publishing it either way feeds the PID loop a rate
+     * it has already acted on.
+     */
+    adis16607FrameState_t *state = adis16607FrameState(gyro);
+    const uint16_t dataCntr = adis16607Word(frame, ADIS16607_BURST_WORD_DATA_CNTR);
+    if (state) {
+        if (state->valid && dataCntr == state->dataCntr) {
+            return false;
+        }
+        state->dataCntr = dataCntr;
+        state->valid = true;
+    }
+
+    gyro->gyroADCRaw[X] = (int16_t)adis16607Word(frame, ADIS16607_BURST_WORD_GYRO + X);
+    gyro->gyroADCRaw[Y] = (int16_t)adis16607Word(frame, ADIS16607_BURST_WORD_GYRO + Y);
+    gyro->gyroADCRaw[Z] = (int16_t)adis16607Word(frame, ADIS16607_BURST_WORD_GYRO + Z);
+
+    gyro->temperature = (int16_t)(((int16_t)adis16607Word(frame, ADIS16607_BURST_WORD_TEMPERATURE))
+                                 * gyro->tempScale + gyro->tempZero);
+
+    return true;
+}
+
+static void adis16607StartBurst(gyroDev_t *gyro)
+{
+    gyro->dev.txBuf[0] = ADIS16607_BURST_CMD;
+
+    busSegment_t segments[] = {
+        {.u.buffers = {NULL, NULL}, ADIS16607_BURST_FRAME_LEN, true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+    segments[0].u.buffers.txData = gyro->dev.txBuf;
+    segments[0].u.buffers.rxData = gyro->dev.rxBuf;
+
+    spiSequence(&gyro->dev, &segments[0]);
+    spiWait(&gyro->dev);
+}
+
+static bool adis16607GyroReadSPI(gyroDev_t *gyro)
+{
+    switch (gyro->gyroModeSPI) {
+    case GYRO_EXTI_INIT:
+    {
+        // Zero, not 0xff: trailing bytes must not look like another command.
+        memset(gyro->dev.txBuf, 0, ADIS16607_BURST_FRAME_LEN);
+
+        gyro->gyroDmaMaxDuration = 5;
+        if (gyro->detectedEXTI > GYRO_EXTI_DETECT_THRESHOLD) {
+#ifdef USE_DMA
+            if (spiUseDMA(&gyro->dev)) {
+                gyro->dev.callbackArg = (uintptr_t)gyro;
+                gyro->dev.txBuf[0] = ADIS16607_BURST_CMD;
+                gyro->segments[0].len = ADIS16607_BURST_FRAME_LEN;
+                gyro->segments[0].callback = mpuIntCallback;
+                gyro->segments[0].u.buffers.txData = gyro->dev.txBuf;
+                // The burst payload starts at byte 0, so no offset.
+                gyro->segments[0].u.buffers.rxData = gyro->dev.rxBuf;
+                gyro->segments[0].negateCS = true;
+                gyro->gyroModeSPI = GYRO_EXTI_INT_DMA;
+            } else
+#endif
+            {
+                gyro->gyroModeSPI = GYRO_EXTI_INT;
+            }
+        } else {
+            gyro->gyroModeSPI = GYRO_EXTI_NO_INT;
+        }
+        break;
+    }
+
+    case GYRO_EXTI_INT:
+    case GYRO_EXTI_NO_INT:
+        adis16607StartBurst(gyro);
+        return adis16607UnpackGyro(gyro);
+
+    case GYRO_EXTI_INT_DMA:
+        // Started by the EXTI handler; don't wait. Worst case is a stale sample.
+        return adis16607UnpackGyro(gyro);
+
+    default:
+        break;
+    }
+
+    return true;
+}
+
+static bool adis16607AccReadSPI(accDev_t *acc)
+{
+    // Same frame the gyro read already fetched - no separate accel transaction.
+    const uint8_t *frame = acc->gyro->dev.rxBuf;
+
+    if (acc->gyro->gyroModeSPI == GYRO_EXTI_INIT) {
+        return true;
+    }
+
+    if (!adis16607BurstChecksumValid(frame)) {
+        return false;
+    }
+
+    acc->ADCRaw[X] = (int16_t)adis16607Word(frame, ADIS16607_BURST_WORD_ACCEL + X);
+    acc->ADCRaw[Y] = (int16_t)adis16607Word(frame, ADIS16607_BURST_WORD_ACCEL + Y);
+    acc->ADCRaw[Z] = (int16_t)adis16607Word(frame, ADIS16607_BURST_WORD_ACCEL + Z);
+
+    return true;
+}
+
+bool adis16607SpiGyroDetect(gyroDev_t *gyro)
+{
+    if (gyro->mpuDetectionResult.sensor != ADIS16607_SPI) {
+        return false;
+    }
+
+    gyro->initFn = adis16607GyroInit;
+    gyro->readFn = adis16607GyroReadSPI;
+
+    return true;
+}
+
+bool adis16607SpiAccDetect(accDev_t *acc)
+{
+    if (acc->mpuDetectionResult.sensor != ADIS16607_SPI) {
+        return false;
+    }
+
+    acc->initFn = adis16607AccInit;
+    acc->readFn = adis16607AccReadSPI;
+
+    return true;
+}
+
+#endif // USE_ACCGYRO_ADIS16607

--- a/src/main/drivers/accgyro/accgyro_spi_adis16607.h
+++ b/src/main/drivers/accgyro/accgyro_spi_adis16607.h
@@ -160,6 +160,8 @@
  * the gyro by 4x with nothing to show for it at runtime. There is therefore no
  * default: a board fitting the part states which one it fitted, in its config.h.
  */
+#if defined(USE_ACCGYRO_ADIS16607)
+
 #ifndef ADIS16607_VARIANT
 #error "ADIS16607_VARIANT must be defined as 2 (ADIS16607-2, +/-450 deg/s) or 3 (ADIS16607-3, +/-2000 deg/s) - the two parts share a DEV_ID and differ 4x in gyro sensitivity"
 #endif
@@ -178,6 +180,8 @@
 // 0.005 degC/LSB, offset 25 degC.
 #define ADIS16607_TEMP_SCALE                0.005f
 #define ADIS16607_TEMP_ZERO                 25.0f
+
+#endif // USE_ACCGYRO_ADIS16607
 
 uint8_t adis16607SpiDetect(const extDevice_t *dev);
 

--- a/src/main/drivers/accgyro/accgyro_spi_adis16607.h
+++ b/src/main/drivers/accgyro/accgyro_spi_adis16607.h
@@ -1,0 +1,185 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "drivers/accgyro/accgyro.h"
+#include "drivers/accgyro/accgyro_mpu.h"
+#include "drivers/bus.h"
+
+// Analog Devices ADIS16607 precision MEMS IMU (gyro + accel).
+
+// t_STALL is 10ns, so no inter-frame delay is needed.
+#define ADIS16607_MAX_SPI_CLK_HZ    10000000
+
+// Bit 7 set means read.
+#define ADIS16607_READ_BIT          0x80
+
+// Registers are 16 bits wide, big-endian on the wire.
+#define ADIS16607_REG_DEV_ID                0x00
+#define ADIS16607_REG_REV_ID                0x01
+#define ADIS16607_REG_DIAG_STAT             0x05
+#define ADIS16607_REG_X_ACCEL_HIGH          0x06
+#define ADIS16607_REG_X_GYRO_HIGH           0x0C
+#define ADIS16607_REG_TEMPERATURE           0x20
+#define ADIS16607_REG_WRITE_LOCK            0x2D
+#define ADIS16607_REG_USER_GPIO_CFG1        0x2F
+#define ADIS16607_REG_SPI_FULLDUPLEX_KEY    0x31
+#define ADIS16607_REG_SPI_HALFDUPLEX_KEY    0x32
+#define ADIS16607_REG_USER_DATA_CFG         0x34
+#define ADIS16607_REG_USER_FIFO_CFG         0x35
+#define ADIS16607_REG_SOFT_RESET            0x36
+#define ADIS16607_REG_MSC_CTRL              0x39
+#define ADIS16607_REG_DEC_RATE              0x3A
+#define ADIS16607_REG_DIGITAL_STATUS        0x4E
+
+// A then B unlocks, B then A locks. The part will not leave its initialisation
+// phase until write lock is set, so locking is mandatory.
+#define ADIS16607_WRITE_LOCK_KEY_A          0xAAAA
+#define ADIS16607_WRITE_LOCK_KEY_B          0x5555
+#define ADIS16607_WRITE_LOCK_LOCKED         0x0001
+
+// Pins the part to half duplex, where the response arrives in the same frame.
+// Required: burst reads only work in half duplex.
+#define ADIS16607_SPI_HALFDUPLEX_KEY_VAL    0xB4B4
+
+// CFG_GPIO_3 is bits [11:9]; 001 is data ready.
+#define ADIS16607_GPIO_CFG1_GPIO3_DATA_RDY  (1 << 9)
+
+#define ADIS16607_DATA_CFG_X_ACCEL_EN       (1 << 0)
+#define ADIS16607_DATA_CFG_Y_ACCEL_EN       (1 << 1)
+#define ADIS16607_DATA_CFG_Z_ACCEL_EN       (1 << 2)
+#define ADIS16607_DATA_CFG_X_GYRO_EN        (1 << 3)
+#define ADIS16607_DATA_CFG_Y_GYRO_EN        (1 << 4)
+#define ADIS16607_DATA_CFG_Z_GYRO_EN        (1 << 5)
+#define ADIS16607_DATA_CFG_X_DELTVEL_EN     (1 << 6)
+#define ADIS16607_DATA_CFG_Y_DELTVEL_EN     (1 << 7)
+#define ADIS16607_DATA_CFG_Z_DELTVEL_EN     (1 << 8)
+#define ADIS16607_DATA_CFG_X_DELTANG_EN     (1 << 9)
+#define ADIS16607_DATA_CFG_Y_DELTANG_EN     (1 << 10)
+#define ADIS16607_DATA_CFG_Z_DELTANG_EN     (1 << 11)
+#define ADIS16607_DATA_CFG_TEMPERATURE_EN   (1 << 12)
+#define ADIS16607_DATA_CFG_TIME_STAMP_EN    (1 << 13)
+#define ADIS16607_DATA_CFG_DATA_CNTR_EN     (1 << 14)
+#define ADIS16607_DATA_CFG_WORD_SIZE_16     (0 << 15)
+#define ADIS16607_DATA_CFG_WORD_SIZE_32     (1 << 15)
+
+// FIFO_THRESHOLD is bits [10:0]; zero disables the FIFO.
+#define ADIS16607_FIFO_CFG_CLEAR_FIFOB      (1 << 15)
+#define ADIS16607_FIFO_CFG_ST_GYRO_EN       (1 << 14)
+#define ADIS16607_FIFO_CFG_ST_ACCEL_EN      (1 << 13)
+#define ADIS16607_FIFO_CFG_DISABLED         0x0000
+
+#define ADIS16607_SOFT_RESET_REG_RESET      (1 << 0)
+
+// FILT_BW is bits [9:8].
+#define ADIS16607_MSC_CTRL_FILT_BW_OFF      (0 << 8)
+#define ADIS16607_MSC_CTRL_FILT_BW_500HZ    (1 << 8)
+#define ADIS16607_MSC_CTRL_FILT_BW_100HZ    (2 << 8)
+#define ADIS16607_MSC_CTRL_FILT_BW_20HZ     (3 << 8)
+
+// f_ODR = 9560 / (DEC_RATE + 1).
+#define ADIS16607_BASE_ODR_HZ               9560
+#define ADIS16607_DEC_RATE_9560HZ           0
+#define ADIS16607_DEC_RATE_4780HZ           1
+#define ADIS16607_DEC_RATE_3186HZ           2
+#define ADIS16607_DEC_RATE_2390HZ           3
+#define ADIS16607_DEC_RATE_1195HZ           7
+
+#define ADIS16607_DIGITAL_STATUS_BOOTLOAD_BUSY (1 << 0)
+
+/*
+ * Burst: a half-duplex read of DIAG_STAT with CS held low past the command
+ * frame clocks out the USER_DATA_CFG-enabled registers in bit order plus a
+ * checksum word - here eleven 16-bit words: status, DIAG_STAT, accel XYZ, gyro
+ * XYZ, temperature, data counter, checksum. Word 0 is the command frame's first
+ * half, so the payload starts at byte 0 of the frame.
+ */
+#define ADIS16607_BURST_CMD                 (ADIS16607_REG_DIAG_STAT | ADIS16607_READ_BIT)
+
+#define ADIS16607_BURST_WORD_STATUS         0
+#define ADIS16607_BURST_WORD_DIAG_STAT      1
+#define ADIS16607_BURST_WORD_ACCEL          2
+#define ADIS16607_BURST_WORD_GYRO           5
+#define ADIS16607_BURST_WORD_TEMPERATURE    8
+#define ADIS16607_BURST_WORD_DATA_CNTR      9
+#define ADIS16607_BURST_WORD_CHECKSUM       10
+#define ADIS16607_BURST_WORD_COUNT          11
+#define ADIS16607_BURST_FRAME_LEN           (ADIS16607_BURST_WORD_COUNT * sizeof(uint16_t))
+
+// 16-bit truncated sum of DIAG_STAT up to (excluding) the checksum word.
+#define ADIS16607_BURST_CHECKSUM_FIRST_WORD ADIS16607_BURST_WORD_DIAG_STAT
+
+/*
+ * Delta velocity/angle and the time stamp are left out: Betaflight integrates
+ * rate itself, and every extra word costs EXTI-to-sample bus time. The data
+ * counter earns its two bytes - a truncated sum cannot tell a re-read of an
+ * unchanged output register from a fresh sample, and the counter can, which is
+ * what keeps the polled path from feeding duplicated samples into the PID loop.
+ */
+#define ADIS16607_USER_DATA_CFG                             \
+    (ADIS16607_DATA_CFG_WORD_SIZE_16                        \
+     | ADIS16607_DATA_CFG_X_ACCEL_EN                        \
+     | ADIS16607_DATA_CFG_Y_ACCEL_EN                        \
+     | ADIS16607_DATA_CFG_Z_ACCEL_EN                        \
+     | ADIS16607_DATA_CFG_X_GYRO_EN                         \
+     | ADIS16607_DATA_CFG_Y_GYRO_EN                         \
+     | ADIS16607_DATA_CFG_Z_GYRO_EN                         \
+     | ADIS16607_DATA_CFG_TEMPERATURE_EN                    \
+     | ADIS16607_DATA_CFG_DATA_CNTR_EN)
+
+/*
+ * 16-bit format sensitivities:
+ *   gyro -2   62.5   LSB/deg/s  over +/-450 deg/s (+/-480 max)
+ *   gyro -3   15.625 LSB/deg/s  over +/-2000 deg/s
+ *   accel    781.25  LSB/g      over +/-40 g, both variants
+ *
+ * DEV_ID reads 0x6000 on both variants and no register reports which part is
+ * fitted, so the variant is a build-time choice, and getting it wrong scales
+ * the gyro by 4x with nothing to show for it at runtime. There is therefore no
+ * default: a board fitting the part states which one it fitted, in its config.h.
+ */
+#ifndef ADIS16607_VARIANT
+#error "ADIS16607_VARIANT must be defined as 2 (ADIS16607-2, +/-450 deg/s) or 3 (ADIS16607-3, +/-2000 deg/s) - the two parts share a DEV_ID and differ 4x in gyro sensitivity"
+#endif
+
+#if ADIS16607_VARIANT == 2
+#define ADIS16607_GYRO_LSB_PER_DPS          62.5f
+#elif ADIS16607_VARIANT == 3
+#define ADIS16607_GYRO_LSB_PER_DPS          15.625f
+#else
+#error "ADIS16607_VARIANT must be 2 or 3 - no other variant exists"
+#endif
+
+#define ADIS16607_GYRO_SCALE                (1.0f / ADIS16607_GYRO_LSB_PER_DPS)
+#define ADIS16607_ACC_1G                    781
+
+// 0.005 degC/LSB, offset 25 degC.
+#define ADIS16607_TEMP_SCALE                0.005f
+#define ADIS16607_TEMP_ZERO                 25.0f
+
+uint8_t adis16607SpiDetect(const extDevice_t *dev);
+
+bool adis16607SpiAccDetect(accDev_t *acc);
+bool adis16607SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/gyro_sync.c
+++ b/src/main/drivers/accgyro/gyro_sync.c
@@ -83,6 +83,16 @@ uint16_t gyroSetSampleRate(gyroDev_t *gyro)
             accSampleRateHz = 833;
             break;
 #endif
+#ifdef USE_ACCGYRO_ADIS16607
+        case ADIS16607_SPI:
+            // 9560 Hz base ODR with DEC_RATE = 1 gives 4780 Hz. The accel words
+            // arrive in the same burst at that rate; 1195 is the rate they are
+            // consumed at, not a hardware decimation.
+            gyro->gyroRateKHz = GYRO_RATE_4780_Hz;
+            gyroSampleRateHz = 4780;
+            accSampleRateHz = 1195;
+            break;
+#endif
         case ICM_45686_SPI:
         case ICM_45605_SPI:
         case ICM_56686_SPI:

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -60,6 +60,7 @@ typedef enum {
     ACC_ICM42686P,
     ACC_ICM56686,
     ACC_VIRTUAL,
+    ACC_ADIS16607,
     ACC_HARDWARE_COUNT
 } accelerationSensor_e;
 

--- a/src/main/sensors/acceleration_init.c
+++ b/src/main/sensors/acceleration_init.c
@@ -52,6 +52,7 @@
 #include "drivers/accgyro/accgyro_spi_icm40609.h"
 
 #include "drivers/accgyro/accgyro_spi_lsm6dso.h"
+#include "drivers/accgyro/accgyro_spi_adis16607.h"
 #include "drivers/accgyro/accgyro_spi_lsm6dsv16x.h"
 
 #include "drivers/accgyro/accgyro_spi_mpu6000.h"
@@ -333,6 +334,15 @@ retry:
     case ACC_LSM6DSK320X:
         if (lsm6dsk320xSpiAccDetect(dev)) {
             accHardware = ACC_LSM6DSK320X;
+            break;
+        }
+        FALLTHROUGH;
+#endif
+
+#ifdef USE_ACCGYRO_ADIS16607
+    case ACC_ADIS16607:
+        if (adis16607SpiAccDetect(dev)) {
+            accHardware = ACC_ADIS16607;
             break;
         }
         FALLTHROUGH;

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -53,6 +53,7 @@
 
 #include "drivers/accgyro/accgyro_spi_l3gd20.h"
 #include "drivers/accgyro/accgyro_spi_lsm6dso.h"
+#include "drivers/accgyro/accgyro_spi_adis16607.h"
 #include "drivers/accgyro/accgyro_spi_lsm6dsv16x.h"
 
 #include "drivers/accgyro/accgyro_spi_mpu6000.h"
@@ -81,7 +82,13 @@
 // The gyro buffer is split 50/50, the first half for the transmit buffer, the second half for the receive buffer
 // This buffer is large enough for the gyros currently supported in accgyro_mpu.c but should be reviewed id other
 // gyro types are supported with SPI DMA.
+// The ADIS16607's burst frame is 22 bytes, which does not fit in the 16 bytes
+// per direction that a 32-byte split buffer provides.
+#if defined(USE_ACCGYRO_ADIS16607)
+#define GYRO_BUF_SIZE 64
+#else
 #define GYRO_BUF_SIZE 32
+#endif
 
 static uint8_t gyroDetectedFlags = 0;
 
@@ -335,6 +342,7 @@ void gyroInitSensor(gyroSensor_t *gyroSensor, const gyroDeviceConfig_t *config)
     case GYRO_ICM45686:
     case GYRO_ICM45605:
     case GYRO_ICM56686:
+    case GYRO_ADIS16607:
         gyroSensor->gyroDev.gyroHasOverflowProtection = true;
         break;
 
@@ -552,6 +560,15 @@ STATIC_UNIT_TESTED gyroHardware_e gyroDetect(gyroDev_t *dev)
     case GYRO_LSM6DSK320X:
         if (lsm6dsk320xSpiGyroDetect(dev)) {
             gyroHardware = GYRO_LSM6DSK320X;
+            break;
+        }
+        FALLTHROUGH;
+#endif
+
+#ifdef USE_ACCGYRO_ADIS16607
+    case GYRO_ADIS16607:
+        if (adis16607SpiGyroDetect(dev)) {
+            gyroHardware = GYRO_ADIS16607;
             break;
         }
         FALLTHROUGH;

--- a/src/main/sensors/sensors.c
+++ b/src/main/sensors/sensors.c
@@ -68,7 +68,8 @@ const char * const lookupTableGyroHardware[GYRO_HARDWARE_COUNT] = {
     [GYRO_ICM42622P] = "ICM42622P",
     [GYRO_ICM42686P] = "ICM42686P",
     [GYRO_ICM56686] = "ICM56686",
-    [GYRO_VIRTUAL] = "VIRTUAL"
+    [GYRO_VIRTUAL] = "VIRTUAL",
+    [GYRO_ADIS16607] = "ADIS16607"
 };
 
 // sync with accelerationSensor_e
@@ -99,7 +100,8 @@ const char * const lookupTableAccHardware[ACC_HARDWARE_COUNT] = {
     [ACC_ICM42622P] = "ICM42622P",
     [ACC_ICM42686P] = "ICM42686P",
     [ACC_ICM56686] = "ICM56686",
-    [ACC_VIRTUAL] = "VIRTUAL"
+    [ACC_VIRTUAL] = "VIRTUAL",
+    [ACC_ADIS16607] = "ADIS16607"
 };
 
 // sync with baroSensor_e

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -160,6 +160,7 @@
     && !defined(USE_ACC_SPI_MPU9250) \
     && !defined(USE_ACCGYRO_IIM42652) \
     && !defined(USE_ACCGYRO_IIM42653) \
+    && !defined(USE_ACCGYRO_ADIS16607) \
     && !defined(USE_VIRTUAL_ACC)
 #error At least one USE_ACC device definition required
 #endif
@@ -188,6 +189,7 @@
     && !defined(USE_GYRO_SPI_MPU9250) \
     && !defined(USE_ACCGYRO_IIM42652) \
     && !defined(USE_ACCGYRO_IIM42653) \
+    && !defined(USE_ACCGYRO_ADIS16607) \
     && !defined(USE_VIRTUAL_GYRO)
 #error At least one USE_GYRO device definition required
 #endif
@@ -585,7 +587,8 @@
     || defined(USE_ACCGYRO_ICM56686) \
     || defined(USE_ACCGYRO_ICM40609D) || defined(USE_ACCGYRO_ICM45605) || defined(USE_ACCGYRO_ICM45686) \
     || defined(USE_ACCGYRO_IIM42652) || defined(USE_ACCGYRO_IIM42653) \
-    || defined(USE_ACCGYRO_LSM6DSV16X) || defined(USE_ACCGYRO_LSM6DSO) || defined(USE_ACCGYRO_LSM6DSK320X)
+    || defined(USE_ACCGYRO_LSM6DSV16X) || defined(USE_ACCGYRO_LSM6DSO) || defined(USE_ACCGYRO_LSM6DSK320X) \
+    || defined(USE_ACCGYRO_ADIS16607)
 #ifndef USE_SPI_GYRO
 #define USE_SPI_GYRO
 #endif

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -111,6 +111,13 @@ baro_ms5611_unittest_DEFINES := \
 accgyro_spi_icm426xx_unittest_SRC := \
 		$(USER_DIR)/drivers/accgyro/accgyro_spi_icm426xx.c
 
+accgyro_spi_adis16607_unittest_SRC := \
+		$(USER_DIR)/drivers/accgyro/accgyro_spi_adis16607.c
+
+accgyro_spi_adis16607_unittest_DEFINES := \
+                USE_ACCGYRO_ADIS16607= \
+                ADIS16607_VARIANT=2
+
 accgyro_spi_icm426xx_unittest_DEFINES := \
                 USE_GYRO_SPI_ICM42605= \
                 USE_ACCGYRO_ICM42622P= \

--- a/src/test/unit/accgyro_spi_adis16607_unittest.cc
+++ b/src/test/unit/accgyro_spi_adis16607_unittest.cc
@@ -1,0 +1,546 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Betaflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdint.h>
+#include <string.h>
+#include <vector>
+
+extern "C" {
+
+#include "platform.h"
+#include "drivers/accgyro/accgyro.h"
+#include "drivers/accgyro/accgyro_mpu.h"
+#include "drivers/accgyro/accgyro_spi_adis16607.h"
+#include "drivers/bus.h"
+#include "pg/pg.h"
+#include "pg/pg_ids.h"
+#include "sensors/gyro.h"
+
+PG_REGISTER(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 0);
+
+} // extern "C"
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// A fake ADIS16607 on the far end of the bus. The SPI stubs at the bottom of the
+// file drive it, so the driver's real init and read paths run unmodified.
+struct FakeAdis {
+    uint16_t reg[0x50];
+    std::vector<std::pair<uint8_t, uint16_t>> writes;
+    uint16_t burstFrame[ADIS16607_BURST_WORD_COUNT]; // wire order, big-endian
+    int burstCount;
+    uint16_t dataCntr;
+    int dropWrites[0x50]; // writes the part silently swallows, per register
+
+    void reset()
+    {
+        memset(reg, 0, sizeof(reg));
+        reg[ADIS16607_REG_DEV_ID] = ADIS16607_DEV_ID_CONST;
+        writes.clear();
+        memset(burstFrame, 0, sizeof(burstFrame));
+        burstCount = 0;
+        dataCntr = 0;
+        memset(dropWrites, 0, sizeof(dropWrites));
+    }
+
+    bool wrote(uint8_t r, uint16_t v) const
+    {
+        for (const auto &w : writes) {
+            if (w.first == r && w.second == v) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    int indexOfLastWrite(uint8_t r) const
+    {
+        int found = -1;
+        for (size_t i = 0; i < writes.size(); i++) {
+            if (writes[i].first == r) {
+                found = (int)i;
+            }
+        }
+        return found;
+    }
+};
+
+static FakeAdis fake;
+
+// Build a burst frame in the device's own wire format: big-endian words with a
+// trailing truncated sum over DIAG_STAT..DATA_CNTR. The data counter advances on
+// every frame, as it does on the part whenever the output registers are rewritten.
+static void fakeSetBurst(int16_t ax, int16_t ay, int16_t az,
+                         int16_t gx, int16_t gy, int16_t gz, int16_t temp)
+{
+    uint16_t host[ADIS16607_BURST_WORD_COUNT] = {};
+    host[ADIS16607_BURST_WORD_ACCEL + 0] = (uint16_t)ax;
+    host[ADIS16607_BURST_WORD_ACCEL + 1] = (uint16_t)ay;
+    host[ADIS16607_BURST_WORD_ACCEL + 2] = (uint16_t)az;
+    host[ADIS16607_BURST_WORD_GYRO + 0] = (uint16_t)gx;
+    host[ADIS16607_BURST_WORD_GYRO + 1] = (uint16_t)gy;
+    host[ADIS16607_BURST_WORD_GYRO + 2] = (uint16_t)gz;
+    host[ADIS16607_BURST_WORD_TEMPERATURE] = (uint16_t)temp;
+    host[ADIS16607_BURST_WORD_DATA_CNTR] = ++fake.dataCntr;
+
+    uint16_t sum = 0;
+    for (int i = ADIS16607_BURST_CHECKSUM_FIRST_WORD; i < ADIS16607_BURST_WORD_CHECKSUM; i++) {
+        sum += host[i];
+    }
+    host[ADIS16607_BURST_WORD_CHECKSUM] = sum;
+
+    for (int i = 0; i < ADIS16607_BURST_WORD_COUNT; i++) {
+        fake.burstFrame[i] = __builtin_bswap16(host[i]);
+    }
+}
+
+class AdisTest : public ::testing::Test {
+protected:
+    gyroDev_t gyro;
+    accDev_t acc;
+    uint8_t txBuf[ADIS16607_BURST_FRAME_LEN];
+    uint8_t rxBuf[ADIS16607_BURST_FRAME_LEN];
+
+    void SetUp() override
+    {
+        fake.reset();
+        memset(&gyro, 0, sizeof(gyro));
+        memset(&acc, 0, sizeof(acc));
+        memset(txBuf, 0, sizeof(txBuf));
+        memset(rxBuf, 0, sizeof(rxBuf));
+        gyro.dev.txBuf = txBuf;
+        gyro.dev.rxBuf = rxBuf;
+        gyro.mpuDetectionResult.sensor = ADIS16607_SPI;
+        acc.mpuDetectionResult.sensor = ADIS16607_SPI;
+        acc.gyro = &gyro;
+    }
+
+    void initGyro()
+    {
+        ASSERT_TRUE(adis16607SpiGyroDetect(&gyro));
+        gyro.initFn(&gyro);
+    }
+};
+
+// --- detection ---------------------------------------------------------------
+
+TEST_F(AdisTest, DetectMatchesDevId)
+{
+    extDevice_t dev = {};
+    EXPECT_EQ(ADIS16607_SPI, adis16607SpiDetect(&dev));
+}
+
+TEST_F(AdisTest, DetectRejectsWrongDevId)
+{
+    extDevice_t dev = {};
+    fake.reg[ADIS16607_REG_DEV_ID] = 0x1234;
+    EXPECT_EQ(MPU_NONE, adis16607SpiDetect(&dev));
+}
+
+TEST_F(AdisTest, DetectEntersHalfDuplexBeforeReading)
+{
+    // Out of reset a bare 32-bit read is parsed as full duplex and answers with a
+    // CRC error, so the probe must write the half-duplex key first.
+    extDevice_t dev = {};
+    adis16607SpiDetect(&dev);
+    ASSERT_FALSE(fake.writes.empty());
+    EXPECT_EQ(ADIS16607_REG_SPI_HALFDUPLEX_KEY, fake.writes[0].first);
+    EXPECT_EQ(ADIS16607_SPI_HALFDUPLEX_KEY_VAL, fake.writes[0].second);
+}
+
+TEST_F(AdisTest, GyroDetectRejectsOtherSensor)
+{
+    gyro.mpuDetectionResult.sensor = MPU_NONE;
+    EXPECT_FALSE(adis16607SpiGyroDetect(&gyro));
+}
+
+TEST_F(AdisTest, AccDetectRejectsOtherSensor)
+{
+    acc.mpuDetectionResult.sensor = MPU_NONE;
+    EXPECT_FALSE(adis16607SpiAccDetect(&acc));
+}
+
+// --- init --------------------------------------------------------------------
+
+TEST_F(AdisTest, InitPublishesScales)
+{
+    initGyro();
+    EXPECT_FLOAT_EQ(1.0f / ADIS16607_GYRO_LSB_PER_DPS, gyro.scale);
+    EXPECT_FLOAT_EQ(ADIS16607_TEMP_SCALE, gyro.tempScale);
+    EXPECT_FLOAT_EQ(ADIS16607_TEMP_ZERO, gyro.tempZero);
+}
+
+TEST_F(AdisTest, VariantSelectsTheGyroSensitivity)
+{
+    // Only the -2 and -3 exist, and no register distinguishes them, so the scale
+    // rides on ADIS16607_VARIANT alone. Getting it wrong is a silent 4x on all
+    // three axes, so pin the selected sensitivity and check the built scale is
+    // its reciprocal.
+    initGyro();
+#if ADIS16607_VARIANT == 2
+    EXPECT_FLOAT_EQ(62.5f, ADIS16607_GYRO_LSB_PER_DPS);
+    EXPECT_FLOAT_EQ(1.0f / 62.5f, gyro.scale);
+#elif ADIS16607_VARIANT == 3
+    EXPECT_FLOAT_EQ(15.625f, ADIS16607_GYRO_LSB_PER_DPS);
+    EXPECT_FLOAT_EQ(1.0f / 15.625f, gyro.scale);
+#else
+#error "test needs updating for a new ADIS16607_VARIANT"
+#endif
+
+    // A reading at the part's maximum must not clip int16_t gyroADCRaw[] on
+    // either variant: 480 deg/s * 62.5 = 30000, 2000 deg/s * 15.625 = 31250.
+    EXPECT_LT(480.0f * 62.5f, 32767.0f);
+    EXPECT_LT(2000.0f * 15.625f, 32767.0f);
+}
+
+TEST_F(AdisTest, InitConfiguresDataAndRate)
+{
+    initGyro();
+    EXPECT_TRUE(fake.wrote(ADIS16607_REG_USER_DATA_CFG, ADIS16607_USER_DATA_CFG));
+    EXPECT_TRUE(fake.wrote(ADIS16607_REG_DEC_RATE, ADIS16607_DEC_RATE_4780HZ));
+    EXPECT_TRUE(fake.wrote(ADIS16607_REG_USER_FIFO_CFG, ADIS16607_FIFO_CFG_DISABLED));
+    EXPECT_TRUE(fake.wrote(ADIS16607_REG_USER_GPIO_CFG1, ADIS16607_GPIO_CFG1_GPIO3_DATA_RDY));
+}
+
+TEST_F(AdisTest, InitZeroesDecRateBeforeSettingIt)
+{
+    // The decimation accumulator only resets through a zero write.
+    initGyro();
+    int zeroAt = -1, setAt = -1;
+    for (size_t i = 0; i < fake.writes.size(); i++) {
+        if (fake.writes[i].first != ADIS16607_REG_DEC_RATE) {
+            continue;
+        }
+        if (fake.writes[i].second == ADIS16607_DEC_RATE_9560HZ && zeroAt < 0) {
+            zeroAt = (int)i;
+        }
+        if (fake.writes[i].second == ADIS16607_DEC_RATE_4780HZ) {
+            setAt = (int)i;
+        }
+    }
+    ASSERT_GE(zeroAt, 0);
+    ASSERT_GE(setAt, 0);
+    EXPECT_LT(zeroAt, setAt);
+}
+
+TEST_F(AdisTest, InitLocksLast)
+{
+    // The part will not leave its initialisation phase until write lock is set,
+    // so the lock has to come after every configuration write.
+    initGyro();
+    const int lockAt = fake.indexOfLastWrite(ADIS16607_REG_WRITE_LOCK);
+    ASSERT_GE(lockAt, 0);
+    EXPECT_EQ((size_t)lockAt, fake.writes.size() - 1);
+    EXPECT_EQ(ADIS16607_WRITE_LOCK_KEY_A, fake.writes[lockAt].second);
+    EXPECT_EQ(ADIS16607_WRITE_LOCK_KEY_B, fake.writes[lockAt - 1].second);
+}
+
+TEST_F(AdisTest, InitOverridesMpuDefaultRegisters)
+{
+    initGyro();
+    EXPECT_EQ(ADIS16607_REG_X_GYRO_HIGH, gyro.gyroDataReg);
+    EXPECT_EQ(ADIS16607_REG_X_ACCEL_HIGH, gyro.accDataReg);
+    EXPECT_EQ(ADIS16607_REG_TEMPERATURE, gyro.tempDataReg);
+    EXPECT_EQ(ADIS16607_BURST_CMD, gyro.dmaReadRegStart);
+}
+
+TEST_F(AdisTest, AccInitPublishesOneG)
+{
+    ASSERT_TRUE(adis16607SpiAccDetect(&acc));
+    acc.initFn(&acc);
+    EXPECT_EQ(ADIS16607_ACC_1G, acc.acc_1G);
+}
+
+// --- readFn mode negotiation -------------------------------------------------
+
+TEST_F(AdisTest, ReadInitFallsBackToPolledWithoutExti)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_INIT;
+    gyro.detectedEXTI = 0;
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    EXPECT_EQ(GYRO_EXTI_NO_INT, gyro.gyroModeSPI);
+}
+
+TEST_F(AdisTest, ReadInitPromotesToInterruptWithExti)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_INIT;
+    gyro.detectedEXTI = 5000;
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    // The USE_DMA branch is compiled out here: enabling it needs DMA types the
+    // unit-test platform shim does not provide, so the DMA segment setup is
+    // covered only on hardware.
+    EXPECT_EQ(GYRO_EXTI_INT, gyro.gyroModeSPI);
+}
+
+TEST_F(AdisTest, ReadInitZeroFillsTxBuf)
+{
+    // Trailing 0xff bytes would look like further read commands to the part.
+    initGyro();
+    memset(txBuf, 0xff, sizeof(txBuf));
+    gyro.gyroModeSPI = GYRO_EXTI_INIT;
+    gyro.readFn(&gyro);
+    for (size_t i = 1; i < sizeof(txBuf); i++) {
+        EXPECT_EQ(0, txBuf[i]) << "txBuf[" << i << "]";
+    }
+}
+
+// --- burst unpack ------------------------------------------------------------
+
+TEST_F(AdisTest, ReadUnpacksGyroAxesAndTemperature)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(0, 0, 0, 1000, -2000, 3000, 1000);
+
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    EXPECT_EQ(1000, gyro.gyroADCRaw[X]);
+    EXPECT_EQ(-2000, gyro.gyroADCRaw[Y]);
+    EXPECT_EQ(3000, gyro.gyroADCRaw[Z]);
+    // 1000 LSB * 0.005 degC/LSB + 25 degC
+    EXPECT_EQ(30, gyro.temperature);
+}
+
+TEST_F(AdisTest, ReadIssuesBurstCommand)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(0, 0, 0, 0, 0, 0, 0);
+    gyro.readFn(&gyro);
+    EXPECT_EQ(ADIS16607_BURST_CMD, txBuf[0]);
+    EXPECT_EQ(1, fake.burstCount);
+}
+
+TEST_F(AdisTest, ReadRejectsBadChecksum)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(0, 0, 0, 111, 222, 333, 0);
+    fake.burstFrame[ADIS16607_BURST_WORD_CHECKSUM] ^= 0x0100;
+
+    EXPECT_FALSE(gyro.readFn(&gyro));
+    EXPECT_EQ(0, gyro.gyroADCRaw[X]); // rejected frame must not be published
+}
+
+TEST_F(AdisTest, ReadNegativeFullScaleSurvivesSignExtension)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(0, 0, 0, -32768, 32767, -1, 0);
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    EXPECT_EQ(-32768, gyro.gyroADCRaw[X]);
+    EXPECT_EQ(32767, gyro.gyroADCRaw[Y]);
+    EXPECT_EQ(-1, gyro.gyroADCRaw[Z]);
+}
+
+TEST_F(AdisTest, DmaModeDoesNotStartATransfer)
+{
+    // In DMA mode the EXTI handler owns the transfer; readFn only unpacks.
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_INT_DMA;
+    fakeSetBurst(0, 0, 0, 7, 8, 9, 0);
+    memcpy(rxBuf, fake.burstFrame, sizeof(fake.burstFrame)); // as the EXTI-driven DMA would have
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    EXPECT_EQ(0, fake.burstCount);
+    EXPECT_EQ(7, gyro.gyroADCRaw[X]);
+}
+
+TEST_F(AdisTest, ReadRejectsRepeatedDataCounter)
+{
+    // A re-read of output registers the part has not rewritten carries a valid
+    // checksum and the previous counter. It is a duplicate, not a sample.
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(0, 0, 0, 1234, 0, 0, 0);
+    ASSERT_TRUE(gyro.readFn(&gyro));
+
+    EXPECT_FALSE(gyro.readFn(&gyro));
+    EXPECT_EQ(1234, gyro.gyroADCRaw[X]); // still the accepted sample
+}
+
+TEST_F(AdisTest, ReadAcceptsAdvancedDataCounter)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(0, 0, 0, 1234, 0, 0, 0);
+    ASSERT_TRUE(gyro.readFn(&gyro));
+
+    fakeSetBurst(0, 0, 0, 4321, 0, 0, 0);
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    EXPECT_EQ(4321, gyro.gyroADCRaw[X]);
+}
+
+TEST_F(AdisTest, ReadRejectsStuckHighFrame)
+{
+    // 0xffff on every word sums to a matching truncated checksum, so MISO stuck
+    // high has to be rejected on its content, as MISO stuck low is.
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_INT_DMA;
+    memset(rxBuf, 0xff, sizeof(rxBuf));
+    EXPECT_FALSE(gyro.readFn(&gyro));
+}
+
+TEST_F(AdisTest, ReadRejectsStuckLowFrame)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_INT_DMA;
+    memset(rxBuf, 0, sizeof(rxBuf));
+    EXPECT_FALSE(gyro.readFn(&gyro));
+}
+
+TEST_F(AdisTest, InitRetriesDroppedConfigWrites)
+{
+    // The part swallows writes while locked or while its bootloader runs. A
+    // dropped USER_DATA_CFG would shift every word of the burst, so init has to
+    // read each configuration register back and write it again until it takes.
+    fake.dropWrites[ADIS16607_REG_USER_DATA_CFG] = 3;
+    fake.dropWrites[ADIS16607_REG_DEC_RATE] = 3;
+    initGyro();
+    EXPECT_EQ(ADIS16607_USER_DATA_CFG, fake.reg[ADIS16607_REG_USER_DATA_CFG]);
+    EXPECT_EQ(ADIS16607_DEC_RATE_4780HZ, fake.reg[ADIS16607_REG_DEC_RATE]);
+}
+
+// --- accel shares the gyro's frame -------------------------------------------
+
+TEST_F(AdisTest, AccReadsGyroFrameWithoutOwnTransfer)
+{
+    initGyro();
+    ASSERT_TRUE(adis16607SpiAccDetect(&acc));
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(11, -22, 33, 0, 0, 0, 0);
+    ASSERT_TRUE(gyro.readFn(&gyro));
+    const int burstsAfterGyroRead = fake.burstCount;
+
+    EXPECT_TRUE(acc.readFn(&acc));
+    EXPECT_EQ(11, acc.ADCRaw[X]);
+    EXPECT_EQ(-22, acc.ADCRaw[Y]);
+    EXPECT_EQ(33, acc.ADCRaw[Z]);
+    EXPECT_EQ(burstsAfterGyroRead, fake.burstCount);
+}
+
+TEST_F(AdisTest, AccReadSucceedsBeforeFirstBurst)
+{
+    // acc readFn can be called while readFn is still negotiating its mode; the
+    // buffer holds no frame yet, so it must not fail the sensor.
+    ASSERT_TRUE(adis16607SpiAccDetect(&acc));
+    gyro.gyroModeSPI = GYRO_EXTI_INIT;
+    EXPECT_TRUE(acc.readFn(&acc));
+}
+
+TEST_F(AdisTest, AccReadRejectsBadChecksum)
+{
+    initGyro();
+    ASSERT_TRUE(adis16607SpiAccDetect(&acc));
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(1, 2, 3, 0, 0, 0, 0);
+    ASSERT_TRUE(gyro.readFn(&gyro));
+    fake.burstFrame[ADIS16607_BURST_WORD_CHECKSUM] ^= 0x0100;
+    memcpy(rxBuf, fake.burstFrame, sizeof(fake.burstFrame));
+    EXPECT_FALSE(acc.readFn(&acc));
+}
+
+// --- frame layout ------------------------------------------------------------
+
+TEST_F(AdisTest, BurstFrameLayout)
+{
+    EXPECT_EQ(22u, (unsigned)ADIS16607_BURST_FRAME_LEN);
+    EXPECT_EQ(0x85, ADIS16607_BURST_CMD);
+    EXPECT_EQ(ADIS16607_BURST_WORD_ACCEL + 3, ADIS16607_BURST_WORD_GYRO);
+    // The payload starts at byte 0 of the frame, with no leading dummy byte to
+    // skip - unlike the MPU-style drivers, which read from &rxBuf[1].
+    EXPECT_EQ(0, ADIS16607_BURST_WORD_STATUS);
+}
+
+TEST_F(AdisTest, UserDataCfgSelectsSixAxesPlusTemperatureIn16Bit)
+{
+    const uint16_t cfg = ADIS16607_USER_DATA_CFG;
+    EXPECT_EQ(0, cfg & ADIS16607_DATA_CFG_WORD_SIZE_32);
+    EXPECT_TRUE(cfg & ADIS16607_DATA_CFG_Z_GYRO_EN);
+    EXPECT_TRUE(cfg & ADIS16607_DATA_CFG_TEMPERATURE_EN);
+    // Extra words would cost bus time in the EXTI-to-sample path.
+    EXPECT_FALSE(cfg & ADIS16607_DATA_CFG_X_DELTVEL_EN);
+    EXPECT_FALSE(cfg & ADIS16607_DATA_CFG_X_DELTANG_EN);
+    EXPECT_FALSE(cfg & ADIS16607_DATA_CFG_TIME_STAMP_EN);
+    // The counter is the exception: it is what makes a duplicated frame visible.
+    EXPECT_TRUE(cfg & ADIS16607_DATA_CFG_DATA_CNTR_EN);
+}
+
+// --- STUBS -------------------------------------------------------------------
+
+extern "C" {
+
+void delay(uint32_t) {}
+void spiSetClkDivisor(const extDevice_t *, uint16_t) {}
+void spiWait(const extDevice_t *) {}
+void spiDmaEnable(const extDevice_t *, bool) {}
+void mpuGyroInit(gyroDev_t *) {}
+void EXTIConfig(IO_t, extiCallbackRec_t *, int, ioConfig_t, extiTrigger_t) {}
+void EXTIEnable(IO_t) {}
+busStatus_e mpuIntCallback(uintptr_t) { return BUS_READY; }
+
+uint16_t spiCalculateDivider(uint32_t)
+{
+    return 2;
+}
+
+bool spiUseDMA(const extDevice_t *)
+{
+    return false;
+}
+
+IO_t IOGetByTag(ioTag_t)
+{
+    return NULL;
+}
+
+// Half-duplex register access: a 3-byte frame is a write, a 4-byte frame is a
+// read whose response lands in the same frame.
+void spiReadWriteBuf(const extDevice_t *, uint8_t *txData, uint8_t *rxData, int len)
+{
+    if (len == 3) {
+        const uint8_t reg = txData[0] & 0x7f;
+        const uint16_t value = (txData[1] << 8) | txData[2];
+        fake.writes.push_back({reg, value});
+        if (reg == ADIS16607_REG_SOFT_RESET) {
+            return; // reset restores defaults, which the fake models as "no change"
+        }
+        if (fake.dropWrites[reg] > 0) {
+            fake.dropWrites[reg]--; // as the part does while locked or booting
+            return;
+        }
+        fake.reg[reg] = value;
+    } else if (len == 4 && rxData) {
+        const uint8_t reg = txData[0] & 0x7f;
+        const uint16_t value = fake.reg[reg];
+        rxData[0] = 0;
+        rxData[1] = 0;
+        rxData[2] = value >> 8;
+        rxData[3] = value & 0xff;
+    }
+}
+
+void spiSequence(const extDevice_t *dev, busSegment_t *segments)
+{
+    fake.burstCount++;
+    if (segments[0].u.buffers.rxData) {
+        memcpy(segments[0].u.buffers.rxData, fake.burstFrame, sizeof(fake.burstFrame));
+    }
+    (void)dev;
+}
+
+} // extern "C"


### PR DESCRIPTION
Adds an accgyro driver for the Analog Devices ADIS16607, a precision MEMS IMU on SPI that returns gyro, accel and temperature in one burst frame. Runs at 4780Hz
in the part's 16-bit output format, FIFO disabled. I wrote it at Analog Devices,
so the register values come from the part's datasheet, which will be published very soon. 
If you would like to confirm the register values are good you can check the Ardupilot and 
PX4 drivers for this part.

The part has no usable WHO_AM_I, and out of reset a bare read is
indistinguishable from a full-duplex frame, so the probe has to write the
half-duplex key before it can read anything. `adis16607SpiDetect` is therefore
last in `gyroSpiDetectFnTable[]`, and `USE_ACCGYRO_ADIS16607` is not in any
default sensor list — a board opts in explicitly. No current target defines it,
so this is inert for all of them.

### Testing

Bench-tested on an STM32N657 with the part on SPI5 — detection, init, burst read,
checksum and gyro + accel unpacking, streaming correctly in Configurator. Logs bellow:
<img width="1645" height="735" alt="Screenshot 2026-08-21 114502" src="https://github.com/user-attachments/assets/e14cd475-81c0-4659-90fc-5b734f03661f" />

Not flight-tested. This was tested only in polled mode. 
25 unit tests, `make test` 71/71, `make preview` builds all 10 preview targets.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the ADIS16607 SPI accelerometer and gyroscope.
  * Added high-rate gyro operation at 4,780 Hz with 1,195 Hz accelerometer sampling.
  * Added automatic sensor detection, initialization, filtering, data-ready interrupts, DMA, and burst data handling.
  * Added checksum validation and protection against invalid sensor frames.

* **Tests**
  * Added comprehensive coverage for sensor detection, configuration, data conversion, transfers, DMA, checksums, and shared sensor readings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->