### PR TITLE
cli: add a peripherals command and drop the function mask from the wire

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6308,7 +6308,7 @@ static void cliPrintSensorPeripheral(const char *stem, sensorIndex_e sensorIndex
         // Indexes 0 and 1 are AUTO and NONE in every hardware enum - a
         // detection that never recorded which device it found has no name
         // worth printing.
-        if (hardwareIndex <= 1 || hardwareIndex >= count) {
+        if (hardwareIndex <= 1 || hardwareIndex >= count || !names[hardwareIndex]) {
             return;
         }
         cliPrintf("%s: %s", stem, names[hardwareIndex]);
@@ -6316,7 +6316,13 @@ static void cliPrintSensorPeripheral(const char *stem, sensorIndex_e sensorIndex
         cliPrintLinefeed();
     } else if (configuredHardware > 1 && configuredHardware < count) {
         // 0 = AUTO, 1 = NONE for every sensor hardware enum
-        cliPrintLinef("%s: %s configured, not detected", stem, names[configuredHardware]);
+        if (names[configuredHardware]) {
+            cliPrintLinef("%s: %s configured, not detected", stem, names[configuredHardware]);
+        } else {
+            // A selection this build has no entry for, e.g. a DroneCAN mag
+            // setting carried onto a build without DroneCAN.
+            cliPrintLinef("%s: %d configured, not detected", stem, configuredHardware);
+        }
     }
 }
 #endif // USE_SENSOR_NAMES

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -5943,6 +5943,11 @@ static int getTaskAverageRateHz(taskId_e taskId, int *averageDeltaTimeUs)
     return taskInfo.averageDeltaTime10thUs == 0 ? 0 : lrintf(1e7f / taskInfo.averageDeltaTime10thUs);
 }
 
