### PR TITLE
Fix conflicting debug_set

### DIFF
--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -272,7 +272,6 @@ static void calculateTargetStep(void)
     if (rescueState.sensor.distanceToHomeCm > GPS_RESCUE_ACCEPT_RADIUS) {
         const float distanceToMoveCm = rescueState.intent.targetVelocityCmS * gpsRescueTaskIntervalSeconds * rescueState.intent.xyStartAttenuator;
         const float scale = distanceToMoveCm / rescueState.sensor.distanceToHomeCm;
-            DEBUG_SET(DEBUG_RTH, 5, lrintf(scale*100.0f));
 
         vector2Scale(&rescueState.intent.stepEF, &rescueState.sensor.currentPositionV, -scale);
     } else {
@@ -686,7 +685,7 @@ void gpsRescueUpdate(void) // called from core.c at TASK_GPS_RESCUE_RATE_HZ
         break;
     }
 
-    DEBUG_SET(DEBUG_GPS_RESCUE_VELOCITY, 1, rescueState.phase);
+    DEBUG_SET(DEBUG_GPS_RESCUE_VELOCITY, 4, rescueState.phase);
     DEBUG_SET(DEBUG_ATTITUDE,            5, rescueState.phase);
     DEBUG_SET(DEBUG_ATTITUDE,            6, lrintf(rescueState.intent.targetVelocityCmS));
 

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -297,10 +297,10 @@ static void handleCrsfLinkStatisticsTxFrame(const crsfLinkStatisticsTx_t* statsP
     }
 #endif
 
-    DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 0, stats.uplink_RSSI);
-    DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 1, stats.uplink_SNR);
-    DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 2, stats.uplink_Link_quality);
-    DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 3, stats.uplink_RSSI_percentage);
+    DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 4, stats.uplink_RSSI);
+    DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 5, stats.uplink_SNR);
+    DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 6, stats.uplink_Link_quality);
+    DEBUG_SET(DEBUG_CRSF_LINK_STATISTICS_UPLINK, 7, stats.uplink_RSSI_percentage);
 }
 #endif
 #endif

--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -486,7 +486,7 @@
 #if defined(USE_SERIALRX_CRSF)
 
 #define USE_CRSF_V3
-#if defined(USE_TELEMETRY_CRSF) && defined(USE_CRSF_V3)
+#if defined(USE_TELEMETRY_CRSF)
 #define USE_CRSF_ACCGYRO_TELEMETRY
 #endif
 


### PR DESCRIPTION
Resolves #15648

- moved CRSF V3 DEBUG_CRSF_LINK_STATISTICS_UPLINK[0,1,2,3] to slots [4,5,6,7]. Slot 6 is probably duplicate.
- moved DEBUG_GPS_RESCUE_VELOCITY[1] to a free slot [4].
- removed DEBUG_RTH[5]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved diagnostic visibility for GPS Rescue by reducing redundant debug output and relocating rescue-phase information.
  - CRSF transmitter link statistics now use dedicated diagnostic channels, preventing overlap with other debug values.
  - Expanded CRSF telemetry compatibility for supported serial receiver configurations.
  - Flight-control behavior and rescue control logic remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->