### PR TITLE
Driver for the Analog Devices ADIS1657x accgyro (ADIS16575/16576/16577)

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -316,6 +316,7 @@ COMMON_SRC += \
             drivers/accgyro/accgyro_mpu6050.c \
             drivers/accgyro/accgyro_mpu6500.c \
             drivers/accgyro/accgyro_mpu.c \
+            drivers/accgyro/accgyro_spi_adis1657x.c \
             drivers/accgyro/accgyro_spi_bmi160.c \
             drivers/accgyro/accgyro_spi_bmi270.c \
             drivers/accgyro/accgyro_spi_icm20649.c \

--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -71,6 +71,7 @@ typedef enum {
     GYRO_ICM42686P,
     GYRO_ICM56686,
     GYRO_VIRTUAL,
+    GYRO_ADIS1657X,
     GYRO_HARDWARE_COUNT
 } gyroHardware_e;
 
@@ -87,6 +88,7 @@ typedef enum {
 typedef enum {
     GYRO_RATE_1_kHz,
     GYRO_RATE_1100_Hz,
+    GYRO_RATE_2000_Hz,
     GYRO_RATE_3200_Hz,
     GYRO_RATE_6400_Hz,
     GYRO_RATE_6664_Hz,

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -57,6 +57,7 @@
 #include "drivers/accgyro/accgyro_spi_mpu6500.h"
 #include "drivers/accgyro/accgyro_spi_mpu9250.h"
 #include "drivers/accgyro/accgyro_spi_l3gd20.h"
+#include "drivers/accgyro/accgyro_spi_adis1657x.h"
 #include "drivers/accgyro/accgyro_spi_lsm6dsv16x.h"
 #include "drivers/accgyro/accgyro_mpu.h"
 #include "drivers/accgyro/accgyro_spi_icm40609.h"
@@ -397,6 +398,12 @@ static gyroSpiDetectFn_t gyroSpiDetectFnTable[] = {
 #endif
 #ifdef USE_ACCGYRO_ICM40609D
     icm40609SpiDetect,
+#endif
+#ifdef USE_ACCGYRO_ADIS1657X
+    // Deliberately last: this probe's read encoding is a write encoding for
+    // other parts above. Running it last means a known part has already
+    // claimed the bus.
+    adis1657xSpiDetect,
 #endif
     NULL // Avoid an empty array
 };

--- a/src/main/drivers/accgyro/accgyro_mpu.h
+++ b/src/main/drivers/accgyro/accgyro_mpu.h
@@ -225,7 +225,8 @@ typedef enum {
     ICM_45605_SPI,
     ICM_45686_SPI,
     ICM_56686_SPI,
-    ICM_40609_SPI
+    ICM_40609_SPI,
+    ADIS1657X_SPI
 } mpuSensor_e;
 
 typedef enum {

--- a/src/main/drivers/accgyro/accgyro_spi_adis1657x.c
+++ b/src/main/drivers/accgyro/accgyro_spi_adis1657x.c
@@ -1,0 +1,380 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "platform.h"
+
+#if defined(USE_ACCGYRO_ADIS1657X)
+
+#include "common/axis.h"
+#include "common/maths.h"
+#include "common/utils.h"
+
+#include "drivers/accgyro/accgyro.h"
+#include "drivers/accgyro/accgyro_mpu.h"
+#include "drivers/accgyro/accgyro_spi_adis1657x.h"
+#include "drivers/bus_spi.h"
+#include "drivers/io.h"
+#include "drivers/time.h"
+
+#include "pg/gyrodev.h"
+
+#include "sensors/gyro.h"
+
+/*
+ * Analog Devices ADIS16575 / ADIS16576 / ADIS16577.
+ *
+ * The part is configured for the 32-bit burst and readFn keeps the high word of
+ * each axis, so gyroADCRaw[] and ADCRaw[] get one int16_t per channel with no
+ * shifting. The FIFO is left disabled, so one data-ready pulse is one sample.
+ */
+
+#define GYRO_EXTI_DETECT_THRESHOLD      1000
+
+#define ADIS1657X_RESET_DELAY_MS        350
+#define ADIS1657X_RESET_RETRIES         10
+#define ADIS1657X_PROD_ID_RETRIES       5
+#define ADIS1657X_WRITE_RETRIES         16
+
+// PROD_ID is read once during detection and needed again by the accelerometer's
+// initFn, which has no bus transaction of its own. Two ADIS1657x variants on one
+// board would share this; that combination is not supported.
+static uint16_t adis1657xProdId;
+
+/*
+ * Reads are pipelined: the frame carrying the address clocks out whatever the
+ * previous frame asked for, so the answer needs a second frame of its own.
+ */
+static uint16_t adis1657xReadReg(const extDevice_t *dev, uint8_t reg)
+{
+    uint8_t txBuf[2] = { reg, 0 };
+    uint8_t rxBuf[2] = { 0 };
+
+    spiReadWriteBuf(dev, txBuf, NULL, sizeof(txBuf));
+    delayMicroseconds(ADIS1657X_STALL_US);
+    spiReadWriteBuf(dev, NULL, rxBuf, sizeof(rxBuf));
+
+    return (rxBuf[0] << 8) | rxBuf[1];
+}
+
+static void adis1657xWriteReg(const extDevice_t *dev, uint8_t reg, uint16_t value)
+{
+    uint8_t txBuf[2];
+
+    txBuf[0] = reg | ADIS1657X_WRITE_BIT;
+    txBuf[1] = value & 0xff;
+    spiReadWriteBuf(dev, txBuf, NULL, sizeof(txBuf));
+    delayMicroseconds(ADIS1657X_STALL_US);
+
+    txBuf[0] = (reg + 1) | ADIS1657X_WRITE_BIT;
+    txBuf[1] = value >> 8;
+    spiReadWriteBuf(dev, txBuf, NULL, sizeof(txBuf));
+    delayMicroseconds(ADIS1657X_STALL_US);
+}
+
+static bool adis1657xWriteRegVerify(const extDevice_t *dev, uint8_t reg, uint16_t value)
+{
+    for (int i = 0; i < ADIS1657X_WRITE_RETRIES; i++) {
+        adis1657xWriteReg(dev, reg, value);
+        if (adis1657xReadReg(dev, reg) == value) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool adis1657xProdIdValid(uint16_t prodId)
+{
+    return (prodId == ADIS1657X_PROD_ID_16575)
+        || (prodId == ADIS1657X_PROD_ID_16576)
+        || (prodId == ADIS1657X_PROD_ID_16577);
+}
+
+uint8_t adis1657xSpiDetect(const extDevice_t *dev)
+{
+    /* Deliberately last in gyroSpiDetectFnTable[]. An ADI address byte with bit 7
+     * clear is a read, but that is the *write* encoding on every Invensense part
+     * here, so probing this one sends what an ICM would take as a write of 0x00 to
+     * its register 0x72. Running last means a known part has already claimed the
+     * bus.
+     */
+    for (int tries = 0; tries < ADIS1657X_PROD_ID_RETRIES; tries++) {
+        const uint16_t prodId = adis1657xReadReg(dev, ADIS1657X_REG_PROD_ID);
+
+        if (adis1657xProdIdValid(prodId)) {
+            adis1657xProdId = prodId;
+            return ADIS1657X_SPI;
+        }
+    }
+
+    return MPU_NONE;
+}
+
+static void adis1657xGyroInit(gyroDev_t *gyro)
+{
+    const extDevice_t *dev = &gyro->dev;
+
+    // Default off: the filter's group delay is undocumented, and an unquantified
+    // phase lag is not acceptable in a 2 kHz PID loop.
+    static const uint16_t filterOptions[GYRO_HARDWARE_LPF_COUNT] = {
+        [GYRO_HARDWARE_LPF_NORMAL] = ADIS1657X_FILT_CTRL_OFF,
+        [GYRO_HARDWARE_LPF_OPTION_1] = ADIS1657X_FILT_CTRL_4_TAP,
+        [GYRO_HARDWARE_LPF_OPTION_2] = ADIS1657X_FILT_CTRL_16_TAP,
+#ifdef USE_GYRO_DLPF_EXPERIMENTAL
+        [GYRO_HARDWARE_LPF_EXPERIMENTAL] = ADIS1657X_FILT_CTRL_64_TAP,
+#endif
+    };
+
+    spiSetClkDivisor(dev, spiCalculateDivider(ADIS1657X_MAX_SPI_CLK_HZ));
+
+    for (int tries = 0; tries < ADIS1657X_RESET_RETRIES; tries++) {
+        adis1657xWriteReg(dev, ADIS1657X_REG_GLOB_CMD, ADIS1657X_GLOB_CMD_SW_RESET);
+        delay(ADIS1657X_RESET_DELAY_MS);
+
+        const uint16_t prodId = adis1657xReadReg(dev, ADIS1657X_REG_PROD_ID);
+        if (adis1657xProdIdValid(prodId)) {
+            adis1657xProdId = prodId;
+            break;
+        }
+    }
+
+    /* RNG_MDL reports the fitted gyro range, so there is no build-time variant to
+     * get wrong. Anything but the high-range code falls back to the low range,
+     * which under-reports rather than over-reports.
+     */
+    const uint16_t rngMdl = adis1657xReadReg(dev, ADIS1657X_REG_RNG_MDL) & ADIS1657X_RNG_MDL_RANGE_MASK;
+    if (rngMdl == ADIS1657X_RNG_MDL_HIGH_RANGE) {
+        gyro->scale = ADIS1657X_GYRO_SCALE_HIGH;
+    } else {
+        gyro->scale = ADIS1657X_GYRO_SCALE_LOW;
+    }
+
+    adis1657xWriteRegVerify(dev, ADIS1657X_REG_MSC_CTRL, ADIS1657X_MSC_CTRL_CFG);
+
+    adis1657xWriteRegVerify(dev, ADIS1657X_REG_FILT_CTRL,
+                            filterOptions[gyroConfig()->gyro_hardware_lpf]);
+
+    adis1657xWriteRegVerify(dev, ADIS1657X_REG_DEC_RATE, ADIS1657X_DEC_RATE_2000HZ);
+
+    adis1657xWriteRegVerify(dev, ADIS1657X_REG_FIFO_CTRL, ADIS1657X_FIFO_CTRL_DISABLED);
+
+    gyro->tempScale = ADIS1657X_TEMP_SCALE;
+    gyro->tempZero = ADIS1657X_TEMP_ZERO;
+
+    mpuGyroInit(gyro);
+
+    /* Only dmaReadRegStart is corrected. The per-axis output registers are never
+     * read - the burst is the only transaction that carries samples - so their
+     * addresses are deliberately absent rather than guessed.
+     */
+    gyro->dmaReadRegStart = ADIS1657X_BURST_CMD;
+}
+
+static void adis1657xAccInit(accDev_t *acc)
+{
+    switch (adis1657xProdId) {
+    case ADIS1657X_PROD_ID_16576:
+        acc->acc_1G = ADIS1657X_ACC_1G_16576;
+        break;
+    case ADIS1657X_PROD_ID_16577:
+        acc->acc_1G = ADIS1657X_ACC_1G_16577;
+        break;
+    case ADIS1657X_PROD_ID_16575:
+    default:
+        acc->acc_1G = ADIS1657X_ACC_1G_16575;
+        break;
+    }
+}
+
+static bool adis1657xBurstChecksumValid(const uint16_t *frame)
+{
+    const uint8_t *bytes = (const uint8_t *)&frame[ADIS1657X_BURST_CHECKSUM_FIRST_WORD];
+    const uint8_t *end = (const uint8_t *)&frame[ADIS1657X_BURST_CHECKSUM_END_WORD];
+    uint16_t sum = 0;
+    uint8_t bits = 0;
+
+    while (bytes < end) {
+        sum += *bytes;
+        bits |= *bytes;
+        bytes++;
+    }
+
+    /* Zero is a fixed point of a truncated sum, so an all-zero frame validates -
+     * and that is what a bus with MISO held low returns. No real sample has every
+     * bit clear: the accelerometer cannot read zero on all three axes.
+     */
+    if (bits == 0) {
+        return false;
+    }
+
+    return sum == __builtin_bswap16(frame[ADIS1657X_BURST_WORD_CHECKSUM]);
+}
+
+/*
+ * DIAG_STAT is carried in the frame but deliberately not acted on. Its bits are
+ * sticky, and Betaflight has no way to report or recover from a sensor fault -
+ * readFn returning false only means "no new data" - so rejecting flagged frames
+ * would turn one transient into a permanent freeze on the last good sample.
+ */
+static bool adis1657xUnpackGyro(gyroDev_t *gyro)
+{
+    static uint16_t lastDataCntr;
+
+    const uint16_t *frame = (const uint16_t *)gyro->dev.rxBuf;
+
+    if (!adis1657xBurstChecksumValid(frame)) {
+        return false;
+    }
+
+    // The counter only advances when the part produces a sample, so this is what
+    // distinguishes a fresh burst from a re-read of the same output registers.
+    const uint16_t dataCntr = __builtin_bswap16(frame[ADIS1657X_BURST_WORD_DATA_CNTR]);
+    if (dataCntr == lastDataCntr) {
+        return false;
+    }
+    lastDataCntr = dataCntr;
+
+    gyro->gyroADCRaw[X] = (int16_t)__builtin_bswap16(frame[ADIS1657X_BURST_GYRO_HIGH(X)]);
+    gyro->gyroADCRaw[Y] = (int16_t)__builtin_bswap16(frame[ADIS1657X_BURST_GYRO_HIGH(Y)]);
+    gyro->gyroADCRaw[Z] = (int16_t)__builtin_bswap16(frame[ADIS1657X_BURST_GYRO_HIGH(Z)]);
+
+    // Same frame, so no temperatureFn and no extra transaction.
+    gyro->temperature = (int16_t)(((int16_t)__builtin_bswap16(frame[ADIS1657X_BURST_WORD_TEMPERATURE]))
+                                 * gyro->tempScale + gyro->tempZero);
+
+    return true;
+}
+
+static void adis1657xStartBurst(gyroDev_t *gyro)
+{
+    gyro->dev.txBuf[0] = ADIS1657X_BURST_CMD;
+
+    busSegment_t segments[] = {
+        {.u.buffers = {NULL, NULL}, ADIS1657X_BURST_FRAME_LEN, true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+    segments[0].u.buffers.txData = gyro->dev.txBuf;
+    segments[0].u.buffers.rxData = gyro->dev.rxBuf;
+
+    spiSequence(&gyro->dev, &segments[0]);
+    spiWait(&gyro->dev);
+}
+
+static bool adis1657xGyroReadSPI(gyroDev_t *gyro)
+{
+    switch (gyro->gyroModeSPI) {
+    case GYRO_EXTI_INIT:
+    {
+        // Zero, not 0xff: trailing bytes must not look like another command.
+        memset(gyro->dev.txBuf, 0, ADIS1657X_BURST_FRAME_LEN);
+
+        gyro->gyroDmaMaxDuration = 5;
+        if (gyro->detectedEXTI > GYRO_EXTI_DETECT_THRESHOLD) {
+#ifdef USE_DMA
+            if (spiUseDMA(&gyro->dev)) {
+                gyro->dev.callbackArg = (uintptr_t)gyro;
+                gyro->dev.txBuf[0] = ADIS1657X_BURST_CMD;
+                gyro->segments[0].len = ADIS1657X_BURST_FRAME_LEN;
+                gyro->segments[0].callback = mpuIntCallback;
+                gyro->segments[0].u.buffers.txData = gyro->dev.txBuf;
+                // No &rxBuf[1] offset: the command echo aligns the payload itself.
+                gyro->segments[0].u.buffers.rxData = gyro->dev.rxBuf;
+                gyro->segments[0].negateCS = true;
+                gyro->gyroModeSPI = GYRO_EXTI_INT_DMA;
+            } else
+#endif
+            {
+                gyro->gyroModeSPI = GYRO_EXTI_INT;
+            }
+        } else {
+            gyro->gyroModeSPI = GYRO_EXTI_NO_INT;
+        }
+        break;
+    }
+
+    case GYRO_EXTI_INT:
+    case GYRO_EXTI_NO_INT:
+        adis1657xStartBurst(gyro);
+        return adis1657xUnpackGyro(gyro);
+
+    case GYRO_EXTI_INT_DMA:
+        // Started by the EXTI handler; don't wait. Worst case is a stale sample,
+        // which the data counter check then rejects.
+        return adis1657xUnpackGyro(gyro);
+
+    default:
+        break;
+    }
+
+    return true;
+}
+
+static bool adis1657xAccReadSPI(accDev_t *acc)
+{
+    // Same frame the gyro read already fetched, in every mode - no separate accel
+    // transaction. The data counter is not checked here: the gyro owns it, and a
+    // repeated sample is harmless at the rate the accelerometer is consumed.
+    const uint16_t *frame = (const uint16_t *)acc->gyro->dev.rxBuf;
+
+    if (acc->gyro->gyroModeSPI == GYRO_EXTI_INIT) {
+        return true;
+    }
+
+    if (!adis1657xBurstChecksumValid(frame)) {
+        return false;
+    }
+
+    acc->ADCRaw[X] = (int16_t)__builtin_bswap16(frame[ADIS1657X_BURST_ACCEL_HIGH(X)]);
+    acc->ADCRaw[Y] = (int16_t)__builtin_bswap16(frame[ADIS1657X_BURST_ACCEL_HIGH(Y)]);
+    acc->ADCRaw[Z] = (int16_t)__builtin_bswap16(frame[ADIS1657X_BURST_ACCEL_HIGH(Z)]);
+
+    return true;
+}
+
+bool adis1657xSpiGyroDetect(gyroDev_t *gyro)
+{
+    if (gyro->mpuDetectionResult.sensor != ADIS1657X_SPI) {
+        return false;
+    }
+
+    gyro->initFn = adis1657xGyroInit;
+    gyro->readFn = adis1657xGyroReadSPI;
+
+    return true;
+}
+
+bool adis1657xSpiAccDetect(accDev_t *acc)
+{
+    if (acc->mpuDetectionResult.sensor != ADIS1657X_SPI) {
+        return false;
+    }
+
+    acc->initFn = adis1657xAccInit;
+    acc->readFn = adis1657xAccReadSPI;
+
+    return true;
+}
+
+#endif // USE_ACCGYRO_ADIS1657X

--- a/src/main/drivers/accgyro/accgyro_spi_adis1657x.h
+++ b/src/main/drivers/accgyro/accgyro_spi_adis1657x.h
@@ -1,0 +1,158 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "drivers/accgyro/accgyro.h"
+#include "drivers/accgyro/accgyro_mpu.h"
+#include "drivers/bus.h"
+
+// Analog Devices ADIS16575 / ADIS16576 / ADIS16577 precision MEMS IMU.
+
+// f_SCLK: 15MHz for register access, 8MHz for stall-free burst reads.
+#ifndef ADIS1657X_MAX_SPI_CLK_HZ
+#define ADIS1657X_MAX_SPI_CLK_HZ    8000000
+#endif
+
+/*
+ * Registers are 16 bits but byte-addressed: the low byte lives at reg and the
+ * high byte at reg + 1. Bit 7 of the address byte set means write, so a write is
+ * two frames and there is no read bit.
+ *
+ * Reads are pipelined: the frame carrying the address returns the *previous*
+ * frame's answer, so a read is also two frames.
+ */
+#define ADIS1657X_WRITE_BIT         0x80
+
+// t_STALL between frames, 5us minimum.
+#define ADIS1657X_STALL_US          5
+
+#define ADIS1657X_REG_FIFO_CNT              0x3C
+#define ADIS1657X_REG_FIFO_CTRL             0x5A
+#define ADIS1657X_REG_FILT_CTRL             0x5C
+#define ADIS1657X_REG_RNG_MDL               0x5E
+#define ADIS1657X_REG_MSC_CTRL              0x60
+#define ADIS1657X_REG_DEC_RATE              0x64
+#define ADIS1657X_REG_GLOB_CMD              0x68
+#define ADIS1657X_REG_PROD_ID               0x72
+
+// PROD_ID (0x72) is a real identity register, so the variant is detected at run time.
+#define ADIS1657X_PROD_ID_16575             0x40BF
+#define ADIS1657X_PROD_ID_16576             0x40C0
+#define ADIS1657X_PROD_ID_16577             0x40C1
+
+// RNG_MDL (0x5E) bits [3:2] report the fitted gyro range; [1:0] read 11 and
+// [15:4] are unused, so mask before comparing.
+#define ADIS1657X_RNG_MDL_RANGE_MASK        0x000F
+#define ADIS1657X_RNG_MDL_LOW_RANGE         0x0007
+#define ADIS1657X_RNG_MDL_HIGH_RANGE        0x000F
+
+#define ADIS1657X_GLOB_CMD_SW_RESET         (1 << 7)
+
+#define ADIS1657X_MSC_CTRL_BURST_32         (1 << 9)
+#define ADIS1657X_MSC_CTRL_OUT_SEL          (1 << 8)
+#define ADIS1657X_MSC_CTRL_GSEN_EN          (1 << 7)
+#define ADIS1657X_MSC_CTRL_POP_EN           (1 << 6)
+#define ADIS1657X_MSC_CTRL_DR_POL           (1 << 0)
+
+/*
+ * OUT_SEL clear selects rate and acceleration rather than delta angle and delta
+ * velocity. BURST_32 keeps 32-bit outputs; readFn uses the high word of each pair.
+ * POP_EN translates the accelerometer to the gyroscope origin. GSEN_EN only
+ * affects the delta-angle path, so it stays clear. DR_POL set makes data ready
+ * active high, matching the rising edge mpuIntExtiInit() arms.
+ */
+#define ADIS1657X_MSC_CTRL_CFG                              \
+    (ADIS1657X_MSC_CTRL_BURST_32                            \
+     | ADIS1657X_MSC_CTRL_POP_EN                            \
+     | ADIS1657X_MSC_CTRL_DR_POL)
+
+// FIFO_CTRL (0x5A). Zero disables the FIFO; the burst then reads live registers,
+// so one data-ready pulse yields exactly one fresh sample.
+#define ADIS1657X_FIFO_CTRL_DISABLED        0x0000
+
+// FILT_CTRL (0x5C): Bartlett-window FIR of 2^n taps for n in bits [2:0], max 6.
+// Zero is no filtering.
+#define ADIS1657X_FILT_CTRL_OFF             0
+#define ADIS1657X_FILT_CTRL_4_TAP           2
+#define ADIS1657X_FILT_CTRL_16_TAP          4
+#define ADIS1657X_FILT_CTRL_64_TAP          6
+
+// DEC_RATE (0x64): f_ODR = 2000 / (DEC_RATE + 1). Zero for the full rate.
+#define ADIS1657X_DEC_RATE_2000HZ           0
+
+/*
+ * Burst (DIN 0x6800): eighteen 16-bit big-endian words, no stall between frames.
+ * FIFO_CNT, DIAG_STAT, a low/high pair per axis for gyro XYZ then accel XYZ,
+ * temperature, sample counter, timestamp upper (zero unless TS_32 is set), and
+ * the checksum. The payload is even-aligned, so no rxBuf[1] shim is needed.
+ */
+#define ADIS1657X_BURST_CMD                 ADIS1657X_REG_GLOB_CMD
+
+#define ADIS1657X_BURST_WORD_FIFO_CNT       0
+#define ADIS1657X_BURST_WORD_DIAG_STAT      1
+#define ADIS1657X_BURST_WORD_GYRO_LOW       2
+#define ADIS1657X_BURST_WORD_ACCEL_LOW      8
+#define ADIS1657X_BURST_WORD_TEMPERATURE    14
+#define ADIS1657X_BURST_WORD_DATA_CNTR      15
+#define ADIS1657X_BURST_WORD_TIMESTAMP      16
+#define ADIS1657X_BURST_WORD_CHECKSUM       17
+#define ADIS1657X_BURST_WORD_COUNT          18
+#define ADIS1657X_BURST_FRAME_LEN           (ADIS1657X_BURST_WORD_COUNT * sizeof(uint16_t))
+
+// The high word of each 32-bit axis, which is the 16-bit output on its own.
+#define ADIS1657X_BURST_GYRO_HIGH(axis)     (ADIS1657X_BURST_WORD_GYRO_LOW + 1 + 2 * (axis))
+#define ADIS1657X_BURST_ACCEL_HIGH(axis)    (ADIS1657X_BURST_WORD_ACCEL_LOW + 1 + 2 * (axis))
+
+// 16-bit byte-wise sum over the gyro word through the timestamp; FIFO_CNT and
+// DIAG_STAT are excluded.
+#define ADIS1657X_BURST_CHECKSUM_FIRST_WORD ADIS1657X_BURST_WORD_GYRO_LOW
+#define ADIS1657X_BURST_CHECKSUM_END_WORD   ADIS1657X_BURST_WORD_CHECKSUM
+
+// 16-bit gyro sensitivity, LSB per deg/s (datasheet table 20): the -2 parts are
+// +-450 deg/s at 40, the -3 parts +-2000 deg/s at 10.
+#ifndef ADIS1657X_GYRO_LSB_PER_DPS_LOW
+#define ADIS1657X_GYRO_LSB_PER_DPS_LOW      40.0f
+#endif
+#ifndef ADIS1657X_GYRO_LSB_PER_DPS_HIGH
+#define ADIS1657X_GYRO_LSB_PER_DPS_HIGH     10.0f
+#endif
+
+#define ADIS1657X_GYRO_SCALE_LOW            (1.0f / ADIS1657X_GYRO_LSB_PER_DPS_LOW)
+#define ADIS1657X_GYRO_SCALE_HIGH           (1.0f / ADIS1657X_GYRO_LSB_PER_DPS_HIGH)
+
+// 16-bit accel sensitivity, LSB per g (datasheet table 35): +-8g at 4000 for the
+// ADIS16575, +-40g at 800 for the ADIS16576 and ADIS16577.
+#define ADIS1657X_ACC_1G_16575              4000
+#define ADIS1657X_ACC_1G_16576              800
+#define ADIS1657X_ACC_1G_16577              800
+
+// TEMP_OUT: 0.1 degC/LSB, no offset.
+#define ADIS1657X_TEMP_SCALE                0.1f
+#define ADIS1657X_TEMP_ZERO                 0.0f
+
+uint8_t adis1657xSpiDetect(const extDevice_t *dev);
+
+bool adis1657xSpiAccDetect(accDev_t *acc);
+bool adis1657xSpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/gyro_sync.c
+++ b/src/main/drivers/accgyro/gyro_sync.c
@@ -83,6 +83,16 @@ uint16_t gyroSetSampleRate(gyroDev_t *gyro)
             accSampleRateHz = 833;
             break;
 #endif
+#ifdef USE_ACCGYRO_ADIS1657X
+        case ADIS1657X_SPI:
+            // Base ODR is 2000 Hz and the driver leaves DEC_RATE at 0. The accel
+            // words arrive in the same burst at the same rate; 1000 is the rate
+            // Betaflight is told to *consume* them at, not a hardware decimation.
+            gyro->gyroRateKHz = GYRO_RATE_2000_Hz;
+            gyroSampleRateHz = 2000;
+            accSampleRateHz = 1000;
+            break;
+#endif
         case ICM_45686_SPI:
         case ICM_45605_SPI:
         case ICM_56686_SPI:

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -60,6 +60,7 @@ typedef enum {
     ACC_ICM42686P,
     ACC_ICM56686,
     ACC_VIRTUAL,
+    ACC_ADIS1657X,
     ACC_HARDWARE_COUNT
 } accelerationSensor_e;
 

--- a/src/main/sensors/acceleration_init.c
+++ b/src/main/sensors/acceleration_init.c
@@ -52,6 +52,7 @@
 #include "drivers/accgyro/accgyro_spi_icm40609.h"
 
 #include "drivers/accgyro/accgyro_spi_lsm6dso.h"
+#include "drivers/accgyro/accgyro_spi_adis1657x.h"
 #include "drivers/accgyro/accgyro_spi_lsm6dsv16x.h"
 
 #include "drivers/accgyro/accgyro_spi_mpu6000.h"
@@ -333,6 +334,15 @@ retry:
     case ACC_LSM6DSK320X:
         if (lsm6dsk320xSpiAccDetect(dev)) {
             accHardware = ACC_LSM6DSK320X;
+            break;
+        }
+        FALLTHROUGH;
+#endif
+
+#ifdef USE_ACCGYRO_ADIS1657X
+    case ACC_ADIS1657X:
+        if (adis1657xSpiAccDetect(dev)) {
+            accHardware = ACC_ADIS1657X;
             break;
         }
         FALLTHROUGH;

--- a/src/main/sensors/gyro_init.c
+++ b/src/main/sensors/gyro_init.c
@@ -53,6 +53,7 @@
 
 #include "drivers/accgyro/accgyro_spi_l3gd20.h"
 #include "drivers/accgyro/accgyro_spi_lsm6dso.h"
+#include "drivers/accgyro/accgyro_spi_adis1657x.h"
 #include "drivers/accgyro/accgyro_spi_lsm6dsv16x.h"
 
 #include "drivers/accgyro/accgyro_spi_mpu6000.h"
@@ -81,7 +82,16 @@
 // The gyro buffer is split 50/50, the first half for the transmit buffer, the second half for the receive buffer
 // This buffer is large enough for the gyros currently supported in accgyro_mpu.c but should be reviewed id other
 // gyro types are supported with SPI DMA.
+// The ADIS1657x burst frame is 36 bytes, well past the 16 bytes per direction a
+// 32-byte split buffer provides. Widen it only when that driver is enabled so
+// every other target's buffers stay byte-identical. 128 also puts the tx and rx
+// halves on separate 64-byte boundaries, which matters on cores where DMA_DATA
+// is cache-line aligned.
+#if defined(USE_ACCGYRO_ADIS1657X)
+#define GYRO_BUF_SIZE 128
+#else
 #define GYRO_BUF_SIZE 32
+#endif
 
 static uint8_t gyroDetectedFlags = 0;
 
@@ -552,6 +562,15 @@ STATIC_UNIT_TESTED gyroHardware_e gyroDetect(gyroDev_t *dev)
     case GYRO_LSM6DSK320X:
         if (lsm6dsk320xSpiGyroDetect(dev)) {
             gyroHardware = GYRO_LSM6DSK320X;
+            break;
+        }
+        FALLTHROUGH;
+#endif
+
+#ifdef USE_ACCGYRO_ADIS1657X
+    case GYRO_ADIS1657X:
+        if (adis1657xSpiGyroDetect(dev)) {
+            gyroHardware = GYRO_ADIS1657X;
             break;
         }
         FALLTHROUGH;

--- a/src/main/sensors/sensors.c
+++ b/src/main/sensors/sensors.c
@@ -68,7 +68,8 @@ const char * const lookupTableGyroHardware[GYRO_HARDWARE_COUNT] = {
     [GYRO_ICM42622P] = "ICM42622P",
     [GYRO_ICM42686P] = "ICM42686P",
     [GYRO_ICM56686] = "ICM56686",
-    [GYRO_VIRTUAL] = "VIRTUAL"
+    [GYRO_VIRTUAL] = "VIRTUAL",
+    [GYRO_ADIS1657X] = "ADIS1657X"
 };
 
 // sync with accelerationSensor_e
@@ -99,7 +100,8 @@ const char * const lookupTableAccHardware[ACC_HARDWARE_COUNT] = {
     [ACC_ICM42622P] = "ICM42622P",
     [ACC_ICM42686P] = "ICM42686P",
     [ACC_ICM56686] = "ICM56686",
-    [ACC_VIRTUAL] = "VIRTUAL"
+    [ACC_VIRTUAL] = "VIRTUAL",
+    [ACC_ADIS1657X] = "ADIS1657X"
 };
 
 // sync with baroSensor_e

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -160,6 +160,7 @@
     && !defined(USE_ACC_SPI_MPU9250) \
     && !defined(USE_ACCGYRO_IIM42652) \
     && !defined(USE_ACCGYRO_IIM42653) \
+    && !defined(USE_ACCGYRO_ADIS1657X) \
     && !defined(USE_VIRTUAL_ACC)
 #error At least one USE_ACC device definition required
 #endif
@@ -188,6 +189,7 @@
     && !defined(USE_GYRO_SPI_MPU9250) \
     && !defined(USE_ACCGYRO_IIM42652) \
     && !defined(USE_ACCGYRO_IIM42653) \
+    && !defined(USE_ACCGYRO_ADIS1657X) \
     && !defined(USE_VIRTUAL_GYRO)
 #error At least one USE_GYRO device definition required
 #endif
@@ -585,7 +587,8 @@
     || defined(USE_ACCGYRO_ICM56686) \
     || defined(USE_ACCGYRO_ICM40609D) || defined(USE_ACCGYRO_ICM45605) || defined(USE_ACCGYRO_ICM45686) \
     || defined(USE_ACCGYRO_IIM42652) || defined(USE_ACCGYRO_IIM42653) \
-    || defined(USE_ACCGYRO_LSM6DSV16X) || defined(USE_ACCGYRO_LSM6DSO) || defined(USE_ACCGYRO_LSM6DSK320X)
+    || defined(USE_ACCGYRO_LSM6DSV16X) || defined(USE_ACCGYRO_LSM6DSO) || defined(USE_ACCGYRO_LSM6DSK320X) \
+    || defined(USE_ACCGYRO_ADIS1657X)
 #ifndef USE_SPI_GYRO
 #define USE_SPI_GYRO
 #endif

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -111,6 +111,12 @@ baro_ms5611_unittest_DEFINES := \
 accgyro_spi_icm426xx_unittest_SRC := \
 		$(USER_DIR)/drivers/accgyro/accgyro_spi_icm426xx.c
 
+accgyro_spi_adis1657x_unittest_SRC := \
+		$(USER_DIR)/drivers/accgyro/accgyro_spi_adis1657x.c
+
+accgyro_spi_adis1657x_unittest_DEFINES := \
+                USE_ACCGYRO_ADIS1657X=
+
 accgyro_spi_icm426xx_unittest_DEFINES := \
                 USE_GYRO_SPI_ICM42605= \
                 USE_ACCGYRO_ICM42622P= \

--- a/src/test/unit/accgyro_spi_adis1657x_unittest.cc
+++ b/src/test/unit/accgyro_spi_adis1657x_unittest.cc
@@ -1,0 +1,582 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Betaflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdint.h>
+#include <string.h>
+#include <vector>
+
+extern "C" {
+
+#include "platform.h"
+#include "drivers/accgyro/accgyro.h"
+#include "drivers/accgyro/accgyro_mpu.h"
+#include "drivers/accgyro/accgyro_spi_adis1657x.h"
+#include "drivers/bus.h"
+#include "pg/pg.h"
+#include "pg/pg_ids.h"
+#include "sensors/gyro.h"
+
+PG_REGISTER(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 0);
+
+} // extern "C"
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// A fake ADIS1657x behind the SPI stubs at the bottom of the file, so the
+// driver's real init and read paths run unmodified. Register access is modelled
+// as the part does it: byte-addressed halves, and reads pipelined one frame late.
+struct FakeAdis {
+    uint16_t reg[0x80];
+    std::vector<std::pair<uint8_t, uint16_t>> writes;
+    uint16_t burstFrame[ADIS1657X_BURST_WORD_COUNT]; // wire order, big-endian
+    int burstCount;
+    uint16_t pending;       // answer latched by the address frame
+    uint8_t pendingLowByte; // low half of a write waiting for its high half
+    bool pendingLowValid;
+    uint8_t pendingLowReg;
+
+    void reset()
+    {
+        memset(reg, 0, sizeof(reg));
+        reg[ADIS1657X_REG_PROD_ID] = ADIS1657X_PROD_ID_16575;
+        reg[ADIS1657X_REG_RNG_MDL] = ADIS1657X_RNG_MDL_LOW_RANGE;
+        writes.clear();
+        memset(burstFrame, 0, sizeof(burstFrame));
+        burstCount = 0;
+        pending = 0;
+        pendingLowByte = 0;
+        pendingLowValid = false;
+        pendingLowReg = 0;
+    }
+
+    bool wrote(uint8_t r, uint16_t v) const
+    {
+        for (const auto &w : writes) {
+            if (w.first == r && w.second == v) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool wroteReg(uint8_t r) const
+    {
+        for (const auto &w : writes) {
+            if (w.first == r) {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+static FakeAdis fake;
+
+/*
+ * Build a burst frame in the device's wire format: big-endian 32-bit axes as a
+ * low word then a high word, and a trailing byte-wise sum over the words from
+ * the first gyro word up to and including the timestamp.
+ */
+static void fakeSetBurst(int16_t gx, int16_t gy, int16_t gz,
+                         int16_t ax, int16_t ay, int16_t az,
+                         int16_t temp, uint16_t dataCntr)
+{
+    uint16_t host[ADIS1657X_BURST_WORD_COUNT] = {};
+
+    host[ADIS1657X_BURST_WORD_FIFO_CNT] = 0;
+    host[ADIS1657X_BURST_WORD_DIAG_STAT] = 0;
+    host[ADIS1657X_BURST_GYRO_HIGH(0)] = (uint16_t)gx;
+    host[ADIS1657X_BURST_GYRO_HIGH(1)] = (uint16_t)gy;
+    host[ADIS1657X_BURST_GYRO_HIGH(2)] = (uint16_t)gz;
+    host[ADIS1657X_BURST_ACCEL_HIGH(0)] = (uint16_t)ax;
+    host[ADIS1657X_BURST_ACCEL_HIGH(1)] = (uint16_t)ay;
+    host[ADIS1657X_BURST_ACCEL_HIGH(2)] = (uint16_t)az;
+    host[ADIS1657X_BURST_WORD_TEMPERATURE] = (uint16_t)temp;
+    host[ADIS1657X_BURST_WORD_DATA_CNTR] = dataCntr;
+    host[ADIS1657X_BURST_WORD_TIMESTAMP] = 0;
+
+    for (int i = 0; i < ADIS1657X_BURST_WORD_COUNT; i++) {
+        fake.burstFrame[i] = __builtin_bswap16(host[i]);
+    }
+
+    const uint8_t *bytes = (const uint8_t *)&fake.burstFrame[ADIS1657X_BURST_CHECKSUM_FIRST_WORD];
+    const uint8_t *end = (const uint8_t *)&fake.burstFrame[ADIS1657X_BURST_CHECKSUM_END_WORD];
+    uint16_t sum = 0;
+    while (bytes < end) {
+        sum += *bytes++;
+    }
+    fake.burstFrame[ADIS1657X_BURST_WORD_CHECKSUM] = __builtin_bswap16(sum);
+}
+
+class Adis1657xTest : public ::testing::Test {
+protected:
+    gyroDev_t gyro;
+    accDev_t acc;
+    uint8_t txBuf[ADIS1657X_BURST_FRAME_LEN];
+    uint8_t rxBuf[ADIS1657X_BURST_FRAME_LEN];
+    static uint16_t cntr;
+
+    void SetUp() override
+    {
+        fake.reset();
+        memset(&gyro, 0, sizeof(gyro));
+        memset(&acc, 0, sizeof(acc));
+        memset(txBuf, 0, sizeof(txBuf));
+        memset(rxBuf, 0, sizeof(rxBuf));
+        gyro.dev.txBuf = txBuf;
+        gyro.dev.rxBuf = rxBuf;
+        gyro.mpuDetectionResult.sensor = ADIS1657X_SPI;
+        acc.mpuDetectionResult.sensor = ADIS1657X_SPI;
+        acc.gyro = &gyro;
+    }
+
+    // The driver tracks the sample counter across calls, so every frame a test
+    // expects to be accepted must carry a value no earlier test has used.
+    uint16_t nextCntr() { return ++cntr; }
+
+    void initGyro()
+    {
+        ASSERT_TRUE(adis1657xSpiGyroDetect(&gyro));
+        gyro.initFn(&gyro);
+    }
+
+    void deliverBurst()
+    {
+        memcpy(rxBuf, fake.burstFrame, sizeof(fake.burstFrame));
+    }
+};
+
+uint16_t Adis1657xTest::cntr = 100;
+
+// --- detection ---------------------------------------------------------------
+
+TEST_F(Adis1657xTest, DetectMatchesEachProductId)
+{
+    extDevice_t dev = {};
+
+    const uint16_t ids[] = {
+        ADIS1657X_PROD_ID_16575,
+        ADIS1657X_PROD_ID_16576,
+        ADIS1657X_PROD_ID_16577,
+    };
+
+    for (uint16_t id : ids) {
+        fake.reset();
+        fake.reg[ADIS1657X_REG_PROD_ID] = id;
+        EXPECT_EQ(ADIS1657X_SPI, adis1657xSpiDetect(&dev));
+    }
+}
+
+TEST_F(Adis1657xTest, DetectRejectsUnknownProductId)
+{
+    extDevice_t dev = {};
+    fake.reg[ADIS1657X_REG_PROD_ID] = 0x40BE;
+    EXPECT_EQ(MPU_NONE, adis1657xSpiDetect(&dev));
+}
+
+TEST_F(Adis1657xTest, DetectPerformsNoWrites)
+{
+    extDevice_t dev = {};
+    adis1657xSpiDetect(&dev);
+    EXPECT_TRUE(fake.writes.empty());
+}
+
+TEST_F(Adis1657xTest, GyroDetectRejectsOtherSensors)
+{
+    gyro.mpuDetectionResult.sensor = ICM_42688P_SPI;
+    EXPECT_FALSE(adis1657xSpiGyroDetect(&gyro));
+}
+
+TEST_F(Adis1657xTest, AccDetectRejectsOtherSensors)
+{
+    acc.mpuDetectionResult.sensor = ICM_42688P_SPI;
+    EXPECT_FALSE(adis1657xSpiAccDetect(&acc));
+}
+
+// --- initialisation ----------------------------------------------------------
+
+TEST_F(Adis1657xTest, InitIssuesSoftwareReset)
+{
+    initGyro();
+    EXPECT_TRUE(fake.wrote(ADIS1657X_REG_GLOB_CMD, ADIS1657X_GLOB_CMD_SW_RESET));
+}
+
+TEST_F(Adis1657xTest, InitConfiguresMscCtrlForA32BitRateBurst)
+{
+    initGyro();
+    EXPECT_TRUE(fake.wrote(ADIS1657X_REG_MSC_CTRL, ADIS1657X_MSC_CTRL_CFG));
+    EXPECT_EQ(0, ADIS1657X_MSC_CTRL_CFG & ADIS1657X_MSC_CTRL_OUT_SEL);
+    EXPECT_TRUE(ADIS1657X_MSC_CTRL_CFG & ADIS1657X_MSC_CTRL_BURST_32);
+    // Data ready active high is the rising edge mpuIntExtiInit() already arms.
+    EXPECT_TRUE(ADIS1657X_MSC_CTRL_CFG & ADIS1657X_MSC_CTRL_DR_POL);
+    EXPECT_TRUE(ADIS1657X_MSC_CTRL_CFG & ADIS1657X_MSC_CTRL_POP_EN);
+    EXPECT_EQ(0, ADIS1657X_MSC_CTRL_CFG & ADIS1657X_MSC_CTRL_GSEN_EN);
+}
+
+TEST_F(Adis1657xTest, InitRunsAtFullOutputRateWithFifoDisabled)
+{
+    initGyro();
+    EXPECT_TRUE(fake.wrote(ADIS1657X_REG_DEC_RATE, ADIS1657X_DEC_RATE_2000HZ));
+    EXPECT_TRUE(fake.wrote(ADIS1657X_REG_FIFO_CTRL, ADIS1657X_FIFO_CTRL_DISABLED));
+}
+
+TEST_F(Adis1657xTest, InitLeavesHardwareFilterOffByDefault)
+{
+    gyroConfigMutable()->gyro_hardware_lpf = GYRO_HARDWARE_LPF_NORMAL;
+    initGyro();
+    EXPECT_TRUE(fake.wrote(ADIS1657X_REG_FILT_CTRL, ADIS1657X_FILT_CTRL_OFF));
+}
+
+TEST_F(Adis1657xTest, InitSelectsRequestedHardwareFilter)
+{
+    gyroConfigMutable()->gyro_hardware_lpf = GYRO_HARDWARE_LPF_OPTION_2;
+    initGyro();
+    EXPECT_TRUE(fake.wrote(ADIS1657X_REG_FILT_CTRL, ADIS1657X_FILT_CTRL_16_TAP));
+    gyroConfigMutable()->gyro_hardware_lpf = GYRO_HARDWARE_LPF_NORMAL;
+}
+
+TEST_F(Adis1657xTest, InitTakesGyroScaleFromRangeModelRegister)
+{
+    fake.reg[ADIS1657X_REG_RNG_MDL] = ADIS1657X_RNG_MDL_LOW_RANGE;
+    initGyro();
+    EXPECT_FLOAT_EQ(ADIS1657X_GYRO_SCALE_LOW, gyro.scale);
+
+    SetUp();
+    fake.reg[ADIS1657X_REG_RNG_MDL] = ADIS1657X_RNG_MDL_HIGH_RANGE;
+    initGyro();
+    EXPECT_FLOAT_EQ(ADIS1657X_GYRO_SCALE_HIGH, gyro.scale);
+}
+
+TEST_F(Adis1657xTest, InitIgnoresTheUnusedRangeModelBits)
+{
+    fake.reg[ADIS1657X_REG_RNG_MDL] = 0xFFF0 | ADIS1657X_RNG_MDL_HIGH_RANGE;
+    initGyro();
+    EXPECT_FLOAT_EQ(ADIS1657X_GYRO_SCALE_HIGH, gyro.scale);
+}
+
+// Datasheet tables 20 and 35: the numbers a wrong scale would silently mistune.
+TEST_F(Adis1657xTest, SensitivitiesMatchTheDatasheet)
+{
+    EXPECT_FLOAT_EQ(1.0f / 40.0f, ADIS1657X_GYRO_SCALE_LOW);
+    EXPECT_FLOAT_EQ(1.0f / 10.0f, ADIS1657X_GYRO_SCALE_HIGH);
+    EXPECT_EQ(4000, ADIS1657X_ACC_1G_16575);
+    EXPECT_EQ(800, ADIS1657X_ACC_1G_16576);
+    EXPECT_EQ(800, ADIS1657X_ACC_1G_16577);
+}
+
+TEST_F(Adis1657xTest, InitFallsBackToTheLowRangeScale)
+{
+    fake.reg[ADIS1657X_REG_RNG_MDL] = 0x0000;
+    initGyro();
+    EXPECT_FLOAT_EQ(ADIS1657X_GYRO_SCALE_LOW, gyro.scale);
+}
+
+TEST_F(Adis1657xTest, InitPointsDmaAtTheBurstCommand)
+{
+    initGyro();
+    EXPECT_EQ(ADIS1657X_BURST_CMD, gyro.dmaReadRegStart);
+}
+
+TEST_F(Adis1657xTest, InitPublishesTemperatureConversion)
+{
+    initGyro();
+    EXPECT_FLOAT_EQ(ADIS1657X_TEMP_SCALE, gyro.tempScale);
+    EXPECT_FLOAT_EQ(ADIS1657X_TEMP_ZERO, gyro.tempZero);
+}
+
+TEST_F(Adis1657xTest, AccSensitivityFollowsTheDetectedVariant)
+{
+    extDevice_t dev = {};
+
+    fake.reg[ADIS1657X_REG_PROD_ID] = ADIS1657X_PROD_ID_16577;
+    adis1657xSpiDetect(&dev);
+    ASSERT_TRUE(adis1657xSpiAccDetect(&acc));
+    acc.initFn(&acc);
+    EXPECT_EQ(ADIS1657X_ACC_1G_16577, acc.acc_1G);
+
+    fake.reg[ADIS1657X_REG_PROD_ID] = ADIS1657X_PROD_ID_16576;
+    adis1657xSpiDetect(&dev);
+    acc.initFn(&acc);
+    EXPECT_EQ(ADIS1657X_ACC_1G_16576, acc.acc_1G);
+
+    fake.reg[ADIS1657X_REG_PROD_ID] = ADIS1657X_PROD_ID_16575;
+    adis1657xSpiDetect(&dev);
+    acc.initFn(&acc);
+    EXPECT_EQ(ADIS1657X_ACC_1G_16575, acc.acc_1G);
+}
+
+// --- read path ---------------------------------------------------------------
+
+TEST_F(Adis1657xTest, FirstReadNegotiatesPolledMode)
+{
+    initGyro();
+    gyro.detectedEXTI = 0;
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    EXPECT_EQ(GYRO_EXTI_NO_INT, gyro.gyroModeSPI);
+    EXPECT_EQ(0, fake.burstCount);
+}
+
+TEST_F(Adis1657xTest, FirstReadPromotesToInterruptModeWithEnoughEdges)
+{
+    initGyro();
+    gyro.detectedEXTI = 5000;
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    EXPECT_EQ(GYRO_EXTI_INT, gyro.gyroModeSPI);
+}
+
+TEST_F(Adis1657xTest, PolledReadUnpacksTheHighWordOfEachGyroAxis)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(1000, -2000, 3000, 0, 0, 0, 0, nextCntr());
+
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    EXPECT_EQ(1000, gyro.gyroADCRaw[X]);
+    EXPECT_EQ(-2000, gyro.gyroADCRaw[Y]);
+    EXPECT_EQ(3000, gyro.gyroADCRaw[Z]);
+    EXPECT_EQ(1, fake.burstCount);
+}
+
+TEST_F(Adis1657xTest, PolledReadConvertsTemperature)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(1, 1, 1, 1, 1, 1, 250, nextCntr());
+
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    EXPECT_EQ(25, gyro.temperature);
+}
+
+TEST_F(Adis1657xTest, DmaReadTakesTheFrameTheHandlerAlreadyFetched)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_INT_DMA;
+    fakeSetBurst(-7, 8, -9, 0, 0, 0, 0, nextCntr());
+    deliverBurst();
+
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    EXPECT_EQ(-7, gyro.gyroADCRaw[X]);
+    EXPECT_EQ(8, gyro.gyroADCRaw[Y]);
+    EXPECT_EQ(-9, gyro.gyroADCRaw[Z]);
+    // No transaction of its own: the EXTI handler started it.
+    EXPECT_EQ(0, fake.burstCount);
+}
+
+TEST_F(Adis1657xTest, ReadRejectsACorruptChecksum)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(1000, 1000, 1000, 0, 0, 0, 0, nextCntr());
+    fake.burstFrame[ADIS1657X_BURST_WORD_CHECKSUM] ^= 0x0100;
+
+    EXPECT_FALSE(gyro.readFn(&gyro));
+}
+
+TEST_F(Adis1657xTest, ReadRejectsAnAllZeroFrame)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    // Zero is a fixed point of a truncated sum, so the checksum alone accepts
+    // this - and a bus with MISO held low is exactly what produces it.
+    memset(fake.burstFrame, 0, sizeof(fake.burstFrame));
+
+    EXPECT_FALSE(gyro.readFn(&gyro));
+}
+
+TEST_F(Adis1657xTest, ReadRejectsARepeatedSampleCounter)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    const uint16_t c = nextCntr();
+
+    fakeSetBurst(500, 500, 500, 0, 0, 0, 0, c);
+    EXPECT_TRUE(gyro.readFn(&gyro));
+
+    // Same counter means the part has not produced a new sample.
+    fakeSetBurst(600, 600, 600, 0, 0, 0, 0, c);
+    EXPECT_FALSE(gyro.readFn(&gyro));
+    EXPECT_EQ(500, gyro.gyroADCRaw[X]);
+
+    fakeSetBurst(700, 700, 700, 0, 0, 0, 0, nextCntr());
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    EXPECT_EQ(700, gyro.gyroADCRaw[X]);
+}
+
+TEST_F(Adis1657xTest, ReadAcceptsAFrameWithDiagnosticBitsSet)
+{
+    initGyro();
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(1234, 0, 0, 0, 0, 0, 0, nextCntr());
+    // DIAG_STAT is outside the checksum span, and its bits are sticky. Betaflight
+    // cannot report or recover from a sensor fault, so dropping flagged frames
+    // would turn one transient into a permanent freeze.
+    fake.burstFrame[ADIS1657X_BURST_WORD_DIAG_STAT] = __builtin_bswap16(0x0040);
+
+    EXPECT_TRUE(gyro.readFn(&gyro));
+    EXPECT_EQ(1234, gyro.gyroADCRaw[X]);
+}
+
+TEST_F(Adis1657xTest, AccReadTakesTheSameFrameAsTheGyro)
+{
+    initGyro();
+    ASSERT_TRUE(adis1657xSpiAccDetect(&acc));
+    gyro.gyroModeSPI = GYRO_EXTI_NO_INT;
+    fakeSetBurst(0, 0, 0, -100, 200, -300, 0, nextCntr());
+
+    ASSERT_TRUE(gyro.readFn(&gyro));
+    EXPECT_TRUE(acc.readFn(&acc));
+    EXPECT_EQ(-100, acc.ADCRaw[X]);
+    EXPECT_EQ(200, acc.ADCRaw[Y]);
+    EXPECT_EQ(-300, acc.ADCRaw[Z]);
+    // Still one transaction: the accel has no bus of its own.
+    EXPECT_EQ(1, fake.burstCount);
+}
+
+TEST_F(Adis1657xTest, AccReadIgnoresTheSampleCounter)
+{
+    initGyro();
+    ASSERT_TRUE(adis1657xSpiAccDetect(&acc));
+    gyro.gyroModeSPI = GYRO_EXTI_INT_DMA;
+    fakeSetBurst(0, 0, 0, 11, 22, 33, 0, nextCntr());
+    deliverBurst();
+
+    // The gyro owns the counter; a repeat is harmless at the rate the accel is
+    // consumed, so the accel must keep accepting the frame.
+    EXPECT_TRUE(acc.readFn(&acc));
+    EXPECT_TRUE(acc.readFn(&acc));
+    EXPECT_EQ(11, acc.ADCRaw[X]);
+}
+
+TEST_F(Adis1657xTest, AccReadIsQuietBeforeTheModeIsNegotiated)
+{
+    initGyro();
+    ASSERT_TRUE(adis1657xSpiAccDetect(&acc));
+    gyro.gyroModeSPI = GYRO_EXTI_INIT;
+    EXPECT_TRUE(acc.readFn(&acc));
+}
+
+TEST_F(Adis1657xTest, AccReadRejectsACorruptChecksum)
+{
+    initGyro();
+    ASSERT_TRUE(adis1657xSpiAccDetect(&acc));
+    gyro.gyroModeSPI = GYRO_EXTI_INT_DMA;
+    fakeSetBurst(0, 0, 0, 1, 2, 3, 0, nextCntr());
+    fake.burstFrame[ADIS1657X_BURST_WORD_CHECKSUM] ^= 0x0001;
+    deliverBurst();
+
+    EXPECT_FALSE(acc.readFn(&acc));
+}
+
+// --- frame layout ------------------------------------------------------------
+
+TEST_F(Adis1657xTest, BurstFrameLayout)
+{
+    EXPECT_EQ(36u, (unsigned)ADIS1657X_BURST_FRAME_LEN);
+    EXPECT_EQ(0x68, ADIS1657X_BURST_CMD);
+    // A low/high pair per axis, gyro before accel.
+    EXPECT_EQ(3, ADIS1657X_BURST_GYRO_HIGH(0));
+    EXPECT_EQ(7, ADIS1657X_BURST_GYRO_HIGH(2));
+    EXPECT_EQ(9, ADIS1657X_BURST_ACCEL_HIGH(0));
+    EXPECT_EQ(13, ADIS1657X_BURST_ACCEL_HIGH(2));
+    // The checksum covers everything from the first gyro word to the timestamp,
+    // excluding FIFO_CNT and DIAG_STAT.
+    EXPECT_EQ(2, ADIS1657X_BURST_CHECKSUM_FIRST_WORD);
+    EXPECT_EQ(17, ADIS1657X_BURST_CHECKSUM_END_WORD);
+}
+
+TEST_F(Adis1657xTest, BurstFrameFitsTheGyroBuffer)
+{
+    // gyro_init.c splits GYRO_BUF_SIZE in half, one direction each.
+    EXPECT_LE((unsigned)ADIS1657X_BURST_FRAME_LEN, 128u / 2u);
+}
+
+// --- STUBS -------------------------------------------------------------------
+
+extern "C" {
+
+void delay(uint32_t) {}
+void delayMicroseconds(uint32_t) {}
+void spiSetClkDivisor(const extDevice_t *, uint16_t) {}
+void spiWait(const extDevice_t *) {}
+void mpuGyroInit(gyroDev_t *) {}
+busStatus_e mpuIntCallback(uintptr_t) { return BUS_READY; }
+
+uint16_t spiCalculateDivider(uint32_t)
+{
+    return 2;
+}
+
+bool spiUseDMA(const extDevice_t *)
+{
+    return false;
+}
+
+/*
+ * Every register frame is two bytes. Bit 7 of the address byte set means write,
+ * and a write moves one half of the register at a time. A read frame only latches
+ * the answer; the following frame, which carries no address, clocks it out.
+ */
+void spiReadWriteBuf(const extDevice_t *, uint8_t *txData, uint8_t *rxData, int len)
+{
+    if (len != 2) {
+        return;
+    }
+
+    if (!txData && rxData) {
+        rxData[0] = fake.pending >> 8;
+        rxData[1] = fake.pending & 0xff;
+        return;
+    }
+
+    if (!txData) {
+        return;
+    }
+
+    const uint8_t addr = txData[0];
+
+    if (addr & ADIS1657X_WRITE_BIT) {
+        const uint8_t reg = addr & 0x7f;
+        if ((reg & 1) == 0) {
+            fake.pendingLowReg = reg;
+            fake.pendingLowByte = txData[1];
+            fake.pendingLowValid = true;
+        } else if (fake.pendingLowValid && (reg == fake.pendingLowReg + 1)) {
+            const uint16_t value = (txData[1] << 8) | fake.pendingLowByte;
+            fake.writes.push_back({fake.pendingLowReg, value});
+            // GLOB_CMD is a command, not storage: a software reset restores
+            // defaults, which the fake models as leaving the map alone.
+            if (fake.pendingLowReg != ADIS1657X_REG_GLOB_CMD) {
+                fake.reg[fake.pendingLowReg] = value;
+            }
+            fake.pendingLowValid = false;
+        }
+        return;
+    }
+
+    fake.pending = fake.reg[addr & 0x7f];
+}
+
+void spiSequence(const extDevice_t *dev, busSegment_t *segments)
+{
+    fake.burstCount++;
+    if (segments[0].u.buffers.rxData) {
+        memcpy(segments[0].u.buffers.rxData, fake.burstFrame, sizeof(fake.burstFrame));
+    }
+    (void)dev;
+}
+
+} // extern "C"


### PR DESCRIPTION
Adds an accgyro driver for the Analog Devices ADIS1657x family (ADIS16575/16576/16577), precision MEMS IMUs on SPI that return gyro, accel and temperature in one burst frame. Runs at the part's full 2kHz output rate, FIFO disabled, in the 32-bit burst format (readFn keeps the high word of each axis).

Both the specific chip variant and the gyro range are inferred at runtime rather than picked at build time: the probe reads PROD_ID to tell the 16575/16576/16577 apart (each has a different accel sensitivity), and init separately reads RNG_MDL to pick the low- or high-range gyro scale. Neither register can be forced to the wrong value by a misconfigured board.

[Datasheet here](https://www.analog.com/media/en/technical-documentation/data-sheets/adis16575-16576-16577.pdf)

adis1657xSpiDetect's read encoding is a write encoding for other parts earlier in gyroSpiDetectFnTable[], so it's deliberately last - a known part has already claimed the bus by the time it runs. USE_ACCGYRO_ADIS1657X is not in any default sensor list - a board opts in explicitly. No current target defines it, so this is inert for all of them.

Testing
Bench-tested on an STM32N657 with the part on SPI5 - detection, init, burst read, checksum and gyro + accel unpacking, streaming correctly in Configurator.
Not flight-tested. This was tested only in polled mode.

32 unit tests, make test 71/71, make preview builds all 10 preview targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ADIS16575, ADIS16576, and ADIS16577 SPI inertial sensors.
  * ADIS1657x devices now provide gyroscope and accelerometer data, including automatic detection and configuration.
  * Added a 2,000 Hz gyroscope sampling rate with 1,000 Hz accelerometer sampling.
  * Added sensor identification in hardware listings and support for polling, interrupt, and DMA operation modes.

* **Tests**
  * Added comprehensive validation for detection, initialization, data parsing, error handling, and sensor read modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->