+#if ENABLE_DRONECAN
+static const char * const nodeHealthNames[] = { "OK", "WARNING", "ERROR", "CRITICAL" };
+static const char * const nodeModeNames[] = { "OPERATIONAL", "INITIALISING", "MAINTENANCE", "UPDATING", "?", "?", "?", "OFFLINE" };
+#endif
+
 RAM_CODE static void cliStatus(const char *cmdName, char *cmdline)
 {
     UNUSED(cmdName);
@@ -6157,8 +6162,6 @@ RAM_CODE static void cliStatus(const char *cmdName, char *cmdline)
         if (dronecanIsInitialised()) {
             cliPrintLinef("DroneCAN: node %d, device %d", dronecanConfig()->node_id, dronecanConfig()->device);
 
-            static const char * const nodeHealthNames[] = { "OK", "WARNING", "ERROR", "CRITICAL" };
-            static const char * const nodeModeNames[] = { "OPERATIONAL", "INITIALISING", "MAINTENANCE", "UPDATING", "?", "?", "?", "OFFLINE" };
             for (uint8_t i = 0; i < dronecanNodesCount(); i++) {
                 const dronecanNodeEntry_t *node = dronecanNodesGet(i);
                 cliPrintf("  node %d: %s (%s", node->nodeId,
@@ -6261,6 +6264,152 @@ RAM_CODE static void cliStatus(const char *cmdName, char *cmdline)
         cliPrintf(" %s", getArmingDisableFlagName(flag));
     }
     cliPrintLinefeed();
+}
+
+#if defined(USE_SENSOR_NAMES)
+static void cliPrintDeviceBus(const extDevice_t *dev)
+{
+    if (!dev || !dev->bus) {
+        return;
+    }
+
+    switch (dev->bus->busType) {
+#ifdef USE_SPI
+    case BUS_TYPE_SPI:
+        cliPrintf(" on SPI%d", SPI_DEV_TO_CFG(spiDeviceByInstance(dev->bus->busType_u.spi.instance)));
+        break;
+#endif
+#ifdef USE_I2C
+    case BUS_TYPE_I2C:
+        cliPrintf(" on I2C%d @0x%02X", I2C_DEV_TO_CFG(dev->bus->busType_u.i2c.device), dev->busType_u.i2c.address);
+        break;
+#endif
+    default:
+        break;
+    }
+}
+
+// One line per sensor class, named by the stem of its *_hardware setting.
+// A class configured to a specific device that never came up still gets a
+// line, so a wiring fault reads as "configured, not detected" rather than
+// silence.
+static void cliPrintSensorPeripheral(const char *stem, sensorIndex_e sensorIndex, uint8_t configuredHardware, const extDevice_t *dev)
+{
+    int count;
+    const char * const *names = sensorHardwareNames(sensorIndex, &count);
+    if (!names) {
+        return;
+    }
+
+    const bool detected = (sensorsMask() & sensorMaskForIndex(sensorIndex)) != 0;
+
+    if (detected) {
+        const uint8_t hardwareIndex = detectedSensors[sensorIndex];
+        // Indexes 0 and 1 are AUTO and NONE in every hardware enum - a
+        // detection that never recorded which device it found has no name
+        // worth printing.
+        if (hardwareIndex <= 1 || hardwareIndex >= count) {
+            return;
+        }
+        cliPrintf("%s: %s", stem, names[hardwareIndex]);
+        cliPrintDeviceBus(dev);
+        cliPrintLinefeed();
+    } else if (configuredHardware > 1 && configuredHardware < count) {
+        // 0 = AUTO, 1 = NONE for every sensor hardware enum
+        cliPrintLinef("%s: %s configured, not detected", stem, names[configuredHardware]);
+    }
+}
+#endif // USE_SENSOR_NAMES
+
+static void cliPeripherals(const char *cmdName, char *cmdline)
+{
+    UNUSED(cmdName);
+    UNUSED(cmdline);
+
+    for (unsigned i = 0; i < ARRAYLEN(serialPortIdentifiers); i++) {
+        const serialPortIdentifier_e identifier = serialPortIdentifiers[i];
+        if (!serialIsPortAvailable(identifier)) {
+            continue;
+        }
+
+        serialPortClaim_t claims[SERIAL_PORT_CLAIM_MAX];
+        const unsigned claimCount = serialGetPortClaims(identifier, claims, ARRAYLEN(claims));
+        if (!claimCount) {
+            continue;
+        }
+
+        const serialPortUsage_t *usage = findSerialPortUsageByIdentifier(identifier);
+        const uint32_t openFunction = (usage && usage->serialPort) ? (uint32_t)usage->function : 0;
+
+        cliPrintf("serial %s:", serialName(identifier, invalidName));
+
+        // Claims the port actually opened for first, each starred; the rest
+        // lost boot arbitration or await a reboot.
+        bool first = true;
+        for (unsigned pass = 0; pass < 2; pass++) {
+            const bool wantActive = (pass == 0);
+            for (unsigned c = 0; c < claimCount; c++) {
+                const bool active = (claims[c].functionMask & openFunction) != 0;
+                if (active != wantActive) {
+                    continue;
+                }
+                cliPrintf(first ? " %s%s" : ", %s%s", claims[c].name, active ? "*" : "");
+                first = false;
+            }
+        }
+        cliPrintLinefeed();
+    }
+
+#if ENABLE_DRONECAN
+    if (dronecanConfig()->enabled && dronecanIsInitialised()) {
+        for (uint8_t i = 0; i < dronecanNodesCount(); i++) {
+            const dronecanNodeEntry_t *node = dronecanNodesGet(i);
+            cliPrintf("can node %d: %s (%s", node->nodeId,
+                      node->infoValid && node->name[0] ? node->name : "no info",
+                      nodeHealthNames[node->health & 0x03]);
+            if (node->mode != UAVCAN_NODE_MODE_OPERATIONAL) {
+                cliPrintf(", %s", nodeModeNames[node->mode & 0x07]);
+            }
+            cliPrint(")");
+
+            static const struct { uint8_t flag; const char *name; } sensorFlagNames[] = {
+                { DRONECAN_NODE_SENSOR_GPS, "gps" },
+                { DRONECAN_NODE_SENSOR_MAG, "mag" },
+                { DRONECAN_NODE_SENSOR_AIRSPEED, "airspeed" },
+                { DRONECAN_NODE_SENSOR_ESC, "esc" },
+            };
+            bool first = true;
+            for (unsigned f = 0; f < ARRAYLEN(sensorFlagNames); f++) {
+                if (node->sensorFlags & sensorFlagNames[f].flag) {
+                    cliPrintf(first ? " %s" : ", %s", sensorFlagNames[f].name);
+                    first = false;
+                }
+            }
+            cliPrintLinefeed();
+        }
+    }
+#endif
+
+#if defined(USE_SENSOR_NAMES)
+    for (unsigned pos = 0; pos < GYRO_COUNT; pos++) {
+        if (!(gyroConfig()->gyrosDetected & BIT(pos))) {
+            continue;
+        }
+        cliPrintf("gyro %d: %s%s", pos + 1, lookupTableGyroHardware[detectedGyros[pos]],
+                  (gyro.gyroEnabledBitmask & BIT(pos)) ? "*" : "");
+        cliPrintDeviceBus(&gyro.gyroSensor[pos].gyroDev.dev);
+        cliPrintLinefeed();
+    }
+#if defined(USE_ACC)
+    cliPrintSensorPeripheral("acc", SENSOR_INDEX_ACC, accelerometerConfig()->acc_hardware, acc.dev.gyro ? &acc.dev.gyro->dev : NULL);
+#endif
+#if defined(USE_BARO)
+    cliPrintSensorPeripheral("baro", SENSOR_INDEX_BARO, barometerConfig()->baro_hardware, &baro.dev.dev);
+#endif
+#if defined(USE_MAG)
+    cliPrintSensorPeripheral("mag", SENSOR_INDEX_MAG, compassConfig()->mag_hardware, &magDev.dev);
+#endif
+#endif // USE_SENSOR_NAMES
 }
 
 RAM_CODE static void cliTasks(const char *cmdName, char *cmdline)
@@ -8351,6 +8500,7 @@ const clicmd_t cmdTable[] = {
 #endif
     CLI_COMMAND_DEF("options", "show build options", NULL, cliOptions),
 #ifndef MINIMAL_CLI
+    CLI_COMMAND_DEF("peripherals", "show attached peripherals", NULL, cliPeripherals),
     CLI_COMMAND_DEF("play_sound", NULL, "[<index>]", cliPlaySound),
 #endif
     CLI_COMMAND_DEF("battery_profile", "change battery profile", "[<index>]", cliBatteryProfile),

--- a/src/main/drivers/compass/compass.h
+++ b/src/main/drivers/compass/compass.h
@@ -39,3 +39,5 @@ typedef struct magDev_s {
     int16_t magGain[3];
     uint16_t magOdrHz;
 } magDev_t;
+
+extern magDev_t magDev;

--- a/src/main/io/serial_feature_map.c
+++ b/src/main/io/serial_feature_map.c
@@ -67,6 +67,80 @@
 #include "telemetry/telemetry.h"
 #endif
 
+#ifdef USE_VTX_COMMON
+static uint32_t vtxFunctionMask(void)
+{
+    switch (vtxSettingsConfig()->vtx_type) {
+#ifdef USE_VTX_SMARTAUDIO
+    case VTXDEV_SMARTAUDIO:
+        return FUNCTION_VTX_SMARTAUDIO;
+#endif
+#ifdef USE_VTX_TRAMP
+    case VTXDEV_TRAMP:
+        return FUNCTION_VTX_TRAMP;
+#endif
+#ifdef USE_VTX_MSP
+    case VTXDEV_MSP:
+        // An MSP VTX talks over MSP on its own UART, so it brings the MSP bit
+        // with it; FUNCTION_VTX_MSP on its own is a conflict.
+        return FUNCTION_VTX_MSP | FUNCTION_MSP;
+#endif
+    default:
+        return 0;
+    }
+}
+#endif
+
+#ifdef USE_OSD
+static uint32_t osdFunctionMask(void)
+{
+    switch (osdConfig()->displayPortDevice) {
+    case OSD_DISPLAYPORT_DEVICE_FRSKYOSD:
+        return FUNCTION_FRSKY_OSD;
+#ifdef USE_MSP_DISPLAYPORT
+    case OSD_DISPLAYPORT_DEVICE_MSP:
+        return FUNCTION_MSP;
+#endif
+    default:
+        return 0;
+    }
+}
+#endif
+
+#ifdef USE_TELEMETRY_PROVIDERS
+static uint32_t telemetryProviderFunctionMask(unsigned providerIndex)
+{
+    switch (telemetryConfig()->providers[providerIndex].protocol) {
+#ifdef USE_TELEMETRY_FRSKY_HUB
+    case TELEMETRY_PROTOCOL_FRSKY_HUB:
+        return FUNCTION_TELEMETRY_FRSKY_HUB;
+#endif
+#ifdef USE_TELEMETRY_HOTT
+    case TELEMETRY_PROTOCOL_HOTT:
+        return FUNCTION_TELEMETRY_HOTT;
+#endif
+#ifdef USE_TELEMETRY_LTM
+    case TELEMETRY_PROTOCOL_LTM:
+        return FUNCTION_TELEMETRY_LTM;
+#endif
+#ifdef USE_TELEMETRY_SMARTPORT
+    case TELEMETRY_PROTOCOL_SMARTPORT:
+        return FUNCTION_TELEMETRY_SMARTPORT;
+#endif
+#ifdef USE_TELEMETRY_MAVLINK
+    case TELEMETRY_PROTOCOL_MAVLINK:
+        return FUNCTION_TELEMETRY_MAVLINK;
+#endif
+#ifdef USE_TELEMETRY_IBUS
+    case TELEMETRY_PROTOCOL_IBUS:
+        return FUNCTION_TELEMETRY_IBUS;
+#endif
+    default:
+        return 0;
+    }
+}
+#endif
+
 uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier)
 {
     if (identifier == SERIAL_PORT_NONE) {
@@ -114,27 +188,7 @@ uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier)
 #endif
 #ifdef USE_VTX_COMMON
     if (vtxSettingsConfig()->vtx_uart == identifier) {
-        switch (vtxSettingsConfig()->vtx_type) {
-#ifdef USE_VTX_SMARTAUDIO
-        case VTXDEV_SMARTAUDIO:
-            mask |= FUNCTION_VTX_SMARTAUDIO;
-            break;
-#endif
-#ifdef USE_VTX_TRAMP
-        case VTXDEV_TRAMP:
-            mask |= FUNCTION_VTX_TRAMP;
-            break;
-#endif
-#ifdef USE_VTX_MSP
-        case VTXDEV_MSP:
-            // An MSP VTX talks over MSP on its own UART, so it brings the MSP bit
-            // with it; FUNCTION_VTX_MSP on its own is a conflict.
-            mask |= FUNCTION_VTX_MSP | FUNCTION_MSP;
-            break;
-#endif
-        default:
-            break;
-        }
+        mask |= vtxFunctionMask();
     }
 #endif
 #ifdef USE_RANGEFINDER
@@ -151,18 +205,7 @@ uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier)
 #endif
 #ifdef USE_OSD
     if (osdConfig()->osd_uart == identifier) {
-        switch (osdConfig()->displayPortDevice) {
-        case OSD_DISPLAYPORT_DEVICE_FRSKYOSD:
-            mask |= FUNCTION_FRSKY_OSD;
-            break;
-#ifdef USE_MSP_DISPLAYPORT
-        case OSD_DISPLAYPORT_DEVICE_MSP:
-            mask |= FUNCTION_MSP;
-            break;
-#endif
-        default:
-            break;
-        }
+        mask |= osdFunctionMask();
     }
     if (osdConfig()->osd_custom_text_uart == identifier) {
         mask |= FUNCTION_OSD_CUSTOM_TEXT;
@@ -170,47 +213,118 @@ uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier)
 #endif
 #ifdef USE_TELEMETRY_PROVIDERS
     for (unsigned i = 0; i < MAX_TELEMETRY_PROVIDERS; i++) {
-        if (telemetryConfig()->providers[i].uart != identifier) {
-            continue;
-        }
-        switch (telemetryConfig()->providers[i].protocol) {
-#ifdef USE_TELEMETRY_FRSKY_HUB
-        case TELEMETRY_PROTOCOL_FRSKY_HUB:
-            mask |= FUNCTION_TELEMETRY_FRSKY_HUB;
-            break;
-#endif
-#ifdef USE_TELEMETRY_HOTT
-        case TELEMETRY_PROTOCOL_HOTT:
-            mask |= FUNCTION_TELEMETRY_HOTT;
-            break;
-#endif
-#ifdef USE_TELEMETRY_LTM
-        case TELEMETRY_PROTOCOL_LTM:
-            mask |= FUNCTION_TELEMETRY_LTM;
-            break;
-#endif
-#ifdef USE_TELEMETRY_SMARTPORT
-        case TELEMETRY_PROTOCOL_SMARTPORT:
-            mask |= FUNCTION_TELEMETRY_SMARTPORT;
-            break;
-#endif
-#ifdef USE_TELEMETRY_MAVLINK
-        case TELEMETRY_PROTOCOL_MAVLINK:
-            mask |= FUNCTION_TELEMETRY_MAVLINK;
-            break;
-#endif
-#ifdef USE_TELEMETRY_IBUS
-        case TELEMETRY_PROTOCOL_IBUS:
-            mask |= FUNCTION_TELEMETRY_IBUS;
-            break;
-#endif
-        default:
-            break;
+        if (telemetryConfig()->providers[i].uart == identifier) {
+            mask |= telemetryProviderFunctionMask(i);
         }
     }
 #endif
 
     return mask;
+}
+
+unsigned serialGetPortClaims(serialPortIdentifier_e identifier, serialPortClaim_t *claims, unsigned maxClaims)
+{
+    unsigned count = 0;
+
+    if (identifier == SERIAL_PORT_NONE) {
+        return 0;
+    }
+
+#define ADD_CLAIM(claimName, mask) \
+    do { \
+        if (count < maxClaims) { \
+            claims[count].name = (claimName); \
+            claims[count].functionMask = (mask); \
+            count++; \
+        } \
+    } while (0)
+
+    static const char * const mspClaimNames[] = { "msp_1", "msp_2", "msp_3" };
+    for (unsigned i = 0; i < MAX_MSP_PORT_COUNT && i < ARRAYLEN(mspClaimNames); i++) {
+        if (mspConfig()->msp_uart[i] == identifier) {
+            ADD_CLAIM(mspClaimNames[i], FUNCTION_MSP);
+        }
+    }
+
+#ifdef USE_GPS
+    if (gpsConfig()->gps_uart == identifier) {
+        ADD_CLAIM("gps", FUNCTION_GPS);
+    }
+#endif
+#if defined(USE_RX_PWM) || defined(USE_RX_PPM) || defined(USE_SERIALRX) || defined(USE_RX_MSP) || defined(USE_RX_SPI)
+    if (rxConfig()->rx_uart == identifier) {
+        ADD_CLAIM("rx", FUNCTION_RX_SERIAL);
+    }
+#endif
+#ifdef USE_BLACKBOX
+    if (blackboxConfig()->blackbox_uart == identifier) {
+        ADD_CLAIM("blackbox", FUNCTION_BLACKBOX);
+    }
+#endif
+#ifdef USE_ESC_SENSOR
+    if (escSensorConfig()->esc_sensor_uart == identifier) {
+        ADD_CLAIM("esc_sensor", FUNCTION_ESC_SENSOR);
+    }
+#endif
+#ifdef USE_RCDEVICE
+    if (rcdeviceConfig()->rcdevice_uart == identifier) {
+        ADD_CLAIM("rcdevice", FUNCTION_RCDEVICE);
+    }
+#endif
+#ifdef USE_GIMBAL
+    if (gimbalTrackConfig()->gimbal_uart == identifier) {
+        ADD_CLAIM("gimbal", FUNCTION_GIMBAL);
+    }
+#endif
+#ifdef USE_VTX_COMMON
+    if (vtxSettingsConfig()->vtx_uart == identifier) {
+        ADD_CLAIM("vtx", vtxFunctionMask());
+    }
+#endif
+#ifdef USE_RANGEFINDER
+    if (rangefinderConfig()->rangefinder_uart == identifier) {
+        uint32_t mask = FUNCTION_LIDAR;
+#ifdef USE_RANGEFINDER_MT
+        // An MSP-transport module's port opens as an implied MSP port, so
+        // that is the function the claim is active under.
+        if (rangefinderTypeUsesMsp(rangefinderConfig()->rangefinder_hardware)) {
+            mask |= FUNCTION_MSP;
+        }
+#endif
+        ADD_CLAIM("rangefinder", mask);
+    }
+#endif
+#ifdef USE_OPTICALFLOW
+    if (opticalflowConfig()->opticalflow_uart == identifier) {
+        uint32_t mask = FUNCTION_LIDAR;
+#ifdef USE_OPTICALFLOW_MT
+        if (opticalflowTypeUsesMsp(opticalflowConfig()->opticalflow_hardware)) {
+            mask |= FUNCTION_MSP;
+        }
+#endif
+        ADD_CLAIM("opticalflow", mask);
+    }
+#endif
+#ifdef USE_OSD
+    if (osdConfig()->osd_uart == identifier) {
+        ADD_CLAIM("osd", osdFunctionMask());
+    }
+    if (osdConfig()->osd_custom_text_uart == identifier) {
+        ADD_CLAIM("osd_custom_text", FUNCTION_OSD_CUSTOM_TEXT);
+    }
+#endif
+#ifdef USE_TELEMETRY_PROVIDERS
+    static const char * const telemetryClaimNames[] = { "telemetry_1", "telemetry_2", "telemetry_3" };
+    for (unsigned i = 0; i < MAX_TELEMETRY_PROVIDERS && i < ARRAYLEN(telemetryClaimNames); i++) {
+        if (telemetryConfig()->providers[i].uart == identifier) {
+            ADD_CLAIM(telemetryClaimNames[i], telemetryProviderFunctionMask(i));
+        }
+    }
+#endif
+
+#undef ADD_CLAIM
+
+    return count;
 }
 
 // Clear any feature PG field currently naming `identifier` so the

--- a/src/main/io/serial_feature_map.h
+++ b/src/main/io/serial_feature_map.h
@@ -31,6 +31,20 @@
 // (MSP_CF_SERIAL_CONFIG) and the CLI `serial` command's output.
 uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier);
 
+// One feature's claim on a port, named by the stem of the owning CLI setting
+// ("gps" owns gps_uart, "msp_1" owns msp_uart_1).  functionMask holds the
+// functions the port opens with when the claim wins boot arbitration; 0 when
+// the feature's current protocol selection cannot open the port at all.
+typedef struct serialPortClaim_s {
+    const char *name;
+    uint32_t functionMask;
+} serialPortClaim_t;
+
+// Every *_uart setting that can name one port at once.
+#define SERIAL_PORT_CLAIM_MAX 17
+
+unsigned serialGetPortClaims(serialPortIdentifier_e identifier, serialPortClaim_t *claims, unsigned maxClaims);
+
 // Clear the claims on just those ports whose functions cannot coexist, sparing
 // MSP so the board stays reachable.  First recovery step for a stored assignment
 // that isSerialConfigValid() rejects, so one bad assignment costs the user that

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1781,7 +1781,10 @@ case MSP_NAME:
                 continue;
             };
             sbufWriteU8(dst, identifier);
