### PR TITLE
The Pitot sensors data added in MSP

### DIFF
--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2178,6 +2178,12 @@ case MSP_NAME:
 #else
         sbufWriteU8(dst, OPTICALFLOW_NONE);
 #endif
+        // Added in MSP API 1.49
+#ifdef USE_PITOT
+        sbufWriteU8(dst, pitotConfig()->pitot_hardware);
+#else
+        sbufWriteU8(dst, PITOT_NONE);
+#endif
         break;
 
     // Added in MSP API 1.46
@@ -2212,6 +2218,11 @@ case MSP_NAME:
 #endif
 #ifdef USE_OPTICALFLOW
         sbufWriteU8(dst, detectedSensors[SENSOR_INDEX_OPTICALFLOW]);
+#else
+        sbufWriteU8(dst, SENSOR_NOT_AVAILABLE);
+#endif
+#ifdef USE_PITOT
+        sbufWriteU8(dst, detectedSensors[SENSOR_INDEX_PITOT]);
 #else
         sbufWriteU8(dst, SENSOR_NOT_AVAILABLE);
 #endif
@@ -3714,6 +3725,13 @@ RAM_CODE static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, int16_t
         if (sbufBytesRemaining(src) >= 1) {
 #ifdef USE_OPTICALFLOW
             opticalflowConfigMutable()->opticalflow_hardware = sbufReadU8(src);
+#else
+            sbufReadU8(src);
+#endif
+        }
+        if (sbufBytesRemaining(src) >= 1) {
+#ifdef USE_PITOT
+            pitotConfigMutable()->pitot_hardware = sbufReadU8(src);
 #else
             sbufReadU8(src);
 #endif

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -153,6 +153,7 @@
 #include "sensors/gyro_init.h"
 #include "sensors/rangefinder.h"
 #include "sensors/opticalflow.h"
+#include "sensors/pitot.h"
 
 #include "telemetry/msp_shared.h"
 #include "telemetry/telemetry.h"
@@ -2326,6 +2327,16 @@ case MSP_NAME:
         sbufWriteU16(dst, (uint16_t)currentPidProfile->angle_pitch_offset);
         break;
     }
+
+    case MSP_PITOT:
+#if defined(USE_PITOT)
+        sbufWriteU32(dst, (uint32_t)MAX(pitot.airspeed, 0.0f));
+        sbufWriteU32(dst, (uint32_t)MAX(pitot.diffPressure, 0.0f));
+#else
+        sbufWriteU32(dst, 0);
+        sbufWriteU32(dst, 0);
+#endif
+        break;
 
     default:
         unsupportedCommand = true;

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -1178,7 +1178,7 @@ RAM_CODE static bool mspProcessOutCommand(mspDescriptor_t srcDesc, int16_t cmdMS
 #else
         sbufWriteU16(dst, 0);
 #endif
-        sbufWriteU16(dst, sensors(SENSOR_ACC) | sensors(SENSOR_BARO) << 1 | sensors(SENSOR_MAG) << 2 | sensors(SENSOR_GPS) << 3 | sensors(SENSOR_RANGEFINDER) << 4 | sensors(SENSOR_GYRO) << 5 | sensors(SENSOR_OPTICALFLOW) << 6);
+        sbufWriteU16(dst, sensors(SENSOR_ACC) | sensors(SENSOR_BARO) << 1 | sensors(SENSOR_MAG) << 2 | sensors(SENSOR_GPS) << 3 | sensors(SENSOR_RANGEFINDER) << 4 | sensors(SENSOR_GYRO) << 5 | sensors(SENSOR_OPTICALFLOW) << 6 | sensors(SENSOR_PITOT) << 7);
         sbufWriteData(dst, &flightModeFlags, 4);        // unconditional part of flags, first 32 bits
         sbufWriteU8(dst, getCurrentPidProfileIndex());
         sbufWriteU16(dst, constrain(getAverageSystemLoadPercent(), 0, LOAD_PERCENTAGE_ONE));

--- a/src/main/msp/msp.c
+++ b/src/main/msp/msp.c
@@ -2341,8 +2341,8 @@ case MSP_NAME:
 
     case MSP_PITOT:
 #if defined(USE_PITOT)
-        sbufWriteU32(dst, (uint32_t)MAX(pitot.airspeed, 0.0f));
-        sbufWriteU32(dst, (uint32_t)MAX(pitot.diffPressure, 0.0f));
+        sbufWriteU32(dst, (uint32_t)(int32_t)pitot.airspeed);
+        sbufWriteU32(dst, (uint32_t)(int32_t)pitot.diffPressure);
 #else
         sbufWriteU32(dst, 0);
         sbufWriteU32(dst, 0);

--- a/src/main/msp/msp_protocol.h
+++ b/src/main/msp/msp_protocol.h
@@ -220,6 +220,7 @@
 #define MSP_GPSSTATISTICS               166  // out message: Get GPS debugging data
 #define MSP_ATTITUDE_QUATERNION         167  // out message: Orientation quaternion components (w, x, y, z)
 #define MSP_WING                        169  // out message: WING settings
+#define MSP_PITOT                       170  // out message: Pitot data
 
 // OSD specific commands (180-189)
 #define MSP_OSD_VIDEO_CONFIG            180  // out message: Get OSD video settings


### PR DESCRIPTION
The Pitot sensors data added in MSP to use it in the BF App

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pitot sensor support for compatible hardware.
  * Sensor status and configuration now include pitot hardware.
  * Added support for reading airspeed and differential-pressure data.
  * Added a new MSP command for pitot sensor data.
  * Sensor configuration commands can set pitot hardware or ignore the setting when unsupported.
  * Pitot readings now preserve negative airspeed and differential-pressure values when reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->