### PR TITLE
feat: softer disarming

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1751,6 +1751,7 @@ static bool blackboxWriteSysinfo(void)
 #endif
 
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_GYRO_CAL_ON_FIRST_ARM, "%d",  armingConfig()->gyro_cal_on_first_arm);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_SWITCH_DISARM_TIME, "%d",     armingConfig()->switch_disarm_time);
         BLACKBOX_PRINT_HEADER_LINE("airmode_activate_throttle", "%d",       rxConfig()->airModeActivateThreshold);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_SERIAL_RX_PROVIDER, "%d",     rxConfig()->serialrx_provider);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_USE_UNSYNCED_PWM, "%d",       motorConfig()->dev.useContinuousUpdate);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1133,6 +1133,7 @@ const clivalue_t valueTable[] = {
     { "auto_disarm_delay",          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 60 }, PG_ARMING_CONFIG, offsetof(armingConfig_t, auto_disarm_delay) },
     { PARAM_NAME_GYRO_CAL_ON_FIRST_ARM, VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, gyro_cal_on_first_arm) },
     { PARAM_NAME_PREARM_ALLOW_REARM, VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, prearm_allow_rearm) },
+    { PARAM_NAME_SWITCH_DISARM_TIME, VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 255 }, PG_ARMING_CONFIG, offsetof(armingConfig_t, switch_disarm_time) },
 // PG_GPS_CONFIG
 #ifdef USE_GPS
     { PARAM_NAME_GPS_PROVIDER,               VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GPS_PROVIDER },   PG_GPS_CONFIG, offsetof(gpsConfig_t, provider) },

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -162,6 +162,9 @@ static timeUs_t disarmAt;     // Time of automatic disarm when "Don't spin the m
 static int lastArmingDisabledReason = 0;
 static timeUs_t lastDisarmTimeUs;
 static int tryingToArm = ARMING_DELAYED_DISARMED;
+static bool switchDisarmActive = false;
+static timeUs_t switchDisarmStartedAt;
+static float switchDisarmMotorScale = 1.0f;
 
 #ifdef USE_RUNAWAY_TAKEOFF
 static timeUs_t runawayTakeoffDeactivateUs = 0;
@@ -502,8 +505,60 @@ if (crashFlipModeActive) {
     }
 }
 
+#define SWITCH_DISARM_TIME_UNIT_US 10000U
+
+void requestSwitchDisarm(void)
+{
+    if (!armingConfig()->switch_disarm_time || featureIsEnabled(FEATURE_3D) || crashFlipModeActive) {
+        disarm(DISARM_REASON_SWITCH);
+        return;
+    }
+
+    if (!switchDisarmActive) {
+        switchDisarmActive = true;
+        switchDisarmStartedAt = micros();
+        switchDisarmMotorScale = 1.0f;
+    }
+}
+
+void cancelSwitchDisarm(void)
+{
+    switchDisarmActive = false;
+    switchDisarmMotorScale = 1.0f;
+}
+
+void updateSwitchDisarm(timeUs_t currentTimeUs)
+{
+    if (!switchDisarmActive) {
+        return;
+    }
+
+    const timeDelta_t elapsedUs = cmpTimeUs(currentTimeUs, switchDisarmStartedAt);
+    const timeDelta_t durationUs = armingConfig()->switch_disarm_time * SWITCH_DISARM_TIME_UNIT_US;
+
+    if (elapsedUs >= durationUs) {
+        const bool armSwitchActive = IS_RC_MODE_ACTIVE(BOXARM);
+        disarm(DISARM_REASON_SWITCH);
+        if (armSwitchActive) {
+            setArmingDisabled(ARMING_DISABLED_ARM_SWITCH);
+        }
+        return;
+    }
+
+    if (elapsedUs > 0) {
+        switchDisarmMotorScale = 1.0f - (float)elapsedUs / durationUs;
+    }
+}
+
+float getSwitchDisarmMotorScale(void)
+{
+    return switchDisarmMotorScale;
+}
+
 void disarm(flightLogDisarmReason_e reason)
 {
+    cancelSwitchDisarm();
+
 #if ENABLE_TELEMETRY_MAVLINK_COMMANDS
     // Drop any MAVLink-commanded mode override so it can never persist into a
     // disarmed state and re-assert modes on the next arm.
@@ -1417,6 +1472,7 @@ static FAST_CODE void subTaskMotorUpdate(timeUs_t currentTimeUs)
         startTime = micros();
     }
 