-            sbufWriteU16(dst, serialSynthesizeFunctionMask(identifier));
+            // Assignments live on the feature PGs and are surfaced over the
+            // CLI; a zero mask here reads as unassigned on old configurators
+            // rather than a view they would try to edit.
+            sbufWriteU16(dst, 0);
             mspWritePortBaudRates(dst, identifier);
         }
         break;
@@ -1800,7 +1803,7 @@ case MSP_NAME:
                 continue;
             };
             sbufWriteU8(dst, identifier);
-            sbufWriteU32(dst, serialSynthesizeFunctionMask(identifier));
+            sbufWriteU32(dst, 0);
             mspWritePortBaudRates(dst, identifier);
         }
         break;

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -258,6 +258,14 @@ uint32_t serialSynthesizeFunctionMask(serialPortIdentifier_e identifier)
     return 0;
 }
 
+unsigned serialGetPortClaims(serialPortIdentifier_e identifier, serialPortClaim_t *claims, unsigned maxClaims)
+{
+    (void)identifier;
+    (void)claims;
+    (void)maxClaims;
+    return 0;
+}
+
 const serialPortIdentifier_e serialPortIdentifiers[SERIAL_PORT_COUNT] = {
     SERIAL_PORT_USB_VCP,
     SERIAL_PORT_USART1,

--- a/src/test/unit/serial_feature_map_unittest.cc
+++ b/src/test/unit/serial_feature_map_unittest.cc
@@ -710,3 +710,77 @@ TEST(SerialFeatureMap, BaudClassesAreIndependentOnASharedPort)
         EXPECT_EQ(expected[c], serialSynthesizePortBaud(SERIAL_PORT_UART4, (serialBaudClass_e)c));
     }
 }
