### PR TITLE
Adjust GPS vs Baro interaction in Kalman

### DIFF
--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -324,7 +324,7 @@ static bool positionEstimatorWantXYFusion(void)
 // the ideal offset barely changes: this loop only ever chases disagreement between
 // the sources, never shared motion.
 #define CROSS_CAL_TAU_RANGEFINDER_S   2.0f
-#define CROSS_CAL_TAU_GPS_S          300.0f // 5min for gps to cross-cal baro offset
+#define CROSS_CAL_TAU_GPS_S          200.0f // ~5min time constant, depending on vAcc, for gps to cross-cal baro offset
 
 typedef struct {
     float rawReading;   // only populated by drifting sources; unused unless offsetPtr is set

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -93,7 +93,7 @@
 
 #define Q_JERK_Z          3000.0f
 #define R_ACCEL_Z          500.0f
-#define R_BARO_ALT        150.0f   // cm^2 lower value favours baro data vs others, reduced by higher user prefer baro values
+#define R_BARO_ALT        100.0f   // cm^2 lower value favours baro data vs others, reduced by higher user prefer baro values
 #define R_GPS_VEL_Z_BASE  100.0f   // (cm/s)^2, increases as sAcc increases to allow more baro / accelerometer influence
 #define R_GPS_ALT_BASE    200.0f   // cm^2 , increases as vAcc increases to allow more baro / accel influence
 #define R_RANGEFINDER_ALT 100.0f   // cm^2

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -91,9 +91,9 @@
 
 #define R_OPTICALFLOW_VEL 200.0f   // (cm/s)^2 at max quality
 
-#define Q_JERK_Z          3000.0f
-#define R_ACCEL_Z          500.0f
-#define R_BARO_ALT        100.0f   // cm^2 lower value favours baro data vs others, reduced by higher user prefer baro values
+#define Q_JERK_Z         3000.0f
+#define R_ACCEL_Z         500.0f
+#define R_BARO_ALT         70.0f   // cm^2 lower value favours baro data vs others, increased by lower user prefer baro values
 #define R_GPS_VEL_Z_BASE  100.0f   // (cm/s)^2, increases as sAcc increases to allow more baro / accelerometer influence
 #define R_GPS_ALT_BASE    200.0f   // cm^2 , increases as vAcc increases to allow more baro / accel influence
 #define R_RANGEFINDER_ALT 100.0f   // cm^2

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -139,7 +139,7 @@
 // so the onset is around 50 cm and it becomes severe below 20 cm.
 #define GROUND_EFFECT_ALT_CM         50.0f  // baro starts losing validity here
 #define GROUND_EFFECT_FULL_ALT_CM    20.0f  // and is worthless below here
-#define GROUND_EFFECT_BARO_R_SCALE  100.0f  // R multiplier once fully in ground effect
+#define GROUND_EFFECT_BARO_R_SCALE  200.0f  // R multiplier once fully in ground effect
 
 // The rangefinder is what tells us we are in ground effect, so a dropout would otherwise
 // switch the protection off at the moment it is most needed: lose the anchor and the

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -324,7 +324,7 @@ static bool positionEstimatorWantXYFusion(void)
 // the ideal offset barely changes: this loop only ever chases disagreement between
 // the sources, never shared motion.
 #define CROSS_CAL_TAU_RANGEFINDER_S   2.0f
-#define CROSS_CAL_TAU_GPS_S          60.0f
+#define CROSS_CAL_TAU_GPS_S          300.0f // 5min for gps to cross-cal baro offset
 
 typedef struct {
     float rawReading;   // only populated by drifting sources; unused unless offsetPtr is set
@@ -821,8 +821,12 @@ static void feedGPSMeasurements(timeUs_t nowUs)
         kalmanUpdatePosition(&kfUp, gpsRelativeAltCm, gpsAltR); // always update position from GPS position innovation
 
         lastZMeasurementUs = nowUs;
-
-        zCal[CAL_Z_GPS].active = true;
+        // cross-calibrate baro to gps slowly and only for lower than default prefer baro values
+        if (positionConfig()->altitude_prefer_baro < 50) {
+            const float gpsCrossCalScale = constrainf((float)gpsSol.acc.vAcc / GPS_ALT_ACCURACY_DENOM, 1.0f, 10.0f);
+            zCal[CAL_Z_GPS].anchorTauS = CROSS_CAL_TAU_GPS_S * gpsCrossCalScale;
+            zCal[CAL_Z_GPS].active = true;
+        }
     }
 #else
     UNUSED(nowUs);

--- a/src/test/unit/position_estimator_unittest.cc
+++ b/src/test/unit/position_estimator_unittest.cc
@@ -976,9 +976,9 @@ TEST_F(PositionEstimatorTest, RangefinderOnlyAboveMaxRangeLosesZValidity)
 TEST_F(PositionEstimatorTest, CrossCalibrationFollowsTheFastestActiveAnchor)
 {
     enabledSensors = SENSOR_GPS | SENSOR_BARO | SENSOR_RANGEFINDER;
-    stateFlags = GPS_FIX; // GPS anchors as well, at its own much slower rate
+    stateFlags = GPS_FIX; // GPS anchors as well, at its own much slower rate, if ltitude_prefer_baro <50
     positionConfigMutable()->altitude_source = ALTITUDE_SOURCE_DEFAULT;
-    positionConfigMutable()->altitude_prefer_baro = 50;
+    positionConfigMutable()->altitude_prefer_baro = 49;
 
     rfAltCm = 80.0f;
     baroAltCm = 100.0f;


### PR DESCRIPTION
This is a simple PR where I slightly revise the interaction between Baro and GPS data sources and how they affect the final reported Kalman altitude. 

#15584 applied a cross-calibration method to the Baro offset value, which shifted the 'incoming raw' baro data towards the long-term average of the GPS estimate, with a time constant of 60s. The Kalman output altitude was then positioned somewhere  between the baro and Gps values, depending on their relative R values. The 'altitude prefer baro' CLI value had the effect of increasing the baro R value, and biasing the Kalman more towards Gps or Rangefinder, when set to lower values. To deal with the 'ground effect' problem, Baro R was boosted at very low altitude whena rangefinder was used.
The default 'altitude prefer baro' value of 50 tended to put the output Kalman value roughly between the offset-adjusted baro and the GPS.

The assumption was that GPS was likely to be a more stable and a better long-term 'source of truth' than baro, and that at very low altitude, Rangefinder would be more accurate again.

Subsequent testing has shown that there are frequent short to medium term Gps variations in altitude readings, not infrequently worse than baro, depending on many things, of course.

@DenisSher sent some logs through showing significant GPS offsets accumulating while a quad was on the ground, that over time resulted in an otherwise reasonably good baro data becoming offset significantly, and pointed out that the offset ended up in the final Kalman altitude.

I subsequently did a lot of tests, resulting in this PR. Changes:
- increase the general relative 'trust' in the Baro by decreasing its base R to 70 from 150.
- increase the cross-cal time constant to 200s, and push it even longer if the Gps vAcc parameter indicates weaker Gps altitude accuracy, so that the adjustment happens mostly when the Gps altitude assessment is best
- completely disable the cross-calibration unless 'altitude prefer baro' is 50 or higher. So that it only applies when the user indicates that the baro has drift issues and trusts gps more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved altitude estimation by placing greater weight on barometric altitude data.
  * Reduced the frequency of GPS-to-barometer offset adjustments for more stable readings.
  * Refined GPS altitude integration based on altitude source preference and GPS vertical accuracy.
  * Reduced reliance on barometric readings during ground-effect conditions to improve altitude stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->