### PR TITLE
Fix string buffer overflows when formatting the version string

### DIFF
--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -275,7 +275,14 @@ static void showWelcomePage(void)
 {
     uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
 
-    tfp_sprintf(lineBuffer, "v%s (%s)", FC_VERSION_STRING, shortGitRevision);
+    // Version and revision no longer share a line: with calver plus an optional suffix
+    // (e.g. "2026.12.0-alpha") "v<version> (<revision>)" overruns lineBuffer.
+    STATIC_ASSERT(sizeof("v" FC_VERSION_STRING) <= sizeof(lineBuffer), version_line_too_long);
+    tfp_sprintf(lineBuffer, "v%s", FC_VERSION_STRING);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
+
+    tfp_sprintf(lineBuffer, "(%s)", shortGitRevision);
     i2c_OLED_set_line(dev, rowIndex++);
     i2c_OLED_send_string(dev, lineBuffer);
 
@@ -428,7 +435,9 @@ static void showGpsPage(void)
     i2c_OLED_set_xy(dev, HALF_SCREEN_CHARACTER_COLUMN_COUNT, rowIndex++);
     i2c_OLED_send_string(dev, lineBuffer);
 
+    STATIC_ASSERT(GPS_PACKET_LOG_ENTRY_COUNT < sizeof(lineBuffer), gps_packet_log_too_long);
     strncpy(lineBuffer, dashboardGpsPacketLog, GPS_PACKET_LOG_ENTRY_COUNT);
+    lineBuffer[GPS_PACKET_LOG_ENTRY_COUNT] = 0;
     padHalfLineBuffer();
     i2c_OLED_set_line(dev, rowIndex++);
     i2c_OLED_send_string(dev, lineBuffer);
@@ -440,7 +449,11 @@ static void showBatteryPage(void)
     uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
 
     if (batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE) {
-        tfp_sprintf(lineBuffer, "Volts: %d.%02d Cells: %d", getBatteryVoltage() / 100, getBatteryVoltage() % 100, getBatteryCellCount());
+        // 123456789012345678901
+        // Volts:DDD.DD Cells:DD
+        // force_battery_cell_count goes up to 24, so both fields can be two digits and the
+        // voltage three; the spaces after the colons are dropped to stay inside the line.
+        tfp_sprintf(lineBuffer, "Volts:%d.%02d Cells:%d", getBatteryVoltage() / 100, getBatteryVoltage() % 100, getBatteryCellCount());
         padLineBuffer();
         i2c_OLED_set_line(dev, rowIndex++);
         i2c_OLED_send_string(dev, lineBuffer);
@@ -469,7 +482,9 @@ static void showBatteryPage(void)
 static void showSensorsPage(void)
 {
     uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
-    static const char *format = "%s %5d %5d %5d";
+    // Field width must hold the widest int16 value ("-32768"); the widths still line
+    // the columns up with the header below.
+    static const char *format = "%s%6d%6d%6d";
 
     i2c_OLED_set_line(dev, rowIndex++);
     i2c_OLED_send_string(dev, "        X     Y     Z");

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -282,6 +282,8 @@ static void showWelcomePage(void)
     i2c_OLED_set_line(dev, rowIndex++);
     i2c_OLED_send_string(dev, lineBuffer);
 
+    // shortGitRevision is __REVISION__, so the same check applies to the revision line.
+    STATIC_ASSERT(sizeof("(" __REVISION__ ")") <= sizeof(lineBuffer), revision_line_too_long);
     tfp_sprintf(lineBuffer, "(%s)", shortGitRevision);
     i2c_OLED_set_line(dev, rowIndex++);
     i2c_OLED_send_string(dev, lineBuffer);

--- a/src/main/msc/emfat_file.c
+++ b/src/main/msc/emfat_file.c
@@ -293,7 +293,7 @@ static void emfat_set_entry_cma(emfat_entry_t *entry)
 #ifdef USE_FLASHFS
 static void emfat_add_log(emfat_entry_t *entry, int number, uint32_t offset, uint32_t size)
 {
-    static char logNames[EMFAT_MAX_LOG_ENTRY][8+1+3];
+    static char logNames[EMFAT_MAX_LOG_ENTRY][8+1+3+1]; // 8.3 name plus terminator
 
     tfp_sprintf(logNames[number], FC_FIRMWARE_IDENTIFIER "_%03d.BBL", number + 1);
     entry->name = logNames[number];

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -669,8 +669,12 @@ uint8_t     0x01 (Parameter version 1)
 */
 static void crsfFrameDeviceInfo(sbuf_t *dst)
 {
-    char buff[30];
-    tfp_sprintf(buff, "%s %s: %s", FC_FIRMWARE_NAME, FC_VERSION_STRING, systemConfig()->boardIdentifier);
+    // tfp_sprintf() is unbounded, so size the buffer from the parts that go into it.
+    // The version string is deliberately left out: with calver plus an optional suffix
+    // (e.g. "2026.12.0-alpha") the name no longer fits, and it is of little use in the
+    // transmitter's device list anyway.
+    char buff[sizeof(FC_FIRMWARE_NAME ": ") + sizeof(systemConfig()->boardIdentifier)];
+    tfp_sprintf(buff, "%s: %s", FC_FIRMWARE_NAME, systemConfig()->boardIdentifier);
 
     uint8_t *lengthPtr = sbufPtr(dst);
     sbufWriteU8(dst, 0);


### PR DESCRIPTION
Addresses: #15658 - but would need to be back ported.

## Problem

Starting the Betaflight Lua script on the radio makes the transmitter request device info from the FC. On a build with a suffixed version string the reply overflows a stack buffer and the FC hangs immediately.

`tfp_sprintf()` is unbounded and there is no `tfp_snprintf()` in the tree, so every buffer it writes into is sized by hand. The calver version string plus an optional suffix (`2026.12.0-alpha`) no longer fits several of them.

`crsfFrameDeviceInfo()` formats `"Betaflight <version>: <board>"` into `char buff[30]`:

```c
char buff[30];
tfp_sprintf(buff, "%s %s: %s", FC_FIRMWARE_NAME, FC_VERSION_STRING, systemConfig()->boardIdentifier);
```

Required is `10 + 3 + strlen(FC_VERSION_STRING) + strlen(boardIdentifier) + 1`. The longest `TARGET_BOARD_IDENTIFIER` in the tree is 5 characters (`A435G`, `A435M`), which leaves room for a version string of at most 11 characters:

| Version string | Board id | Needs | Buffer |
|---|---|---|---|
| `2025.12.6` | 4 | 27 | 30 |
| `2025.12.6` | 5 | 28 | 30 |
| `2025.12.0-RC1` | 4 | 31 | 30 |
| `2026.12.0-alpha` | 5 | 34 | 30 |

So a final release scrapes through with two bytes to spare, and any pre-release or nightly tips over.

## Changes

**`telemetry/crsf.c`** — drop the version string from the device name and derive the buffer size from the parts that go into it, so it cannot drift again. The device name becomes `Betaflight: A435M`. The version is of little use in the transmitter's device list, and there is no plausible setup with several Betaflight FCs on one link where it would disambiguate anything.

Auditing the rest of the version-string formatting turned up three more overflows of the same shape. Two are not version related and would have survived a narrower fix:

**`io/dashboard.c`** (`USE_DASHBOARD`, `lineBuffer` is 21 columns + terminator)

- `showWelcomePage()` needed 27 bytes for `"v<version> (<revision>)"`. The revision moves to its own line — the page only used 2 of 7 available rows — and the version line gets a `STATIC_ASSERT` so a future suffix breaks the build instead of the stack.
- `showSensorsPage()` used `"%s %5d %5d %5d"`. `%5d` is a *minimum* width and `acc.accADC`/`mag.magADC` are int16 range, so `-32768` prints 6 characters and `ACC -32768 -32768 -32768` is 24. `"%s%6d%6d%6d"` is 21 at worst and puts the columns on the same indices (8/14/20) as the `        X     Y     Z` header, so nothing moves for normal values.
- `showBatteryPage()` used `"Volts: %d.%02d Cells: %d"`. `force_battery_cell_count` has a CLI range of 0–24, so cells can be two digits and the voltage three. This already overran by one byte on any plain 12S setup (`Volts: 50.40 Cells: 12`, 22) and by two at the limit (`Volts: 100.80 Cells: 24`, 23). Dropping the spaces after the colons brings the worst case to exactly 21, matching the width-budget comment style already used by the amperage line below it.
- `showGpsPage()` — `dashboardGpsPacketLog` is a rolling `char[21]` with no room for a terminator, so `strncpy()` left none and the following `strlen()` only worked because the last byte of `lineBuffer` happened to still be zero. Terminated explicitly, with an assert on the relative sizes.

**`msc/emfat_file.c`** — `logNames[EMFAT_MAX_LOG_ENTRY][8+1+3]` counted an 8.3 filename but not the terminator, and `BTFL_001.BBL` is exactly 12 characters. Every entry wrote its NUL one byte past its slot; the last of the 100 entries wrote past the array.

## Testing

- `make TARGET=STM32F405` links clean with no warnings. That target compiles all three files — `USE_DASHBOARD` is enabled whenever `USE_I2C`, and `emfat_file.c` is unconditional in `MSC_SRC` for F4/H7 — so the new static assertions are exercised.
- `make test_telemetry_crsf_unittest` passes 4/4. Note that no existing test covers `crsfFrameDeviceInfo()`, so this only proves it compiles.
- Widths and column alignment checked against real worst-case values in a standalone harness.

Not yet checked on hardware — a Lua script start against a radio would confirm the original hang is gone.

## Checked and clean

Everything else that formats version or build metadata into storage: `osd.c` sizes `version_str_buf[sizeof(FC_VERSION_STRING) + 1]` correctly for `"V%s"`; `cms_menu_firmware.c` stores pointers to literals; `blackbox.c` streams through `blackboxPrintfHeaderLine()` with a `blackboxWrite` callback and no fixed buffer; `msp.c` uses `sbufWritePString()`; `cli.c` goes through `bufWriter`; the ESP32 app descriptor and the USB manufacturer strings have room.

## Suggested follow-ups

Deliberately out of scope here, in rough priority order:

1. **Backport to `2025.12-maintenance` and `2026.6-maintenance`.** The `crsf.c` fix at minimum — RC and nightly builds off those branches overflow, which is how this was found. The other three are equally present there.
2. **Add a bounded `tfp_snprintf()` to `common/printf.c`.** `tfp_format()` already takes a `putcf` callback, so a bounding version is a few lines, and it would stop this class of bug recurring instead of relying on hand-arithmetic at every call site.
3. **Sweep the remaining ~230 `tfp_sprintf()` sites**, mostly `osd_elements.c` (91), `osd_warnings.c` (37) and `cli.c` (25). This PR only audited `dashboard.c` in full plus every version/build-string site tree-wide.
4. **Two known-marginal `dashboard.c` sites left alone**, both exactly 21 characters wide with no slack: the task page `"%2d%6d%5d%4d%4d"` overflows only if a task reports a max execution time of 1 s or more, and widening it would break the `Task max  avg mx% av%` header alignment; the amperage line is correct within its own documented `DDD.D`/`DDDDD` budget.
5. **A unit test for `crsfFrameDeviceInfo()`**, asserting the frame contents and that the name fits. There is currently none, which is why a four-byte overflow shipped.
6. **`GIT_SHORT_REVISION_LENGTH` is stale.** `version.h` declares it as 7, but `Makefile:217` generates 9 characters via `git rev-parse --short=9`, and `msp.c:808` does `sbufWriteData(dst, shortGitRevision, GIT_SHORT_REVISION_LENGTH)` — so `MSP_BUILD_INFO` reports a revision truncated to 7 characters. Surfaced while answering review feedback on this PR; it under-reads a longer string rather than overflowing, so it does not belong in an overflow fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Welcome, battery, and sensor screens now use clearer, more consistent text formatting.
  * Version information and the short revision are displayed on separate lines.
  * GPS packet log entries are recorded with complete text.
  * Log filenames are stored correctly, including their terminating character.
  * Device telemetry now reports the firmware name and board identifier in a more focused format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