+
+TEST(SerialFeatureMap, ClaimsEmptyWhenNothingAssigned)
+{
+    resetAllConfigs();
+
+    serialPortClaim_t claims[SERIAL_PORT_CLAIM_MAX];
+    EXPECT_EQ(0u, serialGetPortClaims(SERIAL_PORT_USART1, claims, ARRAYLEN(claims)));
+    EXPECT_EQ(0u, serialGetPortClaims(SERIAL_PORT_NONE, claims, ARRAYLEN(claims)));
+}
+
+TEST(SerialFeatureMap, ClaimsNamedByOwningSetting)
+{
+    resetAllConfigs();
+
+    mspConfigMutable()->msp_uart[1] = SERIAL_PORT_USART2;
+    gpsConfigMutable()->gps_uart = SERIAL_PORT_USART2;
+    telemetryConfigMutable()->providers[1].protocol = TELEMETRY_PROTOCOL_SMARTPORT;
+    telemetryConfigMutable()->providers[1].uart = SERIAL_PORT_USART2;
+
+    serialPortClaim_t claims[SERIAL_PORT_CLAIM_MAX];
+    ASSERT_EQ(3u, serialGetPortClaims(SERIAL_PORT_USART2, claims, ARRAYLEN(claims)));
+
+    EXPECT_STREQ("msp_2", claims[0].name);
+    EXPECT_EQ((uint32_t)FUNCTION_MSP, claims[0].functionMask);
+    EXPECT_STREQ("gps", claims[1].name);
+    EXPECT_EQ((uint32_t)FUNCTION_GPS, claims[1].functionMask);
+    EXPECT_STREQ("telemetry_2", claims[2].name);
+    EXPECT_EQ((uint32_t)FUNCTION_TELEMETRY_SMARTPORT, claims[2].functionMask);
+}
+
+TEST(SerialFeatureMap, ClaimMaskFollowsProtocolSelection)
+{
+    resetAllConfigs();
+
+    vtxSettingsConfigMutable()->vtx_uart = SERIAL_PORT_USART1;
+    serialPortClaim_t claims[SERIAL_PORT_CLAIM_MAX];
+
+    ASSERT_EQ(1u, serialGetPortClaims(SERIAL_PORT_USART1, claims, ARRAYLEN(claims)));
+    EXPECT_STREQ("vtx", claims[0].name);
+    EXPECT_EQ(0u, claims[0].functionMask);
+
+    vtxSettingsConfigMutable()->vtx_type = VTXDEV_MSP;
+    ASSERT_EQ(1u, serialGetPortClaims(SERIAL_PORT_USART1, claims, ARRAYLEN(claims)));
+    EXPECT_EQ((uint32_t)(FUNCTION_VTX_MSP | FUNCTION_MSP), claims[0].functionMask);
+}
+
+TEST(SerialFeatureMap, ClaimMaskCarriesTheImpliedMspTransport)
+{
+    resetAllConfigs();
+
+    rangefinderConfigMutable()->rangefinder_uart = SERIAL_PORT_USART3;
+    rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_TF02;
+    serialPortClaim_t claims[SERIAL_PORT_CLAIM_MAX];
+
+    ASSERT_EQ(1u, serialGetPortClaims(SERIAL_PORT_USART3, claims, ARRAYLEN(claims)));
+    EXPECT_STREQ("rangefinder", claims[0].name);
+    EXPECT_EQ((uint32_t)FUNCTION_LIDAR, claims[0].functionMask);
+
+    rangefinderConfigMutable()->rangefinder_hardware = RANGEFINDER_MTF01;
+    ASSERT_EQ(1u, serialGetPortClaims(SERIAL_PORT_USART3, claims, ARRAYLEN(claims)));
+    EXPECT_EQ((uint32_t)(FUNCTION_LIDAR | FUNCTION_MSP), claims[0].functionMask);
+}
+
+TEST(SerialFeatureMap, ClaimsRespectCallerCapacity)
+{
+    resetAllConfigs();
+
+    mspConfigMutable()->msp_uart[0] = SERIAL_PORT_USART1;
+    gpsConfigMutable()->gps_uart = SERIAL_PORT_USART1;
+    rxConfigMutable()->rx_uart = SERIAL_PORT_USART1;
+
+    serialPortClaim_t claims[2];
+    EXPECT_EQ(2u, serialGetPortClaims(SERIAL_PORT_USART1, claims, ARRAYLEN(claims)));
+}