+    updateSwitchDisarm(currentTimeUs);
     mixTable(currentTimeUs);
 
 #ifdef USE_SERVOS

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -76,6 +76,10 @@ void resetArmingDisabled(void);
 
 void disarm(flightLogDisarmReason_e reason);
 void tryArm(void);
+void requestSwitchDisarm(void);
+void cancelSwitchDisarm(void);
+void updateSwitchDisarm(timeUs_t currentTimeUs);
+float getSwitchDisarmMotorScale(void);
 
 bool processRx(timeUs_t currentTimeUs);
 void processRxModes(timeUs_t currentTimeUs);

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -92,6 +92,7 @@
 #define PARAM_NAME_THROTTLE_LIMIT_PERCENT "throttle_limit_percent"
 #define PARAM_NAME_GYRO_CAL_ON_FIRST_ARM "gyro_cal_on_first_arm"
 #define PARAM_NAME_PREARM_ALLOW_REARM "prearm_allow_rearm"
+#define PARAM_NAME_SWITCH_DISARM_TIME "switch_disarm_time"
 #define PARAM_NAME_DEADBAND "deadband"
 #define PARAM_NAME_YAW_DEADBAND "yaw_deadband"
 #define PARAM_NAME_PID_PROCESS_DENOM "pid_process_denom"

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -82,7 +82,7 @@ PG_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig,
     .yaw_control_reversed = false,
 );
 
-PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 3);
+PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 2);
 
 PG_RESET_TEMPLATE(armingConfig_t, armingConfig,
     .gyro_cal_on_first_arm = 0,

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -82,12 +82,13 @@ PG_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig,
     .yaw_control_reversed = false,
 );
 
-PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 2);
+PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 3);
 
 PG_RESET_TEMPLATE(armingConfig_t, armingConfig,
     .gyro_cal_on_first_arm = 0,
     .auto_disarm_delay = 5,
     .prearm_allow_rearm = 0,
+    .switch_disarm_time = 0,
 );
 
 PG_REGISTER_WITH_RESET_TEMPLATE(flight3DConfig_t, flight3DConfig, PG_MOTOR_3D_CONFIG, 0);
@@ -179,6 +180,7 @@ void processRcStickPositions(void)
         if (IS_RC_MODE_ACTIVE(BOXARM)) {
             rcDisarmTicks = 0;
             // Arming via ARM BOX
+            cancelSwitchDisarm();
             tryArm();
         } else {
             resetTryingToArm();
@@ -195,7 +197,7 @@ void processRcStickPositions(void)
                 rcDisarmTicks++;
                 if (rcDisarmTicks > 3) {
                     // require three duplicate disarm values in a row before we disarm
-                    disarm(DISARM_REASON_SWITCH);
+                    requestSwitchDisarm();
                 }
             }
         }

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -126,6 +126,7 @@ typedef struct armingConfig_s {
     uint8_t gyro_cal_on_first_arm;          // calibrate the gyro right before the first arm
     uint8_t auto_disarm_delay;              // allow automatically disarming multicopters after auto_disarm_delay seconds of zero throttle. Disabled when 0
     uint8_t prearm_allow_rearm;
+    uint8_t switch_disarm_time;             // motor ramp-down time in 10ms steps. Disabled when 0
 } armingConfig_t;
 
 PG_DECLARE(armingConfig_t, armingConfig);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -505,6 +505,20 @@ static void applyMixToMotors(const float motorMix[MAX_SUPPORTED_MOTORS], motorMi
     // DEBUG_EZLANDING 0 is the ezLanding factor 2 is the throttle limit
 }
 
