### PR TITLE
baro temp drift compensation

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1756,6 +1756,7 @@ static bool blackboxWriteSysinfo(void)
 #endif
 #ifdef USE_BARO
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_BARO_HARDWARE, "%d",        barometerConfig()->baro_hardware);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_BARO_DRIFT, "%d",        barometerConfig()->baroTempDriftCmPer10C);
 #endif
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ALTITUDE_SOURCE, "%d",      positionConfig()->altitude_source);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_ALTITUDE_PREFER_BARO, "%d", positionConfig()->altitude_prefer_baro);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -866,6 +866,7 @@ const clivalue_t valueTable[] = {
     { "baro_i2c_device",            VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, 5 }, PG_BAROMETER_CONFIG, offsetof(barometerConfig_t, baro_i2c_device) },
     { "baro_i2c_address",           VAR_UINT8  | HARDWARE_VALUE, .config.minmaxUnsigned = { 0, I2C_ADDR7_MAX }, PG_BAROMETER_CONFIG, offsetof(barometerConfig_t, baro_i2c_address) },
     { PARAM_NAME_BARO_HARDWARE,     VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BARO_HARDWARE }, PG_BAROMETER_CONFIG, offsetof(barometerConfig_t, baro_hardware) },
+    { PARAM_NAME_BARO_DRIFT,        VAR_INT16  | MASTER_VALUE, .config.minmax = { -500, 500 }, PG_BAROMETER_CONFIG, offsetof(barometerConfig_t, baroTempDriftCmPer10C) },
 #endif
 
 // PG_PITOT_CONFIG

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -34,6 +34,7 @@
 #define PARAM_NAME_ACC_LPF_HZ "acc_lpf_hz"
 #define PARAM_NAME_MAG_HARDWARE "mag_hardware"
 #define PARAM_NAME_BARO_HARDWARE "baro_hardware"
+#define PARAM_NAME_BARO_DRIFT "baro_drift"
 #define PARAM_NAME_PITOT_HARDWARE "pitot_hardware"
 #define PARAM_NAME_RC_SMOOTHING "rc_smoothing"
 #define PARAM_NAME_RC_SMOOTHING_AUTO_FACTOR "rc_smoothing_auto_factor"

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -516,18 +516,18 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
                 const float altitude = pressureToAltitude(baro.pressure);
 
                 if (baroIsCalibrated()) {
-                    // zero baro altitude and correct for temperature drift
-                    const float temperatureDriftCorrection =
-                        (baro.temperature - baroTemperatureAtCalibration) *
-                        barometerConfig()->baroTempDriftCmPer10C / 1000.0f;
+                    // zero baro altitude
+                    baro.altitude = altitude - baroGroundAltitude;
 
-                    baro.altitude = altitude - baroGroundAltitude - temperatureDriftCorrection;
-                } else {
-                    // establish stable baroGroundAltitude value to zero baro altitude with
-                    performBaroCalibrationCycle(altitude);
-                    baro.altitude = 0.0f;
+                    // correct physical barometers for temperature drift
+                    if (detectedSensors[SENSOR_INDEX_BARO] != BARO_VIRTUAL) {
+                        const float temperatureDriftCorrection =
+                            (baro.temperature - baroTemperatureAtCalibration) *
+                            barometerConfig()->baroTempDriftCmPer10C / 1000.0f;
+
+                        baro.altitude -= temperatureDriftCorrection;
+                    }
                 }
