### PR TITLE
Derive the flight plan's autopilot dependencies in common_post

### DIFF
--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -823,6 +823,24 @@ extern struct linker_symbol __fontdata_end;
 #endif
 #endif // USE_PINIO
 
+// The flight plan flies through the shared autopilot stack: altitude via alt
+// hold, XY via the position-hold task, waypoints via GPS. Derive all of them
+// here so a build (cloud or target) selecting the flight plan alone still gets
+// a complete, flyable stack; without alt hold the missions would silently fly
+// with no altitude control at all. Placed ahead of the GPS secondary defines
+// below so USE_GPS_RESCUE and friends follow from the derived USE_GPS.
+#if defined(USE_FLIGHT_PLAN)
+#if !defined(USE_GPS)
+#define USE_GPS
+#endif
+#if !defined(USE_ALTITUDE_HOLD)
+#define USE_ALTITUDE_HOLD
+#endif
+#if !defined(USE_POSITION_HOLD)
+#define USE_POSITION_HOLD
+#endif
+#endif // USE_FLIGHT_PLAN
+
 // GPS secondary defines - here (not common_pre.h) because SITL defines
 // USE_GPS in target.h which is included after common_pre.h. USE_GPS_RESCUE
 // additionally requires USE_ACC to match the earlier "!USE_ACC undef"

--- a/src/main/target/common_post.h
+++ b/src/main/target/common_post.h
@@ -331,6 +331,25 @@
 #endif
 #endif
 
+// The flight plan flies through the shared autopilot stack: altitude via alt
+// hold, XY via the position-hold task, waypoints via GPS. Derive all of them
+// here so a build (cloud or target) selecting the flight plan alone still gets
+// a complete, flyable stack; without alt hold the missions would silently fly
+// with no altitude control at all. Placed ahead of every USE_GPS consumer
+// (VARIO below, the !USE_GPS subfeature cleanup, and the GPS secondary
+// defines) so all of them see the derived USE_GPS.
+#if defined(USE_FLIGHT_PLAN)
+#if !defined(USE_GPS)
+#define USE_GPS
+#endif
+#if !defined(USE_ALTITUDE_HOLD)
+#define USE_ALTITUDE_HOLD
+#endif
+#if !defined(USE_POSITION_HOLD)
+#define USE_POSITION_HOLD
+#endif
+#endif // USE_FLIGHT_PLAN
+
 // Add VARIO if BARO or GPS is defined. Remove when none defined.
 #if defined(USE_BARO) || defined(USE_GPS)
 #ifndef USE_VARIO
@@ -822,24 +841,6 @@ extern struct linker_symbol __fontdata_end;
 #define USE_PIN_PULL_UP_DOWN
 #endif
 #endif // USE_PINIO
-
-// The flight plan flies through the shared autopilot stack: altitude via alt
-// hold, XY via the position-hold task, waypoints via GPS. Derive all of them
-// here so a build (cloud or target) selecting the flight plan alone still gets
-// a complete, flyable stack; without alt hold the missions would silently fly
-// with no altitude control at all. Placed ahead of the GPS secondary defines
-// below so USE_GPS_RESCUE and friends follow from the derived USE_GPS.
-#if defined(USE_FLIGHT_PLAN)
-#if !defined(USE_GPS)
-#define USE_GPS
-#endif
-#if !defined(USE_ALTITUDE_HOLD)
-#define USE_ALTITUDE_HOLD
-#endif
-#if !defined(USE_POSITION_HOLD)
-#define USE_POSITION_HOLD
-#endif
-#endif // USE_FLIGHT_PLAN
 
 // GPS secondary defines - here (not common_pre.h) because SITL defines
 // USE_GPS in target.h which is included after common_pre.h. USE_GPS_RESCUE


### PR DESCRIPTION
Follows the observation in #15563 that alt hold can be absent from a flight plan build. A cloud build selecting only the Flight Plan option currently fails to link (flight_plan_nav references gpsSol without USE_GPS), and selecting Flight Plan with GPS but without Altitude Hold links a plan engine with no altitude or position controller at all, since the USE_ALTITUDE_HOLD and USE_POSITION_HOLD defaults sit behind !CLOUD_BUILD in common_pre.h. Missions would silently fly on the pilot's raw throttle. This derives USE_GPS, USE_ALTITUDE_HOLD and USE_POSITION_HOLD from USE_FLIGHT_PLAN in common_post.h, placed ahead of the GPS secondary defines so USE_GPS_RESCUE follows from the derived USE_GPS. Verified on STM32F405: both failure modes reproduce on master, and with this change the same builds link with updateAltHold, updatePosHold and flightPlanNavUpdate all present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Selecting the flight plan now automatically enables the required GPS, altitude-hold, and position-hold capabilities when they are not otherwise configured.
  * GPS-related features now correctly recognize the flight plan’s derived GPS configuration, including during related feature setup.
  * Flight plan configuration is now applied early enough for dependent features to use the correct settings consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->