### PR TITLE
Leave POSHOLD task rate at 100Hz for UPT1 sensor as it was for MT sensor to reduce latency

### DIFF
--- a/src/main/sensors/opticalflow.c
+++ b/src/main/sensors/opticalflow.c
@@ -106,9 +106,6 @@ static bool opticalflowDetect(opticalflowDev_t * dev, uint8_t opticalflowHardwar
             if (upt1OpticalflowDetect(dev)) {
                 opticalflowHardware = OPTICALFLOW_UPT1;
                 rescheduleTask(TASK_OPTICALFLOW, TASK_PERIOD_MS(dev->delayMs));
-#ifdef USE_POSITION_HOLD
-                rescheduleTask(TASK_POSHOLD, TASK_PERIOD_MS(dev->delayMs));
-#endif
             }
             break;
 #endif


### PR DESCRIPTION
Reducing the task rate from 100Hz to 50Hz for the UPT1 sensor was introducing an additional 10ms of variable delay between sensor update and it being acted on. This wasn't being done for the MT sensor. Delay in control loops is bad.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated UPT1 optical-flow handling so position-hold scheduling is no longer triggered when the device is detected.
  - Optical-flow updates continue to be scheduled according to the device’s configured timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->