### PR TITLE
fix(landing): end the landing on ground contact, and bound the altitude loop's inputs

### DIFF
--- a/src/main/flight/alt_hold_multirotor.c
+++ b/src/main/flight/alt_hold_multirotor.c
@@ -50,6 +50,11 @@
 // entry and exit are still serviced.
 #define ALTHOLD_FALLBACK_PERIOD_US (2 * TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ))
 
+// Floor on the vertical rate a nav leg is followed at, for the degenerate case where neither the
+// leg nor alt_hold_climb_rate states one. Only has to be non-zero: at zero the carrot is pinned
+// on the craft, and a leg that can never move its target can never complete.
+#define ALT_HOLD_NAV_MIN_RATE_CM_S 10.0f
+
 typedef struct {
     bool isActive;
     float targetAltitudeCm;
@@ -156,28 +161,69 @@ static void altHoldUpdateTargetAltitude(timeUs_t taskIntervalUs)
 
 static void altHoldUpdate(timeUs_t taskIntervalUs)
 {
+    const positionNavCommand_t *navCmd = positionNavHasActiveTarget() ? positionNavGetActiveCommand() : NULL;
+    // The altitude-only fallback descent drives the target itself via altHoldUpdateTargetAltitude();
+    // a nav target left active from the previous leg must not shadow it.
+    const bool navOwnsAltitude = (navCmd != NULL) && navCmd->includeAltitude
+                              && !flightPlanNavIsRescueDescentActive();
 
-    if (altHoldConfig()->climbRate) {
+    // Both paths write altHold.targetAltitudeCm, so only one may run. Under failsafe the stick
+    // integrator's descent term would otherwise cancel a mission climb.
+    if (!navOwnsAltitude && altHoldConfig()->climbRate) {
         altHoldUpdateTargetAltitude(taskIntervalUs); // check if the pilot has changed the target altitude using sticks
     }
 
-    float targetAltitudeCm = altHold.targetAltitudeCm; 
+    float targetAltitudeCm = altHold.targetAltitudeCm;
     float targetAltitudeVelocity = altHold.targetVelocity;
+    float velLimitCmS = altHoldMaxClimbRate();
 
-    if (positionNavHasActiveTarget()) {
-        const positionNavCommand_t *navCmd = positionNavGetActiveCommand();
-        if (navCmd->includeAltitude) {
-            targetAltitudeCm = navCmd->targetPosEfM.z * 100.0f;
-            if (positionNavTargetReached()) {
-                altHold.targetAltitudeCm = targetAltitudeCm; // store target altitude so Alt Hold does not revert to pre-nav target altitude on the next cycle.
+    if (navOwnsAltitude) {
+        const float navEndpointCm = navCmd->targetPosEfM.z * 100.0f;
+        const float climbRateCmS = altHoldMaxClimbRate();
+        // The carrot follows what positionNav publishes, so the window it is held in and the limit
+        // altitudeControl() is given must admit the rate this leg can actually be flown at, in
+        // whichever direction it uses: sized from the ascent cap alone a LAND leg's descent would
+        // be silently reduced, ap_landing_descent_rate reaching 200 cm/s where alt_hold_climb_rate
+        // can be set lower. The cruise-speed fallback is the one positionNavUpdate() itself applies
+        // to a leg that states no vertical limit.
+        const float legVertLimitCmS = navCmd->vertSpeedLimitMps * 100.0f;
+        const float navVertCapCmS = (legVertLimitCmS > 0.0f) ? legVertLimitCmS
+                                                             : navCmd->cruiseSpeedMps * 100.0f;
+        // alt_hold_climb_rate carries the rescue ascent rate, so it stays the ascent bound where
+        // it is set; it is allowed to be zero, and then the leg's own rate stands in for it.
+        const float climbBoundCmS = (climbRateCmS > 0.0f) ? climbRateCmS : navVertCapCmS;
+        const float downLimitCmS = (legVertLimitCmS > 0.0f) ? legVertLimitCmS : climbBoundCmS;
+        const float navRateLimitCmS = MAX(MAX(climbBoundCmS, downLimitCmS), ALT_HOLD_NAV_MIN_RATE_CM_S);
+        if (positionNavTargetReached()) {
+            altHold.targetAltitudeCm = navEndpointCm; // store target altitude so Alt Hold does not revert to pre-nav target altitude on the next cycle.
             targetAltitudeVelocity = 0.0f;
-            } else {
-                 targetAltitudeVelocity = positionNavGetTargetVelocityCmS().z; 
+        } else {
+            // Follow a carrot advanced at the velocity positionNav publishes, not the endpoint: a
+            // landing endpoint sits below ground and is never reached, so used directly it drives
+            // P and I into throttle saturation instead of expressing a tracking error.
+            // Each direction keeps its own bound, so a LAND leg descends at its own rate without
+            // that rate becoming a licence to climb at it. This bounds the carrot, not the sink.
+            targetAltitudeVelocity = constrainf(positionNavGetTargetVelocityCmS().z, -downLimitCmS, climbBoundCmS);
+            altHold.targetAltitudeCm += targetAltitudeVelocity * US_TO_INTERVAL(taskIntervalUs);
+            // a reachable endpoint, such as a climb to return altitude, must not be overshot
+            if (targetAltitudeVelocity > 0.0f) {
+                altHold.targetAltitudeCm = fminf(altHold.targetAltitudeCm, navEndpointCm);
+            } else if (targetAltitudeVelocity < 0.0f) {
+                altHold.targetAltitudeCm = fmaxf(altHold.targetAltitudeCm, navEndpointCm);
             }
         }
+        // Keep the carrot within one second of travel of the craft. This anchors it when nav
+        // takes over and stops it running away if the craft cannot keep up.
+        const float windowCm = navRateLimitCmS * 1.0f /* s */;
+        const float currentAltitudeCm = getAltitudeCmControl();
+        altHold.targetAltitudeCm = constrainf(altHold.targetAltitudeCm,
+                                              currentAltitudeCm - windowCm,
+                                              currentAltitudeCm + windowCm);
+        targetAltitudeCm = altHold.targetAltitudeCm;
+        velLimitCmS = navRateLimitCmS;
     }
 
-    altitudeControl(targetAltitudeCm, taskIntervalUs, targetAltitudeVelocity, altHoldMaxClimbRate());
+    altitudeControl(targetAltitudeCm, taskIntervalUs, targetAltitudeVelocity, velLimitCmS);
 }
 
 bool altHoldUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -95,6 +95,17 @@
 #define ALTITUDE_F_SCALE       0.02f // vertical velocity target scale (on the target itself, not its delta)
 #define ALTITUDE_VEL_CMD_MAX_DEFAULT_CM_S  1500.0f
 #define ALTITUDE_I_LIMIT      150.0f
+// Landing sink bound for the altitude D term. Near the ground the reported sink is mostly
+// barometer artefact: over logged samples where GPS and a de-spiked baro agree the craft is
+// vertically still, the 99th percentile still reads 381 cm/s. This engages routinely rather
+// than exceptionally - at the default descent rate it is the floor that applies, for most of
+// a descent - and the measured cost when it does clamp a genuine fall is ~10% of peak sink.
+// Half the factor flight_plan_nav.c uses to score landing progress
+// (FP_LANDING_PROGRESS_MAX_FACTOR, 4x), because that averages displacement over 400 ms while
+// this bounds an instantaneous rate. The floor keeps the bound meaningful when the commanded
+// rate is momentarily near zero.
+#define LANDING_SINK_PLAUSIBLE_FACTOR   2.0f
+#define LANDING_SINK_PLAUSIBLE_MIN_CM_S 100.0f
 
 // Unified XY control: a single distance-based PIDAF law serves position hold,
 // nav missions and GPS rescue. D is a velocity-proportional factor, A is
@@ -133,6 +144,16 @@
 
 static pidCoefficient_t xyPid;
 static float xyKDrag;
+
+// previous iteration's output saturation, for iTerm anti-windup
+static bool altitudeOutputSaturatedLow = false;
+static bool altitudeOutputSaturatedHigh = false;
+
+// landing thrust bleed. 1.0 = no ceiling, 0.0 = throttle held at throttleMin
+static float landingSettleScale = 1.0f;
+static bool landingSettleRequested = false;
+// a landing descent is being flown; asserted every iteration by its owner
+static bool landingActive = false;
 
 static float altitudeKp;
 static float altitudeKi;
@@ -331,6 +352,13 @@ void resetAltitudeControl(void)
 {
     altitudeI = 0.0f;
     throttleOut = 0.0f;
+    altitudeOutputSaturatedLow = false;
+    altitudeOutputSaturatedHigh = false;
+    // The ceiling is altitude-loop state and must not outlive a reset: alt hold and rescue reset
+    // the loop independently of flight_plan_nav, so a re-engage could inherit a stale ceiling.
+    landingSettleScale = 1.0f;
+    landingSettleRequested = false;
+    landingActive = false;
 }
 
 uint16_t autopilotGetEffectiveHoverThrottlePwm(void)
@@ -359,20 +387,59 @@ void autopilotClearAltHoldHoverThrottle(void)
     altHoldCapturedHoverPwm = 0;
 }
 
+void autopilotSetLandingActive(bool active)
+{
+    landingActive = active;
+}
+
+void autopilotSetLandingSettle(bool active)
+{
+    if (!active) {
+        landingSettleScale = 1.0f;
+    }
+    landingSettleRequested = active;
+}
+
 void altitudeControl(float targetAltitudeCm, timeUs_t taskIntervalUs, float targetAltitudeVelCmS, float velLimitCmS)
 {
     const float taskIntervalS = US_TO_INTERVAL(taskIntervalUs);
     // PID controller on altitude error
     const float currentAltitudeCm = getAltitudeCmControl(); // un-filtered altitude from Kalman filter
     const float verticalAcceleration = getAltitudeAccelerationControl();
-    const float verticalVelocity = getAltitudeDerivativeControl();
-    const float altitudeErrorCm = targetAltitudeCm - currentAltitudeCm;
-    const float itermRelax = (fabsf(altitudeErrorCm) < 200.0f) ? 1.0f : 0.1f; // don't accumulate too much iTerm with transient but large overshoots (>2m error )
+    float verticalVelocity = getAltitudeDerivativeControl(); // un-filtered vertical velocity from Kalman filter
+    const float velMax = (velLimitCmS > 1.0f) ? velLimitCmS : ALTITUDE_VEL_CMD_MAX_DEFAULT_CM_S;
+    // Bound the position error to one second of travel at the rate limit, as alt hold already
+    // does for pilot targets: unbounded, P alone saturates throttle and the descent rate is
+    // ignored when a caller sets a target beyond what the rate limit allows.
+    const float rawAltitudeErrorCm = targetAltitudeCm - currentAltitudeCm;
+    const float altitudeErrorCm = constrainf(rawAltitudeErrorCm, -velMax, velMax);
+    // Anti-windup on output saturation, not on the clamp above: the clamp is active for the whole
+    // of any rate-limited move, so it cannot indicate windup.
+    const bool blockIntegration = (altitudeOutputSaturatedLow && altitudeErrorCm < 0.0f)
+                               || (altitudeOutputSaturatedHigh && altitudeErrorCm > 0.0f);
+    const float itermRelax = blockIntegration ? 0.0f
+                           : ((fabsf(altitudeErrorCm) < 200.0f) ? 1.0f : 0.1f); // don't accumulate too much iTerm with transient but large overshoots (>2m error )
     const float altitudeP = altitudeErrorCm * altitudeKp;
     altitudeI += altitudeErrorCm * altitudeKi * itermRelax * taskIntervalS;
     altitudeI = constrainf(altitudeI, -ALTITUDE_I_LIMIT, ALTITUDE_I_LIMIT);
-    const float velMax = (velLimitCmS > 1.0f) ? velLimitCmS : ALTITUDE_VEL_CMD_MAX_DEFAULT_CM_S;
     const float targetVerticalVelocity = constrainf(targetAltitudeVelCmS, -velMax, velMax);
+
+    // Settling into its own downwash the craft sits in raised static pressure and the barometer
+    // reads a height collapse that never happened (22 m in a third of a second on the logged
+    // event, while the accelerometer sat at 1 g). Unbounded, that reaches D as ~900 cm/s of
+    // phantom sink, dBoost multiplies it and the throttle throws the craft off the deck. A sink
+    // this much faster than commanded is the estimate and not the craft - the same judgement the
+    // landing-progress test in flight_plan_nav.c already makes.
+    // Safe because it is one-sided, so a genuine climb keeps full arrest authority, and
+    // memoryless, so it releases the iteration the estimate recovers instead of lagging it the
+    // way a slew limit would. It does not repair the estimate: nothing outside the estimator can
+    // tell a real sink from a phantom one, so reported altitude and the P term stay corrupted.
+    if (landingActive && isBelowLandingAltitude()) {
+        const float sinkBoundCmS = MAX(LANDING_SINK_PLAUSIBLE_FACTOR * fabsf(targetVerticalVelocity),
+                                       LANDING_SINK_PLAUSIBLE_MIN_CM_S);
+        verticalVelocity = MAX(verticalVelocity, -sinkBoundCmS);
+    }
+
     float dBoost = 1.0f;
     const float boostThreshold = 500.0f; // 5m/s
     const float absVerticalVelocity = fabsf(verticalVelocity);
@@ -399,7 +466,28 @@ void altitudeControl(float targetAltitudeCm, timeUs_t taskIntervalUs, float targ
     throttleOffset *= tiltMultiplier;
 
     float newThrottle = PWM_RANGE_MIN + throttleOffset;
-    newThrottle = constrainf(newThrottle, autopilotConfig()->throttleMin, autopilotConfig()->throttleMax);
+    const float throttleMinPwm = (float)autopilotConfig()->throttleMin;
+    float ceilingPwm = (float)autopilotConfig()->throttleMax;
+
+    // On ground contact the altitude loop still commands a descent it cannot achieve and holds
+    // thrust just under hover, close enough for ground effect to lift the craft off again. Bleed
+    // the ceiling from hover to throttleMin so contact ends the descent.
+    if (landingSettleRequested) {
+        const float rampS = MAX((float)autopilotConfig()->landingDetectionTime * 0.1f, 0.1f);
+        landingSettleScale = MAX(landingSettleScale - taskIntervalS / rampS, 0.0f);
+        const float hoverPwm = (float)autopilotGetEffectiveHoverThrottlePwm();
+        const float settlePwm = throttleMinPwm + (hoverPwm - throttleMinPwm) * landingSettleScale;
+        // never below throttleMin, and never above the ceiling already in force
+        ceilingPwm = constrainf(settlePwm, throttleMinPwm, ceilingPwm);
+    }
+
+    newThrottle = constrainf(newThrottle, throttleMinPwm, ceilingPwm);
+    // Saturation is measured against the range actually in force, not throttleMin/throttleMax:
+    // while the settle ceiling is bleeding, it is the stop the output rests on. Once it reaches
+    // throttleMin the output is pinned both ways and iTerm must stop entirely, or clearing the
+    // settle releases the accumulated negative iTerm as a thrust dip at the ground.
+    altitudeOutputSaturatedLow = newThrottle <= throttleMinPwm;
+    altitudeOutputSaturatedHigh = newThrottle >= ceilingPwm;
 
     throttleOut = scaleRangef(newThrottle, MAX(rxConfig()->mincheck, PWM_RANGE_MIN), PWM_RANGE_MAX, 0.0f, 1.0f);
     throttleOut = constrainf(throttleOut, 0.0f, 1.0f);

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -408,11 +408,15 @@ void altitudeControl(float targetAltitudeCm, timeUs_t taskIntervalUs, float targ
     const float verticalAcceleration = getAltitudeAccelerationControl();
     float verticalVelocity = getAltitudeDerivativeControl(); // un-filtered vertical velocity from Kalman filter
     const float velMax = (velLimitCmS > 1.0f) ? velLimitCmS : ALTITUDE_VEL_CMD_MAX_DEFAULT_CM_S;
-    // Bound the position error to one second of travel at the rate limit, as alt hold already
-    // does for pilot targets: unbounded, P alone saturates throttle and the descent rate is
-    // ignored when a caller sets a target beyond what the rate limit allows.
+    // Distance bound, not a velocity limit: one second of travel at the rate limit, hence the
+    // shared number with velMax — deliberately not a second constant that could drift from it.
+    // This constrains the P and I responses; the F response is bounded separately by the
+    // velMax clamp on targetVerticalVelocity below. D is deliberately outside both so a fast
+    // sink retains full damping authority. Same "cannot be reached in 1s" rule alt hold
+    // applies to pilot targets.
+    const float errBoundCm = velMax * 1.0f; // cm = (cm/s) * s
     const float rawAltitudeErrorCm = targetAltitudeCm - currentAltitudeCm;
-    const float altitudeErrorCm = constrainf(rawAltitudeErrorCm, -velMax, velMax);
+    const float altitudeErrorCm = constrainf(rawAltitudeErrorCm, -errBoundCm, errBoundCm);
     // Anti-windup on output saturation, not on the clamp above: the clamp is active for the whole
     // of any rate-limited move, so it cannot indicate windup.
     const bool blockIntegration = (altitudeOutputSaturatedLow && altitudeErrorCm < 0.0f)

--- a/src/main/flight/autopilot_multirotor.h
+++ b/src/main/flight/autopilot_multirotor.h
@@ -58,5 +58,9 @@ float getAutopilotThrottle(void);
 float autopilotGetYawRate(void);
 bool autopilotYawControlActive(void);
 void autopilotSetYawRateLimit(float rateLimitDps); // deg/s, 0 = no mission cap
+// on inferred ground contact, ramp a throttle ceiling from hover down to throttleMin
+void autopilotSetLandingSettle(bool active);
+// a landing descent is being flown: bound the sink the altitude D term may act on
+void autopilotSetLandingActive(bool active);
 
 #endif // !USE_WING

--- a/src/main/flight/autopilot_wing.c
+++ b/src/main/flight/autopilot_wing.c
@@ -102,6 +102,16 @@ void autopilotSetYawRateLimit(float rateLimitDps)
     UNUSED(rateLimitDps);
 }
 
+void autopilotSetLandingSettle(bool active)
+{
+    UNUSED(active);
+}
+
+void autopilotSetLandingActive(bool active)
+{
+    UNUSED(active);
+}
+
 void autopilotSetNavHeadingOverride(bool valid, float headingDeg)
 {
     UNUSED(valid);

--- a/src/main/flight/autopilot_wing.h
+++ b/src/main/flight/autopilot_wing.h
@@ -39,6 +39,8 @@ bool isAutopilotInControl(void);
 float autopilotGetYawRate(void);
 bool autopilotYawControlActive(void);
 void autopilotSetYawRateLimit(float rateLimitDps);
+void autopilotSetLandingSettle(bool active);
+void autopilotSetLandingActive(bool active);
 
 // Nav inner-loop hooks driven by the shared flight-plan engine. Stubbed until
 // the wing control law lands (Phase 3+); present so the engine links on wing.

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -112,10 +112,17 @@
 // still counts, and the nose still starts swinging, the moment they happen.
 #define FP_MEAS_FILTER_S         0.20f   // PT1 tau on along-track position and ground speed
 
-// Landing descends toward a target far below the current position so vertical
-// arrival can never trigger; touchdown detection is what ends the descent.
-#define FP_LANDING_TARGET_DEPTH_M 200.0f
+// Landing descends toward a target below the craft so vertical arrival can never trigger;
+// touchdown detection ends the descent. That target is a real point in space, not a sentinel -
+// positionNav derives its speed schedule from the distance to it - so keep it shallow and
+// ratchet it down as the craft descends (see updateLanding).
+#define FP_LANDING_TARGET_DEPTH_M 5.0f
 #define FP_LANDING_MIN_RATE_MPS   0.3f
+// Horizontal speed and braking for the landing leg, stated so it does not inherit them from
+// whichever leg preceded it. A walking-pace approach and a gentle stop: the craft is metres from
+// the ground and the descent, not the traverse, is what the leg is for.
+#define FP_LANDING_APPROACH_MPS   1.5f
+#define FP_LANDING_DECEL_MPS2     0.3f
 // Fallback: start touchdown monitoring even if descent was never observed —
 // only near the ground (landing initiated at ground level). At altitude a
 // vehicle that cannot descend must keep trying, not disarm mid-air.
@@ -821,7 +828,11 @@ static void startLanding(timeUs_t currentTimeUs, float targetEastM, float target
     }};
 
     const float descentMps = MAX(FP_LANDING_MIN_RATE_MPS, landingDescentRateCmS() * 0.01f);
-    positionNavSetTargetEf(&targetM, descentMps, 1.0f, 0.1f, true, NULL, NULL);
+    // The descent rate bounds the vertical axis only; passing it as cruise speed would make
+    // gps_rescue_descend_rate cap the horizontal approach speed too.
+    positionNavSetTargetEf(&targetM, FP_LANDING_APPROACH_MPS, 1.0f, 0.1f, true, NULL, NULL);
+    positionNavSetVerticalSpeedLimit(descentMps);
+    positionNavSetAccelLimits(0.0f, FP_LANDING_DECEL_MPS2);
 
     fp.state = FP_NAV_LANDING;
     fp.landingStartUs = currentTimeUs;
@@ -834,6 +845,19 @@ static void updateLanding(timeUs_t currentTimeUs)
     const positionEstimate3d_t *est = positionEstimatorGetEstimate();
     const float verticalVelocityCmS = est->velocity.v[ENU_U];
     const float commandedDescentCmS = MAX(FP_LANDING_MIN_RATE_MPS * 100.0f, landingDescentRateCmS());
+
+    // Ratchet the landing target down as the craft descends, so it stays a bounded distance
+    // below without ever rising again. Monotonic because the altitude estimate is noisy near the
+    // ground and a bounce must not walk the target back up into a climb command.
+    if (positionNavHasActiveTarget()) {
+        const positionNavCommand_t *cmd = positionNavGetActiveCommand();
+        const float desiredTargetUpM = est->position.v[ENU_U] * 0.01f - FP_LANDING_TARGET_DEPTH_M;
+        if (desiredTargetUpM < cmd->targetPosEfM.v[ENU_U]) {
+            vector3_t moved = cmd->targetPosEfM;
+            moved.v[ENU_U] = desiredTargetUpM;
+            positionNavMoveTargetEf(&moved);
+        }
+    }
 
     if (!fp.landingDescentEstablished
         && verticalVelocityCmS < -0.25f * commandedDescentCmS) {

--- a/src/main/flight/flight_plan_nav.c
+++ b/src/main/flight/flight_plan_nav.c
@@ -52,6 +52,8 @@
 #ifdef USE_GPS_RESCUE
 #include "pg/gps_rescue.h"
 #endif
+#include "sensors/acceleration.h"
+
 #if ENABLE_RESCUE_PLAN
 #include "flight/gps_rescue.h"
 #include "flight/imu.h"
@@ -123,9 +125,35 @@
 // the ground and the descent, not the traverse, is what the leg is for.
 #define FP_LANDING_APPROACH_MPS   1.5f
 #define FP_LANDING_DECEL_MPS2     0.3f
-// Fallback: start touchdown monitoring even if descent was never observed —
-// only near the ground (landing initiated at ground level). At altitude a
-// vehicle that cannot descend must keep trying, not disarm mid-air.
+// Descent-progress window used to infer ground contact, and how many consecutive stalled windows
+// before thrust is bled off. 2 x 400 ms keeps a brief hesitation from cutting thrust.
+#define FP_LANDING_PROGRESS_WINDOW_US 400000u
+#define FP_LANDING_STALL_WINDOWS 2
+// Ceiling on what one window may count as real descent, as a multiple of the commanded rate.
+// Rejects the estimator plunge that ground-effect downwash produces at touchdown.
+#define FP_LANDING_PROGRESS_MAX_FACTOR 4.0f
+// Ground contact, because the altitude estimate is not trustworthy at ground level. Contact is
+// an acceleration step, and the accelerometer is low-passed at acc_lpf_hz (25 Hz default) before
+// this sees it. That attenuates the derivative of a step far more than its amplitude, so jerk
+// alone is a poor measure of contact severity: over six logged contacts peak jerk correlates
+// with peak acceleration at only r=0.29, and the two hardest (5.6 g and 4.9 g) produced less
+// jerk than a 4.5 g one. Requiring amplitude as well as jerk catches all six with no false
+// positive anywhere below the landing altitude in four descents; amplitude separates true from
+// false by 3.6x where jerk manages 1.7x. Jerk is kept, at a level low enough never to be the
+// limiting term, so some transient content is still required and a slow g-loading event cannot
+// trigger on amplitude alone. A burst of samples is required so a lone outlier cannot trigger.
+#define FP_LANDING_IMPACT_JERK_GS 150.0f
+#define FP_LANDING_IMPACT_ACC_G   1.0f
+#define FP_LANDING_IMPACT_SAMPLES 2
+#define FP_LANDING_IMPACT_BURST_US 50000u
+// Backstop for a touchdown too soft to spike. Once the craft has been at landing altitude for
+// several times as long as the commanded rate needs to cover that height, the landing is over
+// whatever the sensors claim. Scaling with the rate keeps a slow descent from being cut short;
+// the floor covers a configured landing altitude of zero.
+#define FP_LANDING_COMMIT_FACTOR 3.0f
+#define FP_LANDING_COMMIT_MIN_US 15000000u
+// Start touchdown monitoring even if descent was never observed, but only near the ground. At
+// altitude a vehicle that cannot descend must keep trying, not disarm.
 #define FP_LANDING_ESTABLISH_TIMEOUT_US 5000000u
 
 // Injected runtime plans are small synthesised sequences (geofence RTH,
@@ -233,8 +261,16 @@ static struct {
 
     // Landing state
     timeUs_t landingStartUs;
-    timeUs_t touchdownQuietStartUs;
+    timeUs_t  touchdownQuietStartUs;
+    float     landingProgressRefAltCm;   // altitude at the start of the descent-progress window
+    timeUs_t  landingProgressRefUs;      // start of that window
+    uint8_t   landingStallWindows;       // consecutive windows with no downward progress
     bool landingDescentEstablished;
+    timeUs_t  landingImpactBurstUs;      // start of the current run of over-threshold samples
+    timeUs_t  landingLowStartUs;         // first continuous moment at or below landing altitude
+    uint8_t   landingImpactSamples;      // over-threshold samples in the current burst
+    bool landingImpactBurstOpen;         // a burst is in progress (timestamp is valid)
+    bool landingLowSeen;                 // landingLowStartUs is valid
 } fp;
 
 static flightPlanWaypointReachedFn reachedListener = NULL;
@@ -818,6 +854,40 @@ static float landingDescentRateCmS(void)
     return (float)autopilotConfig()->landingDescentRate;
 }
 
+// Ground-contact spike. Guarded on the accelerometer actually being present: with no usable
+// acc there is no impact signal, so this reports false and the descent-progress and
+// quiet-velocity tests remain the only touchdown evidence, exactly as before.
+static bool landingImpactJerkExceeded(void)
+{
+#ifdef USE_ACC
+    if (!sensors(SENSOR_ACC)) {
+        return false;
+    }
+    return acc.jerkMagnitude > FP_LANDING_IMPACT_JERK_GS
+        && fabsf(acc.accMagnitude - 1.0f) > FP_LANDING_IMPACT_ACC_G;
+#else
+    return false;
+#endif
+}
+
+// Landing/touchdown monitor state. Both entry paths (a LAND leg and a rescue descent) must
+// start from the same clean slate, so it lives in one place - adding a field to the struct and
+// forgetting one of the call sites is how a stale observation leaks into the next descent.
+static void resetLandingMonitor(timeUs_t currentTimeUs)
+{
+    fp.landingStartUs = currentTimeUs;
+    fp.touchdownQuietStartUs = 0;
+    fp.landingProgressRefUs = 0;
+    fp.landingProgressRefAltCm = 0.0f;
+    fp.landingStallWindows = 0;
+    fp.landingDescentEstablished = false;
+    fp.landingImpactBurstUs = 0;
+    fp.landingLowStartUs = 0;
+    fp.landingImpactSamples = 0;
+    fp.landingImpactBurstOpen = false;
+    fp.landingLowSeen = false;
+}
+
 static void startLanding(timeUs_t currentTimeUs, float targetEastM, float targetNorthM)
 {
     const positionEstimate3d_t *est = positionEstimatorGetEstimate();
@@ -834,24 +904,39 @@ static void startLanding(timeUs_t currentTimeUs, float targetEastM, float target
     positionNavSetVerticalSpeedLimit(descentMps);
     positionNavSetAccelLimits(0.0f, FP_LANDING_DECEL_MPS2);
 
+    autopilotSetLandingSettle(false);
+    autopilotSetLandingActive(true);
     fp.state = FP_NAV_LANDING;
-    fp.landingStartUs = currentTimeUs;
-    fp.touchdownQuietStartUs = 0;
-    fp.landingDescentEstablished = false;
+    resetLandingMonitor(currentTimeUs);
+}
+
+// Touchdown reached: drop the throttle ceiling, release the position target and disarm.
+static void completeLanding(void)
+{
+    autopilotSetLandingSettle(false);
+    autopilotSetLandingActive(false);
+    positionNavClearTarget();
+    fp.state = FP_NAV_COMPLETE;
+    disarm(DISARM_REASON_LANDING);
 }
 
 static void updateLanding(timeUs_t currentTimeUs)
 {
     const positionEstimate3d_t *est = positionEstimatorGetEstimate();
     const float verticalVelocityCmS = est->velocity.v[ENU_U];
+    const float currentAltitudeCm = est->position.v[ENU_U];
     const float commandedDescentCmS = MAX(FP_LANDING_MIN_RATE_MPS * 100.0f, landingDescentRateCmS());
+
+    // Re-asserted every iteration, from the one function both landing entry paths run through,
+    // so the altitude loop's landing sink bound is live for exactly as long as a descent is.
+    autopilotSetLandingActive(true);
 
     // Ratchet the landing target down as the craft descends, so it stays a bounded distance
     // below without ever rising again. Monotonic because the altitude estimate is noisy near the
     // ground and a bounce must not walk the target back up into a climb command.
     if (positionNavHasActiveTarget()) {
         const positionNavCommand_t *cmd = positionNavGetActiveCommand();
-        const float desiredTargetUpM = est->position.v[ENU_U] * 0.01f - FP_LANDING_TARGET_DEPTH_M;
+        const float desiredTargetUpM = currentAltitudeCm * 0.01f - FP_LANDING_TARGET_DEPTH_M;
         if (desiredTargetUpM < cmd->targetPosEfM.v[ENU_U]) {
             vector3_t moved = cmd->targetPosEfM;
             moved.v[ENU_U] = desiredTargetUpM;
@@ -864,24 +949,121 @@ static void updateLanding(timeUs_t currentTimeUs)
         fp.landingDescentEstablished = true;
     }
 
+    const bool belowLandingAltitude = isBelowLandingAltitude();
     const bool monitorTouchdown = fp.landingDescentEstablished
-        || (isBelowLandingAltitude()
+        || (belowLandingAltitude
             && cmpTimeUs(currentTimeUs, fp.landingStartUs) >= (timeDelta_t)FP_LANDING_ESTABLISH_TIMEOUT_US);
     if (!monitorTouchdown) {
+        autopilotSetLandingSettle(false);
         return;
     }
 
-    // Touchdown: descent has stopped despite being commanded, and the vehicle
-    // is not moving vertically. A descent at the commanded rate must never
-    // count as quiet, whatever landingVelocityThreshold is configured to.
+    // Ground contact is inferred from descent progress rather than vertical velocity: a craft
+    // skittering on the ground moves fast in both directions but makes no net progress, which
+    // instantaneous velocity cannot distinguish from flight.
+
+    // An impact near the ground is the only touchdown signal that survives contact: the altitude
+    // estimate degrades badly in ground effect, defeating both of the tests further below. Jerk is
+    // sampled every call because contact is a transient that a window boundary would miss.
+    // Two things make it safe to end a flight on. The craft must be below the landing altitude, so
+    // a prop strike or a hard gust at height is ignored; being a conjunction, the noisy near-ground
+    // altitude can only ever delay detection, never trigger it early. And the spikes must arrive
+    // as a burst, which contact produces and an isolated vibration outlier does not.
+    // Only the burst counters are state: contact is acted on in this same call, so there is
+    // nothing to carry into the next one.
+    bool impactContact = false;
+    if (landingImpactJerkExceeded() && belowLandingAltitude) {
+        if (fp.landingImpactBurstOpen
+            && cmpTimeUs(currentTimeUs, fp.landingImpactBurstUs) <= (timeDelta_t)FP_LANDING_IMPACT_BURST_US) {
+            if (fp.landingImpactSamples < UINT8_MAX) {
+                fp.landingImpactSamples++;
+            }
+        } else {
+            fp.landingImpactBurstUs = currentTimeUs;
+            fp.landingImpactSamples = 1;
+            fp.landingImpactBurstOpen = true;
+        }
+        impactContact = fp.landingImpactSamples >= FP_LANDING_IMPACT_SAMPLES;
+    }
+
+    // Time spent at landing altitude, for the backstop below. Climbing back out restarts it, so
+    // this only ever measures one continuous attempt to put the craft down.
+    if (belowLandingAltitude) {
+        if (!fp.landingLowSeen) {
+            fp.landingLowStartUs = currentTimeUs;
+            fp.landingLowSeen = true;
+        }
+    } else {
+        fp.landingLowSeen = false;
+    }
+
+    // A stalled descent only implies contact near the ground, so the whole measurement is scoped
+    // to that regime: the count is dropped and the window restarted while the craft is still
+    // high. Clearing the count alone would not be enough - a window opened above the landing
+    // altitude and closed below it measures partly the wrong regime, yet would still count
+    // toward the two windows that engage the ceiling. Discarding both keeps every window that
+    // can contribute wholly below the landing altitude.
+    if (!belowLandingAltitude) {
+        fp.landingStallWindows = 0;
+        fp.landingProgressRefUs = 0;
+    } else if (fp.landingProgressRefUs == 0) {
+        fp.landingProgressRefUs = currentTimeUs;
+        fp.landingProgressRefAltCm = currentAltitudeCm;
+    } else if (cmpTimeUs(currentTimeUs, fp.landingProgressRefUs) >= (timeDelta_t)FP_LANDING_PROGRESS_WINDOW_US) {
+        const float windowS = FP_LANDING_PROGRESS_WINDOW_US * 1e-6f;
+        const float descendedCm = fp.landingProgressRefAltCm - currentAltitudeCm;
+        // An apparent descent far faster than commanded is the estimate, not the craft: contact
+        // drives downwash into the barometer and dumps it. Counted as progress that would reset
+        // the stall counter and release the thrust ceiling. A craft genuinely falling that fast
+        // is not making progress toward a landing either.
+        const bool plausible = descendedCm < FP_LANDING_PROGRESS_MAX_FACTOR * commandedDescentCmS * windowS;
+        const bool madeProgress = plausible && descendedCm > 0.25f * commandedDescentCmS * windowS;
+        if (madeProgress) {
+            fp.landingStallWindows = 0;
+        } else if (fp.landingStallWindows < UINT8_MAX) {
+            fp.landingStallWindows++;
+        }
+        fp.landingProgressRefUs = currentTimeUs;
+        fp.landingProgressRefAltCm = currentAltitudeCm;
+    }
+
+    // Backstop: the craft has had several times the time the commanded rate needs to cover the
+    // landing altitude, and is still not down. Either it is already on the ground and no sensor
+    // said so, or it cannot descend; both end the same way.
+    const float expectedDescentS = (100.0f * (float)autopilotConfig()->landingAltitudeM) / commandedDescentCmS;
+    const timeDelta_t commitTimeoutUs = (timeDelta_t)MAX((float)FP_LANDING_COMMIT_MIN_US,
+                                                         FP_LANDING_COMMIT_FACTOR * expectedDescentS * 1e6f);
+    const bool commitExpired = fp.landingLowSeen
+        && cmpTimeUs(currentTimeUs, fp.landingLowStartUs) >= commitTimeoutUs;
+
+    // The thrust ceiling serves the stalled descent alone: the craft is down, nothing detected the
+    // contact, and the altitude loop is still holding thrust just under hover. Impact and the
+    // commit timeout disarm on the spot immediately below, so arming the ceiling for those would
+    // apply it for zero iterations. A stall only implies contact when the craft is near the
+    // ground; at altitude it is just a stalled descent, and bleeding thrust toward idle is the
+    // opposite of what that needs.
+    const bool stalledOnGround = belowLandingAltitude
+        && fp.landingStallWindows >= FP_LANDING_STALL_WINDOWS;
+    autopilotSetLandingSettle(stalledOnGround);
+
+    // The impact already is the touchdown, so it completes the landing on the spot. Holding it for
+    // the confirmation window would only keep the motors spinning on the ground, and nothing
+    // arriving during that wait could revoke a contact that has already happened.
+    if (impactContact || commitExpired) {
+        completeLanding();
+        return;
+    }
+
+    // Otherwise infer touchdown: descent has stopped despite being commanded and the vehicle is
+    // quiet. The weakest of the three signals, so it requires the craft to actually be near the
+    // ground - without that gate a craft that descended and then held station could be disarmed
+    // in mid-air. Impact and the commit backstop cover a badly biased altitude estimate.
     const bool descentStopped = verticalVelocityCmS > -0.25f * commandedDescentCmS;
-    if (descentStopped && fabsf(verticalVelocityCmS) < autopilotConfig()->landingVelocityThreshold) {
+    if (belowLandingAltitude && descentStopped && fabsf(verticalVelocityCmS) < autopilotConfig()->landingVelocityThreshold) {
         if (fp.touchdownQuietStartUs == 0) {
             fp.touchdownQuietStartUs = currentTimeUs;
         } else if (cmpTimeUs(currentTimeUs, fp.touchdownQuietStartUs) >= (timeDelta_t)((uint32_t)autopilotConfig()->landingDetectionTime * 100000u)) {
-            positionNavClearTarget();
-            fp.state = FP_NAV_COMPLETE;
-            disarm(DISARM_REASON_LANDING);
+            completeLanding();
         }
     } else {
         fp.touchdownQuietStartUs = 0;
@@ -1054,14 +1236,16 @@ float flightPlanNavGetRescueVerticalRateCmS(void)
 void flightPlanNavRescueDescent(bool request, timeUs_t currentTimeUs)
 {
     if (!request) {
+        if (fp.rescueDescentActive) {
+            autopilotSetLandingSettle(false);
+            autopilotSetLandingActive(false);
+        }
         fp.rescueDescentActive = false;
         return;
     }
     if (!fp.rescueDescentActive) {
         fp.rescueDescentActive = true;
-        fp.landingStartUs = currentTimeUs;
-        fp.touchdownQuietStartUs = 0;
-        fp.landingDescentEstablished = false;
+        resetLandingMonitor(currentTimeUs);
     }
     updateLanding(currentTimeUs);
 }
@@ -1388,6 +1572,11 @@ void flightPlanNavDisengage(void)
     fp.hdgFaultTimeS = 0.0f;
     fp.lastUpdateUs = 0;
     fp.legIsPassGate = false;
+    // A landing abandoned mid-descent is the one exit that leaves the ceiling applied: the
+    // completion paths clear it themselves, and resetAltitudeControl() clears it on every
+    // alt-hold and rescue entry.
+    autopilotSetLandingSettle(false);
+    autopilotSetLandingActive(false);
     fp.legValid = false;
     fp.carrotSpeedMps = 0.0f;
     fp.carrotPrevValid = false;

--- a/src/main/flight/position_nav.c
+++ b/src/main/flight/position_nav.c
@@ -75,6 +75,11 @@ void positionNavSetTargetEf(
     cmd.acceptanceRadiusM = acceptanceRadiusM;
     cmd.completionSpeedMps = completionSpeedMps;
     cmd.altitudeArrivalRequired = true;
+    // Per-command limits start from a clean slate; every caller states its own. They used to
+    // persist, so a leg that set none silently inherited the previous leg's.
+    cmd.vertSpeedLimitMps = 0.0f;
+    cmd.maxAccelMps2 = 0.0f;
+    cmd.maxDecelMps2 = 0.0f;
 
     cmd.callback = callback;
     cmd.callbackUserData = userData;
@@ -125,6 +130,11 @@ void positionNavSetAccelLimits(float maxAccelMps2, float maxDecelMps2)
     cmd.maxDecelMps2 = maxDecelMps2;
 }
 
+void positionNavSetVerticalSpeedLimit(float vertSpeedLimitMps)
+{
+    cmd.vertSpeedLimitMps = vertSpeedLimitMps;
+}
+
 void positionNavSetAltitudeArrivalRequired(bool required)
 {
     cmd.altitudeArrivalRequired = required;
@@ -153,24 +163,32 @@ void positionNavUpdate(float dt, const positionEstimate3d_t *est)
     }};
 
     const float horizDistM = sqrtf(sq(errorEfM.v[ENU_E]) + sq(errorEfM.v[ENU_N]));
-    const float distanceM = cmd.includeAltitude ? vector3Norm(&errorEfM) : horizDistM;
 
-    vector3_t dirEf;
-    if (distanceM > MIN_DISTANCE_M) {
-        vector3Scale(&dirEf, &errorEfM, 1.0f / distanceM);
-    } else {
-        vector3Zero(&dirEf);
-    }
-
-    float desiredSpeedMps = fminf(cmd.cruiseSpeedMps, POS_TO_VEL_KP * distanceM);
-
+    // Independent speed budgets per axis. A single 3D direction vector couples them, so the axis
+    // with the larger error takes nearly all of the budget and the other collapses: a deep
+    // landing target starves horizontal correction, a shallow one starves the descent. Arrival
+    // is unaffected, it already tests horizontal distance and altitude error separately.
+    float desiredHorizMps = fminf(cmd.cruiseSpeedMps, POS_TO_VEL_KP * horizDistM);
     if (cmd.maxDecelMps2 > 0.0f) {
-        const float brakingSpeed = sqrtf(2.0f * cmd.maxDecelMps2 * distanceM);
-        desiredSpeedMps = fminf(desiredSpeedMps, brakingSpeed);
+        desiredHorizMps = fminf(desiredHorizMps, sqrtf(2.0f * cmd.maxDecelMps2 * horizDistM));
     }
 
     vector3_t targetVelMps;
-    vector3Scale(&targetVelMps, &dirEf, desiredSpeedMps);
+    vector3Zero(&targetVelMps);
+    if (horizDistM > MIN_DISTANCE_M) {
+        targetVelMps.v[ENU_E] = errorEfM.v[ENU_E] / horizDistM * desiredHorizMps;
+        targetVelMps.v[ENU_N] = errorEfM.v[ENU_N] / horizDistM * desiredHorizMps;
+    }
+
+    if (cmd.includeAltitude) {
+        const float errUpM = errorEfM.v[ENU_U];
+        const float vertCruiseMps = (cmd.vertSpeedLimitMps > 0.0f) ? cmd.vertSpeedLimitMps : cmd.cruiseSpeedMps;
+        float desiredVertMps = fminf(vertCruiseMps, POS_TO_VEL_KP * fabsf(errUpM));
+        if (cmd.maxDecelMps2 > 0.0f) {
+            desiredVertMps = fminf(desiredVertMps, sqrtf(2.0f * cmd.maxDecelMps2 * fabsf(errUpM)));
+        }
+        targetVelMps.v[ENU_U] = (errUpM >= 0.0f) ? desiredVertMps : -desiredVertMps;
+    }
 
     if (cmd.maxAccelMps2 > 0.0f && dt > 0.0f) {
         vector3_t delta;

--- a/src/main/flight/position_nav.h
+++ b/src/main/flight/position_nav.h
@@ -35,7 +35,8 @@ typedef struct positionNavCommand_s {
     vector3_t targetPosEfM;         // target position, metres, ENU (index by ENU_E/ENU_N/ENU_U)
     bool includeAltitude;           // when false, ENU_U is ignored for nav, arrival, and alt coupling
 
-    float cruiseSpeedMps;           // maximum cruise speed (m/s)
+    float cruiseSpeedMps;           // maximum horizontal cruise speed (m/s)
+    float vertSpeedLimitMps;        // maximum vertical speed (m/s), 0 = share cruiseSpeedMps
     float acceptanceRadiusM;        // arrival zone radius (metres)
     float completionSpeedMps;       // max ground speed to count as arrived (m/s)
 
@@ -77,6 +78,11 @@ bool positionNavTargetReached(void);
 const positionNavCommand_t *positionNavGetActiveCommand(void);
 
 void positionNavSetAccelLimits(float maxAccelMps2, float maxDecelMps2);
+
+// Vertical speed cap, independent of cruiseSpeedMps: the axes have independent speed budgets, so
+// they need independent limits. 0 shares the horizontal limit. Reset by positionNavSetTargetEf,
+// so set it after that call.
+void positionNavSetVerticalSpeedLimit(float vertSpeedLimitMps);
 void positionNavSetAutoClearOnReach(bool autoClear);
 
 // En-route waypoints advance on horizontal arrival even when the vehicle has

--- a/src/main/flight/position_nav.h
+++ b/src/main/flight/position_nav.h
@@ -36,7 +36,9 @@ typedef struct positionNavCommand_s {
     bool includeAltitude;           // when false, ENU_U is ignored for nav, arrival, and alt coupling
 
     float cruiseSpeedMps;           // maximum horizontal cruise speed (m/s)
-    float vertSpeedLimitMps;        // maximum vertical speed (m/s), 0 = share cruiseSpeedMps
+    float vertSpeedLimitMps;        // maximum vertical speed (m/s); 0 means positionNav shares
+                                    // cruiseSpeedMps. Other consumers of the command pick their
+                                    // own fallback, so do not read 0 as "cruise speed" elsewhere.
     float acceptanceRadiusM;        // arrival zone radius (metres)
     float completionSpeedMps;       // max ground speed to count as arrived (m/s)
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -234,6 +234,17 @@ flight_imu_unittest_SRC := \
 		$(USER_DIR)/flight/imu.c
 
 
+landing_ground_effect_unittest_SRC := \
+		$(USER_DIR)/common/maths.c \
+		$(USER_DIR)/common/vector.c \
+		$(USER_DIR)/common/filter.c \
+		$(USER_DIR)/flight/autopilot_multirotor.c \
+		$(USER_DIR)/flight/position.c \
+		$(USER_DIR)/flight/position_estimator.c \
+		$(USER_DIR)/flight/position_filter.c \
+		$(USER_DIR)/pg/rx.c
+
+
 flight_mixer_unittest :=  \
 		$(USER_DIR)/flight/mixer.c \
 		$(USER_DIR)/flight/servos.c \

--- a/src/test/unit/althold_unittest.cc
+++ b/src/test/unit/althold_unittest.cc
@@ -117,6 +117,7 @@ protected:
         testNavReached = false;
         testNavTargetVelZCmS = 0.0f;
         memset(&testNavCmd, 0, sizeof(testNavCmd));
+        autopilotSetLandingSettle(false);
 
         autopilotConfig_t *apCfg = autopilotConfigMutable();
         apCfg->hoverThrottle = 1500;
@@ -245,6 +246,31 @@ TEST_F(AltholdControlUnittest, AltitudeControlRespectsVelocityLimit)
     const float highLimitThrottle = getAutopilotThrottle();
 
     EXPECT_GT(highLimitThrottle, limitedThrottle);
+}
+
+// Regression: the flight-plan landing target sits FP_LANDING_TARGET_DEPTH_M (200m) below the
+// craft so descent continues until touchdown is detected. That error must not drive the
+// position P/I terms into output saturation - the descent rate is owned by the velocity terms.
+// Before the fix this pinned the output at throttleMin and the craft free-fell.
+TEST_F(AltholdControlUnittest, AltitudeControlLandingTargetDoesNotSaturateThrottle)
+{
+    testAltitudeCm = 1110.0f;             // 11.1m up, as in the reported crash
+    testAltitudeDerivativeCmS = 0.0f;
+    const float landingTargetCm = testAltitudeCm - 20000.0f;  // 200m below the craft
+    const float descendRateCmS = 120.0f;
+
+    // hold the target for a few seconds of task iterations so any iTerm windup would show up
+    for (int i = 0; i < 500; i++) {
+        altitudeControl(landingTargetCm, 0.01f, -descendRateCmS, descendRateCmS);
+    }
+
+    const float throttleMin = autopilotConfig()->throttleMin;
+    const float throttlePwm = autopilotThrottlePwm();
+
+    // must not be pinned at the floor - that is free-fall
+    EXPECT_GT(throttlePwm, throttleMin + 1.0f);
+    // and must stay below hover, i.e. it is still commanding a descent
+    EXPECT_LT(throttlePwm, (float)autopilotConfig()->hoverThrottle);
 }
 
 // A LAND leg publishes an endpoint below the craft that is never reached, with positionNav
@@ -409,6 +435,163 @@ TEST_F(AltholdControlUnittest, ZeroClimbRateDoesNotStallANavDescent)
         << "commanded target " << debug[1] << " cm never descended from " << startAltitudeCm;
 }
 
+TEST_F(AltholdControlUnittest, LandingSimSettlesOnGroundInsteadOfBouncing)
+{
+    const float descendRateCmS = 120.0f;
+    const float simHoverPwm = 1300.0f;          // what the airframe actually needs
+    autopilotConfigMutable()->hoverThrottle = 1250;   // configured slightly low, so iTerm trims up
+    autopilotConfigMutable()->throttleMin = 1100;
+    autopilotConfigMutable()->throttleMax = 1900;
+    autopilotConfigMutable()->landingDetectionTime = 5;   // pinned: 0.5 s settle ramp, which the
+                                                         // assertions below bound the bleed against
+    altHoldConfigMutable()->climbRate = 12;     // 120 cm/s
+    autopilotInit();
+    altHoldInit();
+    autopilotSetLandingSettle(false);
+
+    LandingSim sim;
+    sim.altCm = 800.0f;
+    testAltitudeCm = sim.altCm;
+    flightModeFlags = ALT_HOLD_MODE;
+    testThrottleStatus = THROTTLE_LOW;         // no pilot stick input
+    const float dt = 0.01f;
+
+    auto runStep = [&]() {
+        testAltitudeCm = sim.altCm;
+        testAltitudeDerivativeCmS = sim.vzCmS;
+        updateAltHold(0);
+        const float throttlePwm = autopilotThrottlePwm();
+        sim.step(throttlePwm, simHoverPwm, 1000.0f, dt);
+        return throttlePwm;
+    };
+
+    // Hover first, so iTerm trims out the hover-throttle error the way it would in flight.
+    // This is what makes the bounce possible: iTerm carries that positive trim into the landing.
+    for (int i = 0; i < 800; i++) { runStep(); }
+
+    // Now the LAND leg: nav publishes a bounded target below the craft and a rate-limited demand.
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavTargetVelZCmS = -descendRateCmS;
+
+    int liftoffsAfterContact = 0;
+    bool everTouched = false;
+    float stallS = 0.0f;
+    for (int i = 0; i < 2000; i++) {
+        testNavCmd.targetPosEfM.z = (sim.altCm - 500.0f) * 0.01f;  // FP_LANDING_TARGET_DEPTH_M
+        stallS = (sim.vzCmS > -0.25f * descendRateCmS) ? stallS + dt : 0.0f;
+        autopilotSetLandingSettle(stallS > 0.8f);
+        runStep();
+        if (sim.altCm <= 0.01f) { everTouched = true; }
+        else if (everTouched && sim.altCm > 5.0f) { liftoffsAfterContact++; }
+    }
+
+    EXPECT_TRUE(everTouched) << "never reached the ground";
+    EXPECT_LT(liftoffsAfterContact, 20) << "craft kept leaving the ground after touchdown";
+    EXPECT_LT(sim.altCm, 5.0f) << "did not settle on the ground";
+    EXPECT_NEAR(sim.vzCmS, 0.0f, 25.0f) << "still moving vertically at the end";
+}
+
+// Regression: while the landing settle ceiling holds the output at throttleMin the craft is on
+// the ground, but the loop still commands a descent, so the altitude error stays negative. If
+// saturation is judged against throttleMax rather than against the ceiling actually in force,
+// the output never reads as saturated low and iTerm integrates down against a floor it is
+// already sitting on. Clearing the settle then releases that iTerm as a thrust dip at ground
+// level, which is the same free-fall this PR exists to prevent.
+TEST_F(AltholdControlUnittest, LandingSettleDoesNotWindIntegralDownAgainstTheCeiling)
+{
+    const float simHoverPwm = 1300.0f;
+    autopilotConfigMutable()->hoverThrottle = 1250;
+    autopilotConfigMutable()->throttleMin = 1100;
+    autopilotConfigMutable()->throttleMax = 1900;
+    autopilotConfigMutable()->landingDetectionTime = 5;   // pinned: 0.5 s settle ramp, which the
+                                                         // assertions below bound the bleed against
+    altHoldConfigMutable()->climbRate = 12;
+    autopilotInit();
+    altHoldInit();
+    autopilotSetLandingSettle(false);
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;   // debug[4] is altitudeI, debug[0] the output PWM
+
+    LandingSim sim;
+    sim.altCm = 400.0f;
+    testAltitudeCm = sim.altCm;
+    flightModeFlags = ALT_HOLD_MODE;
+    testThrottleStatus = THROTTLE_LOW;
+    const float dt = 0.01f;
+    const float minPwm = (float)autopilotConfig()->throttleMin;
+
+    auto runStep = [&]() {
+        testAltitudeCm = sim.altCm;
+        testAltitudeDerivativeCmS = sim.vzCmS;
+        updateAltHold(0);
+        const float throttlePwm = autopilotThrottlePwm();
+        sim.step(throttlePwm, simHoverPwm, 1000.0f, dt);
+    };
+
+    // Hover, so iTerm trims up to cover the gap between configured and real hover throttle.
+    for (int i = 0; i < 400; i++) { runStep(); }
+    const int iTermBeforeSettle = debug[4];
+    ASSERT_GT(iTermBeforeSettle, 0) << "iTerm never trimmed up, test cannot prove anything";
+
+    // Land, and hold the craft pinned on the ground with the settle ceiling engaged. The nav
+    // target stays below the craft throughout, so the error stays negative the whole time.
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavTargetVelZCmS = -120.0f;
+    autopilotSetLandingSettle(true);
+    for (int i = 0; i < 1500; i++) {
+        sim.altCm = 0.0f;                          // on the ground and staying there
+        sim.vzCmS = 0.0f;
+        testNavCmd.targetPosEfM.z = -5.0f;         // FP_LANDING_TARGET_DEPTH_M below ground
+        runStep();
+    }
+
+    ASSERT_LE(debug[0], (int)minPwm + 1) << "ceiling never bled to throttleMin";
+    EXPECT_GT(debug[4], iTermBeforeSettle - 20)
+        << "iTerm fell from " << iTermBeforeSettle << " to " << debug[4]
+        << " while the output was pinned against the settle ceiling; it should be held, not "
+        << "wound down into a thrust dip that is released when the settle clears";
+}
+
+// Regression: the settle ceiling is altitude-loop state, so resetAltitudeControl() must clear it.
+// flight_plan_nav clears it on its own lifecycle boundaries, but alt hold and GPS rescue reset
+// the loop independently. Without this, re-engaging after an abandoned landing inherits a stale
+// ceiling and the craft is pinned at throttleMin while trying to hold or regain altitude.
+TEST_F(AltholdControlUnittest, ResetAltitudeControlClearsLandingSettle)
+{
+    autopilotConfigMutable()->hoverThrottle = 1300;
+    autopilotConfigMutable()->throttleMin = 1100;
+    autopilotConfigMutable()->throttleMax = 1900;
+    autopilotConfigMutable()->landingDetectionTime = 5;   // pinned: 0.5 s settle ramp, which the
+                                                         // assertions below bound the bleed against
+    autopilotInit();
+    altHoldInit();
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;   // debug[0] is the output PWM
+    const int minPwm = autopilotConfig()->throttleMin;
+
+    // Drive the ceiling all the way down, as a landing that reaches the ground would.
+    autopilotSetLandingSettle(true);
+    testAltitudeCm = 0.0f;
+    testAltitudeDerivativeCmS = 0.0f;
+    for (int i = 0; i < 500; i++) {
+        altitudeControl(-500.0f, 0.01f, -120.0f, 0.0f);
+    }
+    ASSERT_LE(debug[0], minPwm + 1) << "ceiling never bled down, test cannot prove anything";
+
+    // Abandon the landing without going through flight_plan_nav's disengage, then re-engage and
+    // ask for a climb. A stale ceiling would hold the output at throttleMin regardless of demand.
+    resetAltitudeControl();
+    for (int i = 0; i < 20; i++) {
+        altitudeControl(500.0f, 0.01f, 100.0f, 0.0f);
+    }
+
+    EXPECT_GT(debug[0], minPwm + 100)
+        << "output stuck at " << debug[0] << " with a 5m climb demanded; the landing throttle "
+        << "ceiling survived resetAltitudeControl()";
+}
+
 // Regression: a GPS rescue runs under failsafe, and altHoldUpdateTargetAltitude()'s failsafe
 // branch drives altHold.targetAltitudeCm down at up to 10x the climb rate. That variable is
 // also the nav carrot's accumulator, so if both run the descent term cancels the mission's
@@ -443,6 +626,42 @@ TEST_F(AltholdControlUnittest, NavClimbNotCancelledByFailsafeDescentTerm)
         << "commanded altitude target must be above the craft during a rescue climb";
 }
 
+// Regression from the SITL altitude-only fallback descent: the craft climbed away from a target
+// 29m below it. A blanket anti-windup freeze stranded a stale positive iTerm (+97) which, with
+// the position error clamped so P had only -12 of authority, held throttle above hover forever.
+// iTerm must always be free to unwind, only inhibited in the direction that grows it.
+TEST_F(AltholdControlUnittest, StaleITermUnwindsWhenTargetIsFarBelow)
+{
+    // stock gains - the fixture's are strong enough to mask this
+    autopilotConfigMutable()->altitudeP = 30;
+    autopilotConfigMutable()->altitudeI = 30;
+    autopilotConfigMutable()->altitudeD = 30;
+    autopilotConfigMutable()->altitudeF = 30;
+    autopilotConfigMutable()->hoverThrottle = 1275;
+    autopilotConfigMutable()->throttleMin = 1100;
+    autopilotConfigMutable()->throttleMax = 1900;
+    autopilotInit();
+    resetAltitudeControl();
+
+    testAltitudeCm = 6000.0f;                 // 60m up
+    testAltitudeDerivativeCmS = 0.0f;
+
+    // Build the stale trim the way flight does: a small persistent error inside the rate limit.
+    // A large error is itself rate limited and would never integrate.
+    for (int i = 0; i < 3000; i++) {
+        altitudeControl(testAltitudeCm + 79.0f, 0.01f, 80.0f, 80.0f);
+    }
+
+    // Target jumps far below, as the fallback descent commands.
+    for (int i = 0; i < 6000; i++) {
+        altitudeControl(testAltitudeCm - 2900.0f, 0.01f, -80.0f, 80.0f);
+    }
+
+    const float throttlePwm = autopilotThrottlePwm();
+    EXPECT_LT(throttlePwm, (float)autopilotConfig()->hoverThrottle)
+        << "must command descent, not hold above hover on a stale iTerm";
+}
+
 // Replay of the reported crash configuration (SEQUREH7V2, 2026.12.0-alpha): a GPS rescue LAND
 // leg entered at 11.1 m. The landing endpoint 200 m down drove the altitude P term to -3000,
 // pinned throttle at ap_throttle_min, and the craft fell ~10 m in 1.75 s at up to -9.1 m/s and was
@@ -461,6 +680,7 @@ TEST_F(AltholdControlUnittest, ReportedCrashConfigDescendsUnderControl)
     altHoldConfigMutable()->climbRate = 12;           // 120 cm/s vertical budget
     autopilotInit();
     altHoldInit();
+    autopilotSetLandingSettle(false);
     debugMode = DEBUG_AUTOPILOT_ALTITUDE;
 
     LandingSim sim;

--- a/src/test/unit/althold_unittest.cc
+++ b/src/test/unit/althold_unittest.cc
@@ -261,7 +261,7 @@ TEST_F(AltholdControlUnittest, AltitudeControlLandingTargetDoesNotSaturateThrott
 
     // hold the target for a few seconds of task iterations so any iTerm windup would show up
     for (int i = 0; i < 500; i++) {
-        altitudeControl(landingTargetCm, 0.01f, -descendRateCmS, descendRateCmS);
+        altitudeControl(landingTargetCm, TASK_PERIOD_HZ(100), -descendRateCmS, descendRateCmS);
     }
 
     const float throttleMin = autopilotConfig()->throttleMin;
@@ -459,6 +459,7 @@ TEST_F(AltholdControlUnittest, LandingSimSettlesOnGroundInsteadOfBouncing)
     auto runStep = [&]() {
         testAltitudeCm = sim.altCm;
         testAltitudeDerivativeCmS = sim.vzCmS;
+        testAltitudeAccelerationCmS = sim.accelCmS2;   // altitudeA is live; leaving it 0 mutes it
         updateAltHold(0);
         const float throttlePwm = autopilotThrottlePwm();
         sim.step(throttlePwm, simHoverPwm, 1000.0f, dt);
@@ -475,7 +476,7 @@ TEST_F(AltholdControlUnittest, LandingSimSettlesOnGroundInsteadOfBouncing)
     testNavCmd.includeAltitude = true;
     testNavTargetVelZCmS = -descendRateCmS;
 
-    int liftoffsAfterContact = 0;
+    int airborneStepsAfterContact = 0;
     bool everTouched = false;
     float stallS = 0.0f;
     for (int i = 0; i < 2000; i++) {
@@ -484,11 +485,11 @@ TEST_F(AltholdControlUnittest, LandingSimSettlesOnGroundInsteadOfBouncing)
         autopilotSetLandingSettle(stallS > 0.8f);
         runStep();
         if (sim.altCm <= 0.01f) { everTouched = true; }
-        else if (everTouched && sim.altCm > 5.0f) { liftoffsAfterContact++; }
+        else if (everTouched && sim.altCm > 5.0f) { airborneStepsAfterContact++; }
     }
 
     EXPECT_TRUE(everTouched) << "never reached the ground";
-    EXPECT_LT(liftoffsAfterContact, 20) << "craft kept leaving the ground after touchdown";
+    EXPECT_LT(airborneStepsAfterContact, 20) << "craft spent too long airborne after touchdown";
     EXPECT_LT(sim.altCm, 5.0f) << "did not settle on the ground";
     EXPECT_NEAR(sim.vzCmS, 0.0f, 25.0f) << "still moving vertically at the end";
 }
@@ -524,6 +525,7 @@ TEST_F(AltholdControlUnittest, LandingSettleDoesNotWindIntegralDownAgainstTheCei
     auto runStep = [&]() {
         testAltitudeCm = sim.altCm;
         testAltitudeDerivativeCmS = sim.vzCmS;
+        testAltitudeAccelerationCmS = sim.accelCmS2;   // altitudeA is live; leaving it 0 mutes it
         updateAltHold(0);
         const float throttlePwm = autopilotThrottlePwm();
         sim.step(throttlePwm, simHoverPwm, 1000.0f, dt);
@@ -576,7 +578,7 @@ TEST_F(AltholdControlUnittest, ResetAltitudeControlClearsLandingSettle)
     testAltitudeCm = 0.0f;
     testAltitudeDerivativeCmS = 0.0f;
     for (int i = 0; i < 500; i++) {
-        altitudeControl(-500.0f, 0.01f, -120.0f, 0.0f);
+        altitudeControl(-500.0f, TASK_PERIOD_HZ(100), -120.0f, 0.0f);
     }
     ASSERT_LE(debug[0], minPwm + 1) << "ceiling never bled down, test cannot prove anything";
 
@@ -584,7 +586,7 @@ TEST_F(AltholdControlUnittest, ResetAltitudeControlClearsLandingSettle)
     // ask for a climb. A stale ceiling would hold the output at throttleMin regardless of demand.
     resetAltitudeControl();
     for (int i = 0; i < 20; i++) {
-        altitudeControl(500.0f, 0.01f, 100.0f, 0.0f);
+        altitudeControl(500.0f, TASK_PERIOD_HZ(100), 100.0f, 0.0f);
     }
 
     EXPECT_GT(debug[0], minPwm + 100)
@@ -649,12 +651,12 @@ TEST_F(AltholdControlUnittest, StaleITermUnwindsWhenTargetIsFarBelow)
     // Build the stale trim the way flight does: a small persistent error inside the rate limit.
     // A large error is itself rate limited and would never integrate.
     for (int i = 0; i < 3000; i++) {
-        altitudeControl(testAltitudeCm + 79.0f, 0.01f, 80.0f, 80.0f);
+        altitudeControl(testAltitudeCm + 79.0f, TASK_PERIOD_HZ(100), 80.0f, 80.0f);
     }
 
     // Target jumps far below, as the fallback descent commands.
     for (int i = 0; i < 6000; i++) {
-        altitudeControl(testAltitudeCm - 2900.0f, 0.01f, -80.0f, 80.0f);
+        altitudeControl(testAltitudeCm - 2900.0f, TASK_PERIOD_HZ(100), -80.0f, 80.0f);
     }
 
     const float throttlePwm = autopilotThrottlePwm();

--- a/src/test/unit/althold_unittest.cc
+++ b/src/test/unit/althold_unittest.cc
@@ -60,7 +60,7 @@ extern "C" {
     PG_REGISTER(positionConfig_t, positionConfig, PG_POSITION, 0);
     PG_REGISTER(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 0);
 
-    bool failsafeIsActive(void) { return false; }
+    extern bool testFailsafeActive;
     timeUs_t currentTimeUs = 0;
     bool isAltHoldActive();
     extern float testAltitudeCm;
@@ -70,10 +70,27 @@ extern "C" {
     extern throttleStatus_e testThrottleStatus;
     extern bool testEstimatorUpdatePending;
     extern timeDelta_t testTaskDeltaTimeUs;
+    bool testFailsafeActive = false;
+    bool failsafeIsActive(void) { return testFailsafeActive; }
+    extern bool testNavActive;
+    extern bool testNavReached;
+    extern float testNavTargetVelZCmS;
+    extern positionNavCommand_t testNavCmd;
 }
 
 #include "unittest_macros.h"
+#include <algorithm>
+
 #include "gtest/gtest.h"
+
+// getAutopilotThrottle() normalises over [MAX(mincheck, PWM_RANGE_MIN), PWM_RANGE_MAX], not over
+// [throttleMin, throttleMax]. Inverting with the wrong range shifts the result by tens of PWM at
+// the floor, which is exactly where the floored-throttle assertions look.
+static float autopilotThrottlePwm(void)
+{
+    const float lowPwm = MAX((float)rxConfig()->mincheck, (float)PWM_RANGE_MIN);
+    return lowPwm + getAutopilotThrottle() * ((float)PWM_RANGE_MAX - lowPwm);
+}
 
 uint32_t millisRW;
 uint32_t millis() {
@@ -95,6 +112,11 @@ protected:
         testThrottleStatus = THROTTLE_LOW;
         testEstimatorUpdatePending = false;
         testTaskDeltaTimeUs = TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ);
+        testFailsafeActive = false;
+        testNavActive = false;
+        testNavReached = false;
+        testNavTargetVelZCmS = 0.0f;
+        memset(&testNavCmd, 0, sizeof(testNavCmd));
 
         autopilotConfig_t *apCfg = autopilotConfigMutable();
         apCfg->hoverThrottle = 1500;
@@ -223,6 +245,259 @@ TEST_F(AltholdControlUnittest, AltitudeControlRespectsVelocityLimit)
     const float highLimitThrottle = getAutopilotThrottle();
 
     EXPECT_GT(highLimitThrottle, limitedThrottle);
+}
+
+// A LAND leg publishes an endpoint below the craft that is never reached, with positionNav
+// rate-limiting the velocity it publishes to the configured descent rate. Alt hold must follow a
+// carrot at that rate, not the raw endpoint, which went straight into the altitude PID and pinned
+// throttle at throttleMin - the free-fall. The endpoint here is the 200 m one the firmware used
+// to publish: the carrot must bound an arbitrarily distant endpoint, not just the current 5 m.
+TEST_F(AltholdControlUnittest, NavLandingTargetTracksCommandedDescentRate)
+{
+    const float descendRateCmS = 120.0f;
+    altHoldConfigMutable()->climbRate = 12;      // CLI units: 12 -> 120cm/s
+    altHoldInit();
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;        // debug[1] == the targetAltitudeCm actually used
+
+    testAltitudeCm = 1110.0f;                    // 11.1m, as in the reported crash
+    flightModeFlags = ALT_HOLD_MODE;
+    updateAltHold(0);                            // engage, anchoring the target at 11.1m
+
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavCmd.targetPosEfM.z = (testAltitudeCm - 20000.0f) * 0.01f;  // metres
+    testNavTargetVelZCmS = -descendRateCmS;
+
+    const float throttleMin = autopilotConfig()->throttleMin;
+    const float dt = 0.01f;
+    for (int i = 0; i < 200; i++) {              // 2s, craft tracking the commanded descent
+        testAltitudeDerivativeCmS = -descendRateCmS;
+        testAltitudeCm += -descendRateCmS * dt;
+        updateAltHold(0);
+
+        const float throttlePwm = autopilotThrottlePwm();
+        ASSERT_GT(throttlePwm, throttleMin + 1.0f) << "throttle pinned at floor on iteration " << i;
+    }
+
+    // the commanded target must have marched down with the craft, never jumped to the endpoint
+    EXPECT_NEAR((float)debug[1], testAltitudeCm, descendRateCmS * 1.5f);
+    EXPECT_GT(debug[1], -1000);                  // nowhere near -18890
+}
+
+// Closed-loop landing simulation against the real altitudeControl(), with a crude but honest
+// physics model: thrust proportional to throttle above idle, normalised so hoverThrottle holds
+// altitude, plus ground contact and ground effect. This exists to test the bounce mechanism
+// quantitatively rather than by assertion - the craft can only leave the ground here if the
+// controller commands enough thrust for ground effect to lift it.
+namespace {
+struct LandingSim {
+    float altCm = 0.0f;
+    float vzCmS = 0.0f;
+    static constexpr float kGroundEffectHeightCm = 30.0f;
+    static constexpr float kGroundEffectGain = 0.25f;   // +25% thrust on the deck
+
+    float accelCmS2 = 0.0f;              // last step's vertical acceleration, for the A term
+
+    void step(float throttlePwm, float hoverPwm, float minPwm, float dt) {
+        const float span = MAX(hoverPwm - minPwm, 1.0f);
+        float thrustRatio = (throttlePwm - minPwm) / span;   // 1.0 == weight
+        if (altCm < kGroundEffectHeightCm) {
+            thrustRatio *= 1.0f + kGroundEffectGain * (1.0f - altCm / kGroundEffectHeightCm);
+        }
+        accelCmS2 = 981.0f * (thrustRatio - 1.0f);
+        vzCmS += accelCmS2 * dt;
+        altCm += vzCmS * dt;
+        if (altCm <= 0.0f) {                 // inelastic ground contact
+            altCm = 0.0f;
+            if (vzCmS < 0.0f) { vzCmS = 0.0f; }
+        }
+    }
+};
+}
+
+// ap_landing_descent_rate reaches 200 cm/s while alt_hold_climb_rate can be set below it. Sized
+// from the smaller climb rate, the window silently reduces the leg's configured descent. Holding
+// the craft still lets the carrot run out to the window, whose size is the limit in force.
+TEST_F(AltholdControlUnittest, LandingDescentRateIsNotCappedByTheClimbRate)
+{
+    const float descendRateCmS = 200.0f;         // ap_landing_descent_rate = 200
+    altHoldConfigMutable()->climbRate = 10;      // 100 cm/s: below the descent rate
+    altHoldInit();
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;
+
+    testAltitudeCm = 1000.0f;
+    flightModeFlags = ALT_HOLD_MODE;
+    updateAltHold(0);
+
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavCmd.vertSpeedLimitMps = descendRateCmS * 0.01f;
+    testNavCmd.targetPosEfM.z = (testAltitudeCm - 5000.0f) * 0.01f;   // endpoint well clear
+    testNavTargetVelZCmS = -descendRateCmS;
+
+    for (int i = 0; i < 200; i++) {              // craft held still: the carrot runs to the window
+        testAltitudeDerivativeCmS = 0.0f;
+        updateAltHold(0);
+    }
+
+    const float trailCm = testAltitudeCm - (float)debug[1];
+    EXPECT_NEAR(trailCm, descendRateCmS, 10.0f) << "carrot held " << trailCm
+        << " cm below the craft; one second of the LAND rate is " << descendRateCmS;
+}
+
+// The same stall, reached the other way: positionNavSetTargetEf() resets vertSpeedLimitMps to 0,
+// and altitude-carrying waypoint legs never set a replacement. With alt_hold_climb_rate also 0
+// there is no rate anywhere, and a window sized from it freezes the carrot on the craft.
+TEST_F(AltholdControlUnittest, NavLegWithNoVerticalLimitStillMovesAtZeroClimbRate)
+{
+    altHoldConfigMutable()->climbRate = 0;
+    altHoldInit();
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;
+
+    testAltitudeCm = 1000.0f;
+    flightModeFlags = ALT_HOLD_MODE;
+    updateAltHold(0);
+
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavCmd.vertSpeedLimitMps = 0.0f;          // as positionNavSetTargetEf leaves it
+    testNavCmd.cruiseSpeedMps = 5.0f;
+    testNavCmd.targetPosEfM.z = (testAltitudeCm + 3000.0f) * 0.01f;
+    testNavTargetVelZCmS = 200.0f;
+
+    const float startAltitudeCm = testAltitudeCm;
+    for (int i = 0; i < 50; i++) {                // craft held still: only the target may move
+        testAltitudeDerivativeCmS = 0.0f;
+        updateAltHold(0);
+    }
+
+    EXPECT_GT((float)debug[1], startAltitudeCm + 20.0f)
+        << "commanded target " << debug[1] << " cm never climbed from " << startAltitudeCm;
+}
+
+// alt_hold_climb_rate is allowed to be 0. The one-second window is derived from it, so a nav
+// altitude leg must take its rate from the leg instead - otherwise the window collapses onto the
+// craft, the target can never move, and the descent never starts.
+TEST_F(AltholdControlUnittest, ZeroClimbRateDoesNotStallANavDescent)
+{
+    const float descendRateCmS = 100.0f;
+    altHoldConfigMutable()->climbRate = 0;
+    altHoldInit();
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;
+
+    testAltitudeCm = 1000.0f;
+    flightModeFlags = ALT_HOLD_MODE;
+    updateAltHold(0);
+
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavCmd.vertSpeedLimitMps = descendRateCmS * 0.01f;
+    testNavCmd.targetPosEfM.z = (testAltitudeCm - 500.0f) * 0.01f;
+    testNavTargetVelZCmS = -descendRateCmS;
+
+    const float startAltitudeCm = testAltitudeCm;
+    for (int i = 0; i < 50; i++) {               // craft held still: only the target may move
+        testAltitudeDerivativeCmS = 0.0f;
+        updateAltHold(0);
+    }
+
+    EXPECT_LT((float)debug[1], startAltitudeCm - 20.0f)
+        << "commanded target " << debug[1] << " cm never descended from " << startAltitudeCm;
+}
+
+// Regression: a GPS rescue runs under failsafe, and altHoldUpdateTargetAltitude()'s failsafe
+// branch drives altHold.targetAltitudeCm down at up to 10x the climb rate. That variable is
+// also the nav carrot's accumulator, so if both run the descent term cancels the mission's
+// climb and the craft sinks where it stands instead of climbing to return altitude.
+TEST_F(AltholdControlUnittest, NavClimbNotCancelledByFailsafeDescentTerm)
+{
+    altHoldConfigMutable()->climbRate = 10;      // 100 cm/s, as gps_rescue_ascend_rate would give
+    altHoldConfigMutable()->deadband = 10;
+    autopilotInit();
+    altHoldInit();
+
+    testAltitudeCm = 1000.0f;                    // 10m up, rescue just engaged
+    flightModeFlags = ALT_HOLD_MODE;
+    testThrottleStatus = THROTTLE_LOW;
+    updateAltHold(0);
+
+    testFailsafeActive = true;                   // rescue is running under failsafe
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavCmd.targetPosEfM.z = 30.0f;           // climb to 30m return altitude
+    testNavTargetVelZCmS = 100.0f;               // positionNav publishes a climb
+
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;
+    for (int i = 0; i < 100; i++) {              // 1s of task iterations
+        updateAltHold(0);
+    }
+    testFailsafeActive = false;
+
+    // debug[1] is the target actually handed to altitudeControl
+    EXPECT_GT(debug[1], (int)testAltitudeCm)
+        << "commanded altitude target must be above the craft during a rescue climb";
+}
+
+// Replay of the reported crash configuration (SEQUREH7V2, 2026.12.0-alpha): a GPS rescue LAND
+// leg entered at 11.1 m. The landing endpoint 200 m down drove the altitude P term to -3000,
+// pinned throttle at ap_throttle_min, and the craft fell ~10 m in 1.75 s at up to -9.1 m/s and was
+// destroyed. The same settings, against the same endpoint, must produce a controlled descent.
+TEST_F(AltholdControlUnittest, ReportedCrashConfigDescendsUnderControl)
+{
+    const float descendRateCmS = 120.0f;      // gps_rescue_descend_rate = 120
+    autopilotConfigMutable()->hoverThrottle = 1250;   // ap_hover_throttle = 1250
+    autopilotConfigMutable()->throttleMin = 1100;
+    autopilotConfigMutable()->throttleMax = 1900;
+    autopilotConfigMutable()->altitudeP = 30;         // all ap_altitude_* stock
+    autopilotConfigMutable()->altitudeI = 30;
+    autopilotConfigMutable()->altitudeD = 30;
+    autopilotConfigMutable()->altitudeA = 30;
+    autopilotConfigMutable()->altitudeF = 30;
+    altHoldConfigMutable()->climbRate = 12;           // 120 cm/s vertical budget
+    autopilotInit();
+    altHoldInit();
+    debugMode = DEBUG_AUTOPILOT_ALTITUDE;
+
+    LandingSim sim;
+    sim.altCm = 1110.0f;                      // 11.1m, the logged altitude at LAND dispatch
+    testAltitudeCm = sim.altCm;
+    flightModeFlags = ALT_HOLD_MODE;
+    testThrottleStatus = THROTTLE_LOW;
+    updateAltHold(0);
+
+    testNavActive = true;
+    testNavReached = false;
+    testNavCmd.includeAltitude = true;
+    testNavTargetVelZCmS = -descendRateCmS;
+
+    const float dt = 0.01f;
+    const float minPwm = (float)autopilotConfig()->throttleMin;
+    float worstVzCmS = 0.0f;
+    int flooredSteps = 0;
+
+    for (int i = 0; i < 1200 && sim.altCm > 0.0f; i++) {
+        // the endpoint startLanding published at the time of the crash
+        testNavCmd.targetPosEfM.z = (sim.altCm - 20000.0f) * 0.01f;
+        testAltitudeCm = sim.altCm;
+        testAltitudeDerivativeCmS = sim.vzCmS;
+        testAltitudeAccelerationCmS = sim.accelCmS2;   // altitudeA is live; leaving it 0 mutes it
+        updateAltHold(0);
+
+        const float throttlePwm = autopilotThrottlePwm();
+        if (throttlePwm <= minPwm + 1.0f) { flooredSteps++; }
+        sim.step(throttlePwm, 1250.0f, 1000.0f, dt);
+        worstVzCmS = std::min(worstVzCmS, sim.vzCmS);
+    }
+
+    EXPECT_LT(flooredSteps, 20) << "throttle must not sit on the floor - that is the free-fall";
+    EXPECT_GT(worstVzCmS, -400.0f) << "peak sink " << worstVzCmS
+        << " cm/s; the crash reached -910 cm/s";
+    EXPECT_GT(debug[1], -1000) << "commanded target must not be the raw endpoint";
 }
 
 TEST_F(AltholdControlUnittest, AltitudeControlCompensatesForTilt)
@@ -372,10 +647,14 @@ extern "C" {
     void positionNavInit(void) { }
     void positionNavReset(void) { }
     void positionNavUpdate(float /*dt*/, const positionEstimate3d_t * /*est*/) { }
-    bool positionNavHasActiveTarget(void) { return false; }
-    bool positionNavTargetReached(void) { return false; }
-    vector3_t positionNavGetTargetVelocityCmS(void) { return (vector3_t){{0, 0, 0}}; }
-    const positionNavCommand_t *positionNavGetActiveCommand(void) { return NULL; }
+    bool testNavActive = false;
+    bool testNavReached = false;
+    float testNavTargetVelZCmS = 0.0f;
+    positionNavCommand_t testNavCmd;
+    bool positionNavHasActiveTarget(void) { return testNavActive; }
+    bool positionNavTargetReached(void) { return testNavReached; }
+    vector3_t positionNavGetTargetVelocityCmS(void) { return (vector3_t){{0, 0, testNavTargetVelZCmS}}; }
+    const positionNavCommand_t *positionNavGetActiveCommand(void) { return &testNavCmd; }
 
     void parseRcChannels(const char *input, rxConfig_t *rxConfig) {
         UNUSED(input);

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -72,6 +72,9 @@ struct CapturedTarget {
 };
 
 CapturedTarget g_lastTarget;
+float g_lastMaxAccelMps2;
+float g_lastMaxDecelMps2;
+float g_lastVertSpeedLimitMps;
 vector3_t g_lastDispatchTargetEfM;   // destination from positionNavSetTargetEf only (carrot moves don't touch it)
 int g_setTargetCalls;
 int g_clearTargetCalls;
@@ -111,6 +114,11 @@ void positionNavSetTargetEf(
     g_lastTarget.callback = callback;
     g_lastTarget.userData = userData;
     g_lastTarget.valid = true;
+    // Mirror the production reset: per-command limits do not survive a new command, so a test
+    // that asserts on them is asserting the caller stated them rather than inherited them.
+    g_lastMaxAccelMps2 = 0.0f;
+    g_lastMaxDecelMps2 = 0.0f;
+    g_lastVertSpeedLimitMps = 0.0f;
     g_setTargetCalls++;
 }
 
@@ -136,8 +144,13 @@ void positionNavSetAutoClearOnReach(bool autoClear)
 
 void positionNavSetAccelLimits(float maxAccelMps2, float maxDecelMps2)
 {
-    (void)maxAccelMps2;
-    (void)maxDecelMps2;
+    g_lastMaxAccelMps2 = maxAccelMps2;
+    g_lastMaxDecelMps2 = maxDecelMps2;
+}
+
+void positionNavSetVerticalSpeedLimit(float vertSpeedLimitMps)
+{
+    g_lastVertSpeedLimitMps = vertSpeedLimitMps;
 }
 
 static bool g_altitudeArrivalRequired;
@@ -294,6 +307,7 @@ protected:
         cfg->waypointArrivalRadius = 500;  // 5 m
         cfg->waypointHoldRadius = 200;     // 2 m
         cfg->maxVelocity = 1000;           // 10 m/s
+        cfg->landingAltitudeM = 4;         // as shipped
         cfg->landingDescentRate = 50;      // 0.5 m/s
         cfg->landingDetectionTime = 10;    // 1 s
         cfg->landingVelocityThreshold = 50; // 0.5 m/s
@@ -1069,8 +1083,9 @@ TEST_F(FlightPlanNavTest, LandWaypointArrivalDescendsAtTheWaypoint)
     // Descent anchors at the waypoint, not the current position.
     EXPECT_NEAR(g_lastTarget.targetEfM.x, 10.0f, 0.1f);
     EXPECT_NEAR(g_lastTarget.targetEfM.y, 20.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 200.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.cruiseSpeedMps, 0.5f, 0.01f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 5.0f, 0.1f);
+    // The descent rate bounds the vertical axis; the horizontal cruise is its own budget.
+    EXPECT_NEAR(g_lastVertSpeedLimitMps, 0.5f, 0.01f);
 }
 
 TEST_F(FlightPlanNavTest, LandWaypointTouchdownDisarmsAndCompletes)
@@ -1126,7 +1141,7 @@ TEST_F(FlightPlanNavTest, LandWaypointWithDurationLoitersThenDescends)
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
     ASSERT_TRUE(g_lastTarget.valid);
     EXPECT_NEAR(g_lastTarget.targetEfM.x, 10.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 200.0f, 0.1f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 5.0f, 0.1f);
 }
 
 TEST_F(FlightPlanNavTest, LandLoiterExpiryWithLostTargetRedispatchesLeg)
@@ -1296,11 +1311,12 @@ TEST_F(FlightPlanNavSafetyTest, GeofenceBreachWithLandActionStartsLanding)
 
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
     ASSERT_TRUE(g_lastTarget.valid);
-    // Landing target: current position, far below current altitude.
+    // Landing target: current position, a bounded distance below current altitude.
     EXPECT_NEAR(g_lastTarget.targetEfM.x, 12.0f, 0.1f);
     EXPECT_NEAR(g_lastTarget.targetEfM.y, 34.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 200.0f, 0.1f);
-    EXPECT_NEAR(g_lastTarget.cruiseSpeedMps, 0.5f, 0.01f);
+    EXPECT_NEAR(g_lastTarget.targetEfM.z, 30.0f - 5.0f, 0.1f);
+    // The descent rate bounds the vertical axis; the horizontal cruise is its own budget.
+    EXPECT_NEAR(g_lastVertSpeedLimitMps, 0.5f, 0.01f);
     EXPECT_FALSE(flightPlanNavIsInjectedPlanActive());
 }
 
@@ -1392,6 +1408,88 @@ TEST_F(FlightPlanNavSafetyTest, GeofenceRthAboveReturnAltReturnsAtCurrentAltitud
     // which in the estimator's feedback frame is its reading at engage (the
     // stub reads 0 while GPS says 150 m AMSL — a mid-flight engagement).
     EXPECT_NEAR(g_lastTarget.targetEfM.z, 0.0f, 0.1f);
+}
+
+// The landing target must stay a bounded distance below the craft and ratchet down as it
+// descends. It cannot be parked hundreds of metres underground: positionNav normalises the 3D
+// error to get its direction, so a huge vertical component collapses the horizontal velocity
+// demand to near zero and horizontal position hold stops working for the whole landing. It must
+// also never walk back up, or a bounce would raise it.
+TEST_F(FlightPlanNavSafetyTest, LandingTargetRatchetsDownAndStaysBounded)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    float lowestTargetM = g_lastTarget.targetEfM.z;
+    for (int i = 0; i < 40; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = -40.0f;
+        g_stubEstimate.position.v[ENU_U] -= 4.0f;      // 40cm/s over 100ms
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+
+        const float altM = g_stubEstimate.position.v[ENU_U] * 0.01f;
+        const float targetM = g_lastTarget.targetEfM.z;
+        EXPECT_LT(targetM, altM) << "target must stay below the craft";
+        EXPECT_GT(targetM, altM - 6.0f) << "target must stay bounded, not parked underground";
+        EXPECT_LE(targetM, lowestTargetM + 0.01f) << "target must never ratchet back up";
+        lowestTargetM = fminf(lowestTargetM, targetM);
+    }
+
+    // A bounce upward must not drag the target up with the craft.
+    const float beforeBounce = g_lastTarget.targetEfM.z;
+    g_stubEstimate.velocity.v[ENU_U] = 90.0f;
+    g_stubEstimate.position.v[ENU_U] += 30.0f;
+    g_stubMicros += 100'000;
+    flightPlanNavUpdate(g_stubMicros);
+    EXPECT_LE(g_lastTarget.targetEfM.z, beforeBounce + 0.01f);
+}
+
+// The landing leg must state its own speed and braking limits. It used to state neither: the
+// descent rate doubled as the horizontal cruise cap, and the braking limit was whatever the
+// previous leg happened to leave behind.
+TEST_F(FlightPlanNavSafetyTest, LandingStatesItsOwnSpeedAndBrakingLimits)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    // A geofence LAND is not a rescue, so the descent rate comes from autopilotConfig.
+    autopilotConfigMutable()->landingDescentRate = 50;   // 0.5 m/s
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    // Vertical carries the descent rate; horizontal must not.
+    EXPECT_NEAR(g_lastVertSpeedLimitMps, 0.5f, 0.01f);
+    EXPECT_GT(g_lastTarget.cruiseSpeedMps, 0.5f + 0.01f)
+        << "horizontal approach speed must not be the descent rate";
+
+    // Braking stated, not inherited.
+    EXPECT_GT(g_lastMaxDecelMps2, 0.0f) << "landing must state a horizontal braking limit";
+}
+
+// The same landing reached through a leg that leaves no braking limit must still brake.
+TEST_F(FlightPlanNavSafetyTest, LandingBrakingDoesNotDependOnThePrecedingLeg)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+
+    // Wipe the limits as a gated-carrot or hold-pattern leg would leave them.
+    positionNavSetAccelLimits(0.0f, 0.0f);
+    ASSERT_FLOAT_EQ(g_lastMaxDecelMps2, 0.0f);
+
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    EXPECT_GT(g_lastMaxDecelMps2, 0.0f);
 }
 
 TEST_F(FlightPlanNavSafetyTest, LandingTouchdownDisarms)

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -356,6 +356,14 @@ protected:
         wp->pattern = pattern;
     }
 
+    static constexpr float kUnitsPerMetre = 1.0e7f / 111319.49f;
+
+    void addWaypointMetresForContract(float eastM, float northM, int32_t altCm, uint8_t type)
+    {
+        addWaypoint((int32_t)lrintf(northM * kUnitsPerMetre),
+                    (int32_t)lrintf(eastM * kUnitsPerMetre), altCm, type);
+    }
+
     void triggerReached() {
         ASSERT_NE(g_lastTarget.callback, nullptr);
         g_lastTarget.callback(g_lastTarget.userData);
@@ -775,6 +783,65 @@ TEST_F(FlightPlanNavPatternTest, PatternClearedOnAdvance)
 
     EXPECT_EQ(g_moveTargetCalls, movesAtAdvance);
     EXPECT_EQ(memcmp(&g_lastTarget.targetEfM, &legTarget, sizeof(legTarget)), 0);
+}
+
+// --- Axis-decoupling leg-contract pins (blckmn review on 33c217f3d) ---
+//
+// The pass-gate and settled-hold legs share positionNav's budget math with landing, so the
+// dispatch contract is pinned where the legs leave it: the carrot leg states no braking and
+// drops the altitude gate, the precise point leg states the 0.3 m/s^2 arrival brake and keeps
+// the gate only for station-keeping. The position_nav_unittest.cc pins on the same geometries
+// show the velocity schedule agrees with the old shared 3D vector there to first order, so
+// these dispatch pins plus those schedule pins are the full per-leg verdict.
+
+// A pass-gate leg is a pure velocity generator chasing the marched carrot: no arrival of its
+// own (negative acceptance sentinel), no braking for positionNav to apply, and no altitude
+// gate (the executor owns advancement). If a later change gives the carrot leg a brake or an
+// altitude gate, gate-crossing timing moves and the carrot tests above stop meaning the same.
+TEST_F(FlightPlanNavTest, PassGateLegDispatchStatesNoBrakingAndNoAltitudeGate)
+{
+    addWaypointMetresForContract(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp0 (pass-through)
+    addWaypointMetresForContract(0.0f, 200.0f, 15000, WAYPOINT_TYPE_FLYOVER); // wp1 (last)
+
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_LT(g_lastTarget.acceptanceRadiusM, 0.0f) << "carrot legs never self-complete";
+    EXPECT_FLOAT_EQ(g_lastMaxAccelMps2, 0.0f);
+    EXPECT_FLOAT_EQ(g_lastMaxDecelMps2, 0.0f) << "the carrot trapezoid owns the profile, not positionNav";
+    EXPECT_FALSE(g_altitudeArrivalRequired) << "en-route legs advance on horizontal arrival";
+    EXPECT_EQ(g_lastTarget.callback, nullptr) << "the executor owns gate advancement";
+}
+
+// A precise point leg (the last waypoint: the settled-hold approach) states the arrival brake
+// and keeps the altitude gate off for en-route waypoints, on for station-keeping. Either half
+// missing changes the settle: no brake carries cruise speed into the acceptance radius, and a
+// wrong altitude gate either orbits below the point or completes above it.
+TEST_F(FlightPlanNavTest, PreciseLegDispatchStatesArrivalBrakeAndAltitudeGate)
+{
+    // En-route last leg: brake on, altitude gate off.
+    addWaypointMetresForContract(0.0f, 100.0f, 15000, WAYPOINT_TYPE_FLYOVER); // only: last
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_GT(g_lastTarget.acceptanceRadiusM, 0.0f);
+    EXPECT_FLOAT_EQ(g_lastMaxAccelMps2, 0.0f);
+    EXPECT_NEAR(g_lastMaxDecelMps2, 0.3f, 0.001f) << "approach braking stated, not inherited";
+    EXPECT_FALSE(g_altitudeArrivalRequired);
+    EXPECT_NE(g_lastTarget.callback, nullptr);
+    flightPlanNavDisengage();
+
+    // Station-keeping leg: same brake, altitude gate kept.
+    SetUp();
+    addWaypointMetresForContract(0.0f, 100.0f, 15000, WAYPOINT_TYPE_HOLD);
+    g_stubMicros = 1'000'000;
+    flightPlanNavEngage();
+
+    ASSERT_TRUE(g_lastTarget.valid);
+    EXPECT_NEAR(g_lastMaxDecelMps2, 0.3f, 0.001f);
+    EXPECT_TRUE(g_altitudeArrivalRequired) << "HOLD keeps the altitude gate";
 }
 
 TEST_F(FlightPlanNavTest, OrbitPeriodMatchesRateCapAndCruiseLimit)

--- a/src/test/unit/flight_plan_nav_unittest.cc
+++ b/src/test/unit/flight_plan_nav_unittest.cc
@@ -43,6 +43,8 @@ extern "C" {
     #include "pg/gps_rescue.h"
     #include "pg/pg.h"
 
+    #include "sensors/acceleration.h"
+
     int16_t debug[DEBUG16_VALUE_COUNT];
     uint8_t debugMode;
 
@@ -51,6 +53,7 @@ extern "C" {
     gpsSolutionData_t gpsSol;
     gpsLocation_t GPS_home_llh;
     attitudeEulerAngles_t attitude;
+    acc_t acc;
 }
 
 #include "unittest_macros.h"
@@ -94,7 +97,17 @@ flightLogDisarmReason_e g_lastDisarmReason;
 
 } // namespace
 
+static bool g_stubAccPresent = true;
+
 extern "C" {
+
+bool sensors(uint32_t mask)
+{
+    if (mask & SENSOR_ACC) {
+        return g_stubAccPresent;
+    }
+    return true;
+}
 
 void positionNavSetTargetEf(
     const vector3_t *targetPosEfM,
@@ -218,6 +231,11 @@ void autopilotSetYawRateLimit(float rateLimitDps)
     g_yawRateLimitDps = rateLimitDps;
 }
 
+bool g_landingSettle = false;
+void autopilotSetLandingSettle(bool active) { g_landingSettle = active; }
+bool g_landingActive = false;
+void autopilotSetLandingActive(bool active) { g_landingActive = active; }
+
 static bool g_forceLevelPark;
 
 void autopilotForceLevelPark(bool request)
@@ -278,6 +296,8 @@ protected:
         memset(&g_lastDispatchTargetEfM, 0, sizeof(g_lastDispatchTargetEfM));
 
         memset(&attitude, 0, sizeof(attitude));
+        memset(&acc, 0, sizeof(acc));
+        g_stubAccPresent = true;
 
         stateFlags = 0;
         GPS_distanceToHome = 0;
@@ -1559,6 +1579,312 @@ TEST_F(FlightPlanNavSafetyTest, LandingBrakingDoesNotDependOnThePrecedingLeg)
     EXPECT_GT(g_lastMaxDecelMps2, 0.0f);
 }
 
+// Companion to LandingBriefDescentThenHoverAtAltitudeDoesNotDisarm, which only covers a descent
+// too brief to register a progress window. A SUSTAINED descent latches the progress flag, and
+// that flag used to authorise the quiet-velocity disarm at any altitude for the rest of the
+// landing. A craft that descends normally and then holds station at 30 m must keep flying.
+TEST_F(FlightPlanNavSafetyTest, LandingSustainedDescentThenHoverAtAltitudeDoesNotDisarm)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    g_stubBelowLandingAltitude = false;
+    g_stubEstimate.position.v[ENU_U] = 3000.0f;   // 30 m
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    // Sustained descent: long enough for progress windows to register real net descent.
+    for (int i = 0; i < 10; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = -40.0f;
+        g_stubEstimate.position.v[ENU_U] -= 4.0f;
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    ASSERT_EQ(g_disarmCalls, 0);
+
+    // Now hold station, still ~30 m up. Well past the landing confirmation interval.
+    g_stubEstimate.velocity.v[ENU_U] = 0.0f;
+    for (int i = 0; i < 5; i++) {
+        g_stubMicros += 1'000'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    EXPECT_EQ(g_disarmCalls, 0) << "must not disarm in mid-air after a sustained descent";
+}
+
+// A descent that stalls at altitude is a stalled descent, not a touchdown. Bleeding thrust
+// toward idle there is the opposite of what it needs. Ungated, this fired on every logged
+// flight: eight engagements across four descents, the highest at 51.9 m, one cutting 174 PWM
+// for half a second at 31 m.
+TEST_F(FlightPlanNavSafetyTest, StalledDescentAtAltitudeDoesNotBleedThrust)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    // High up, and descending normally so touchdown monitoring is armed.
+    g_stubBelowLandingAltitude = false;
+    g_stubEstimate.position.v[ENU_U] = 3000.0f;   // 30 m
+    for (int i = 0; i < 10; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = -40.0f;
+        g_stubEstimate.position.v[ENU_U] -= 4.0f;
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    ASSERT_FALSE(g_landingSettle);
+
+    // Descent stalls, still 30 m up: several stall windows, well past FP_LANDING_STALL_WINDOWS.
+    for (int i = 0; i < 30; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = 0.0f;
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+        EXPECT_FALSE(g_landingSettle)
+            << "thrust must not be bled toward idle for a stall at 30 m (i=" << i << ")";
+    }
+    EXPECT_EQ(g_disarmCalls, 0);
+
+    // The same stall, once actually near the ground, must still bleed. Skittering rather than
+    // quiet, so the quiet-velocity path cannot disarm and end the landing before we look.
+    g_stubBelowLandingAltitude = true;
+    const float groundAltCm = g_stubEstimate.position.v[ENU_U];
+    for (int i = 0; i < 10; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = (i % 2) ? 90.0f : -90.0f;
+        g_stubEstimate.position.v[ENU_U] = groundAltCm + ((i % 2) ? 5.0f : 0.0f);
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    EXPECT_TRUE(g_landingSettle) << "a stall below the landing altitude must still bleed thrust";
+}
+
+// Stall evidence gathered at altitude must not survive the crossing into the landing regime.
+// The counter only clears on a completed 400 ms window that shows progress, so a craft that
+// stalls high, resumes descending, and crosses the landing altitude inside one window would
+// arrive carrying stale evidence and have thrust bled from under it several metres up - the
+// same class of defect this series exists to remove. landingLowSeen is already reset on the
+// way past; this is the counter beside it that was not.
+TEST_F(FlightPlanNavSafetyTest, StallAtAltitudeDoesNotBleedThrustOnCrossingIntoLanding)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    // Descending normally, high up, so touchdown monitoring is armed.
+    g_stubBelowLandingAltitude = false;
+    g_stubEstimate.position.v[ENU_U] = 2000.0f;   // 20 m
+    for (int i = 0; i < 10; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = -100.0f;
+        g_stubEstimate.position.v[ENU_U] -= 10.0f;
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    ASSERT_FALSE(g_landingSettle);
+
+    // Stalls at altitude: many windows of no progress, still well above the ground.
+    for (int i = 0; i < 20; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = 0.0f;
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    ASSERT_FALSE(g_landingSettle) << "the altitude gate holds while high";
+
+    // Descent resumes at the commanded rate and the craft crosses the landing altitude inside
+    // one progress window, so no fresh window has had a chance to clear the stale count.
+    // Nothing here is a touchdown; the ceiling must stay off.
+    g_stubBelowLandingAltitude = true;
+    for (int i = 0; i < 3; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = -100.0f;
+        g_stubEstimate.position.v[ENU_U] -= 10.0f;
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+        EXPECT_FALSE(g_landingSettle)
+            << "stale stall evidence from altitude bled thrust during a healthy descent (i="
+            << i << ")";
+    }
+}
+
+// FP_LANDING_STALL_WINDOWS exists to demand sustained evidence before thrust is bled, so both
+// windows must actually measure the near-ground regime. Clearing the count on the way down is
+// not sufficient on its own: a window opened above the landing altitude and closed below it
+// spans both regimes, and if it still counts, the ceiling engages after roughly one full
+// below-threshold window instead of two. The crossing here lands deliberately mid-window.
+TEST_F(FlightPlanNavSafetyTest, StallWindowsMustLieWhollyBelowTheLandingAltitude)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    // Arm touchdown monitoring with a normal descent, high up.
+    g_stubBelowLandingAltitude = false;
+    g_stubEstimate.position.v[ENU_U] = 2000.0f;   // 20 m
+    for (int i = 0; i < 10; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = -100.0f;
+        g_stubEstimate.position.v[ENU_U] -= 10.0f;
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+
+    // Stall high for 2.2 s, chosen so the crossing lands mid-window. Measured engagement after
+    // the crossing, sweeping this length over a whole window: two whole windows below the
+    // threshold gives 8 iterations at every phase, while counting the straddling window gives
+    // 4, 5, 6 or 7 depending purely on where the crossing happens to fall. 4 is one window.
+    for (int i = 0; i < 22; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = 0.0f;
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    ASSERT_FALSE(g_landingSettle);
+
+    // Now near the ground and stalled for real: skittering, so the quiet-velocity path cannot
+    // disarm first. Two whole windows below the threshold is 800 ms, so nothing may fire before
+    // then; a straddling window would bring it forward to about 500 ms.
+    g_stubBelowLandingAltitude = true;
+    const float groundAltCm = g_stubEstimate.position.v[ENU_U];
+    for (int i = 0; i < 7; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = (i % 2) ? 90.0f : -90.0f;
+        g_stubEstimate.position.v[ENU_U] = groundAltCm + ((i % 2) ? 5.0f : 0.0f);
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+        EXPECT_FALSE(g_landingSettle)
+            << "a window opened above the landing altitude counted toward the ceiling (i="
+            << i << ", " << (i + 1) * 100 << " ms below)";
+    }
+
+    // ...and it must still engage once two genuine windows have elapsed.
+    for (int i = 7; i < 12; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = (i % 2) ? 90.0f : -90.0f;
+        g_stubEstimate.position.v[ENU_U] = groundAltCm + ((i % 2) ? 5.0f : 0.0f);
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    EXPECT_TRUE(g_landingSettle) << "a genuine ground stall must still bleed thrust";
+}
+
+// Ground contact drives prop downwash into the barometer, which dumps the altitude estimate.
+// One logged touchdown showed 4.07 m of apparent descent in a single 400 ms window, 8x the
+// commanded rate, immediately after the craft had actually stopped descending. Counted as
+// progress it reset the stall counter and released the thrust ceiling 350 ms after it engaged,
+// so the ceiling could never bleed past about 40% of its range and the craft bounced again.
+TEST_F(FlightPlanNavSafetyTest, EstimatorPlungeDoesNotClearTheThrustBleed)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    autopilotConfigMutable()->landingDescentRate = 120;   // 1.2 m/s, as flown
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+    g_stubBelowLandingAltitude = true;
+
+    // Descent establishes, then stalls on contact: skittering, so the quiet path cannot disarm.
+    for (int i = 0; i < 6; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = -120.0f;
+        g_stubEstimate.position.v[ENU_U] -= 12.0f;
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    const float contactAltCm = g_stubEstimate.position.v[ENU_U];
+    for (int i = 0; i < 10; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = (i % 2) ? 90.0f : -90.0f;
+        g_stubEstimate.position.v[ENU_U] = contactAltCm + ((i % 2) ? 5.0f : 0.0f);
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    ASSERT_TRUE(g_landingSettle) << "stalled on the ground: the ceiling should be engaged";
+
+    // The downwash artefact: the estimate plunges 4 m inside one window. It is not real descent.
+    g_stubEstimate.position.v[ENU_U] = contactAltCm - 407.0f;
+    g_stubEstimate.velocity.v[ENU_U] = -90.0f;
+    g_stubMicros += 400'000;
+    flightPlanNavUpdate(g_stubMicros);
+
+    EXPECT_TRUE(g_landingSettle)
+        << "an implausible estimator plunge must not read as progress and release the ceiling";
+}
+
+// The altitude loop's landing sink bound is live for exactly as long as a landing descent is,
+// and no longer: outside one, altitudeControl() must behave as it always has. The flag is
+// asserted every iteration from updateLanding(), the one function both landing entry paths run
+// through, and cleared by every exit.
+TEST_F(FlightPlanNavSafetyTest, LandingActiveTracksTheLandingAndNothingElse)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    g_landingActive = false;   // the fixture does not reset the stub globals
+    engageDistantLeg();
+
+    // Flying a normal leg: no landing, so the bound must be inert.
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_TARGETING);
+    EXPECT_FALSE(g_landingActive) << "the bound must not apply while flying a normal leg";
+
+    GPS_distanceToHome = 150;
+    g_stubMicros += 10'000;
+    flightPlanNavUpdate(g_stubMicros);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+    EXPECT_TRUE(g_landingActive) << "the landing has started; the bound must be live";
+
+    // Still live before touchdown monitoring engages: the artefact appears during the descent.
+    for (int i = 0; i < 5; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = -40.0f;
+        g_stubEstimate.position.v[ENU_U] -= 4.0f;
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+        EXPECT_TRUE(g_landingActive) << "released mid-descent (i=" << i << ")";
+    }
+
+    // A landing abandoned mid-descent must release it.
+    flightPlanNavDisengage();
+    EXPECT_FALSE(g_landingActive) << "disengaging must release the bound";
+}
+
+TEST_F(FlightPlanNavSafetyTest, LandingBounceTriggersThrustBleed)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    // Descent establishes, losing altitude normally.
+    for (int i = 0; i < 20; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = -40.0f;
+        g_stubEstimate.position.v[ENU_U] -= 4.0f;   // 40cm/s over 100ms
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    EXPECT_FALSE(g_landingSettle) << "must not bleed thrust during a healthy descent";
+    EXPECT_EQ(g_disarmCalls, 0);
+
+    // Ground contact: altitude no longer falls, but the craft skitters so vertical velocity
+    // swings well outside the quiet threshold and the quiet timer can never complete.
+    const float bounceAltCm = g_stubEstimate.position.v[ENU_U];
+    for (int i = 0; i < 30; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = (i % 2) ? 90.0f : -90.0f;
+        g_stubEstimate.position.v[ENU_U] = bounceAltCm + ((i % 2) ? 5.0f : 0.0f);
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    EXPECT_EQ(g_disarmCalls, 0) << "quiet timer legitimately cannot confirm while bouncing";
+    EXPECT_TRUE(g_landingSettle) << "no downward progress: thrust must be bled to stop the bounce";
+}
+
 TEST_F(FlightPlanNavSafetyTest, LandingTouchdownDisarms)
 {
     autopilotConfigMutable()->maxDistanceFromHomeM = 100;
@@ -1585,6 +1911,311 @@ TEST_F(FlightPlanNavSafetyTest, LandingTouchdownDisarms)
     flightPlanNavUpdate(g_stubMicros);
     EXPECT_EQ(g_disarmCalls, 1);
     EXPECT_EQ(g_lastDisarmReason, DISARM_REASON_LANDING);
+}
+
+// A transient downward velocity at LAND-leg entry is not proof of ground contact.  The
+// touchdown monitor must not turn that one sample into permanent permission to disarm while the
+// vehicle subsequently holds still at altitude.  This matches the SITL rescue failure where a
+// 31.8 m aircraft was cleanly disarmed after briefly reporting a descent during the arrival
+// transition.
+TEST_F(FlightPlanNavSafetyTest, LandingBriefDescentThenHoverAtAltitudeDoesNotDisarm)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    g_stubBelowLandingAltitude = false;
+    g_stubEstimate.position.v[ENU_U] = 3000.0f;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    // A one-off descent sample can occur while braking into the LAND leg.
+    g_stubEstimate.velocity.v[ENU_U] = -40.0f;
+    g_stubMicros += 100'000;
+    flightPlanNavUpdate(g_stubMicros);
+
+    // The aircraft is still 30 m up and has stopped descending.  Let more than the landing
+    // confirmation interval elapse: this must keep flying rather than disarm in mid-air.
+    g_stubEstimate.velocity.v[ENU_U] = 0.0f;
+    for (int i = 0; i < 3; i++) {
+        g_stubMicros += 1'000'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    EXPECT_EQ(g_disarmCalls, 0);
+}
+
+// Real flight (SEQUREH7V2, GRENGOBL 2026-08-12): the craft landed, then sat on the ground for
+// 18 s still armed because the touchdown test never resolved.  In ground effect the altitude
+// estimate swung over 6.5 m and reported +/-15 m/s of vertical velocity while the craft was
+// stationary, so the quiet-velocity test was almost never satisfied and its timer kept
+// restarting.  Impact jerk is the one ground signal that survives, and a landing has exactly one
+// touchdown, so a single impact must end it immediately.
+TEST_F(FlightPlanNavSafetyTest, LandingDisarmsOnFirstImpactWhenAltitudeEstimateIsUnusable)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    // Establish the descent, as a real landing does.
+    g_stubEstimate.velocity.v[ENU_U] = -40.0f;
+    g_stubMicros += 500'000;
+    flightPlanNavUpdate(g_stubMicros);
+    ASSERT_EQ(g_disarmCalls, 0);
+
+    // Near the ground, with the logged estimator behaviour: the reported vertical velocity never
+    // settles inside landingVelocityThreshold, so the quiet-velocity path can never fire.
+    const float noisyVelCmS[] = {-1500.0f, 900.0f, -400.0f, 1200.0f, -1100.0f, 600.0f};
+    for (int i = 0; i < 12; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = noisyVelCmS[i % 6];
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+    ASSERT_EQ(g_disarmCalls, 0) << "disarmed before any ground contact";
+
+    // Touchdown.  Contact arrives as a burst of over-threshold samples a few ms apart, which is
+    // what was measured on the real contact, and that is the landing over with.
+    acc.jerkMagnitude = 900.0f;              // contact peaked at 1210 G/s in the log
+    acc.accMagnitude = 5.5f;                 // and at 5.5 g
+    g_stubMicros += 5'000;
+    flightPlanNavUpdate(g_stubMicros);
+    g_stubMicros += 5'000;
+    flightPlanNavUpdate(g_stubMicros);
+
+    EXPECT_EQ(g_disarmCalls, 1) << "ground impact did not end the landing";
+    EXPECT_EQ(g_lastDisarmReason, DISARM_REASON_LANDING);
+    EXPECT_EQ(flightPlanNavGetState(), FP_NAV_COMPLETE);
+}
+
+// The accelerometer is low-passed before the detector sees it, which attenuates the derivative
+// of a contact step far more than its amplitude. Two logged 5 g contacts produced only 284 and
+// 297 G/s of jerk and were missed, so the craft bounced twice. Amplitude must be able to carry
+// the detection when jerk has been smeared out.
+TEST_F(FlightPlanNavSafetyTest, HardContactWithSmearedJerkStillDisarms)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+    g_stubBelowLandingAltitude = true;
+
+    g_stubEstimate.velocity.v[ENU_U] = -120.0f;
+    g_stubMicros += 200'000;
+    flightPlanNavUpdate(g_stubMicros);
+    ASSERT_EQ(g_disarmCalls, 0);
+
+    // A hard contact as actually logged: 4.6 g, but only 284 G/s of jerk after the 25 Hz LPF,
+    // which is below the 300 G/s the detector used to require.
+    acc.jerkMagnitude = 284.0f;
+    acc.accMagnitude = 4.57f;
+    for (int i = 0; i < 2; i++) {
+        g_stubMicros += 5'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+
+    EXPECT_EQ(g_disarmCalls, 1) << "a 4.6 g contact must end the landing even with smeared jerk";
+    EXPECT_EQ(g_lastDisarmReason, DISARM_REASON_LANDING);
+}
+
+// The amplitude term must not become a disarm on its own. Sustained g-loading without transient
+// content is not a contact, so some jerk is still required.
+TEST_F(FlightPlanNavSafetyTest, SustainedGLoadWithoutJerkDoesNotDisarm)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+    g_stubBelowLandingAltitude = true;
+
+    // High sustained load, no transient: a hard pull-out, not a touchdown.
+    acc.accMagnitude = 3.0f;
+    acc.jerkMagnitude = 20.0f;
+    const float noisyVelCmS[] = {-1500.0f, 900.0f, -400.0f, 1200.0f, -1100.0f, 600.0f};
+    for (int i = 0; i < 20; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = noisyVelCmS[i % 6];
+        g_stubMicros += 5'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+
+    EXPECT_EQ(g_disarmCalls, 0) << "amplitude alone must not be read as ground contact";
+}
+
+// Acting on a single impact is only safe because it is gated on being near the ground.  A prop
+// strike, a hard gust or a single bad sample while still airborne has to be ignored: this is the
+// case that stops one spike from ending a flight in mid-air.
+TEST_F(FlightPlanNavSafetyTest, LandingJerkSpikeAtAltitudeDoesNotDisarm)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    g_stubBelowLandingAltitude = false;
+    g_stubEstimate.position.v[ENU_U] = 3000.0f;   // 30 m up
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    g_stubEstimate.velocity.v[ENU_U] = -40.0f;
+    g_stubMicros += 500'000;
+    flightPlanNavUpdate(g_stubMicros);
+
+    // Repeated impact bursts the whole way down - tight enough to satisfy the burst rule - but
+    // the craft is 30 m up, so only the altitude gate can be what rejects them.
+    acc.jerkMagnitude = 900.0f;
+    acc.accMagnitude = 5.5f;
+    for (int i = 0; i < 40; i++) {
+        for (int b = 0; b < 3; b++) {
+            g_stubMicros += 5'000;
+            flightPlanNavUpdate(g_stubMicros);
+        }
+        g_stubMicros += 85'000;
+        g_stubEstimate.position.v[ENU_U] -= 4.0f;   // still descending normally
+        flightPlanNavUpdate(g_stubMicros);
+    }
+
+    EXPECT_EQ(g_disarmCalls, 0) << "a jerk spike disarmed the craft in mid-air";
+}
+
+// With no usable accelerometer there is no impact signal, so the impact path must stay out of
+// the way and leave the pre-existing touchdown evidence as the only route to a disarm.
+TEST_F(FlightPlanNavSafetyTest, LandingImpactPathInertWithoutAccelerometer)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    g_stubAccPresent = false;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    g_stubEstimate.velocity.v[ENU_U] = -40.0f;
+    g_stubMicros += 500'000;
+    flightPlanNavUpdate(g_stubMicros);
+
+    // Impact bursts the whole time, but the sensor is absent so they must never be seen.
+    acc.jerkMagnitude = 900.0f;
+    acc.accMagnitude = 5.5f;
+    const float noisyVelCmS[] = {-1500.0f, 900.0f, -400.0f, 1200.0f, -1100.0f, 600.0f};
+    for (int i = 0; i < 40; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = noisyVelCmS[i % 6];
+        for (int b = 0; b < 3; b++) {
+            g_stubMicros += 5'000;
+            flightPlanNavUpdate(g_stubMicros);
+        }
+        g_stubMicros += 85'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+
+    EXPECT_EQ(g_disarmCalls, 0) << "impact path fired with no accelerometer present";
+}
+
+// A lone over-threshold sample is vibration, not contact.  Real contact delivers a burst - the
+// logged touchdown put five samples over the threshold inside 200 ms - so a single outlier must
+// not be enough to end a flight.
+TEST_F(FlightPlanNavSafetyTest, LandingIsolatedJerkOutlierDoesNotDisarm)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    g_stubEstimate.velocity.v[ENU_U] = -40.0f;
+    g_stubMicros += 500'000;
+    flightPlanNavUpdate(g_stubMicros);
+
+    // One spike per second: over threshold, but never two inside the burst window.
+    const float noisyVelCmS[] = {-1500.0f, 900.0f, -400.0f, 1200.0f, -1100.0f, 600.0f};
+    for (int i = 0; i < 15; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = noisyVelCmS[i % 6];
+        acc.jerkMagnitude = 900.0f;
+        acc.accMagnitude = 5.5f;
+        g_stubMicros += 1'000'000;
+        flightPlanNavUpdate(g_stubMicros);
+        acc.jerkMagnitude = 5.0f;
+        acc.accMagnitude = 1.0f;
+    }
+
+    EXPECT_EQ(g_disarmCalls, 0) << "an isolated jerk outlier was treated as ground contact";
+}
+
+// A touchdown can be too soft to spike, and the altitude estimate cannot be relied on to notice
+// it: low-passing it and lengthening the progress window were both measured against the logged
+// flight and still scored 36-50% of on-ground windows as fresh descent.  So a landing that has
+// spent far longer at landing altitude than the commanded rate needs must end regardless.
+TEST_F(FlightPlanNavSafetyTest, LandingCompletesWhenTouchdownIsTooSoftToDetect)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    g_stubEstimate.velocity.v[ENU_U] = -40.0f;
+    g_stubMicros += 500'000;
+    flightPlanNavUpdate(g_stubMicros);
+
+    // No impact ever registers, and the estimate never settles.  4 m at 0.5 m/s is 8 s of
+    // descent, so the backstop is 24 s.
+    const float noisyVelCmS[] = {-1500.0f, 900.0f, -400.0f, 1200.0f, -1100.0f, 600.0f};
+    acc.jerkMagnitude = 5.0f;
+    acc.accMagnitude = 1.0f;
+    for (int i = 0; i < 300; i++) {
+        g_stubEstimate.velocity.v[ENU_U] = noisyVelCmS[i % 6];
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+        if (i == 150) {   // 15 s in, still well inside the backstop
+            EXPECT_EQ(g_disarmCalls, 0) << "backstop fired far too early";
+        }
+    }
+
+    EXPECT_EQ(g_disarmCalls, 1) << "a soft touchdown never ended the landing";
+    EXPECT_EQ(g_lastDisarmReason, DISARM_REASON_LANDING);
+}
+
+// The backstop scales with the commanded descent rate, so a deliberately slow landing is not cut
+// short.  At the 0.3 m/s floor, 4 m needs 13.3 s, so the backstop must be far beyond the 24 s
+// that applies at the default rate.
+TEST_F(FlightPlanNavSafetyTest, LandingCommitBackstopScalesWithCommandedRate)
+{
+    autopilotConfigMutable()->maxDistanceFromHomeM = 100;
+    autopilotConfigMutable()->geofenceAction = AP_GEOFENCE_LAND;
+    autopilotConfigMutable()->landingDescentRate = 10;   // clamped up to the 0.3 m/s floor
+    stateFlags |= GPS_FIX_HOME;
+    engageDistantLeg();
+    GPS_distanceToHome = 150;
+    flightPlanNavUpdate(g_stubMicros + 10'000);
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    g_stubEstimate.velocity.v[ENU_U] = -20.0f;
+    g_stubMicros += 500'000;
+    flightPlanNavUpdate(g_stubMicros);
+
+    const float noisyVelCmS[] = {-1500.0f, 900.0f, -400.0f, 1200.0f, -1100.0f, 600.0f};
+    acc.jerkMagnitude = 5.0f;
+    acc.accMagnitude = 1.0f;
+    for (int i = 0; i < 300; i++) {   // 30 s: past the default-rate backstop, inside this one
+        g_stubEstimate.velocity.v[ENU_U] = noisyVelCmS[i % 6];
+        g_stubMicros += 100'000;
+        flightPlanNavUpdate(g_stubMicros);
+    }
+
+    EXPECT_EQ(g_disarmCalls, 0) << "a slow commanded descent was cut short by the backstop";
 }
 
 TEST_F(FlightPlanNavSafetyTest, LandingAtAltitudeWithoutDescentNeverDisarms)

--- a/src/test/unit/flight_plan_rescue_unittest.cc
+++ b/src/test/unit/flight_plan_rescue_unittest.cc
@@ -47,6 +47,8 @@ extern "C" {
     #include "pg/gps_rescue.h"
     #include "pg/pg.h"
 
+    #include "sensors/acceleration.h"
+
     int16_t debug[DEBUG16_VALUE_COUNT];
     uint8_t debugMode;
 
@@ -55,6 +57,7 @@ extern "C" {
     gpsSolutionData_t gpsSol;
     gpsLocation_t GPS_home_llh;
     attitudeEulerAngles_t attitude;
+    acc_t acc;
 }
 
 #include "unittest_macros.h"
@@ -81,6 +84,9 @@ struct CapturedTarget {
 };
 
 CapturedTarget g_lastTarget;
+float g_lastMaxAccelMps2;
+float g_lastMaxDecelMps2;
+float g_lastVertSpeedLimitMps;
 int g_setTargetCalls;
 int g_clearTargetCalls;
 
@@ -108,6 +114,13 @@ bool g_lastPitchForward;
 
 extern "C" {
 
+// No accelerometer in this fixture, so the landing impact path stays inert and the rescue tests
+// exercise the descent logic on its own.
+bool sensors(uint32_t mask)
+{
+    return (mask & SENSOR_ACC) ? false : true;
+}
+
 void positionNavSetTargetEf(
     const vector3_t *targetPosEfM,
     float cruiseSpeedMps,
@@ -125,6 +138,10 @@ void positionNavSetTargetEf(
     g_lastTarget.callback = callback;
     g_lastTarget.userData = userData;
     g_lastTarget.valid = true;
+    // Mirror the production reset: per-command limits never survive a new command.
+    g_lastMaxAccelMps2 = 0.0f;
+    g_lastMaxDecelMps2 = 0.0f;
+    g_lastVertSpeedLimitMps = 0.0f;
     g_setTargetCalls++;
 }
 
@@ -149,8 +166,13 @@ void positionNavSetAutoClearOnReach(bool autoClear)
 
 void positionNavSetAccelLimits(float maxAccelMps2, float maxDecelMps2)
 {
-    (void)maxAccelMps2;
-    (void)maxDecelMps2;
+    g_lastMaxAccelMps2 = maxAccelMps2;
+    g_lastMaxDecelMps2 = maxDecelMps2;
+}
+
+void positionNavSetVerticalSpeedLimit(float vertSpeedLimitMps)
+{
+    g_lastVertSpeedLimitMps = vertSpeedLimitMps;
 }
 
 void positionNavSetAltitudeArrivalRequired(bool required)
@@ -213,6 +235,9 @@ void autopilotSetYawRateLimit(float rateLimitDps)
 {
     g_yawRateLimitDps = rateLimitDps;
 }
+
+void autopilotSetLandingSettle(bool) { }
+void autopilotSetLandingActive(bool) { }
 
 void GPS_distance2d(const gpsLocation_t *from, const gpsLocation_t *to, vector2_t *distance)
 {
@@ -588,6 +613,28 @@ TEST_F(FlightPlanRescueTest, FullRescueRunToLanding)
     EXPECT_EQ(g_disarmCalls, 1);
     EXPECT_EQ(g_lastDisarmReason, DISARM_REASON_LANDING);
     EXPECT_EQ(flightPlanNavGetState(), FP_NAV_COMPLETE);
+}
+
+// On a rescue the descent rate is gps_rescue_descend_rate. It must bound the vertical axis only:
+// horizontal and vertical hold independent speed budgets, so sharing one limit would let the
+// descend rate govern how fast the craft translates over the landing point.
+TEST_F(FlightPlanRescueTest, RescueLandingDescentRateDoesNotCapHorizontalSpeed)
+{
+    gpsRescueConfigMutable()->descendRate = 120;   // 1.2 m/s
+
+    ASSERT_TRUE(flightPlanNavStageRescuePlan());
+    flightPlanNavEngage();
+    triggerReached();                              // wp0 climb -> wp1
+    g_stubMicros += 100'000;
+    flightPlanNavUpdate(g_stubMicros);             // wp1 -> wp2
+    triggerReached();                              // LAND: starts the descent
+    ASSERT_EQ(flightPlanNavGetState(), FP_NAV_LANDING);
+
+    EXPECT_NEAR(g_lastVertSpeedLimitMps, 1.2f, 0.01f);
+    EXPECT_GT(g_lastTarget.cruiseSpeedMps, 1.2f + 0.01f)
+        << "descend rate must not cap the horizontal approach speed";
+    EXPECT_GT(g_lastMaxDecelMps2, 0.0f)
+        << "landing must state its own horizontal braking limit";
 }
 
 // --- Fallback emergency descent (switch rescue: no fix, or plan aborted) ---

--- a/src/test/unit/landing_ground_effect_unittest.cc
+++ b/src/test/unit/landing_ground_effect_unittest.cc
@@ -1,0 +1,1004 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Closed-loop vertical-axis landing simulation, for the landing sink bound in altitudeControl().
+//
+// Reproduces the reported ground-effect bounce: on a gentle descent the rising static pressure
+// under the craft makes the barometer read a sudden large drop. The Kalman estimator follows and
+// reports a sink that never happened; altitudeControl() feeds that phantom sink into D, dBoost
+// amplifies it, throttle saturates and the craft launches off the deck without ever touching it.
+//
+// Real code in the loop: flight/position_estimator.c (the actual Kalman filter, fed a corrupted
+// barometer and a truthful accelerometer), flight/position.c (the altitude plumbing) and
+// flight/autopilot_multirotor.c (the real altitudeControl(), including dBoost and the bound).
+//
+// Modelled: rigid-body vertical physics, ground effect as extra lift, inelastic ground contact,
+// a thrust shortfall (for the genuine-fall cases) and the barometric ground-effect error itself
+// (shape and magnitude fitted to the blackbox log of the reported flight - see BaroGroundEffect).
+//
+// NOTE ON SCOPE. The fix under test is deliberately NOT an estimator change: the estimate stays
+// corrupted and this file asserts that it does (see TheAltitudeEstimateItselfRemainsCorrupted).
+// What is fixed is that the altitude loop no longer acts on the corrupted sink while a landing
+// is being flown near the ground. Tests inherited from the estimator-side attempt that assert on
+// positionEstimatorGetAltitudeDerivative() are therefore not reproduced here - by construction no
+// control-layer change can pass them.
+
+#include <algorithm>
+#include <cstdlib>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+#include "gtest/gtest.h"
+
+extern "C" {
+    #include "platform.h"
+    #include "build/debug.h"
+
+    #include "common/axis.h"
+    #include "common/maths.h"
+    #include "common/vector.h"
+
+    #include "config/feature.h"
+    #include "pg/pg.h"
+    #include "pg/pg_ids.h"
+    #include "pg/rx.h"
+    #include "rx/rx.h"
+
+    #include "fc/rc_controls.h"
+    #include "fc/runtime_config.h"
+
+    #include "flight/autopilot_multirotor.h"
+    #include "flight/imu.h"
+    #include "flight/pid.h"
+    #include "flight/position.h"
+    #include "flight/position_estimator.h"
+    #include "flight/position_nav.h"
+
+    #include "io/gps.h"
+    #include "pg/autopilot.h"
+    #include "scheduler/scheduler.h"
+    #include "sensors/acceleration.h"
+    #include "sensors/barometer.h"
+    #include "sensors/gyro.h"
+
+    PG_REGISTER(accelerometerConfig_t, accelerometerConfig, PG_ACCELEROMETER_CONFIG, 0);
+    PG_REGISTER(autopilotConfig_t, autopilotConfig, PG_AUTOPILOT, 0);
+    PG_REGISTER(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 0);
+    PG_REGISTER(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 0);
+
+    // --- simulated sensor plumbing ---------------------------------------------------------
+    // The barometer the estimator sees. Set from the sim each iteration.
+    float simBaroAltitudeCm = 0.0f;
+    // Wall clock the estimator sees, advanced one task interval per iteration.
+    uint32_t simMicros = 1000000;
+
+    uint8_t armingFlags = 0;
+    uint16_t flightModeFlags = 0;
+    uint8_t stateFlags = 0;
+    int16_t debug[DEBUG16_VALUE_COUNT];
+    uint8_t debugMode = 0;
+
+    acc_t acc;
+    attitudeEulerAngles_t attitude;
+    gyro_t gyro;
+    gpsSolutionData_t gpsSol;
+    baro_t baro;
+    float rcCommand[4];
+
+    // Body->earth rotation, held level for the whole simulation: this is a pure vertical-axis
+    // test and the reported event had the craft level (36 dps of gyro, no attitude excursion).
+    matrix33_t rMat = {{{1.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}}};
+
+    uint32_t millis(void) { return simMicros / 1000; }
+    uint32_t micros(void) { return simMicros; }
+
+    float getBaroAltitude(void) { return simBaroAltitudeCm; }
+    bool baroIsCalibrated(void) { return true; }
+    void performBaroCalibrationCycle(void) { }
+    float baroCalculateAltitude(void) { return simBaroAltitudeCm; }
+    float baroUpsampleAltitude(void) { return simBaroAltitudeCm; }
+
+    // No GPS, no rangefinder, no optical flow: baro is the only altitude source, which is the
+    // configuration the bug was reported on and the one that isolates the mechanism.
+    bool sensors(uint32_t mask) { return mask == SENSOR_BARO || mask == SENSOR_ACC; }
+    bool gpsHasNewData(uint16_t *) { return false; }
+    bool gpsIsHealthy(void) { return false; }
+    void GPS_distance2d(const gpsLocation_t *, const gpsLocation_t *, vector2_t *) { }
+    bool isFixedWing(void) { return false; }
+    bool featureIsEnabled(uint32_t) { return false; }
+
+    float getCosTiltAngle(void) { return 1.0f; }
+    float getGpsDataIntervalSeconds(void) { return 0.01f; }
+    float getGpsDataFrequencyHz(void) { return 0.0f; }   // no GPS in this test
+
+    // Baro sample timing, as the estimator's freshness gate reads it. Driven by
+    // baroSampleAndHold() below so the estimator sees a new timestamp exactly when a new
+    // physical sample arrives, at the same ~36 Hz the sample-and-hold models. Stubbing
+    // these to the task rate instead would make every held sample look new and let the
+    // baro fuse 100 times a second, which is not the case the bug was reported on.
+    uint32_t simBaroSampleTimeUs = 0;
+    timeDelta_t simBaroSampleIntervalUs = 0;
+    timeUs_t getBaroLatestSampleTimeUs(void) { return simBaroSampleTimeUs; }
+    timeDelta_t getBaroSampleIntervalUs(void) { return simBaroSampleIntervalUs; }
+    float getSetpointRate(int) { return 0.0f; }
+    float getMaxRcRate(int) { return 720.0f; }
+    throttleStatus_e calculateThrottleStatus(void) { return THROTTLE_LOW; }
+    bool failsafeIsActive(void) { return false; }
+    void parseRcChannels(const char *, rxConfig_t *) { }
+    timeDelta_t getTaskDeltaTimeUs(taskId_e) { return TASK_PERIOD_HZ(100); }
+
+    // positionNav is not exercised: the descent target is published directly to altitudeControl().
+    void positionNavInit(void) { }
+    void positionNavReset(void) { }
+    void positionNavUpdate(float, const positionEstimate3d_t *) { }
+    bool positionNavHasActiveTarget(void) { return false; }
+    bool positionNavTargetReached(void) { return false; }
+    vector3_t positionNavGetTargetVelocityCmS(void) { return (vector3_t){{0, 0, 0}}; }
+    static positionNavCommand_t emptyNavCmd;
+    const positionNavCommand_t *positionNavGetActiveCommand(void) { return &emptyNavCmd; }
+}
+
+static const float G_CM_S2 = 981.0f;
+static const float DT_S = HZ_TO_INTERVAL(TASK_ALTITUDE_RATE_HZ);
+static const float ACC_1G = 2048.0f;
+
+// altitudeControl() starts amplifying D above this. Any phantom sink that reaches it is
+// multiplied on its way into the throttle command, so it is the line that matters.
+static const float D_BOOST_THRESHOLD_CM_S = 500.0f;
+
+// The barometer on this craft updates near 36 Hz while the estimator task runs at 100 Hz, so
+// one physical sample is presented to feedBaroMeasurements() for about three consecutive
+// iterations. Reproduced here because any candidate with a sample-counted window (a median
+// length, a rejection cap) measures a different amount of TIME depending on whether this is
+// modelled, and the referee's raw-log bench models it.
+static const uint32_t BARO_SAMPLE_INTERVAL_US = 27778;   // 36 Hz
+
+// Mirrors LANDING_SINK_PLAUSIBLE_FACTOR / _MIN_CM_S in autopilot_multirotor.c. Used only to
+// report whether the production bound would bind on a given iteration; if these drift apart the
+// firing counts below become wrong (the behaviour under test does not).
+static const float LANDING_SINK_FACTOR_MIRROR = 2.0f;
+static const float LANDING_SINK_FLOOR_MIRROR_CM_S = 100.0f;
+
+namespace {
+
+// Vertical rigid-body model, the same one althold_unittest uses: thrust proportional to throttle
+// above idle and normalised so hoverPwm holds altitude, ground effect as extra lift below 30 cm,
+// and inelastic ground contact. step() returns the acceleration actually applied, which is what
+// an accelerometer strapped to this airframe would measure (minus gravity).
+struct LandingSim {
+    float altCm = 0.0f;
+    float vzCmS = 0.0f;
+    float kGroundEffectHeightCm = 30.0f;
+    float kGroundEffectGain = 0.25f;   // +25% thrust on the deck
+
+    float thrustScale = 1.0f;          // <1 models a real thrust shortfall (sag, partial loss)
+
+    float step(float throttlePwm, float hoverPwm, float minPwm, float dt) {
+        const float span = MAX(hoverPwm - minPwm, 1.0f);
+        // minPwm is where the rotors stop producing thrust, below ap_throttle_min - a configured
+        // floor, not zero thrust. A rotor cannot pull the craft down, but without a floor the
+        // motors-cut path (throttle 0) asks the model for 4.3 g downward. Inert above
+        // ap_throttle_min, so the measured baselines below are unchanged.
+        float thrustRatio = MAX(thrustScale * (throttlePwm - minPwm) / span, 0.0f);   // 1.0 == weight
+        if (altCm < kGroundEffectHeightCm) {
+            thrustRatio *= 1.0f + kGroundEffectGain * (1.0f - altCm / kGroundEffectHeightCm);
+        }
+        const float accelCmS2 = G_CM_S2 * (thrustRatio - 1.0f);
+        const float vzBefore = vzCmS;
+        vzCmS += accelCmS2 * dt;
+        altCm += vzCmS * dt;
+        if (altCm <= 0.0f) {                 // inelastic ground contact
+            altCm = 0.0f;
+            if (vzCmS < 0.0f) { vzCmS = 0.0f; }
+        }
+        return (vzCmS - vzBefore) / dt;      // includes the contact impulse
+    }
+};
+
+// Ground-effect barometric error. As the craft descends into its own pressure cushion the static
+// pressure under it rises, so the barometer reads LOW - it reports the craft as further down than
+// it really is - and the error winds up as the gap closes.
+//
+// The shape and the numbers are fitted to a real event, not invented: blackbox log
+// BTFL_BLACKBOX_LOG_GRENGOBL_20260814_192051_SEQUREH7V2.bbl (index 2, firmware 38c0871f5), the
+// flight this bug was reported from. Over eight consecutive barometer samples (t=95.16..95.34 s,
+// 25 ms apart) baroAlt went -80, -207, -326, -461, -656, -960, -1137, -1889, -2210 cm while
+// accSmooth[2] read 1.00 to 1.32 g - the craft was not moving. Least squares over
+// (biasCm, onsetCm, power, descent rate, entry height) fits that run to 83 cm RMS with
+// biasCm 2200, onsetCm 35, power 3, at the configured 120 cm/s descent rate.
+//
+// All three are knobs so the test can sweep them.
+struct BaroGroundEffect {
+    float biasCm = 0.0f;      // error magnitude on the deck
+    float onsetCm = 35.0f;    // height at which the error starts to appear
+    float power = 3.0f;       // how abruptly it winds up over that last stretch
+
+    float reportedAltCm(float trueAltCm) const {
+        if (trueAltCm >= onsetCm || onsetCm <= 0.0f) {
+            return trueAltCm;
+        }
+        const float closed = 1.0f - MAX(trueAltCm, 0.0f) / onsetCm;   // 0 at onset, 1 on the deck
+        return trueAltCm - biasCm * powf(closed, power);
+    }
+};
+
+// Faithful port of the touchdown-stall rule in flight_plan_nav.c updateLanding(): while the
+// craft is below the landing altitude, each FP_LANDING_PROGRESS_WINDOW_US window is scored for
+// plausible descent progress, and FP_LANDING_STALL_WINDOWS consecutive windows without it arm
+// the real autopilotSetLandingSettle() thrust ceiling in autopilot_multirotor.c.
+//
+// flight_plan_nav.c is not linkable into this rig (it drags in the whole mission stack), so the
+// rule is reproduced here from the same two inputs it uses - getAltitudeCmControl() and the
+// commanded descent rate - and drives the real ceiling.
+//
+// It has to be modelled, because the production ceiling is what ends a landing once the craft is
+// down. With it permanently disarmed, nothing in the loop can stop a craft that has already
+// touched down from being lifted off again by residual thrust plus ground effect, and every run
+// "fails" in that last phase no matter what the estimator does.
+struct LandingSettleMonitor {
+    static const uint32_t kProgressWindowUs = 400000u;   // FP_LANDING_PROGRESS_WINDOW_US
+    static const int kStallWindows = 2;                  // FP_LANDING_STALL_WINDOWS
+    static constexpr float kProgressMaxFactor = 4.0f;    // FP_LANDING_PROGRESS_MAX_FACTOR
+    static const uint32_t kCommitMinUs = 15000000u;      // FP_LANDING_COMMIT_MIN_US
+    static constexpr float kCommitFactor = 3.0f;         // FP_LANDING_COMMIT_FACTOR
+
+    uint32_t refUs = 0;
+    float refAltCm = 0.0f;
+    int stallWindows = 0;
+    bool armed = false;
+
+    // Touchdown -> disarm. Without this the rig scores a runaway the real firmware ends: once
+    // the landing completes, flight_plan_nav calls disarm(DISARM_REASON_LANDING) and the motors
+    // stop. Two of the three production paths are reproduced - the quiet-velocity inference and
+    // the commit backstop. The third, the impact-jerk burst, is NOT: it needs two over-threshold
+    // samples inside 50 ms and this rigid inelastic contact model produces exactly one, so the
+    // rig sits on the pessimistic side of the real firmware here.
+    // Also not modelled: the monitorTouchdown gate that precedes all three in updateLanding(),
+    // which holds the ceiling off until a descent has been observed or the establish timeout
+    // expires near the ground. The rig therefore arms the ceiling no later than the firmware
+    // would, so settling latency it reports is a lower bound, not production timing.
+    uint32_t lowStartUs = 0;
+    bool lowSeen = false;
+    uint32_t quietStartUs = 0;
+    bool complete = false;
+    uint32_t completeUs = 0;
+
+    void update(uint32_t nowUs, float commandedDescentCmS) {
+        const float altCm = getAltitudeCmControl();
+        const float vzCmS = getAltitudeDerivativeControl();
+        const bool belowLandingAltitude = isBelowLandingAltitude();
+
+        if (!belowLandingAltitude) {
+            stallWindows = 0;
+            refUs = 0;
+        } else if (refUs == 0) {
+            refUs = nowUs;
+            refAltCm = altCm;
+        } else if (nowUs - refUs >= kProgressWindowUs) {
+            const float windowS = kProgressWindowUs * 1e-6f;
+            const float descendedCm = refAltCm - altCm;
+            const bool plausible = descendedCm < kProgressMaxFactor * commandedDescentCmS * windowS;
+            const bool madeProgress = plausible && descendedCm > 0.25f * commandedDescentCmS * windowS;
+            if (madeProgress) {
+                stallWindows = 0;
+            } else {
+                stallWindows++;
+            }
+            refUs = nowUs;
+            refAltCm = altCm;
+        }
+        armed = belowLandingAltitude && stallWindows >= kStallWindows;
+        autopilotSetLandingSettle(armed);
+
+        // Continuous time at landing altitude; climbing back out restarts it.
+        if (belowLandingAltitude) {
+            if (!lowSeen) { lowStartUs = nowUs; lowSeen = true; }
+        } else {
+            lowSeen = false;
+        }
+        const float expectedDescentS =
+            (100.0f * (float)autopilotConfig()->landingAltitudeM) / commandedDescentCmS;
+        const uint32_t commitUs = (uint32_t)MAX((float)kCommitMinUs,
+                                                kCommitFactor * expectedDescentS * 1e6f);
+        if (lowSeen && (nowUs - lowStartUs) >= commitUs) {
+            markComplete(nowUs);
+        }
+
+        // Quiet-velocity touchdown inference.
+        const bool descentStopped = vzCmS > -0.25f * commandedDescentCmS;
+        if (belowLandingAltitude && descentStopped
+            && fabsf(vzCmS) < (float)autopilotConfig()->landingVelocityThreshold) {
+            if (quietStartUs == 0) {
+                quietStartUs = nowUs;
+            } else if ((nowUs - quietStartUs)
+                       >= (uint32_t)autopilotConfig()->landingDetectionTime * 100000u) {
+                markComplete(nowUs);
+            }
+        } else {
+            quietStartUs = 0;
+        }
+    }
+
+    void markComplete(uint32_t nowUs) {
+        if (!complete) { complete = true; completeUs = nowUs; }
+    }
+};
+
+struct LandingResult {
+    float entryAltCm = 0.0f;        // true altitude when the baro error started
+    float peakAfterEntryCm = 0.0f;  // highest true altitude reached after that
+    float worstSinkCmS = 0.0f;      // most negative true velocity seen after entry
+    float worstReportedVzCmS = 0.0f;// most negative velocity the controller was handed
+    float worstReportedVzPreContactCmS = 0.0f; // ... before the craft first reached the ground
+    float peakThrottlePwm = 0.0f;
+    bool touched = false;
+    bool enteredGroundEffect = false;
+
+    // peakAfterEntryCm on its own cannot tell "thrown off the deck without ever touching it"
+    // (the reported failure, and the altitude loop's problem) from "landed, then lifted again
+    // by residual thrust" (the touchdown detector's problem). They have different causes and
+    // different owners, so they are measured separately.
+    float lowestAltCm = 1e9f;       // lowest true altitude reached at any point
+    float contactVzCmS = 0.0f;      // true sink rate at the lowest point
+    float liftoffFromAltCm = -1.0f; // running-minimum altitude the first >20 cm climb started from
+    bool launched = false;          // that climb happened at all
+
+    // "Touches down and STAYS down": the highest true altitude reached at any time after the
+    // craft first reaches the ground, and where it finished.
+    float postTouchdownPeakCm = 0.0f;
+    float finalAltCm = 0.0f;
+    float startAltCm = 0.0f;
+    // The reported failure, measured without a threshold: how far the craft rose above the
+    // lowest altitude it had reached, at any time BEFORE it first touched the ground. Zero for
+    // a monotone descent onto the deck; large only if the craft was thrown back off it.
+    float preContactReboundCm = 0.0f;
+    float preContactMinCm = 1e9f;
+    bool disarmed = false;          // the landing completed and the motors were cut
+    float disarmAltCm = -1.0f;      // true altitude at that moment - the landing's quality
+    float disarmTimeS = -1.0f;      // seconds from the start of the descent
+    // Does the landing sink bound in altitudeControl() actually bind? Computed from the same
+    // inputs the production code uses, on the same iteration, before altitudeControl() runs.
+    int boundFireCount = 0;         // iterations on which it clamped
+    int boundFirePreContact = 0;    // ... of those, before the craft first reached the ground
+    int iterationCount = 0;
+    float peakThrottlePreContactPwm = 0.0f;  // the number that decides whether it launches
+    float worstBoundedInputCmS = 0.0f;  // most negative reported vz it had to clamp
+    // The sink altitudeControl() ACTUALLY acts on, i.e. after the landing bound: this, not the
+    // estimator's raw output, is what D and dBoost see.
+    float worstEffectiveVzPreContactCmS = 0.0f;
+    float boundSetpointCmS = 0.0f;      // the bound in force
+};
+
+
+} // namespace
+
+class LandingGroundEffectTest : public ::testing::Test {
+protected:
+    static constexpr float kSimHoverPwm = 1300.0f;   // what the airframe actually needs
+    static constexpr float kMinPwm = 1100.0f;
+    static constexpr float kMaxPwm = 1900.0f;
+
+    void SetUp() override {
+        memset(&attitude, 0, sizeof(attitude));
+        memset(&gpsSol, 0, sizeof(gpsSol));
+        memset(rcCommand, 0, sizeof(rcCommand));
+        memset(debug, 0, sizeof(debug));
+        flightModeFlags = 0;
+        debugMode = 0;
+        simMicros = 1000000;
+        sBaroHeldCm = 0.0f;
+        sBaroLastSampleUs = 0;
+        simBaroSampleTimeUs = 0;
+        simBaroSampleIntervalUs = 0;
+
+        acc.dev.acc_1G = (uint16_t)ACC_1G;
+        acc.dev.acc_1G_rec = 1.0f / ACC_1G;
+        setAccelUpCmS2(0.0f);
+
+        // The reporter's own settings, from BTFL_cli_GRENGOBL_20260815_174855_SEQUREH7V2.txt.
+        autopilotConfig_t *cfg = autopilotConfigMutable();
+        cfg->hoverThrottle = 1250;          // configured slightly low, so iTerm trims up in hover
+        cfg->throttleMin = (uint16_t)kMinPwm;
+        cfg->throttleMax = (uint16_t)kMaxPwm;
+        cfg->altitudeP = 30;                // all stock
+        cfg->altitudeI = 30;
+        cfg->altitudeD = 30;
+        cfg->altitudeA = 30;                // added by #15584; stock means stock
+        cfg->altitudeF = 30;
+        cfg->landingAltitudeM = 4;          // ap_landing_altitude_m
+        cfg->landingDetectionTime = 10;     // ap_landing_detection_time
+        cfg->landingVelocityThreshold = 50; // ap_landing_velocity_threshold, for the quiet path
+        cfg->maxAngle = 50;
+        cfg->positionCutoff = 30;
+
+        rxConfigMutable()->mincheck = 1050;
+
+        // The shipped position defaults. Spelled out rather than taken from the PG reset
+        // template because the unit-test link does not run pgResetAll(); with a zeroed PG the
+        // estimator's barometer R would be inflated 100x and the filter would not be the one
+        // that flies.
+        positionConfig_t *posCfg = positionConfigMutable();
+        posCfg->altitude_source = ALTITUDE_SOURCE_DEFAULT;
+        posCfg->altitude_prefer_baro = 100;
+        posCfg->altitude_lpf = 300;
+        posCfg->altitude_d_lpf = 300;
+        posCfg->rangefinder_max_range_cm = 400;
+
+        armingFlags = ARMED;   // the configuration that actually flies
+        autopilotInit();
+        resetAltitudeControl();
+        positionInit();
+
+        // Establish the estimator's altitude frame on the ground, which is what arming does in
+        // flight. The estimator zeroes each source against its first sample (baroAltOffsetCm),
+        // so that sample has to be taken at zero height. Take it after the craft is already at
+        // hover height and the KF's origin sits at hover height instead: holding "300 cm" then
+        // flies the craft to 600 and every altitude in the test is offset by the launch height.
+        simBaroAltitudeCm = baroSampleAndHold(0.0f);
+        positionEstimatorResetZ();
+        calculateEstimatedAltitude();
+    }
+
+    // Present a measured vertical acceleration to the estimator via the accelerometer, in the
+    // units the driver would deliver: specific force, so 1 g while stationary or in steady hover.
+    static void setAccelUpCmS2(float accelUpCmS2) {
+        acc.accADC.x = 0.0f;
+        acc.accADC.y = 0.0f;
+        acc.accADC.z = (accelUpCmS2 / 980.665f + 1.0f) * ACC_1G;
+    }
+
+    static void advanceClock() { simMicros += (uint32_t)lrintf(DT_S * 1e6f); }
+
+    // ~36 Hz sensor read by a 100 Hz task: hold each physical sample until the next is due.
+    float sBaroHeldCm = 0.0f;
+    uint32_t sBaroLastSampleUs = 0;
+    float baroSampleAndHold(float readingCm) {
+        if (sBaroLastSampleUs == 0
+            || (uint32_t)(simMicros - sBaroLastSampleUs) >= BARO_SAMPLE_INTERVAL_US) {
+            sBaroLastSampleUs = simMicros;
+            sBaroHeldCm = readingCm;
+            simBaroSampleTimeUs = simMicros;
+            simBaroSampleIntervalUs = (timeDelta_t)BARO_SAMPLE_INTERVAL_US;
+        }
+        return sBaroHeldCm;
+    }
+
+    // One 100 Hz iteration of the whole chain: sensors -> estimator -> position.c -> altitudeControl
+    // -> physics. Returns the commanded throttle in PWM units.
+    float iterate(LandingSim &sim, const BaroGroundEffect &ge, float targetAltCm, float targetVelCmS,
+                  float velLimitCmS, bool motorsCut = false) {
+        simBaroAltitudeCm = baroSampleAndHold(ge.reportedAltCm(sim.altCm));
+
+        calculateEstimatedAltitude();                       // real position_estimator.c + position.c
+        altitudeControl(targetAltCm, DT_S, targetVelCmS, velLimitCmS);  // real altitudeControl()
+
+        // disarm(DISARM_REASON_LANDING): the landing is over and the motors stop.
+        // getAutopilotThrottle() normalises over [MAX(mincheck, PWM_RANGE_MIN), PWM_RANGE_MAX],
+        // not over [kMinPwm, kMaxPwm]; inverting with the wrong range shifts the result by tens of
+        // PWM at the floor, where the launch this rig measures begins.
+        const float lowPwm = MAX((float)rxConfig()->mincheck, (float)PWM_RANGE_MIN);
+        const float throttlePwm = motorsCut ? 0.0f
+                                            : lowPwm + getAutopilotThrottle() * ((float)PWM_RANGE_MAX - lowPwm);
+        const float measuredAccelUp = sim.step(throttlePwm, kSimHoverPwm, 1000.0f, DT_S);
+        setAccelUpCmS2(measuredAccelUp);                    // truthful accelerometer, next cycle
+
+        advanceClock();
+        return throttlePwm;
+    }
+
+    // Hover at the given altitude long enough for the Kalman filter to converge and for iTerm to
+    // trim out the gap between the configured and the real hover throttle. That trim is part of
+    // the reported scenario: it is carried into the landing.
+    void settleInHover(LandingSim &sim, const BaroGroundEffect &ge, float holdAltCm, int steps) {
+        for (int i = 0; i < steps; i++) {
+            iterate(sim, ge, holdAltCm, 0.0f, 100.0f);
+        }
+    }
+
+    // Descend from hover to the ground at descendRateCmS, following a carrot that marches down at
+    // the commanded rate and is not allowed to run more than one second of travel ahead of the
+    // craft - the same bounded-carrot behaviour positionNav gives a LAND leg. When `settle` is
+    // supplied, the production touchdown thrust ceiling is armed by the same rule flight_plan_nav
+    // uses.
+    LandingResult flyLanding(LandingSim &sim, const BaroGroundEffect &ge, float descendRateCmS,
+                             int maxSteps, LandingSettleMonitor *settle = nullptr,
+                             bool landingActive = true) {
+        LandingResult r;
+        float carrotCm = getAltitudeCmControl();
+        const float startAltCm = sim.altCm;
+        r.startAltCm = startAltCm;
+        bool descentBegun = false;
+
+        for (int i = 0; i < maxSteps; i++) {
+            // updateLanding() re-asserts this every iteration for the whole of a descent; passing
+            // false is what every non-landing caller of altitudeControl() gets.
+            autopilotSetLandingActive(landingActive);
+            if (settle != nullptr) {
+                settle->update(simMicros, descendRateCmS);
+            }
+            carrotCm -= descendRateCmS * DT_S;
+            carrotCm = MAX(carrotCm, getAltitudeCmControl() - descendRateCmS);
+
+            const float beforeAltCm = sim.altCm;
+            const float reportedVz = getAltitudeDerivativeControl();
+
+            // Would the production landing sink bound bind on this iteration? Same inputs, same
+            // arithmetic, evaluated before altitudeControl() consumes them.
+            r.iterationCount++;
+            float effectiveVz = reportedVz;
+            if (landingActive && isBelowLandingAltitude()) {
+                const float boundCmS = MAX(LANDING_SINK_FACTOR_MIRROR * descendRateCmS,
+                                           LANDING_SINK_FLOOR_MIRROR_CM_S);
+                r.boundSetpointCmS = boundCmS;
+                if (reportedVz < -boundCmS) {
+                    r.boundFireCount++;
+                    if (!r.touched) { r.boundFirePreContact++; }
+                    r.worstBoundedInputCmS = std::min(r.worstBoundedInputCmS, reportedVz);
+                }
+                effectiveVz = MAX(reportedVz, -boundCmS);
+            }
+            if (r.enteredGroundEffect && !r.touched) {
+                r.worstEffectiveVzPreContactCmS =
+                    std::min(r.worstEffectiveVzPreContactCmS, effectiveVz);
+            }
+
+            const bool motorsCut = (settle != nullptr) && settle->complete;
+            if (motorsCut && !r.disarmed) {
+                r.disarmed = true;
+                r.disarmAltCm = sim.altCm;
+                r.disarmTimeS = i * DT_S;
+            }
+            const float throttlePwm =
+                iterate(sim, ge, carrotCm, -descendRateCmS, descendRateCmS, motorsCut);
+
+            if (!r.enteredGroundEffect && beforeAltCm <= ge.onsetCm) {
+                r.enteredGroundEffect = true;
+                r.entryAltCm = beforeAltCm;
+                r.peakAfterEntryCm = beforeAltCm;
+            }
+            if (r.enteredGroundEffect) {
+                r.peakAfterEntryCm = std::max(r.peakAfterEntryCm, sim.altCm);
+                r.worstSinkCmS = std::min(r.worstSinkCmS, sim.vzCmS);
+                r.worstReportedVzCmS = std::min(r.worstReportedVzCmS, reportedVz);
+                if (!r.touched) {
+                    r.worstReportedVzPreContactCmS =
+                        std::min(r.worstReportedVzPreContactCmS, reportedVz);
+                }
+                r.peakThrottlePwm = std::max(r.peakThrottlePwm, throttlePwm);
+                if (!r.touched) {
+                    r.peakThrottlePreContactPwm = std::max(r.peakThrottlePreContactPwm, throttlePwm);
+                }
+            }
+            if (sim.altCm < r.lowestAltCm) {
+                r.lowestAltCm = sim.altCm;
+                r.contactVzCmS = std::min(sim.vzCmS, (sim.altCm - beforeAltCm) / DT_S);
+            }
+            // First climb of more than 20 cm off the running minimum, once the descent has
+            // actually started. The arming condition matters: a hover that has not finished
+            // converging drifts by more than 20 cm at the start of the run and would otherwise
+            // register as a launch from the entry altitude.
+            if (!descentBegun && sim.altCm < startAltCm - 20.0f) {
+                descentBegun = true;
+                r.lowestAltCm = sim.altCm;
+            }
+            if (descentBegun && !r.launched && sim.altCm > r.lowestAltCm + 20.0f) {
+                r.launched = true;
+                r.liftoffFromAltCm = r.lowestAltCm;
+            }
+            if (!r.touched && sim.altCm <= 0.0f && beforeAltCm > 0.0f) {
+                r.touched = true;
+            }
+            if (r.touched) {
+                r.postTouchdownPeakCm = std::max(r.postTouchdownPeakCm, sim.altCm);
+            } else if (descentBegun) {
+                r.preContactMinCm = std::min(r.preContactMinCm, sim.altCm);
+                r.preContactReboundCm = std::max(r.preContactReboundCm,
+                                                 sim.altCm - r.preContactMinCm);
+            }
+        }
+        r.finalAltCm = sim.altCm;
+        return r;
+    }
+
+};
+
+// The barometer error fitted to the logged event, as the parameters the reproduction uses.
+static const float LOGGED_BIAS_CM = 2200.0f;
+static const float LOGGED_ONSET_CM = 35.0f;
+static const float LOGGED_POWER = 3.0f;
+
+// ---------------------------------------------------------------------------------------------
+// 1. Control: an honest barometer must be completely unaffected.
+// ---------------------------------------------------------------------------------------------
+// The bound sits at twice the commanded descent rate with a 1 m/s floor, and a landing that is
+// tracking its profile never gets near it. Measured here the reported sink peaks at -121 cm/s
+// against a 100 cm/s bound only at the moment of contact, and every number below - peak throttle
+// 1307 PWM, lift-off from 10.22 cm, final 4.25 cm - is identical with the bound applied and with
+// it removed. (The rig floats at 30 cm/s even with a perfect sensor; that is the rig, not the fix.)
+TEST_F(LandingGroundEffectTest, GentleDescentWithAnHonestBaroLandsWithoutBouncing)
+{
+    const float descendRateCmS = 60.0f;
+
+    BaroGroundEffect ge;                   // biasCm defaults to zero: no artefact
+    ge.onsetCm = LOGGED_ONSET_CM;
+
+    LandingSim sim;
+    sim.altCm = 300.0f;
+    settleInHover(sim, ge, 300.0f, 600);   // 6 s, so the KF converges and iTerm trims up
+    // Holds the commanded 300 cm. Against the pre-#15584 estimator the rig floated down to
+    // ~220 cm over these 6 s; the Kalman filter tracks the hover well enough that it no longer
+    // does, so this asserts the target rather than the old float.
+    ASSERT_NEAR(sim.altCm, 300.0f, 60.0f) << "hover never settled; the landing proves nothing";
+
+    const LandingResult r = flyLanding(sim, ge, descendRateCmS, 1500);
+
+    ASSERT_TRUE(r.enteredGroundEffect) << "never got low enough to enter ground effect";
+    ASSERT_TRUE(r.touched) << "never reached the ground";
+
+    EXPECT_LE(r.peakAfterEntryCm, r.entryAltCm + 5.0f)
+        << "climbed from " << r.entryAltCm << " cm to " << r.peakAfterEntryCm << " cm on the deck";
+    EXPECT_GT(r.contactVzCmS, -3.0f * descendRateCmS)
+        << "touched down at " << r.contactVzCmS << " cm/s, asked for " << -descendRateCmS;
+    EXPECT_LT(sim.altCm, 5.0f) << "did not settle on the ground";
+}
+
+// ---------------------------------------------------------------------------------------------
+// 2. REPRODUCTION OF THE REPORTED BOUNCE, AND THE ACCEPTANCE TEST FOR THE FIX.
+// ---------------------------------------------------------------------------------------------
+// The reporter's event end to end: gentle descent, the logged barometer collapse winds in over
+// the last 35 cm, the estimator turns it into a phantom sink, altitudeControl feeds that into D
+// and the craft launches off the deck without ever touching it.
+//
+// Measured on this rig at biasCm 2200 / onsetCm 35 / power 3 and 60 cm/s commanded descent, with
+// the production thrust ceiling and touchdown/disarm rules in the loop and the barometer held at
+// its real ~36 Hz:
+//
+//                                 unfixed        with the landing sink bound
+//   peak commanded throttle       1592 PWM       1319 PWM
+//   ... before first contact      1557 PWM       1313 PWM
+//   thrown off the deck by         160 cm           0 cm  (it reached the ground first)
+//   peak height after touchdown    204 cm          65 cm
+//   landing completed at          19.0 s          12.6 s, both on the deck
+//
+// The estimator is untouched, so the phantom sink itself is unchanged and is not asserted on
+// here; test 6 measures what that leaves exposed.
+TEST_F(LandingGroundEffectTest, LoggedGroundEffectBaroCollapseMustNotLaunchTheCraft)
+{
+    const float descendRateCmS = 60.0f;
+
+    BaroGroundEffect ge;
+    ge.biasCm = LOGGED_BIAS_CM;
+    ge.onsetCm = LOGGED_ONSET_CM;
+    ge.power = LOGGED_POWER;
+
+    LandingSim sim;
+    sim.altCm = 300.0f;
+    settleInHover(sim, ge, 300.0f, 600);
+    // Holds the commanded 300 cm. Against the pre-#15584 estimator the rig floated down to
+    // ~220 cm over these 6 s; the Kalman filter tracks the hover well enough that it no longer
+    // does, so this asserts the target rather than the old float.
+    ASSERT_NEAR(sim.altCm, 300.0f, 60.0f) << "hover never settled; the landing proves nothing";
+
+    LandingSettleMonitor settle;
+    const LandingResult r = flyLanding(sim, ge, descendRateCmS, 3000, &settle);
+
+    ASSERT_TRUE(r.enteredGroundEffect) << "never got low enough to enter ground effect";
+
+    EXPECT_TRUE(r.touched) << "never reached the ground: it flew away instead of landing";
+    EXPECT_LT(r.lowestAltCm, 2.0f)
+        << "the closest the craft got to the ground was " << r.lowestAltCm << " cm";
+
+    // The reported failure in one number: how far the craft rose above the lowest point it had
+    // reached, at any time BEFORE it first touched the ground. This one fitted scenario no longer
+    // separates fixed from unfixed on #15584's estimator - it stays under this bar either way -
+    // so it is kept as a floor, and the sweep below carries the ablation. What is left here is
+    // the estimate itself: at the worst point the filter reports -430 cm of altitude, and the
+    // terms it drives are P (clamped by the nav-target rate limit), D (clamped by the sink
+    // bound), I, against A and F. Closing that needs an estimator-side fix - #15584's
+    // baroGroundEffectRScale(), which cannot fire here because this rig has no rangefinder - not
+    // a tighter bound.
+    EXPECT_LT(r.preContactReboundCm, 80.0f)
+        << "the craft was thrown " << r.preContactReboundCm
+        << " cm back up without ever touching down (peak throttle before contact "
+        << r.peakThrottlePreContactPwm << " PWM, peak reported sink "
+        << r.worstReportedVzCmS << " cm/s) - that is the bounce";
+
+    // A landing never needs thrust far above hover; the airframe here needs about 1300 PWM. This
+    // is an absolute sanity bound, not a discriminating one: with the sink bound removed this
+    // scenario measures 1409 PWM against 1411 with it. The sweep below is what separates the two.
+    EXPECT_LT(r.peakThrottlePwm, 1450.0f)
+        << "commanded " << r.peakThrottlePwm << " PWM during a 60 cm/s landing";
+    EXPECT_LT(sim.altCm, 5.0f) << "did not settle on the ground: finished at " << sim.altCm << " cm";
+}
+
+// ---------------------------------------------------------------------------------------------
+// 3. And it stays down, with the production touchdown thrust ceiling in the loop.
+// ---------------------------------------------------------------------------------------------
+// Once the craft is down, ending the landing is the touchdown detector's job. The residual
+// excursion here is that detector's latency - two 400 ms stall windows plus a 1 s ceiling bleed -
+// and it happens after the craft has already reached the ground.
+TEST_F(LandingGroundEffectTest, LandingCompletesWithTheProductionThrustCeiling)
+{
+    BaroGroundEffect ge;
+    ge.biasCm = LOGGED_BIAS_CM;
+    ge.onsetCm = LOGGED_ONSET_CM;
+    ge.power = LOGGED_POWER;
+
+    LandingSim sim;
+    sim.altCm = 300.0f;
+    settleInHover(sim, ge, 300.0f, 600);
+
+    LandingSettleMonitor settle;
+    const LandingResult r = flyLanding(sim, ge, 60.0f, 3000, &settle);
+
+    ASSERT_TRUE(r.touched) << "never reached the ground";
+    EXPECT_LT(sim.altCm, 5.0f)
+        << "did not settle on the ground: finished at " << sim.altCm
+        << " cm with the thrust ceiling " << (settle.armed ? "armed" : "released");
+    // The landing must actually end, and end on the deck rather than by dropping the craft from
+    // height when the commit backstop expires. Measured: complete at 12.6 s, 0.0 cm.
+    EXPECT_TRUE(r.disarmed) << "the landing never completed";
+    EXPECT_LT(r.disarmAltCm, 5.0f)
+        << "the landing completed with the craft still " << r.disarmAltCm
+        << " cm up, so the motors were cut on a craft that had not landed";
+    // 204 cm unfixed, 65 cm here. This excursion happens after the craft has already reached the
+    // ground and belongs to the touchdown detector's latency, not to the altitude loop.
+    EXPECT_LT(r.postTouchdownPeakCm, 100.0f)
+        << "lifted back off the deck to " << r.postTouchdownPeakCm
+        << " cm after touchdown (peak throttle " << r.peakThrottlePwm << " PWM)";
+}
+
+// ---------------------------------------------------------------------------------------------
+// 4. SCOPING. With no landing active the code is inert, and the original bug reappears intact.
+// ---------------------------------------------------------------------------------------------
+// autopilotSetLandingActive(true) is reached from exactly one function, updateLanding() in
+// flight_plan_nav.c, which runs only for a LAND leg or a rescue descent. Every other caller of
+// altitudeControl() - alt hold, GPS rescue climb/cruise, position hold - leaves the flag false.
+// This is that configuration, and it must still fail exactly as the unpatched firmware does:
+// if this test ever starts passing its EXPECTs, the bound has leaked outside a landing.
+TEST_F(LandingGroundEffectTest, TheBoundIsInertWhenNoLandingIsActive)
+{
+    BaroGroundEffect ge;
+    ge.biasCm = LOGGED_BIAS_CM;
+    ge.onsetCm = LOGGED_ONSET_CM;
+    ge.power = LOGGED_POWER;
+
+    LandingSim sim;
+    sim.altCm = 300.0f;
+    settleInHover(sim, ge, 300.0f, 600);
+
+    LandingSettleMonitor settle;
+    const LandingResult r = flyLanding(sim, ge, 60.0f, 3000, &settle, false /* no landing */);
+
+    // The unfixed behaviour. Against the pre-#15584 estimator this cell reached 1592 PWM; the
+    // Kalman filter attenuates the phantom sink (see test 7) so it now reaches 1404, but the
+    // excursion is still there and still unbounded, which is what this test is for.
+    EXPECT_GT(r.peakThrottlePwm, 1380.0f)
+        << "peak throttle was only " << r.peakThrottlePwm
+        << " PWM with no landing active: something is bounding the loop outside a landing";
+    EXPECT_GT(r.preContactReboundCm, 50.0f)
+        << "the craft was only thrown " << r.preContactReboundCm
+        << " cm off the deck with no landing active: the bound is not scoped to landings";
+}
+
+// ---------------------------------------------------------------------------------------------
+// 5. The bound is one-sided and memoryless: a genuine climb keeps full arrest authority.
+// ---------------------------------------------------------------------------------------------
+// This is where the rejected slew-rate limiter on the same signal failed. Being a lagged state it
+// still read -127 cm/s while the craft was genuinely climbing at +237, and kept commanding thrust
+// for over a second. A one-sided clamp cannot: upward velocity is passed through untouched, so
+// the peak height reached and the throttle cut are identical with the bound and without it.
+TEST_F(LandingGroundEffectTest, GenuineClimbDuringALandingIsNotBounded)
+{
+    const float climbRates[] = { 100.0f, 237.0f, 460.0f };
+    for (float climb : climbRates) {
+        float peak[2] = { 0.0f, 0.0f };
+        float minPwm[2] = { 0.0f, 0.0f };
+        for (int guard = 0; guard <= 1; guard++) {
+            SetUp();
+            BaroGroundEffect ge;               // honest barometer: the climb is real
+            LandingSim sim;
+            sim.altCm = 200.0f;
+            settleInHover(sim, ge, 200.0f, 600);
+            sim.vzCmS = climb;
+            float carrotCm = getAltitudeCmControl();
+            peak[guard] = sim.altCm;
+            minPwm[guard] = 9999.0f;
+            for (int i = 0; i < 400; i++) {
+                autopilotSetLandingActive(guard != 0);
+                carrotCm -= 60.0f * DT_S;
+                carrotCm = MAX(carrotCm, getAltitudeCmControl() - 60.0f);
+                const float pwm = iterate(sim, ge, carrotCm, -60.0f, 60.0f);
+                peak[guard] = std::max(peak[guard], sim.altCm);
+                minPwm[guard] = std::min(minPwm[guard], pwm);
+            }
+        }
+        EXPECT_FLOAT_EQ(peak[1], peak[0])
+            << "a genuine " << climb << " cm/s climb during a landing was arrested differently "
+            << "with the bound (" << peak[1] << " cm) than without it (" << peak[0] << " cm)";
+        EXPECT_FLOAT_EQ(minPwm[1], minPwm[0])
+            << "a genuine " << climb << " cm/s climb produced a different throttle cut";
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// 6. WHAT THE BOUND COSTS: a genuine fall inside a landing, and it is quantified, not zero.
+// ---------------------------------------------------------------------------------------------
+// A real thrust shortfall - the accelerometer corroborates it, so the estimate is right - during
+// the last 3 m of a landing. D acts in full on the first 120 cm/s of sink (2x the 60 cm/s
+// commanded) and is bounded beyond that, so the craft falls slightly faster before the loop
+// recovers it. Measured peak true sink, unbounded vs bounded:
+//
+//   15% shortfall   -152 -> -155 cm/s
+//   30% shortfall   -257 -> -283 cm/s
+//   45% shortfall   -357 -> -388 cm/s
+//
+// That is the honest price of the fix: about 10% more peak sink in a genuine below-4 m fall, in
+// exchange for the 1746 -> 1314 PWM in test 2. It lands in every case.
+TEST_F(LandingGroundEffectTest, GenuineFallDuringALandingCostsLittleArrestAuthority)
+{
+    const float sags[] = { 0.85f, 0.70f, 0.55f };
+    for (float sag : sags) {
+        float worst[2] = { 0.0f, 0.0f };
+        bool touched[2] = { false, false };
+        for (int guard = 0; guard <= 1; guard++) {
+            SetUp();
+            BaroGroundEffect ge;               // honest barometer: the fall is real
+            LandingSim sim;
+            sim.altCm = 300.0f;
+            settleInHover(sim, ge, 300.0f, 600);
+            float carrotCm = getAltitudeCmControl();
+            // 18 s at 60 cm/s. The hover now settles at ~300 cm rather than the ~220 cm the
+            // pre-#15584 estimator floated down to, and a 45% thrust shortfall costs further
+            // altitude that has to be re-flown, so 6 s no longer reaches the ground.
+            for (int i = 0; i < 1800 && !touched[guard]; i++) {
+                autopilotSetLandingActive(guard != 0);
+                sim.thrustScale = (i >= 20 && i < 120) ? sag : 1.0f;   // 1 s of shortfall
+                carrotCm -= 60.0f * DT_S;
+                carrotCm = MAX(carrotCm, getAltitudeCmControl() - 60.0f);
+                const float before = sim.altCm;
+                iterate(sim, ge, carrotCm, -60.0f, 60.0f);
+                worst[guard] = std::min(worst[guard], sim.vzCmS);
+                touched[guard] = touched[guard] || (sim.altCm <= 0.0f && before > 0.0f);
+            }
+        }
+        EXPECT_TRUE(touched[1]) << "a " << (1.0f - sag) * 100.0f << "% thrust shortfall stopped "
+                                << "the craft reaching the ground with the bound applied";
+        EXPECT_GT(worst[1], 1.25f * worst[0])
+            << "a genuine fall from a " << (1.0f - sag) * 100.0f << "% thrust shortfall reached "
+            << worst[1] << " cm/s with the bound against " << worst[0]
+            << " cm/s without it: the bound is costing too much arrest authority";
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// 7. WHAT REMAINS EXPOSED. The altitude estimate is still wrong, and this asserts that it is.
+// ---------------------------------------------------------------------------------------------
+// This fix is in the controller, not the filter, so everything else that consumes the estimate -
+// the reported/OSD altitude, the altitude P term, isBelowLandingAltitude(), the landing target
+// ratchet - still sees the collapse. It is bounded in practice: the altitude error term is
+// already clamped to one second of travel at the rate limit, which caps P's contribution at a
+// few PWM during a landing, and the phantom is transient. But it is real, and pretending
+// otherwise by deleting this test would hide the one thing an estimator-side fix would buy.
+TEST_F(LandingGroundEffectTest, TheAltitudeEstimateItselfRemainsCorrupted)
+{
+    BaroGroundEffect ge;
+    ge.biasCm = LOGGED_BIAS_CM;
+    ge.onsetCm = LOGGED_ONSET_CM;
+    ge.power = LOGGED_POWER;
+
+    LandingSim sim;
+    sim.altCm = 300.0f;
+    settleInHover(sim, ge, 300.0f, 600);
+
+    float worstEstimatorVz = 0.0f;
+    for (int i = 0; i < 600 && sim.altCm > 0.5f; i++) {
+        sim.altCm -= 60.0f * DT_S;
+        sim.vzCmS = -60.0f;
+        simBaroAltitudeCm = baroSampleAndHold(ge.reportedAltCm(sim.altCm));
+        setAccelUpCmS2(0.0f);                 // constant velocity: the accelerometer reads 1 g
+        calculateEstimatedAltitude();
+        worstEstimatorVz = std::min(worstEstimatorVz, positionEstimatorGetVerticalVelocity());
+        advanceClock();
+    }
+
+    // Unfixed by this commit: the filter still believes the collapse. #15584's Kalman estimator
+    // attenuates it from about -945 cm/s to about -342 cm/s - a real improvement, and the reason
+    // the threshold here is no longer the dBoost knee - but it does not remove it, and the
+    // no-rangefinder configuration this rig models is precisely the one where #15584's
+    // ground-effect R derate cannot fire (baroGroundEffectRScale() returns 1.0 without a
+    // rangefinder). The bound stops the altitude loop acting on it; nothing here stops the
+    // filter believing it.
+    EXPECT_LT(worstEstimatorVz, -0.5f * D_BOOST_THRESHOLD_CM_S)
+        << "the estimator reported only " << worstEstimatorVz
+        << " cm/s: if the filter is no longer fooled then something changed in the estimator, "
+        << "and this fix's whole claim to being scoped to the landing needs re-checking";
+}
+
+// ---------------------------------------------------------------------------------------------
+// 8. The artefact parameters are a least-squares fit to one logged event. Sweep around them.
+// ---------------------------------------------------------------------------------------------
+// A fix that only works at the fitted point is worthless. Each cell is compared against its own
+// honest-barometer control rather than an absolute number, because the rig has behaviours of its
+// own: at 30 cm/s the modelled ground effect alone floats the craft off from about 10 cm even
+// with a perfect sensor. Only the difference the artefact makes is attributable to the fix.
+TEST_F(LandingGroundEffectTest, GroundEffectArtefactSweep)
+{
+    const float biases[] = { 500.0f, 1100.0f, 2200.0f, 4400.0f };
+    const float onsets[] = { 20.0f, 35.0f, 60.0f };
+    const float rates[]  = { 30.0f, 60.0f, 120.0f };
+
+    for (float onset : onsets) {
+        for (float rate : rates) {
+            SetUp();
+            BaroGroundEffect clean;
+            clean.onsetCm = onset;
+            LandingSim controlSim;
+            controlSim.altCm = 300.0f;
+            settleInHover(controlSim, clean, 300.0f, 600);
+            LandingSettleMonitor controlSettle;
+            const LandingResult c = flyLanding(controlSim, clean, rate, 3000, &controlSettle);
+            const float controlReboundCm = c.preContactReboundCm;
+
+            for (float bias : biases) {
+                SetUp();
+                BaroGroundEffect ge;
+                ge.biasCm = bias;
+                ge.onsetCm = onset;
+                ge.power = LOGGED_POWER;
+
+                LandingSim sim;
+                sim.altCm = 300.0f;
+                settleInHover(sim, ge, 300.0f, 600);
+                LandingSettleMonitor settle;
+                const LandingResult r = flyLanding(sim, ge, rate, 3000, &settle);
+
+                const std::string at = "bias " + std::to_string((int)bias) + " onset "
+                                     + std::to_string((int)onset) + " rate " + std::to_string((int)rate)
+                                     + " (honest-baro control rebounded "
+                                     + std::to_string((int)controlReboundCm) + " cm)";
+
+                EXPECT_TRUE(r.touched) << at << ": never reached the ground";
+                EXPECT_LT(r.lowestAltCm, 3.0f) << at << ": closest approach " << r.lowestAltCm << " cm";
+                // Worst cell across this grid, measured ON vs OFF over the whole 36-cell sweep
+                // against #15584's estimator: 1564 PWM with the bound against 1816 (throttleMax)
+                // without it, and 11 of the 36 cells saturate at throttleMax unbounded. Peak
+                // rebound over the grid is 74 cm bounded against 201 cm unbounded. That ratio,
+                // not the absolute number, is what this test is asserting; the absolutes are
+                // re-baselined from measurement and carry ~5% margin.
+                EXPECT_LT(r.peakThrottlePreContactPwm, 1500.0f)
+                    << at << ": commanded " << r.peakThrottlePreContactPwm
+                    << " PWM before ever reaching the ground";
+                EXPECT_LT(r.peakThrottlePwm, 1650.0f)
+                    << at << ": commanded " << r.peakThrottlePwm << " PWM during a landing";
+                // Rebound is bounded, not eliminated, and this is the ablation that shows it.
+                // Worst residual over this grid is 122 cm, at onset 60 / rate 120; with the sink
+                // bound removed the same grid reaches 180 cm and saturates the throttle at
+                // kMaxPwm in seven cells, which the two assertions above catch. So the bound
+                // stops the launch without closing the residual: what is left needs an
+                // estimator-side fix, not a tighter clamp.
+                EXPECT_LT(r.preContactReboundCm, controlReboundCm + 140.0f)
+                    << at << ": thrown " << r.preContactReboundCm
+                    << " cm back up before ever touching down";
+            }
+        }
+    }
+}
+

--- a/src/test/unit/landing_ground_effect_unittest.cc
+++ b/src/test/unit/landing_ground_effect_unittest.cc
@@ -156,7 +156,7 @@ extern "C" {
 }
 
 static const float G_CM_S2 = 981.0f;
-static const float DT_S = HZ_TO_INTERVAL(TASK_ALTITUDE_RATE_HZ);
+static const float DT_S = HZ_TO_INTERVAL(TASK_POSITION_RATE_HZ);
 static const float ACC_1G = 2048.0f;
 
 // altitudeControl() starts amplifying D above this. Any phantom sink that reaches it is
@@ -453,7 +453,7 @@ protected:
         // flies the craft to 600 and every altitude in the test is offset by the launch height.
         simBaroAltitudeCm = baroSampleAndHold(0.0f);
         positionEstimatorResetZ();
-        calculateEstimatedAltitude();
+        positionUpdate();
     }
 
     // Present a measured vertical acceleration to the estimator via the accelerometer, in the
@@ -486,8 +486,11 @@ protected:
                   float velLimitCmS, bool motorsCut = false) {
         simBaroAltitudeCm = baroSampleAndHold(ge.reportedAltCm(sim.altCm));
 
-        calculateEstimatedAltitude();                       // real position_estimator.c + position.c
-        altitudeControl(targetAltCm, DT_S, targetVelCmS, velLimitCmS);  // real altitudeControl()
+        positionUpdate();                       // real position_estimator.c + position.c
+        // altitudeControl() takes microSECONDS since #15670 (timeUs_t): pass the 100 Hz
+        // task period, not DT_S seconds. DT_S (0.01) truncated to a timeUs_t is 0 us, which
+        // freezes the iTerm integration and the settle-ceiling ramp, so the hover sinks.
+        altitudeControl(targetAltCm, TASK_PERIOD_HZ(100), targetVelCmS, velLimitCmS);
 
         // disarm(DISARM_REASON_LANDING): the landing is over and the motors stop.
         // getAutopilotThrottle() normalises over [MAX(mincheck, PWM_RANGE_MIN), PWM_RANGE_MAX],
@@ -496,7 +499,7 @@ protected:
         const float lowPwm = MAX((float)rxConfig()->mincheck, (float)PWM_RANGE_MIN);
         const float throttlePwm = motorsCut ? 0.0f
                                             : lowPwm + getAutopilotThrottle() * ((float)PWM_RANGE_MAX - lowPwm);
-        const float measuredAccelUp = sim.step(throttlePwm, kSimHoverPwm, 1000.0f, DT_S);
+        const float measuredAccelUp = sim.step(throttlePwm, kSimHoverPwm, kMinPwm, DT_S);
         setAccelUpCmS2(measuredAccelUp);                    // truthful accelerometer, next cycle
 
         advanceClock();
@@ -628,9 +631,9 @@ static const float LOGGED_POWER = 3.0f;
 // 1. Control: an honest barometer must be completely unaffected.
 // ---------------------------------------------------------------------------------------------
 // The bound sits at twice the commanded descent rate with a 1 m/s floor, and a landing that is
-// tracking its profile never gets near it. Measured here the reported sink peaks at -121 cm/s
+// tracking its profile never gets near it. Measured here the reported sink peaks at -69 cm/s
 // against a 100 cm/s bound only at the moment of contact, and every number below - peak throttle
-// 1307 PWM, lift-off from 10.22 cm, final 4.25 cm - is identical with the bound applied and with
+// 1300 PWM, no liftoff, final 0.00 cm - is identical with the bound applied and with
 // it removed. (The rig floats at 30 cm/s even with a perfect sensor; that is the rig, not the fix.)
 TEST_F(LandingGroundEffectTest, GentleDescentWithAnHonestBaroLandsWithoutBouncing)
 {
@@ -642,8 +645,8 @@ TEST_F(LandingGroundEffectTest, GentleDescentWithAnHonestBaroLandsWithoutBouncin
     LandingSim sim;
     sim.altCm = 300.0f;
     settleInHover(sim, ge, 300.0f, 600);   // 6 s, so the KF converges and iTerm trims up
-    // Holds the commanded 300 cm. Against the pre-#15584 estimator the rig floated down to
-    // ~220 cm over these 6 s; the Kalman filter tracks the hover well enough that it no longer
+    // Holds the commanded 300 cm. An older estimator floated down over these 6 s instead of
+    // holding; the Kalman filter tracks the hover well enough that it no longer
     // does, so this asserts the target rather than the old float.
     ASSERT_NEAR(sim.altCm, 300.0f, 60.0f) << "hover never settled; the landing proves nothing";
 
@@ -671,11 +674,11 @@ TEST_F(LandingGroundEffectTest, GentleDescentWithAnHonestBaroLandsWithoutBouncin
 // its real ~36 Hz:
 //
 //                                 unfixed        with the landing sink bound
-//   peak commanded throttle       1592 PWM       1319 PWM
-//   ... before first contact      1557 PWM       1313 PWM
-//   thrown off the deck by         160 cm           0 cm  (it reached the ground first)
-//   peak height after touchdown    204 cm          65 cm
-//   landing completed at          19.0 s          12.6 s, both on the deck
+//   peak commanded throttle       1678 PWM       1391 PWM
+//   ... before first contact      1415 PWM       1346 PWM
+//   thrown off the deck by         51 cm           47 cm  (it reached the ground first)
+//   peak height after touchdown    139 cm          32 cm
+//   landing completed at          never           11.8 s, on the deck
 //
 // The estimator is untouched, so the phantom sink itself is unchanged and is not asserted on
 // here; test 6 measures what that leaves exposed.
@@ -691,8 +694,8 @@ TEST_F(LandingGroundEffectTest, LoggedGroundEffectBaroCollapseMustNotLaunchTheCr
     LandingSim sim;
     sim.altCm = 300.0f;
     settleInHover(sim, ge, 300.0f, 600);
-    // Holds the commanded 300 cm. Against the pre-#15584 estimator the rig floated down to
-    // ~220 cm over these 6 s; the Kalman filter tracks the hover well enough that it no longer
+    // Holds the commanded 300 cm. An older estimator floated down over these 6 s instead of
+    // holding; the Kalman filter tracks the hover well enough that it no longer
     // does, so this asserts the target rather than the old float.
     ASSERT_NEAR(sim.altCm, 300.0f, 60.0f) << "hover never settled; the landing proves nothing";
 
@@ -709,7 +712,7 @@ TEST_F(LandingGroundEffectTest, LoggedGroundEffectBaroCollapseMustNotLaunchTheCr
     // reached, at any time BEFORE it first touched the ground. This one fitted scenario no longer
     // separates fixed from unfixed on #15584's estimator - it stays under this bar either way -
     // so it is kept as a floor, and the sweep below carries the ablation. What is left here is
-    // the estimate itself: at the worst point the filter reports -430 cm of altitude, and the
+    // the estimate itself: at the worst point the filter reports -2625 cm of altitude, and the
     // terms it drives are P (clamped by the nav-target rate limit), D (clamped by the sink
     // bound), I, against A and F. Closing that needs an estimator-side fix - #15584's
     // baroGroundEffectRScale(), which cannot fire here because this rig has no rangefinder - not
@@ -722,7 +725,7 @@ TEST_F(LandingGroundEffectTest, LoggedGroundEffectBaroCollapseMustNotLaunchTheCr
 
     // A landing never needs thrust far above hover; the airframe here needs about 1300 PWM. This
     // is an absolute sanity bound, not a discriminating one: with the sink bound removed this
-    // scenario measures 1409 PWM against 1411 with it. The sweep below is what separates the two.
+    // scenario measures 1678 PWM against 1391 with it. The sweep below is what separates the two.
     EXPECT_LT(r.peakThrottlePwm, 1450.0f)
         << "commanded " << r.peakThrottlePwm << " PWM during a 60 cm/s landing";
     EXPECT_LT(sim.altCm, 5.0f) << "did not settle on the ground: finished at " << sim.altCm << " cm";
@@ -753,12 +756,12 @@ TEST_F(LandingGroundEffectTest, LandingCompletesWithTheProductionThrustCeiling)
         << "did not settle on the ground: finished at " << sim.altCm
         << " cm with the thrust ceiling " << (settle.armed ? "armed" : "released");
     // The landing must actually end, and end on the deck rather than by dropping the craft from
-    // height when the commit backstop expires. Measured: complete at 12.6 s, 0.0 cm.
+    // height when the commit backstop expires. Measured: complete at 11.8 s, 0.0 cm.
     EXPECT_TRUE(r.disarmed) << "the landing never completed";
     EXPECT_LT(r.disarmAltCm, 5.0f)
         << "the landing completed with the craft still " << r.disarmAltCm
         << " cm up, so the motors were cut on a craft that had not landed";
-    // 204 cm unfixed, 65 cm here. This excursion happens after the craft has already reached the
+    // 139 cm unfixed, 32 cm here. This excursion happens after the craft has already reached the
     // ground and belongs to the touchdown detector's latency, not to the altitude loop.
     EXPECT_LT(r.postTouchdownPeakCm, 100.0f)
         << "lifted back off the deck to " << r.postTouchdownPeakCm
@@ -784,12 +787,15 @@ TEST_F(LandingGroundEffectTest, TheBoundIsInertWhenNoLandingIsActive)
     sim.altCm = 300.0f;
     settleInHover(sim, ge, 300.0f, 600);
 
-    LandingSettleMonitor settle;
-    const LandingResult r = flyLanding(sim, ge, 60.0f, 3000, &settle, false /* no landing */);
+    // landingActive = false: production non-landing paths never run updateLanding(), so the
+    // settle monitor must not run either. A null monitor reproduces that: the bound stays off
+    // (landingActive gates it in flyLanding) and the ceiling never arms, so this cell shows the
+    // unpatched behaviour intact.
+    const LandingResult r = flyLanding(sim, ge, 60.0f, 3000, nullptr, false /* no landing */);
 
-    // The unfixed behaviour. Against the pre-#15584 estimator this cell reached 1592 PWM; the
-    // Kalman filter attenuates the phantom sink (see test 7) so it now reaches 1404, but the
-    // excursion is still there and still unbounded, which is what this test is for.
+    // The unfixed behaviour. The Kalman filter attenuates the phantom sink (see test 7) but
+    // this cell still reaches 1678 PWM here, and the excursion is still there and still
+    // unbounded, which is what this test is for.
     EXPECT_GT(r.peakThrottlePwm, 1380.0f)
         << "peak throttle was only " << r.peakThrottlePwm
         << " PWM with no landing active: something is bounding the loop outside a landing";
@@ -846,12 +852,13 @@ TEST_F(LandingGroundEffectTest, GenuineClimbDuringALandingIsNotBounded)
 // commanded) and is bounded beyond that, so the craft falls slightly faster before the loop
 // recovers it. Measured peak true sink, unbounded vs bounded:
 //
-//   15% shortfall   -152 -> -155 cm/s
-//   30% shortfall   -257 -> -283 cm/s
-//   45% shortfall   -357 -> -388 cm/s
+//   15% shortfall   -78 -> -78 cm/s
+//   30% shortfall   -116 -> -116 cm/s
+//   45% shortfall   -171 -> -202 cm/s
 //
-// That is the honest price of the fix: about 10% more peak sink in a genuine below-4 m fall, in
-// exchange for the 1746 -> 1314 PWM in test 2. It lands in every case.
+// That is the honest price of the fix: up to ~19% more peak sink in the deepest genuine
+// below-4 m fall tested, nothing measurable in the shallower two, in
+// exchange for the 1678 -> 1391 PWM in test 2. It lands in every case.
 TEST_F(LandingGroundEffectTest, GenuineFallDuringALandingCostsLittleArrestAuthority)
 {
     const float sags[] = { 0.85f, 0.70f, 0.55f };
@@ -865,9 +872,8 @@ TEST_F(LandingGroundEffectTest, GenuineFallDuringALandingCostsLittleArrestAuthor
             sim.altCm = 300.0f;
             settleInHover(sim, ge, 300.0f, 600);
             float carrotCm = getAltitudeCmControl();
-            // 18 s at 60 cm/s. The hover now settles at ~300 cm rather than the ~220 cm the
-            // pre-#15584 estimator floated down to, and a 45% thrust shortfall costs further
-            // altitude that has to be re-flown, so 6 s no longer reaches the ground.
+            // 18 s at 60 cm/s. The hover now settles at ~300 cm, and a 45% thrust shortfall costs
+            // further altitude that has to be re-flown, so 6 s no longer reaches the ground.
             for (int i = 0; i < 1800 && !touched[guard]; i++) {
                 autopilotSetLandingActive(guard != 0);
                 sim.thrustScale = (i >= 20 && i < 120) ? sag : 1.0f;   // 1 s of shortfall
@@ -914,13 +920,14 @@ TEST_F(LandingGroundEffectTest, TheAltitudeEstimateItselfRemainsCorrupted)
         sim.vzCmS = -60.0f;
         simBaroAltitudeCm = baroSampleAndHold(ge.reportedAltCm(sim.altCm));
         setAccelUpCmS2(0.0f);                 // constant velocity: the accelerometer reads 1 g
-        calculateEstimatedAltitude();
+        positionUpdate();
         worstEstimatorVz = std::min(worstEstimatorVz, positionEstimatorGetVerticalVelocity());
         advanceClock();
     }
 
-    // Unfixed by this commit: the filter still believes the collapse. #15584's Kalman estimator
-    // attenuates it from about -945 cm/s to about -342 cm/s - a real improvement, and the reason
+    // Unfixed by this commit: the filter still believes the collapse. Measured this session
+    // at about -383 cm/s against a genuine -60 cm/s descent - the Kalman estimator attenuates
+    // the collapse but does not remove it, and the
     // the threshold here is no longer the dBoost knee - but it does not remove it, and the
     // no-rangefinder configuration this rig models is precisely the one where #15584's
     // ground-effect R derate cannot fire (baroGroundEffectRScale() returns 1.0 without a
@@ -936,9 +943,16 @@ TEST_F(LandingGroundEffectTest, TheAltitudeEstimateItselfRemainsCorrupted)
 // 8. The artefact parameters are a least-squares fit to one logged event. Sweep around them.
 // ---------------------------------------------------------------------------------------------
 // A fix that only works at the fitted point is worthless. Each cell is compared against its own
-// honest-barometer control rather than an absolute number, because the rig has behaviours of its
-// own: at 30 cm/s the modelled ground effect alone floats the craft off from about 10 cm even
-// with a perfect sensor. Only the difference the artefact makes is attributable to the fix.
+// honest-barometer control rather than an absolute number, because only the difference the
+// artefact makes is attributable to the fix. The 30 cm/s cells used to need a special branch:
+// pre-rebase the rig's ported touchdown monitor completed those landings mid-air (motors cut
+// high, both peak throttles 0.0 PWM). Post-rebase that artefact is gone, measured this session:
+// all twelve rate-30 cells descend under thrust (smallest pre-contact peak 1293 PWM) and every
+// completed landing disarms on the deck (disarmAltCm 0.00 cm; the bias-500 and bias-2200 cells
+// at onset 60 / rate 30 are still on the ground un-disarmed when the 30 s window ends, at
+// 14.79 / 0.00 cm final). No cell cuts high, so all 36 cells assert the same guarded throttle
+// bounds below. The 0.0-guards stay on every cell: if the mid-air cut ever returns, they are
+// what catches it.
 TEST_F(LandingGroundEffectTest, GroundEffectArtefactSweep)
 {
     const float biases[] = { 500.0f, 1100.0f, 2200.0f, 4400.0f };
@@ -977,21 +991,33 @@ TEST_F(LandingGroundEffectTest, GroundEffectArtefactSweep)
 
                 EXPECT_TRUE(r.touched) << at << ": never reached the ground";
                 EXPECT_LT(r.lowestAltCm, 3.0f) << at << ": closest approach " << r.lowestAltCm << " cm";
+                // Guard: a 0.0 peak means no thrust was ever commanded, and the
+                // bounds below would pass vacuously. Fail first, loudly.
+                EXPECT_GT(r.peakThrottlePreContactPwm, 0.0f)
+                    << at << ": no pre-contact thrust recorded: the bounds below "
+                    << "would pass without exercising anything";
+                EXPECT_GT(r.peakThrottlePwm, 0.0f)
+                    << at << ": no thrust recorded at all: the bound below "
+                    << "would pass without exercising anything";
                 // Worst cell across this grid, measured ON vs OFF over the whole 36-cell sweep
-                // against #15584's estimator: 1564 PWM with the bound against 1816 (throttleMax)
-                // without it, and 11 of the 36 cells saturate at throttleMax unbounded. Peak
-                // rebound over the grid is 74 cm bounded against 201 cm unbounded. That ratio,
+                // on the rebased code: 1460 PWM pre-contact (bias 4400 / onset 20 / rate 120)
+                // and 1553 peak (bias 2200 / onset 60 / rate 120) with the bound, against
+                // 1900/1900 without it (bias 4400 cells, where the ablation saturates at
+                // throttleMax 1900 in nine cells). Peak
+                // rebound over the grid is 103 cm bounded (bias 4400 / onset 60 / rate 120)
+                // against 237 cm unbounded (bias 4400 / onset 60 / rate 30). That ratio,
                 // not the absolute number, is what this test is asserting; the absolutes are
                 // re-baselined from measurement and carry ~5% margin.
-                EXPECT_LT(r.peakThrottlePreContactPwm, 1500.0f)
+                EXPECT_LT(r.peakThrottlePreContactPwm, 1540.0f)
                     << at << ": commanded " << r.peakThrottlePreContactPwm
                     << " PWM before ever reaching the ground";
-                EXPECT_LT(r.peakThrottlePwm, 1650.0f)
+                EXPECT_LT(r.peakThrottlePwm, 1640.0f)
                     << at << ": commanded " << r.peakThrottlePwm << " PWM during a landing";
                 // Rebound is bounded, not eliminated, and this is the ablation that shows it.
-                // Worst residual over this grid is 122 cm, at onset 60 / rate 120; with the sink
-                // bound removed the same grid reaches 180 cm and saturates the throttle at
-                // kMaxPwm in seven cells, which the two assertions above catch. So the bound
+                // Worst residual over this grid is 103 cm, at bias 4400 / onset 60 / rate 120;
+                // with the sink bound removed the same grid reaches 237 cm (bias 4400 /
+                // onset 60 / rate 30) and saturates the throttle at kMaxPwm in nine cells,
+                // which the two assertions above catch. So the bound
                 // stops the launch without closing the residual: what is left needs an
                 // estimator-side fix, not a tighter clamp.
                 EXPECT_LT(r.preContactReboundCm, controlReboundCm + 140.0f)
@@ -1001,4 +1027,3 @@ TEST_F(LandingGroundEffectTest, GroundEffectArtefactSweep)
         }
     }
 }
-

--- a/src/test/unit/position_nav_unittest.cc
+++ b/src/test/unit/position_nav_unittest.cc
@@ -37,6 +37,8 @@ extern "C" {
 }
 
 #include "unittest_macros.h"
+#include <cmath>
+
 #include "gtest/gtest.h"
 
 static positionEstimate3d_t makeEstimate(float eastCm, float northCm, float velEastCmS, float velNorthCmS, float upCm = 0.0f, float velUpCmS = 0.0f)
@@ -71,6 +73,125 @@ protected:
         lastCallbackUserData = NULL;
     }
 };
+
+// --- Axis decoupling edge cases ---
+//
+// Horizontal and vertical have independent speed budgets. Sharing one 3D direction vector meant
+// whichever axis had the larger error took nearly all of the budget and the other collapsed:
+// a landing target far below stalled horizontal position hold, and once that target was made
+// shallow, any horizontal error stalled the descent instead. These pin both directions.
+
+TEST_F(PositionNavTest, VerticalRateSurvivesLargeHorizontalError)
+{
+    // landing case: 5 m below, but still 20 m out horizontally
+    const vector3_t target = {{ 20.0f, 0.0f, -5.0f }};
+    positionNavSetTargetEf(&target, 0.8f, 1.0f, 0.1f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);   // full second so the accel slew is not the limit
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(vel.z, -80.0f, 5.0f) << "descent must hold the commanded rate, not a 3D fraction";
+    EXPECT_NEAR(vel.x, 80.0f, 5.0f) << "horizontal must still close at cruise";
+}
+
+TEST_F(PositionNavTest, HorizontalRateSurvivesLargeVerticalError)
+{
+    // the original defect: target parked far below collapsed horizontal correction
+    const vector3_t target = {{ 2.0f, 0.0f, -200.0f }};
+    positionNavSetTargetEf(&target, 1.2f, 1.0f, 0.1f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_GT(vel.x, 100.0f) << "2m of horizontal error must still command real correction";
+    EXPECT_NEAR(vel.z, -120.0f, 5.0f);
+}
+
+TEST_F(PositionNavTest, DirectlyBelowGivesPureVerticalNoNaN)
+{
+    const vector3_t target = {{ 0.0f, 0.0f, -5.0f }};
+    positionNavSetTargetEf(&target, 0.8f, 1.0f, 0.1f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_FALSE(std::isnan(vel.x));
+    EXPECT_FALSE(std::isnan(vel.y));
+    EXPECT_FALSE(std::isnan(vel.z));
+    EXPECT_NEAR(vel.x, 0.0f, 0.01f);
+    EXPECT_NEAR(vel.y, 0.0f, 0.01f);
+    EXPECT_LT(vel.z, -10.0f);
+}
+
+TEST_F(PositionNavTest, LevelTargetGivesNoVerticalComponent)
+{
+    const vector3_t target = {{ 10.0f, 0.0f, 0.0f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.5f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(vel.z, 0.0f, 0.01f);
+    EXPECT_GT(vel.x, 0.0f);
+}
+
+TEST_F(PositionNavTest, VerticalSuppressedWhenIncludeAltitudeFalse)
+{
+    const vector3_t target = {{ 10.0f, 0.0f, -50.0f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.5f, false, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(vel.z, 0.0f, 0.01f) << "altitude must be ignored entirely";
+    EXPECT_GT(vel.x, 0.0f);
+}
+
+TEST_F(PositionNavTest, ClimbSignIsPositive)
+{
+    const vector3_t target = {{ 0.0f, 0.0f, 20.0f }};
+    positionNavSetTargetEf(&target, 1.0f, 1.0f, 0.1f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+    EXPECT_NEAR(positionNavGetTargetVelocityCmS().z, 100.0f, 5.0f);
+}
+
+TEST_F(PositionNavTest, NeitherAxisExceedsCruiseSpeed)
+{
+    // decoupling gives each axis its own budget, so the 3D magnitude may exceed cruise;
+    // what must hold is that no single axis does.
+    const vector3_t target = {{ 60.0f, 60.0f, 60.0f }};
+    positionNavSetTargetEf(&target, 3.0f, 1.0f, 0.5f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    for (int i = 0; i < 200; i++) { positionNavUpdate(0.05f, &est); }  // past the accel slew
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    const float horiz = sqrtf(vel.x * vel.x + vel.y * vel.y);
+    EXPECT_LE(horiz, 300.0f + 1.0f) << "horizontal budget is cruise";
+    EXPECT_LE(fabsf(vel.z), 300.0f + 1.0f) << "vertical budget is cruise";
+}
+
+TEST_F(PositionNavTest, VerticalBrakesNearTargetIndependentlyOfHorizontal)
+{
+    // 0.2 m below but 50 m out: vertical must taper even though horizontal is wide open
+    const vector3_t target = {{ 50.0f, 0.0f, -0.2f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.5f, true, NULL, NULL);
+    positionNavSetAccelLimits(2.5f, 2.5f);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_LT(fabsf(vel.z), 120.0f) << "vertical must brake on its own small error";
+    EXPECT_GT(vel.x, 200.0f) << "horizontal must not be slowed by the vertical braking";
+}
 
 // --- Direction correctness ---
 
@@ -188,6 +309,140 @@ TEST_F(PositionNavTest, BrakingLimitsSpeedNearTarget)
     // Kp speed = 1.0 * 1.0 = 1.0 m/s = 100 cm/s
     // min(10, 1.0, 2.0) = 1.0 → 100 cm/s
     EXPECT_NEAR(speedCmS, 100.0f, 5.0f);
+}
+
+// A new command must not inherit the previous command's braking limit. Landing never set its
+// own, so its horizontal braking silently depended on which leg preceded it: an approach leg
+// left 0.3 m/s^2, a gated carrot or hold pattern left none at all.
+TEST_F(PositionNavTest, SetTargetClearsPreviousAccelLimits)
+{
+    const vector3_t farTarget = {{ 100.0f, 0.0f, 0.0f }};
+    positionNavSetTargetEf(&farTarget, 10.0f, 0.5f, 0.3f, false, NULL, NULL);
+    positionNavSetAccelLimits(0.0f, 2.0f);
+
+    // New command, no accel limits stated: the 2.0 m/s^2 brake must not carry over.
+    const vector3_t target = {{ 1.0f, 0.0f, 0.0f }};
+    positionNavSetTargetEf(&target, 10.0f, 0.5f, 0.3f, false, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(0.01f, &est);
+
+    const positionNavCommand_t *cmd = positionNavGetActiveCommand();
+    EXPECT_FLOAT_EQ(cmd->maxDecelMps2, 0.0f);
+    EXPECT_FLOAT_EQ(cmd->maxAccelMps2, 0.0f);
+
+    // Without a brake the speed is the pure Kp term: 1.0 * 1.0 m = 100 cm/s.
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(sqrtf(vel.x * vel.x + vel.y * vel.y), 100.0f, 5.0f);
+}
+
+// Horizontal and vertical hold independent speed budgets, so they must also hold independent
+// speed limits. A landing passes a descent rate; without this the same number would cap the
+// horizontal approach speed, letting gps_rescue_descend_rate govern horizontal motion.
+TEST_F(PositionNavTest, VerticalSpeedLimitIsIndependentOfCruiseSpeed)
+{
+    // 20 m east, 20 m below: both axes far enough that only the speed caps bind.
+    const vector3_t target = {{ 20.0f, 0.0f, -20.0f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.3f, true, NULL, NULL);
+    positionNavSetVerticalSpeedLimit(1.0f);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(0.01f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(sqrtf(vel.x * vel.x + vel.y * vel.y), 500.0f, 5.0f);  // horizontal on cruise
+    EXPECT_NEAR(vel.z, -100.0f, 5.0f);                                // vertical on its own cap
+}
+
+TEST_F(PositionNavTest, VerticalSpeedLimitZeroSharesCruiseSpeed)
+{
+    const vector3_t target = {{ 20.0f, 0.0f, -20.0f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.3f, true, NULL, NULL);
+    // no vertical limit stated
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(0.01f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(vel.z, -500.0f, 5.0f);
+}
+
+TEST_F(PositionNavTest, SetTargetClearsPreviousVerticalSpeedLimit)
+{
+    const vector3_t target = {{ 20.0f, 0.0f, -20.0f }};
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.3f, true, NULL, NULL);
+    positionNavSetVerticalSpeedLimit(1.0f);
+    positionNavSetTargetEf(&target, 5.0f, 1.0f, 0.3f, true, NULL, NULL);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(0.01f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(vel.z, -500.0f, 5.0f);  // back to the shared cruise limit
+}
+
+// The ratio of commanded horizontal velocity to horizontal error, alpha = v_target / h, is not
+// a trajectory detail: autopilot_multirotor.c builds pidF as targetVelocity * Kd, so the closed
+// horizontal law is tilt = (Kp + Kd*alpha)*h - Kd*v. alpha therefore sets the effective position
+// gain while the damping term Kd stays fixed, and at stock gains (Kp 0.045, Kd 0.090) alpha has
+// more authority over the loop gain than Kp does.
+//
+// This pins alpha for the landing geometry, where the target is held a fixed
+// FP_LANDING_TARGET_DEPTH_M (5 m) below the craft and the horizontal error is inside the LAND
+// arrival gate (waypointHoldRadius, 2 m default). Before horizontal and vertical were given
+// independent budgets the shared 3D direction vector made alpha about 0.3 /s here; it is now
+// bounded by the braking term. If a change to the speed schedule moves these numbers, it has
+// changed the horizontal loop gain and needs to be justified as such, not just as a speed tweak.
+TEST_F(PositionNavTest, LandingHorizontalVelocityToErrorRatioIsBounded)
+{
+    struct { float h; float expectedAlpha; } cases[] = {
+        { 0.5f, 1.000f },   // Kp term binds: sqrt(2*0.3*0.5)=0.55 > 1.0*0.5
+        { 1.0f, 0.775f },   // braking binds: sqrt(0.6)/1.0
+        { 2.0f, 0.548f },   // braking binds: sqrt(1.2)/2.0
+    };
+
+    for (const auto &c : cases) {
+        // Landing geometry: target c.h east and 5 m below, descent rate on the vertical axis.
+        const vector3_t target = {{ c.h, 0.0f, -5.0f }};
+        positionNavSetTargetEf(&target, 1.5f, 1.0f, 0.1f, true, NULL, NULL);
+        positionNavSetVerticalSpeedLimit(1.5f);
+        positionNavSetAccelLimits(0.0f, 0.3f);
+
+        positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+        positionNavUpdate(0.01f, &est);
+
+        const vector3_t vel = positionNavGetTargetVelocityCmS();
+        const float alpha = (sqrtf(vel.x * vel.x + vel.y * vel.y) * 0.01f) / c.h;
+        EXPECT_NEAR(alpha, c.expectedAlpha, 0.02f)
+            << "alpha changed at h=" << c.h << " m: this is a horizontal loop-gain change";
+    }
+}
+
+// The vertical axis of a landing is deliberately NOT tapered by the horizontal error. The target
+// is ratcheted to stay a fixed depth below the craft, so the descent runs at the commanded rate
+// whatever the horizontal miss. Pinned because the pre-decoupling code did the opposite: it
+// slowed the descent when horizontally far, which read as a glide path.
+TEST_F(PositionNavTest, LandingDescentRateIsIndependentOfHorizontalError)
+{
+    float firstVz = 0.0f;
+    for (float h : { 0.0f, 1.0f, 2.0f, 10.0f }) {
+        const vector3_t target = {{ h, 0.0f, -5.0f }};
+        positionNavSetTargetEf(&target, 1.5f, 1.0f, 0.1f, true, NULL, NULL);
+        positionNavSetVerticalSpeedLimit(1.2f);
+        positionNavSetAccelLimits(0.0f, 0.3f);
+
+        positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+        positionNavUpdate(0.01f, &est);
+
+        const float vz = positionNavGetTargetVelocityCmS().z;
+        if (h == 0.0f) {
+            firstVz = vz;
+            EXPECT_LT(vz, 0.0f) << "must command a descent";
+        } else {
+            EXPECT_NEAR(vz, firstVz, 1.0f)
+                << "descent rate moved with horizontal error at h=" << h;
+        }
+    }
 }
 
 TEST_F(PositionNavTest, BrakingDominatesWhenVeryClose)

--- a/src/test/unit/position_nav_unittest.cc
+++ b/src/test/unit/position_nav_unittest.cc
@@ -462,6 +462,98 @@ TEST_F(PositionNavTest, BrakingDominatesWhenVeryClose)
     EXPECT_NEAR(speedCmS, 10.0f, 2.0f);
 }
 
+// --- Settled-hold and pass-gate leg geometries ---
+//
+// blckmn's review question on the axis decoupling: the shared 3D direction vector was also the
+// old behaviour on the settled-hold leg (station-keeping arrival braking) and the pass-gate
+// leg (no braking, marched carrot), so either could change. Both legs keep the altitude gate
+// off — settled-hold keeps station (LAND-style) or drops it entirely (en-route), the carrot
+// never sets a vertical limit — so the horizontal and vertical errors are small and bounded
+// together, and the budget math below shows the old shared vector agreed with the new split
+// budgets there to first order. These pin the new budgets directly in those geometries, with
+// the simulation loop style of althold_unittest.cc: advance a fake estimate toward the
+// commanded velocity and watch the published rate converge. Numbers below are measured from
+// the built binary (PASS lines), not hand-derived.
+
+// Settled-hold geometry: 1.5 m out horizontally and 0.5 m off in height, arrival braking on,
+// the full commanded pair a station-keeping leg states (landing states 1.5 m/s + 0.3 m/s^2;
+// this uses the same numbers with the acceptance radius (0.5 m) inside the 1.5 m error,
+// as a HOLD leg's 2 m radius sits inside a far-approach error).
+TEST_F(PositionNavTest, SettledHoldLegCommandsBothAxesAtBrakingSchedule)
+{
+    const vector3_t target = {{ 1.5f, 0.0f, -0.5f }};
+    positionNavSetTargetEf(&target, 1.5f, 0.5f, 1000.0f, true, NULL, NULL);
+    positionNavSetAccelLimits(0.0f, 0.3f);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(0.01f, &est);
+
+    // Horizontal: min(1.5 cruise, 1.0*1.5 Kp, sqrt(2*0.3*1.5)=0.949 braking).
+    // Vertical:   min(1.5 shared cruise, 1.0*0.5=0.5 Kp, sqrt(2*0.3*0.5)=0.548 braking):
+    // the Kp term binds, measured -50.0 cm/s on the built binary.
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(sqrtf(vel.x * vel.x + vel.y * vel.y), 94.9f, 3.0f);
+    EXPECT_NEAR(vel.z, -50.0f, 3.0f);
+}
+
+// The old shared-3D-vector code would have commanded a single budget split along the 3D
+// direction; on this geometry it agrees with the split budgets (horizontal within ~1 cm/s).
+// A future change that moves the settled-hold horizontal rate off the braking schedule must
+// be justified as a loop-gain change, same as the landing alpha pin above.
+TEST_F(PositionNavTest, SettledHoldLegHorizontalRateMatchesOldSharedVector)
+{
+    const vector3_t target = {{ 1.5f, 0.0f, -0.5f }};
+    positionNavSetTargetEf(&target, 1.5f, 0.5f, 1000.0f, true, NULL, NULL);
+    positionNavSetAccelLimits(0.0f, 0.3f);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(0.01f, &est);
+
+    // Old law: distance = sqrt(1.5^2+0.5^2) = 1.581 m; speed = min(1.5, 1.581, sqrt(0.6*1.581))
+    // = 0.974 m/s along (1.5, 0, -0.5)/1.581, i.e. horizontal 92.4 cm/s.
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(sqrtf(vel.x * vel.x + vel.y * vel.y), 92.4f, 5.0f)
+        << "settled-hold horizontal rate moved off the old shared-vector value";
+}
+
+// Pass-gate geometry: the executor marches the carrot a bounded lead ahead of the craft and
+// states no braking, so each axis runs its own Kp term. A 6 m lead at 5 m/s cruise sits
+// beyond the 5 m Kp knee: horizontal saturates at cruise while the small vertical offset
+// tapers on its own error. Pinned because the old code coupled them: the same geometry
+// yielded ~4.99 m/s horizontal and a ~41 cm/s climb, i.e. the vertical carrot lagged the
+// waypoint altitude and alt hold chased a shallower climb.
+TEST_F(PositionNavTest, PassGateLegHorizontalCruiseDoesNotStarveVertical)
+{
+    const vector3_t target = {{ 6.0f, 0.0f, 0.5f }};
+    positionNavSetTargetEf(&target, 5.0f, -1.0f, 1000.0f, true, NULL, NULL);
+    positionNavSetAccelLimits(0.0f, 0.0f);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);   // full second so the accel slew is not the limit
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(sqrtf(vel.x * vel.x + vel.y * vel.y), 500.0f, 5.0f);
+    EXPECT_NEAR(vel.z, 50.0f, 3.0f) << "vertical tapers on its own 0.5 m error, not the 6 m lead";
+}
+
+// Pass-gate approach at the cruise knee: a 3 m lead at 3 m/s cruise. Both axes inside their
+// Kp knees, so each commands Kp * its own error — horizontal 300 cm/s, vertical 50 cm/s for
+// a 0.5 m altitude offset. The old shared vector gave ~295 cm/s horizontal and ~49 cm/s
+// vertical here: same first-order behaviour, now exact per axis.
+TEST_F(PositionNavTest, PassGateLegTracksBothAxesOnOwnErrors)
+{
+    const vector3_t target = {{ 3.0f, 0.0f, 0.5f }};
+    positionNavSetTargetEf(&target, 3.0f, -1.0f, 1000.0f, true, NULL, NULL);
+    positionNavSetAccelLimits(0.0f, 0.0f);
+
+    positionEstimate3d_t est = makeEstimate(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    positionNavUpdate(1.0f, &est);
+
+    const vector3_t vel = positionNavGetTargetVelocityCmS();
+    EXPECT_NEAR(sqrtf(vel.x * vel.x + vel.y * vel.y), 300.0f, 5.0f);
+    EXPECT_NEAR(vel.z, 50.0f, 3.0f);
+}
+
 // --- Arrival detection ---
 
 TEST_F(PositionNavTest, ArrivalDetectedWhenWithinRadiusAndSlow)


### PR DESCRIPTION
claude: Claude wrote this branch, this description, and the split from #15563.

> [!IMPORTANT]
> **Stacked on #15563**, which is the bottom three commits of this branch and will disappear
> from the diff when it merges. This PR is the top commit:
> `git diff dgalants/fix-autopilot-landing-freefall...dgalants/fix-autopilot-altitude-landing`
>
> Build with **Flight Plan**, **GPS** and **Altitude Hold**.

#15563 fixes how a landing is commanded. This covers what happens once the craft reaches the
ground, and bounds the two inputs the altitude loop cannot currently trust.

Two of the three parts rest on one blackbox plus simulation, and @ctzsnooze has said the updated
Kalman may already cover the ground-effect case. Worth a log before this merges — see
"Not established" at the bottom for exactly what is and is not shown.

## Ground contact does not end the descent

Nothing reduces thrust after touchdown, so the altitude loop keeps commanding a descent the
ground is preventing and holds thrust just under hover — close enough for ground effect to lift
the craft again.

The only touchdown test is a quiet-velocity timer, and it resets on any transient:

```c
} else {
    fp.touchdownQuietStartUs = 0;
}
```

A craft skittering on its feet moves fast in *both* directions, so the timer never confirms.
Instantaneous vertical velocity cannot separate a bouncing craft from a flying one.

Contact is now inferred three ways, all gated on being below the landing altitude, and once
inferred a throttle ceiling bleeds from hover to `throttleMin`:

- **Impact** — jerk and acceleration amplitude together, as a burst. The accelerometer is
  low-passed at `acc_lpf_hz` (25 Hz default) before this sees it, which attenuates the derivative
  of a step far more than its amplitude: across six logged contacts jerk correlates with peak
  acceleration at r=0.29, and the two hardest (5.6 g, 4.9 g) produced less jerk than a 4.5 g one.
  Amplitude separates true from false by 3.6x where jerk manages 1.7x. Jerk stays, low enough
  never to be the limiting term, so a slow g-loading event cannot trigger on amplitude alone.
- **Stalled descent** — net progress over consecutive 400 ms windows, with a ceiling on what one
  window may count so the estimator plunge downwash produces cannot pass as progress.
- **Commit timeout** — scaled by the commanded rate, for a touchdown too soft to spike.

## Ground effect corrupts the sink D acts on

Reported as: a gentle landing bounced once, gained momentum, hit the ground. The blackbox says
the craft never touched the ground before it jumped.

```
t=95.15  baroAlt  -80cm   accZ 1.12g   motors 560    <- descending normally
t=95.45  baroAlt -563cm   accZ 2.98g   motors 1034   <- thrust surge, +3g UPWARD
t=95.90  baroAlt  +62cm   accZ 0.24g   motors 285    <- 0.24g, level: falling
t=96.84  baroAlt -300cm   accZ 4.86g   gyro 1255dps  <- the real ground contact
```

Peak gyro over the first event is **36 dps**, against 18 dps of quiet-descent noise and 1255 dps
at the real impact. The barometer collapsed ~20 m in 200 ms, which needs ~47 g; the accelerometer
read 1 g throughout. `dBoost` amplified D, throttle saturated, the craft launched.

The sink D may act on during a landing is now bounded. One-sided, so a genuine climb keeps full
arrest authority; memoryless, so it releases the iteration the estimate recovers instead of
lagging it the way a slew limit would. It does not repair the estimate — nothing outside the
estimator can tell a real sink from a phantom one, so reported altitude and the P term stay
corrupted.

This replaces an earlier attempt in `feedBaroMeasurements()`; #15584 changed the estimator
underneath it, and the loop-side bound is the smaller change.

## Bounding the position error in `altitudeControl()`

P and I come from the raw position error, so any caller setting a target beyond the rate limit
saturates the output on P alone. #15563 bounds the nav target before it arrives, but every other
caller sets its own and none is bounded — so the rule goes where the error is formed:
`velMax × 1 s`, a distance, the same bound alt hold applies to pilot targets at
`alt_hold_multirotor.c:148-154` (current master).

That bound is active throughout any rate-limited move, so it cannot indicate integral windup.
Anti-windup keys on the throttle demand exceeding the output range instead.

## Testing

Each test was checked to fail with the corresponding source reverted to #15563.

- `flight_plan_nav`, 16 cases: a bounce triggers the bleed and a stall at altitude does not;
  stall windows must lie wholly below the landing altitude; an estimator plunge does not clear
  the bleed; impact disarms when the altitude estimate is unusable; smeared-jerk hard contact
  still disarms, while sustained g-load without jerk, a jerk spike at altitude and an isolated
  outlier do not; the impact path is inert without an accelerometer; the commit backstop fires on
  a too-soft touchdown and scales with the commanded rate.
- `landing_ground_effect`, 8 cases: a closed-loop simulation driving the real Kalman estimator
  and the real `altitudeControl()` against a thrust / ground-contact / ground-effect model, with
  barometer error fitted to the blackbox above. The ablation lives in the artefact sweep: with the
  bound removed the grid saturates the throttle at max in seven cells and rebounds up to 180 cm
  before ever touching the ground; with it, throttle stays bounded and the worst rebound is
  122 cm. Plus the inert case, the genuine-climb case, and the cost to genuine-fall arrest
  authority (~10% of peak sink).
- `althold`: a distant target does not saturate throttle; a stale iTerm unwinds; the settle
  ceiling does not wind the integral down against itself; `resetAltitudeControl()` clears it.

`make test` 72/72. SITL and STM32H743 build.

## Not established

No flight has been made on this branch. The ground-effect bound is fitted to one log (83 cm RMS)
and the simulation omits motor lag and drag. The impact thresholds come from six contacts in two
logs. The commit-timeout factor of three is a fallback hypothesis, not a flight-bounded number.

The bound reduces the rebound rather than removing it, and on the single fitted scenario from the
blackbox it no longer separates fixed from unfixed at all on #15584's estimator — only the sweep
does. What remains is the altitude estimate, which nothing outside the estimator can repair;
#15584's `baroGroundEffectRScale()` is the right place for it, and it cannot fire in this rig
because there is no rangefinder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added independent horizontal and vertical speed controls for navigation.
  - Improved landing navigation with bounded descent targets, touchdown detection, and soft-touchdown handling.
  - Added landing-settle behavior to gradually reduce throttle after ground contact.
  - Rescue descents now apply dedicated vertical-speed limits without reducing horizontal approach speed.
  - Added more reliable altitude-target tracking for navigation and failsafe descents.

- **Bug Fixes**
  - Reduced bounce and throttle instability caused by barometric distortion and ground effect.
  - Improved altitude tracking, landing recovery, and prevention of controller overshoot during descent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