+static void applySwitchDisarmMotorScale(void)
+{
+    const float scale = getSwitchDisarmMotorScale();
+    if (scale >= 1.0f) {
+        return;
+    }
+
+    for (int i = 0; i < mixerRuntime.motorCount; i++) {
+        if (motor[i] >= mixerRuntime.motorOutputLow) {
+            motor[i] = mixerRuntime.motorOutputLow + scale * (motor[i] - mixerRuntime.motorOutputLow);
+        }
+    }
+}
+
 static float applyThrottleLimit(float throttle)
 {
     if (currentControlRateProfile->throttle_limit_percent < 100 && !RPM_LIMIT_ACTIVE) {
@@ -842,6 +856,8 @@ FAST_CODE_NOINLINE_CRITICAL void mixTable(timeUs_t currentTimeUs)
         // Apply the mix to motor endpoints
         applyMixToMotors(motorMix, activeMixer);
     }
+
+    applySwitchDisarmMotorScale();
 }
 
 void mixerSetThrottleAngleCorrection(int correctionValue)

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -882,6 +882,45 @@ TEST(ArmingPreventionTest, GPSRescueSwitchPreventsArm)
     EXPECT_FALSE(IS_RC_MODE_ACTIVE(BOXGPSRESCUE));
 }
 
+TEST(ArmingPreventionTest, SwitchDisarmTimeUsesTenMillisecondSteps)
+{
+    boxBitmask_t activeModes = {};
+    rcModeUpdate(&activeModes);
+    simulationFeatureFlags = 0;
+    simulationTime = 1000;
+    armingFlags = ARMED;
+    armingConfigMutable()->switch_disarm_time = 100;
+
+    requestSwitchDisarm();
+    updateSwitchDisarm(simulationTime);
+    EXPECT_FLOAT_EQ(1.0f, getSwitchDisarmMotorScale());
+    EXPECT_TRUE(ARMING_FLAG(ARMED));
+
+    simulationTime += 500000;
+    updateSwitchDisarm(simulationTime);
+    EXPECT_FLOAT_EQ(0.5f, getSwitchDisarmMotorScale());
+    EXPECT_TRUE(ARMING_FLAG(ARMED));
+
+    simulationTime += 500000;
+    updateSwitchDisarm(simulationTime);
+    EXPECT_FALSE(ARMING_FLAG(ARMED));
+    EXPECT_FLOAT_EQ(1.0f, getSwitchDisarmMotorScale());
+
+    armingConfigMutable()->switch_disarm_time = 0;
+}
+
+TEST(ArmingPreventionTest, ZeroSwitchDisarmTimeDisarmsImmediately)
+{
+    simulationFeatureFlags = 0;
+    armingFlags = ARMED;
+    armingConfigMutable()->switch_disarm_time = 0;
+
+    requestSwitchDisarm();
+
+    EXPECT_FALSE(ARMING_FLAG(ARMED));
+    EXPECT_FLOAT_EQ(1.0f, getSwitchDisarmMotorScale());
+}
+
 TEST(ArmingPreventionTest, ParalyzeOnAtBoot)
 {
     // given

--- a/src/test/unit/rc_controls_unittest.cc
+++ b/src/test/unit/rc_controls_unittest.cc
@@ -744,6 +744,8 @@ bool featureIsEnabled(uint32_t) { return false;}
 bool sensors(uint32_t) { return false;}
 void tryArm(void) {}
 void disarm(flightLogDisarmReason_e) {}
+void requestSwitchDisarm(void) {}
+void cancelSwitchDisarm(void) {}
 void dashboardDisablePageCycling() {}
 void dashboardEnablePageCycling() {}
 


### PR DESCRIPTION
## Summary
Adds an optional soft-disarm transition when the pilot turns off the arm switch. Instead of immediately stopping the motors, their output is reduced toward the normal idle endpoint over a configurable period. The existing disarm behavior runs when the transition completes.

## Configuration
New CLI setting controls the ramp duration:
`switch_disarm_time`, unit is in 10ms increments, aka 100 = 1 second. Maximum value is 255, or 2.55 seconds. Set this to 0 to disable it.

## Behavior
- Applies only to manual arm-switch disarming
- Other disarm reasons remain immediate
- 3D and crash-flip disarming remain immediate
- Returning the arm switch high during the transition cancels the soft disarm
- Motor output ramps toward the valid armed idle endpoint before stopping, avoiding reserved DShot command values
- The configured value is included in Blackbox headers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timed disarming through the ARM switch.
  * Motors now ramp down smoothly before disarming when a delay is configured.
  * Added CLI access to configure the delay from 0–255 units.
  * Disarming remains immediate when the delay is set to zero or in applicable safety conditions.
* **Bug Fixes**
  * Prevented re-arming while the ARM switch remains active after a timed disarm.
* **Tests**
  * Added coverage for delayed and immediate switch disarming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->