### PR TITLE
Mark dmarwaxi as shareable (non-cached)

### DIFF
--- a/src/platform/STM32/memprot_stm32h7xx.c
+++ b/src/platform/STM32/memprot_stm32h7xx.c
@@ -59,13 +59,21 @@ mpuRegion_t mpuRegions[] = {
         .bufferable = MPU_ACCESS_NOT_BUFFERABLE,
     },
     {
-        // A region in AXI RAM accessible from SDIO internal DMA
+        // A region in AXI RAM accessible from SDIO internal DMA.
+        //
+        // Shareable, like the dmaram region above, so the M7 leaves it out of the
+        // D cache. Both regions must agree: PMSAv7 rounds each up to a natural
+        // power-of-two window, and once the two windows overlap the higher-numbered
+        // region's attributes win over the whole of the overlap. A non-shareable
+        // region here can therefore silently make dmaram cacheable, and bus_spi
+        // skips cache maintenance for anything inside dmaram on the strength of its
+        // address alone - so DMA writes land in RAM that the CPU never re-reads.
         .start      = (uint32_t)&dmarwaxi_start,
         .end        = (uint32_t)&dmarwaxi_end,
         .size       = 0,  // Size determined by ".end"
         .perm       = MPU_REGION_FULL_ACCESS,
         .exec       = MPU_INSTRUCTION_ACCESS_ENABLE,
-        .shareable  = MPU_ACCESS_NOT_SHAREABLE,
+        .shareable  = MPU_ACCESS_SHAREABLE,
         .cacheable  = MPU_ACCESS_CACHEABLE,
         .bufferable = MPU_ACCESS_NOT_BUFFERABLE,
     },


### PR DESCRIPTION
<!DOCTYPE html><head></head><div class="expandable unchanged js-expandable rich-diff-level-zero" style="box-sizing: border-box; margin-top: 0px !important; margin-left: var(--base-size-16); caret-color: rgb(31, 35, 40); color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><p class="unchanged rich-diff-level-one" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16);">This is a critical bug for H7.</p><p class="unchanged rich-diff-level-one" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16);">Whilst testing<span class="Apple-converted-space"> </span><a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="5187305420" data-permission-text="Title is private" data-url="https://github.com/betaflight/betaflight/issues/15584" href="https://github.com/betaflight/betaflight/pull/15584" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: var(--fgColor-accent,var(--color-accent-fg)); text-decoration: underline; white-space: normal; text-underline-offset: 0.2rem;">betaflight/betaflight#15584</a><span class="Apple-converted-space"> </span>on an H7 I found I was getting bad glitching in flight and inspection of logs showed that the raw gyro data was only being updated just over 100 times per second. I tracked this down to the DMA buffer (<code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">gyroBuf</code>) for the gyro, which sits in the<span class="Apple-converted-space"> </span><code class="notranslate" style="box-sizing: border-box; font-family: var(--fontStack-monospace,ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace); font-size: 11.9px; tab-size: var(--tab-size-preference); white-space: break-spaces; background-color: var(--bgColor-neutral-muted,var(--color-neutral-muted)); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">.dmaram_data</code><span class="Apple-converted-space"> </span>section of memory, being cached, which it shouldn't be. Gyro data was only being refreshed when the cache was randomly invalidated.</p></div><p class="vicinity rich-diff-level-zero" style="box-sizing: border-box; margin-top: 0px; margin-bottom: var(--base-size-16); margin-left: var(--base-size-16); caret-color: rgb(31, 35, 40); color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">This was due to the two regions below, the first non-cached, the second cached, occupying the same 64K block of memory, and the second definition won. The fix is to make both regions shareable.</p><div class="expandable unchanged js-expandable rich-diff-level-zero" style="box-sizing: border-box; margin-left: var(--base-size-16); caret-color: rgb(31, 35, 40); color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><markdown-accessiblity-table class="rich-diff-level-one" data-catalyst="" style="box-sizing: border-box; display: block;">
MPU region | Section | Window | Attribute
-- | -- | -- | --
1 | dmaram 0x24011ca0–0x24016e60 | 0x24010000–0x24020000 | Shareable
2 | dmarwaxi 0x24016e60–0x24018994 | 0x24010000–0x24020000 | Non-Shareable

</markdown-accessiblity-table></div><ins style="box-sizing: border-box; box-shadow: inset 4px 0 0 var(--borderColor-success-muted,var(--color-success-muted)); text-decoration: none; border-radius: 0px; display: block; border-top: 0px; border-bottom: 0px; caret-color: rgb(31, 35, 40); color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px;"><h2 class="rich-diff-level-zero" style="box-sizing: border-box; margin-top: var(--base-size-24); margin-bottom: var(--base-size-16); font-size: 1.5em; font-weight: var(--base-text-weight-semibold,600); line-height: 1.25; border-bottom: 1px solid var(--borderColor-muted,var(--color-border-muted)); padding-bottom: 0.3em; margin-left: var(--base-size-16);">Summary by CodeRabbit</h2></ins><ul class="added rich-diff-level-zero" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px !important; padding-left: 2em; box-shadow: inset 4px 0 0 var(--borderColor-success-muted,var(--color-success-muted)); border-radius: 0px; display: block; border-top: 0px; border-bottom: 0px; background: var(--bgColor-success-muted,var(--color-success-subtle)); text-decoration: none; caret-color: rgb(31, 35, 40); color: rgb(31, 35, 40); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans Backtick Fix&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px;"><li class="rich-diff-level-one" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px; margin-left: var(--base-size-16);"><strong style="box-sizing: border-box; font-weight: var(--base-text-weight-semibold,600);">Bug Fixes</strong><ul style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px; padding-left: 2em;"><li style="box-sizing: border-box;">Updated AXI RAM memory protection settings to ensure consistent shareability across overlapping memory regions.</li><li style="box-sizing: border-box; margin-top: 0.25em;">Prevents incorrect cache behavior that could disrupt SPI bus operations.</li></ul></li></ul>This is a critical bug for H7.

Whilst testing [betaflight/betaflight#15584](https://github.com/betaflight/betaflight/pull/15584) on an H7 I found I was getting bad glitching in flight and inspection of logs showed that the raw gyro data was only being updated just over 100 times per second. I tracked this down to the DMA buffer (gyroBuf) for the gyro, which sits in the .dmaram_data section of memory, being cached, which it shouldn't be. Gyro data was only being refreshed when the cache was randomly invalidated.

This was due to the two regions below, the first non-cached, the second cached, occupying the same 64K block of memory, and the second definition won. The fix is to make both regions shareable.

MPU region	Section	Window	Attribute
1	dmaram 0x24011ca0–0x24016e60	0x24010000–0x24020000	Shareable
2	dmarwaxi 0x24016e60–0x24018994	0x24010000–0x24020000	Non-Shareable
Summary by CodeRabbit

Bug Fixes
Updated AXI RAM memory protection settings to ensure consistent shareability across overlapping memory regions.
Prevents incorrect cache behavior that could disrupt SPI bus operations.