### PR TITLE
Resolve the uncached DMA RAM range from the MPU at boot

### DIFF
--- a/src/main/drivers/memprot.h
+++ b/src/main/drivers/memprot.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
+
 typedef struct mpuRegion_s {
     uint32_t start;
     uint32_t end;        // Zero if determined by size member (MPU_REGION_SIZE_xxx)
@@ -36,3 +39,13 @@ extern unsigned mpuRegionCount;
 
 void memProtReset(void);
 void memProtConfigure(mpuRegion_t *mpuRegions, unsigned regionCount);
+
+// Narrow [start, end) to the longest span within it that the processor will keep out of
+// the D cache, judged from the regions the MPU actually holds rather than from the table
+// it was configured with. Returns an empty range if there is no such span. Available
+// where memProtConfigure() programs a PMSAv7 MPU.
+void memProtFindUncachedRange(uint32_t start, uint32_t end, uint32_t *uncachedStart, uint32_t *uncachedEnd);
+
+// Work out which part of the DMA sections is genuinely uncached, for the bus drivers that
+// skip cache maintenance there. Implemented by the platforms that need it.
+void memProtResolveDmaRam(void);

--- a/src/platform/STM32/bus_spi_ll.c
+++ b/src/platform/STM32/bus_spi_ll.c
@@ -380,7 +380,7 @@ void spiInternalInitStream(const extDevice_t *dev, volatile busSegment_t *segmen
     if (txData) {
 #ifdef __DCACHE_PRESENT
 #ifdef STM32H7
-        if ((txData < &_dmaram_start__) || (txData >= &_dmaram_end__)) {
+        if (!isDmaramUncached(txData, len)) {
 #else
         // No need to flush DTCM memory
         if (!IS_DTCM(txData)) {
@@ -413,7 +413,7 @@ void spiInternalInitStream(const extDevice_t *dev, volatile busSegment_t *segmen
 #ifdef __DCACHE_PRESENT
             // No need to flush/invalidate DTCM memory
 #ifdef STM32H7
-            if ((rxData < &_dmaram_start__) || (rxData >= &_dmaram_end__)) {
+            if (!isDmaramUncached(rxData, len)) {
 #else
             // No need to flush DTCM memory
             if (!IS_DTCM(rxData)) {

--- a/src/platform/STM32/include/platform/platform.h
+++ b/src/platform/STM32/include/platform/platform.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #if defined(STM32G474xx)
 #include "stm32g4xx.h"
 #include "stm32g4xx_hal.h"
@@ -476,6 +479,30 @@
 #define DMA_RW_AXI __attribute__((section(".DMA_RW_AXI"), aligned(32)))
 extern uint8_t _dmaram_start__;
 extern uint8_t _dmaram_end__;
+
+/* The part of the above the MPU is actually leaving out of the D cache, resolved at boot
+ * by memProtResolveDmaRam(). This answers only whether a transfer needs cache maintenance
+ * to stay coherent - the linker symbols still answer where a buffer was placed, and so
+ * whether DMA can reach it at all.
+ *
+ * Held in DTCM as a base and a length, both loads coming from zero wait state memory.
+ * Zero until resolved, which reads as "cached", so a transfer before then gets the full
+ * maintenance rather than none.
+ *
+ * The whole buffer has to be inside the span, not just its first byte: the span can end
+ * part way through the dmaram sections, and a buffer straddling that edge would otherwise
+ * have its cached tail go unmaintained.
+ */
+extern uint32_t dmaramUncachedBase;
+extern uint32_t dmaramUncachedLength;
+
+static inline bool isDmaramUncached(const void *addr, uint32_t len)
+{
+    const uint32_t offset = (uint32_t)addr - dmaramUncachedBase;
+
+    // The second test cannot underflow: the first has established offset < length
+    return (offset < dmaramUncachedLength) && (len <= dmaramUncachedLength - offset);
+}
 #elif defined(STM32N6)
 #define DMA_RAM __attribute__((section(".DMA_RAM"), aligned(32)))
 #define DMA_RW_AXI __attribute__((section(".DMA_RW_AXI"), aligned(32)))

--- a/src/platform/STM32/memprot_hal.c
+++ b/src/platform/STM32/memprot_hal.c
@@ -18,15 +18,175 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "platform.h"
+
+#include "common/utils.h"
 
 #include "drivers/memprot.h"
 
 static void memProtConfigError(void)
 {
     for (;;) {}
+}
+
+/* Read back the region attributes the MPU will actually apply to an address.
+ *
+ * A region's declared attributes are not necessarily the ones it ends up with. PMSAv7
+ * requires every region to be a natural power of two, so memProtConfigure() rounds each
+ * one up until it covers the section it was given, which makes regions overlap routinely
+ * even where the sections they describe do not touch. In an overlap the highest-numbered
+ * region wins outright, taking its attributes with it.
+ *
+ * Returns false if no enabled region covers the address, leaving the background (default
+ * memory map) attributes in force.
+ */
+static bool memProtGetRegionAttributes(uint32_t addr, uint32_t *rasr)
+{
+    bool covered = false;
+
+    for (unsigned region = 0; region < MAX_MPU_REGIONS; region++) {
+        MPU->RNR = region;
+        const uint32_t regionRbar = MPU->RBAR;
+        const uint32_t regionRasr = MPU->RASR;
+
+        if (!(regionRasr & MPU_RASR_ENABLE_Msk)) {
+            continue;
+        }
+
+        // RASR SIZE semantics: region bytes = 2^(SIZE + 1), based at a multiple of that size
+        const uint32_t size = 1U << (((regionRasr & MPU_RASR_SIZE_Msk) >> MPU_RASR_SIZE_Pos) + 1);
+        const uint32_t base = regionRbar & ~(size - 1);
+
+        if ((addr < base) || (addr - base >= size)) {
+            continue;
+        }
+
+        // Regions of 256 bytes or more are split into eighths, any of which can be
+        // disabled; where one is, the region does not apply.
+        if (size >= 256) {
+            const uint32_t srd = (regionRasr & MPU_RASR_SRD_Msk) >> MPU_RASR_SRD_Pos;
+            if (srd & (1U << ((addr - base) / (size / 8)))) {
+                continue;
+            }
+        }
+
+        // A later region would override this one, so record it and keep looking
+        *rasr = regionRasr;
+        covered = true;
+    }
+
+    return covered;
+}
+
+/* Whether the processor will keep an address out of the D cache.
+ *
+ * The Cortex-M7 has no cache coherency hardware, so it never allocates Normal memory
+ * marked shareable into the L1 data cache. That is what keeps the DMA regions coherent
+ * without explicit maintenance.
+ */
+static bool memProtAddrIsUncached(uint32_t addr)
+{
+    uint32_t rasr;
+
+    if (!memProtGetRegionAttributes(addr, &rasr)) {
+        // Background attributes, so assume the worst
+        return false;
+    }
+
+    return (rasr & MPU_RASR_S_Msk) || !(rasr & MPU_RASR_C_Msk);
+}
+
+// Collect the addresses within (start, end) at which the winning region, and so the
+// attributes in force, can change. Sub-region edges are not among them: memProtConfigure()
+// never disables a sub-region.
+static unsigned memProtCollectEdges(uint32_t start, uint32_t end, uint32_t *edges, unsigned maxEdges)
+{
+    unsigned count = 0;
+
+    for (unsigned region = 0; region < MAX_MPU_REGIONS; region++) {
+        MPU->RNR = region;
+        const uint32_t regionRbar = MPU->RBAR;
+        const uint32_t regionRasr = MPU->RASR;
+
+        if (!(regionRasr & MPU_RASR_ENABLE_Msk)) {
+            continue;
+        }
+
+        const uint32_t size = 1U << (((regionRasr & MPU_RASR_SIZE_Msk) >> MPU_RASR_SIZE_Pos) + 1);
+        const uint32_t base = regionRbar & ~(size - 1);
+        const uint32_t regionEdges[] = { base, base + size };
+
+        for (unsigned i = 0; i < ARRAYLEN(regionEdges); i++) {
+            const uint32_t edge = regionEdges[i];
+
+            if ((edge <= start) || (edge >= end) || (count >= maxEdges)) {
+                continue;
+            }
+
+            // Insertion sort, keeping the list ordered and free of duplicates
+            unsigned pos = count;
+            while ((pos > 0) && (edges[pos - 1] > edge)) {
+                edges[pos] = edges[pos - 1];
+                pos--;
+            }
+            if ((pos < count) && (edges[pos] == edge)) {
+                // Already present, so undo the shift
+                while (pos < count) {
+                    edges[pos] = edges[pos + 1];
+                    pos++;
+                }
+                continue;
+            }
+            edges[pos] = edge;
+            count++;
+        }
+    }
+
+    return count;
+}
+
+void memProtFindUncachedRange(uint32_t start, uint32_t end, uint32_t *uncachedStart, uint32_t *uncachedEnd)
+{
+    // Nothing found yet, expressed as an empty range
+    *uncachedStart = start;
+    *uncachedEnd = start;
+
+    if (start >= end) {
+        return;
+    }
+
+    uint32_t edges[2 * MAX_MPU_REGIONS];
+    const unsigned edgeCount = memProtCollectEdges(start, end, edges, ARRAYLEN(edges));
+
+    /* The edges cut [start, end) into spans of constant attributes, so one probe per span
+     * settles it. Return the longest run of adjacent uncached spans: a single range keeps
+     * the test cheap for callers, and a caller finding its buffer outside it is only
+     * obliged to fall back to explicit cache maintenance.
+     */
+    uint32_t runStart = start;
+    bool inRun = false;
+
+    for (unsigned i = 0; i <= edgeCount; i++) {
+        const uint32_t spanStart = (i == 0) ? start : edges[i - 1];
+        const uint32_t spanEnd = (i == edgeCount) ? end : edges[i];
+
+        if (memProtAddrIsUncached(spanStart)) {
+            if (!inRun) {
+                runStart = spanStart;
+                inRun = true;
+            }
+            if (spanEnd - runStart > *uncachedEnd - *uncachedStart) {
+                *uncachedStart = runStart;
+                *uncachedEnd = spanEnd;
+            }
+        } else {
+            inRun = false;
+        }
+    }
 }
 
 void memProtConfigure(mpuRegion_t *regions, unsigned regionCount)

--- a/src/platform/STM32/memprot_stm32h7xx.c
+++ b/src/platform/STM32/memprot_stm32h7xx.c
@@ -61,19 +61,15 @@ mpuRegion_t mpuRegions[] = {
     {
         // A region in AXI RAM accessible from SDIO internal DMA.
         //
-        // Shareable, like the dmaram region above, so the M7 leaves it out of the
-        // D cache. Both regions must agree: PMSAv7 rounds each up to a natural
-        // power-of-two window, and once the two windows overlap the higher-numbered
-        // region's attributes win over the whole of the overlap. A non-shareable
-        // region here can therefore silently make dmaram cacheable, and bus_spi
-        // skips cache maintenance for anything inside dmaram on the strength of its
-        // address alone - so DMA writes land in RAM that the CPU never re-reads.
+        // Left cached, unlike dmaram above: its users do their own cache maintenance
+        // so that they can read the buffers back at cached speed. DShot bitbang in
+        // particular walks its input buffer repeatedly to decode telemetry.
         .start      = (uint32_t)&dmarwaxi_start,
         .end        = (uint32_t)&dmarwaxi_end,
         .size       = 0,  // Size determined by ".end"
         .perm       = MPU_REGION_FULL_ACCESS,
         .exec       = MPU_INSTRUCTION_ACCESS_ENABLE,
-        .shareable  = MPU_ACCESS_SHAREABLE,
+        .shareable  = MPU_ACCESS_NOT_SHAREABLE,
         .cacheable  = MPU_ACCESS_CACHEABLE,
         .bufferable = MPU_ACCESS_NOT_BUFFERABLE,
     },
@@ -83,3 +79,35 @@ mpuRegion_t mpuRegions[] = {
 unsigned mpuRegionCount = ARRAYLEN(mpuRegions);
 
 STATIC_ASSERT(ARRAYLEN(mpuRegions) <= MAX_MPU_REGIONS, MPU_region_count_exceeds_limit);
+
+/* The part of the dmaram sections that is genuinely uncached.
+ *
+ * bus_spi skips the cache maintenance around a DMA transfer when the buffer is in memory
+ * the processor is keeping out of the D cache. Which memory that is cannot be read off
+ * the region table: rounding each region up to a power-of-two window makes overlaps
+ * routine, and in an overlap the highest-numbered region's attributes win over all of it,
+ * so a neighbouring region can strip the shareable bit off dmaram without either section
+ * moving.
+ *
+ * Reading it back from the programmed MPU settles it, and costs nothing in the hot path
+ * beyond two loads. A configuration that does not deliver an uncached dmaram narrows the
+ * range, or empties it, and the transfers that fall outside get the maintenance they need
+ * - slower, rather than wrong.
+ *
+ * Zero until resolved, which reads as "cached" for every address.
+ */
+FAST_DATA_ZERO_INIT uint32_t dmaramUncachedBase;
+FAST_DATA_ZERO_INIT uint32_t dmaramUncachedLength;
+
+void memProtResolveDmaRam(void)
+{
+#ifdef USE_DMA_RAM
+    uint32_t uncachedStart;
+    uint32_t uncachedEnd;
+
+    memProtFindUncachedRange((uint32_t)&dmaram_start, (uint32_t)&dmaram_end, &uncachedStart, &uncachedEnd);
+
+    dmaramUncachedBase = uncachedStart;
+    dmaramUncachedLength = uncachedEnd - uncachedStart;
+#endif
+}

--- a/src/platform/STM32/startup/system_stm32h7xx.c
+++ b/src/platform/STM32/startup/system_stm32h7xx.c
@@ -955,6 +955,9 @@ void SystemInit (void)
 
     memProtConfigure(mpuRegions, mpuRegionCount);
 
+    // Record which part of the DMA sections the MPU is actually leaving uncached
+    memProtResolveDmaRam();
+
     // Enable CPU L1-Cache
     SCB_EnableICache();
     SCB_EnableDCache();

--- a/src/platform/common/stm32/bus_spi_hw.c
+++ b/src/platform/common/stm32/bus_spi_hw.c
@@ -61,7 +61,7 @@ FAST_IRQ_HANDLER static void spiRxIrqHandler(dmaChannelDescriptor_t* descriptor)
 #ifdef __DCACHE_PRESENT
 #ifdef STM32H7
     if (bus->curSegment->u.buffers.rxData &&
-        ((bus->curSegment->u.buffers.rxData < &_dmaram_start__) || (bus->curSegment->u.buffers.rxData >= &_dmaram_end__))) {
+        !isDmaramUncached(bus->curSegment->u.buffers.rxData, bus->curSegment->len)) {
 #else
     if (bus->curSegment->u.buffers.rxData) {
 #endif


### PR DESCRIPTION
This is a better solution for the issue fixed in https://github.com/betaflight/betaflight/pull/15641

Whilst testing https://github.com/betaflight/betaflight/pull/15584 on an H7 I found I was getting bad glitching in flight and inspection of logs showed that the raw gyro data was only being updated just over 100 times per second. I tracked this down to the DMA buffer (`gyroBuf`) for the gyro, which sits in the `.dmaram_data` section of memory, being cached, which it shouldn't be. Gyro data was only being refreshed when the cache was randomly invalidated.

This was due to the two regions below, the first non-cached, the second cached, occupying the same 64K block of memory, and the second definition won. The fix is to determine at boot, and then check at runtime, if a given buffer is in shareable (not requiring cache management) or non-shareable (requiring flush/invalidate) memory.

MPU region | Section | Window | Attribute
-- | -- | -- | --
1 | dmaram 0x24011ca0–0x24016e60 | 0x24010000–0x24020000 | Shareable
2 | dmarwaxi 0x24016e60–0x24018994 | 0x24010000–0x24020000 | Non-Shareable


Currently the SPI bus driver skips the cache maintenance around an SPI DMA transfer when the buffer lies between `_dmaram_start__` and `_dmaram_end__`, taking that to mean the processor is keeping it out of the D cache. Unfortunately the linker symbols say where the sections were placed; they say nothing about the attributes
those addresses ended up with.

PMSAv7 regions must be a natural power of two, so `memProtConfigure()` rounds each one up until it covers its section, which makes overlaps routine even where the sections do not touch. In an overlap the highest-numbered region's attributes win over all of it, so a neighbouring region can strip the shareable bit off `dmaram` without either
section moving - which is what `dmarwaxi` did on H743 once the build grew enough for its window to reach 64KB. The result was silent: DMA writes landing in memory the processor then read from cache, for every SPI device at once, until a line happened to be evicted.

The symptom on a `SEQUREH7` was that the gyro's raw sample rate fell from 8kHz to about 127Hz with nothing reported anywhere.

The solution implemented in this PR is to read the region attributes back from the MPU after programming it, narrow
the range to the part that is genuinely uncached, and decide the cache maintenance from that. This changes only whether the flush and invalidate are needed; where a buffer sits, and so whether DMA can reach it, is still
a placement question the linker symbols answer.

The test takes a length as well as an address, because the resolved range can end part way through the sections and a buffer straddling that edge would otherwise have its cached tail go unmaintained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved STM32H7 DMA buffer cache handling when memory regions are only partially uncached.
  * Prevented unnecessary or missing cache maintenance during SPI transfers.
  * Improved detection of genuinely uncached DMA memory based on configured memory protection settings.
  * Updated SDIO DMA memory attributes to improve consistency with expected access behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->