-
                 if (baro.lastDataTimeUs != 0) {
                     const timeDelta_t intervalUs = cmpTimeUs(currentTimeUs, baro.lastDataTimeUs);
                     if (intervalUs > 0) {

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -400,6 +400,7 @@ bool baroIsCalibrated(void)
 
 void baroStartCalibration(void)
 {
+    baroTemperatureAtCalibration = 0;
     if (detectedSensors[SENSOR_INDEX_BARO] == BARO_VIRTUAL) {
         baroCalibrated = true;
         return;
@@ -413,6 +414,7 @@ void baroStartCalibration(void)
 void baroSetGroundLevel(void)
 {
     baroGroundAltitude = 0;
+    baroTemperatureAtCalibration = 0;
     baroCalibrated = false;
     calibrationCycles = NUM_GROUND_LEVEL_CYCLES;
     calibrationCycleCount = 0;

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -62,7 +62,7 @@
 
 baro_t baro;                        // barometer access functions
 
-PG_REGISTER_WITH_RESET_FN(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 3);
+PG_REGISTER_WITH_RESET_FN(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 4);
 
 #ifndef DEFAULT_BARO_DEVICE
 #define DEFAULT_BARO_DEVICE BARO_DEFAULT
@@ -166,6 +166,7 @@ void pgResetFn_barometerConfig(barometerConfig_t *barometerConfig)
 
     barometerConfig->baro_eoc_tag = IO_TAG(BARO_EOC_PIN);
     barometerConfig->baro_xclr_tag = IO_TAG(BARO_XCLR_PIN);
+    barometerConfig->baroTempDriftCmPer10C = 0;
 }
 
 #define NUM_CALIBRATION_CYCLES   100        // 10 seconds init_delay + 100 * 25 ms = 12.5 seconds before valid baro altitude
@@ -174,6 +175,7 @@ void pgResetFn_barometerConfig(barometerConfig_t *barometerConfig)
 static uint16_t calibrationCycles = 0;      // baro calibration = get new ground pressure value
 static uint16_t calibrationCycleCount = 0;
 static float baroGroundAltitude = 0.0f;
+static int32_t baroTemperatureAtCalibration = 0;
 static bool baroCalibrated = false;
 static bool baroReady = false;
 
@@ -510,9 +512,14 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
             // If baro.pressure is invalid then skip altitude counting / call of calibration cycle
             if (baro.pressure > 0) {
                 const float altitude = pressureToAltitude(baro.pressure);
+
                 if (baroIsCalibrated()) {
-                    // zero baro altitude
-                    baro.altitude = altitude - baroGroundAltitude;
+                    // zero baro altitude and correct for temperature drift
+                    const float temperatureDriftCorrection =
+                        (baro.temperature - baroTemperatureAtCalibration) *
+                        barometerConfig()->baroTempDriftCmPer10C / 1000.0f;
+
+                    baro.altitude = altitude - baroGroundAltitude - temperatureDriftCorrection;
                 } else {
                     // establish stable baroGroundAltitude value to zero baro altitude with
                     performBaroCalibrationCycle(altitude);
@@ -590,13 +597,15 @@ timeDelta_t getBaroSampleIntervalUs(void)
 static void performBaroCalibrationCycle(const float altitude)
 {
     baroGroundAltitude += altitude;
+    baroTemperatureAtCalibration += baro.temperature;
     calibrationCycleCount++;
 
     if (calibrationCycleCount >= calibrationCycles) {
         baroGroundAltitude /= calibrationCycleCount;  // simple average
+        baroTemperatureAtCalibration /= calibrationCycleCount;
+
         baroCalibrated = true;
         calibrationCycleCount = 0;
     }
 }
-
 #endif /* BARO */

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -518,14 +518,13 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
                 if (baroIsCalibrated()) {
                     // zero baro altitude
                     baro.altitude = altitude - baroGroundAltitude;
-
+                    DEBUG_SET(DEBUG_BARO, 4, lrintf(baro.altitude)); // cm, no temp compensation
                     // correct physical barometers for temperature drift
                     if (detectedSensors[SENSOR_INDEX_BARO] != BARO_VIRTUAL) {
-                        const float temperatureDriftCorrection =
-                            (baro.temperature - baroTemperatureAtCalibration) *
-                            barometerConfig()->baroTempDriftCmPer10C / 1000.0f;
-
+                        const float temperatureDriftCorrection = (baro.temperature - baroTemperatureAtCalibration)
+                            * barometerConfig()->baroTempDriftCmPer10C / 1000.0f;
                         baro.altitude -= temperatureDriftCorrection;
+                        DEBUG_SET(DEBUG_BARO, 3, lrintf(baro.altitude)); // cm, with temp compensation
                     }
                 } else {
                     // establish stable baroGroundAltitude value to zero baro altitude with
@@ -546,11 +545,8 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
                     baro.altitude = 0.0f;
                 }
             }
-            if (debugMode == DEBUG_BARO) {
                 DEBUG_SET(DEBUG_BARO, 1, lrintf(baro.pressure / 100.0f));   // hPa
                 DEBUG_SET(DEBUG_BARO, 2, baro.temperature);                 // c°C
-                DEBUG_SET(DEBUG_BARO, 3, lrintf(baro.altitude));            // cm
-            }
 
             if (baro.dev.combined_read) {
                 state = BARO_STATE_PRESSURE_START;

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -561,7 +561,7 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
                     sleepTime = targetCycleUs - cycleElapsedUs;
                 }
             }
-             break;
+            break;
     }
 
     // Where we are using a state machine call schedulerIgnoreTaskExecRate() for all states bar one

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -543,10 +543,9 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
                     baro.altitude = 0.0f;
                 }
             }
-                DEBUG_SET(DEBUG_BARO, 1, lrintf(baro.pressure / 100.0f)); // hPa
-                DEBUG_SET(DEBUG_BARO, 2, baro.temperature);               // c°C
-                DEBUG_SET(DEBUG_BARO, 3, lrintf(baro.altitude));          // cm, with temp compensation if not virtual
-
+            DEBUG_SET(DEBUG_BARO, 1, lrintf(baro.pressure / 100.0f)); // hPa
+            DEBUG_SET(DEBUG_BARO, 2, baro.temperature);               // c°C
+            DEBUG_SET(DEBUG_BARO, 3, lrintf(baro.altitude));          // cm, with temp compensation if not virtual
 
             if (baro.dev.combined_read) {
                 state = BARO_STATE_PRESSURE_START;

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -527,7 +527,12 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
 
                         baro.altitude -= temperatureDriftCorrection;
                     }
+                } else {
+                    // establish stable baroGroundAltitude value to zero baro altitude with
+                    performBaroCalibrationCycle(altitude);
+                    baro.altitude = 0.0f;
                 }