### PR DESCRIPTION
Adds a read-only `peripherals` CLI command listing everything attached to the board in one place: each serial port with the feature claims on it (the claim the port actually opened for is starred and listed first, so a claim that lost boot arbitration or awaits a reboot is visible at a glance), discovered DroneCAN nodes with health and sensor classes, and the detected gyro/acc/baro/mag hardware with its bus. A sensor configured to a specific device that never came up reads as `configured, not detected`.

With assignments living on the feature PGs and surfaced over the CLI, `MSP_CF_SERIAL_CONFIG` and `MSP2_COMMON_SERIAL_CONFIG` now report a zero function mask, so old configurators show ports as unassigned rather than a read-only view they would try to edit. `serialSynthesizeFunctionMask` stays internal as the conflict arbiter. The configurator side (per-device tiles on the Ports tab) rides on this command.

Verified on SITL and on a NERO F722 on the bench (MSP VTX active claim starred after reboot, conflicting and pending claims listed unstarred, zero mask on the wire with real baud bytes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `peripherals` CLI command showing configured serial devices, DroneCAN nodes, and connected sensors with bus information.
  * Added detailed serial port claim reporting for assigned features and related transport functions.

* **Changes**
  * Serial configuration responses now omit synthesized function masks while preserving port and baud-rate information.

* **Tests**
  * Added coverage for serial port claims, including device-specific mappings, transport implications, and claim capacity limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->