### PR TITLE
fix(build): gate link arguments file on GNU make 4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,18 @@ DFUSE-PACK  := src/utils/dfuse-pack.py
 
 # Command used to link the final ELF. Platform makefiles can override this
 # when linking requires a dedicated linker instead of the C compiler driver.
+# $(file ...) needs GNU make 4.0; macOS ships 3.81, which silently expands it to
+# nothing and leaves the linker looking for an arguments file that was never written.
+ifeq ($(filter 3.%,$(MAKE_VERSION)),)
 ELF_LINK_CMD = $(file > $@.args,$(filter-out %.ld,$^)) $(CROSS_CC) -o $@ @$@.args $(LD_FLAGS)
+else
+# Exported so the warning is emitted once, not once per recursive make invocation.
+ifndef OLD_MAKE_WARNED
+export OLD_MAKE_WARNED := 1
+$(warning GNU make $(MAKE_VERSION) detected, falling back to linking without an arguments file. Support for GNU make older than 4.0 may be dropped in a future release. macOS ships an old system make: install a current one with 'brew install make' and build with gmake.)
+endif
+ELF_LINK_CMD = $(CROSS_CC) -o $@ $(filter-out %.ld,$^) $(LD_FLAGS)
+endif
 
 # Preprocessor helpers (generic .h parsing)
 include $(MAKE_SCRIPT_DIR)/preprocess.mk
@@ -493,7 +504,7 @@ endif
 
 TARGET_EF_HASH_FILE := $(TARGET_OBJ_DIR)/.efhash_$(TARGET_EF_HASH)
 
-CLEAN_ARTIFACTS := $(TARGET_ELF) $(TARGET_EXST_ELF) $(TARGET_MAP)
+CLEAN_ARTIFACTS := $(TARGET_ELF) $(TARGET_ELF).args $(TARGET_EXST_ELF) $(TARGET_MAP)
 CLEAN_ARTIFACTS += $(wildcard $(BIN_DIR)/*$(TARGET_NAME_CLEAN)*)
 
 # Make sure build date and revision is updated on every incremental build


### PR DESCRIPTION
Builds on macOS fail to link since #15591. The `$(file ...)` function needs GNU make 4.0, and macOS still ships 3.81 as the system make. On 3.81 `file` is not a builtin, so `$(file > $@.args,...)` parses as a reference to an undefined variable and expands to nothing: no arguments file is written, but the recipe still passes `@$@.args` to the linker, so it fails on a missing response file instead of a syntax error.

Gates the arguments file on the make version and falls back to linking the objects directly on 3.x, with a one-off warning that support for pre-4.0 make may be dropped. The warning guard is exported so the hundreds of recursive make invocations in a full build stay quiet. `$(file ...)` was the only make 4.0 construct in the build system, so this is enough to restore 3.81.

Also adds the arguments file to `CLEAN_ARTIFACTS`. It lands beside the ELF in `obj/main` rather than inside the per-target object directory, so `make clean` was leaving it behind.

Verified on STM32F405 with the real toolchain: the 3.x fallback links to a byte-identical ELF, and the warning appears exactly once through a recursive `make hex` and not at all on 4.4.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build compatibility across GNU Make versions.
  * Added cleanup for generated linker argument files.
  * Older GNU Make versions now receive a clear warning and continue using direct linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->