+
                 if (baro.lastDataTimeUs != 0) {
                     const timeDelta_t intervalUs = cmpTimeUs(currentTimeUs, baro.lastDataTimeUs);
                     if (intervalUs > 0) {
@@ -541,7 +546,6 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
                     baro.altitude = 0.0f;
                 }
             }
-
             if (debugMode == DEBUG_BARO) {
                 DEBUG_SET(DEBUG_BARO, 1, lrintf(baro.pressure / 100.0f));   // hPa
                 DEBUG_SET(DEBUG_BARO, 2, baro.temperature);                 // c°C

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -514,24 +514,22 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
             // If baro.pressure is invalid then skip altitude counting / call of calibration cycle
             if (baro.pressure > 0) {
                 const float altitude = pressureToAltitude(baro.pressure);
-
                 if (baroIsCalibrated()) {
                     // zero baro altitude
                     baro.altitude = altitude - baroGroundAltitude;
-                    DEBUG_SET(DEBUG_BARO, 4, lrintf(baro.altitude)); // cm, no temp compensation
+                    DEBUG_SET(DEBUG_BARO, 4, lrintf(baro.altitude)); // cm, before temp compensation
+
                     // correct physical barometers for temperature drift
                     if (detectedSensors[SENSOR_INDEX_BARO] != BARO_VIRTUAL) {
                         const float temperatureDriftCorrection = (baro.temperature - baroTemperatureAtCalibration)
                             * barometerConfig()->baroTempDriftCmPer10C / 1000.0f;
                         baro.altitude -= temperatureDriftCorrection;
-                        DEBUG_SET(DEBUG_BARO, 3, lrintf(baro.altitude)); // cm, with temp compensation
                     }
                 } else {
                     // establish stable baroGroundAltitude value to zero baro altitude with
                     performBaroCalibrationCycle(altitude);
                     baro.altitude = 0.0f;
                 }
-
                 if (baro.lastDataTimeUs != 0) {
                     const timeDelta_t intervalUs = cmpTimeUs(currentTimeUs, baro.lastDataTimeUs);
                     if (intervalUs > 0) {
@@ -545,8 +543,10 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
                     baro.altitude = 0.0f;
                 }
             }
-                DEBUG_SET(DEBUG_BARO, 1, lrintf(baro.pressure / 100.0f));   // hPa
-                DEBUG_SET(DEBUG_BARO, 2, baro.temperature);                 // c°C
+                DEBUG_SET(DEBUG_BARO, 1, lrintf(baro.pressure / 100.0f)); // hPa
+                DEBUG_SET(DEBUG_BARO, 2, baro.temperature);               // c°C
+                DEBUG_SET(DEBUG_BARO, 3, lrintf(baro.altitude));          // cm, with temp compensation if not virtual
+
 
             if (baro.dev.combined_read) {
                 state = BARO_STATE_PRESSURE_START;

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -561,7 +561,7 @@ uint32_t baroUpdate(timeUs_t currentTimeUs)
                     sleepTime = targetCycleUs - cycleElapsedUs;
                 }
             }
-            break;
+             break;
     }
 
     // Where we are using a state machine call schedulerIgnoreTaskExecRate() for all states bar one

--- a/src/main/sensors/barometer.h
+++ b/src/main/sensors/barometer.h
@@ -53,6 +53,7 @@ typedef struct barometerConfig_s {
     uint8_t baro_hardware;                  // Barometer hardware to use
     ioTag_t baro_eoc_tag;
     ioTag_t baro_xclr_tag;
+    int16_t baroTempDriftCmPer10C;   // cm per 10°C, signed
 } barometerConfig_t;
 
 PG_DECLARE(barometerConfig_t, barometerConfig);


### PR DESCRIPTION

Many barometer chips  consistantly drift with temperature because the internal compensation is not all that good.

This PR allows the user to enter the drift in altiude in cm for a 10 degrees increase in temp in the new `     c`CLI value. This is used to compensate for temperature changes.

Confirmed to work with about 10-12 boards - see images below. Works *really well*.


Easiest way to determine the `baro_drift` value to use is:
- set debug mode to `BARO`
- in Configurator, go to Sensors and `Show live Sensor Data`, enabling 'debug' so you can see the baro debug values
-  unplug the FC and let it cool down to room temp.
- quickly show live sensor data and note the baro temperature. Don't worry if it does not match room temp
- note the altitude change in cm once the baro temp has risen by 10 deg C.
- enter that number as the `baro_drift`value
- if the altitude climbs temperature increases, the entered drift value should be positive, and  vice versa
- save the `baro_drift`value

Each FC / baro will need to be set individually, but only once.

Thanks to @denis-sher for testing and help with developing this feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable barometer temperature-drift correction through `baro_drift`, adjustable from -500 to 500 cm per 10°C.
  - Physical barometer altitude readings now compensate for temperature changes since calibration.
  - Calibration records the average temperature for improved correction accuracy.
  - The correction baseline refreshes when calibration starts or the ground level is set.
  - Temperature-drift correction does not apply to virtual barometers.

- **Bug Fixes**
  - Restored physical barometer calibration completion when the sensor is not yet calibrated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->