### PR TITLE
fix(build): drop baseline SD card default on 512K targets

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -202,9 +202,11 @@
 #define USE_RX_SX127X
 #endif // !USE_RX_SPI
 
+#if TARGET_FLASH_SIZE >= 1024
 #if !defined(USE_EXST) && !defined(USE_SDCARD)
 #define USE_SDCARD
 #endif
+#endif // TARGET_FLASH_SIZE >= 1024
 
 #endif // !defined(USE_CONFIG)
 


### PR DESCRIPTION
The config-less baseline builds enable every driver the MCU can carry, and STM32F446 had been sitting at 99.92% of its 480K FLASH1 region. The Kalman position estimator (#15584) added 1540 bytes, mostly `taskCalculateAltitude` and `kalmanPredict`, tipping it to 100.24% and breaking CI.

SD card support (FatFS, asyncfatfs, both SPI and SDIO backends) costs around 21K on F4 and is an unlikely pairing with a 512K flash, so the automatic default is now gated on `TARGET_FLASH_SIZE >= 1024`. That block already sits inside the `!CLOUD_BUILD` / `!USE_CONFIG` guards, so cloud builds and every board config are untouched; boards that carry an SD card set `USE_SDCARD` in their own `config.h`. SDIO and SPI SD compile coverage is retained by the F745, H723/H725/H735/H743, X32M7B and N657 baselines.

STM32F446 drops from 492685 to 470981 bytes (95.82%), STM32F411 to 91.70%.

Alternatives considered: `-finline-limit=20` (the existing F411 treatment, saves 29K) penalises real F446 boards that already fit comfortably, and gating `USE_USB_MSC` or `USE_USB_CDC_HID` would strip those features from F411 and F446 cloud builds since they are defined in `platform/platform.h` outside the cloud-build guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted SD card support selection for classic builds.
  * Targets with less than 1024 KB of flash no longer enable SD card support automatically, helping preserve available resources.
  * Larger targets continue to receive automatic SD card support where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->