### PR TITLE
Event-drive ALTHOLD and POSHOLD from the position estimator to reduce latency

### DIFF
--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -71,6 +71,7 @@
 
 #define HZ_TO_INTERVAL(x) (1.0f / (x))
 #define HZ_TO_INTERVAL_US(x) (1000000 / (x))
+#define US_TO_INTERVAL(us) ((us) * 1e-6f)   // microseconds to seconds
 
 #define SCALE_FACTOR(in_start, in_end, out_start, out_end) \
     ((float)((out_end) - (out_start)) / (float)((in_end) - (in_start)))

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -307,13 +307,13 @@ static void taskUpdateMag(timeUs_t currentTimeUs)
 }
 #endif
 
-#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER)
-static void taskCalculateAltitude(timeUs_t currentTimeUs)
+#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER) || defined(USE_OPTICALFLOW)
+static void taskPositionUpdate(timeUs_t currentTimeUs)
 {
     UNUSED(currentTimeUs);
-    calculateEstimatedAltitude();
+    positionUpdate();
 }
-#endif // USE_BARO || USE_GPS
+#endif // USE_BARO || USE_GPS || USE_RANGEFINDER || USE_OPTICALFLOW
 
 #if defined(USE_RANGEFINDER)
 static void taskUpdateRangefinder(timeUs_t currentTimeUs)
@@ -419,11 +419,11 @@ task_attribute_t task_attributes[TASK_COUNT] = {
 #endif
 
 #ifdef USE_ALTITUDE_HOLD
-    [TASK_ALTHOLD] = DEFINE_TASK("ALTHOLD", NULL, NULL, updateAltHold, TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ), TASK_PRIORITY_LOW),
+    [TASK_ALTHOLD] = DEFINE_TASK("ALTHOLD", NULL, altHoldUpdateCheck, updateAltHold, TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ), TASK_PRIORITY_LOW), // Event driven by the position estimator, falls back to periodic scheduling
 #endif
 
 #ifdef USE_POSITION_HOLD
-    [TASK_POSHOLD] = DEFINE_TASK("POSHOLD", NULL, NULL, updatePosHold, TASK_PERIOD_HZ(POSHOLD_TASK_RATE_HZ), TASK_PRIORITY_LOW),
+    [TASK_POSHOLD] = DEFINE_TASK("POSHOLD", NULL, posHoldUpdateCheck, updatePosHold, TASK_PERIOD_HZ(POSHOLD_TASK_RATE_HZ), TASK_PRIORITY_LOW), // Event driven by the position estimator, falls back to periodic scheduling
 #endif
 
 #ifdef USE_MAG
@@ -434,8 +434,8 @@ task_attribute_t task_attributes[TASK_COUNT] = {
     [TASK_BARO] = DEFINE_TASK("BARO", NULL, NULL, taskUpdateBaro, TASK_PERIOD_HZ(TASK_BARO_RATE_HZ), TASK_PRIORITY_LOW),
 #endif
 
-#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER)
-    [TASK_ALTITUDE] = DEFINE_TASK("ALTITUDE", NULL, NULL, taskCalculateAltitude, TASK_PERIOD_HZ(TASK_ALTITUDE_RATE_HZ), TASK_PRIORITY_LOW),
+#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER) || defined(USE_OPTICALFLOW)
+    [TASK_POSITION] = DEFINE_TASK("POSITION", NULL, NULL, taskPositionUpdate, TASK_PERIOD_HZ(TASK_POSITION_RATE_HZ), TASK_PRIORITY_LOW), // Runs the position estimator, which in turn schedules ALTHOLD and POSHOLD
 #endif
 
 #ifdef USE_DASHBOARD
@@ -604,14 +604,19 @@ void tasksInit(void)
     setTaskEnabled(TASK_GPS_RESCUE, featureIsEnabled(FEATURE_GPS));
 #endif
 
+    // Both hold modes are driven by TASK_POSITION, so they are judged on the same
+    // terms as it is (see below) restricted to the axes each one needs: Z sources
+    // for altitude hold, XY sources for position hold. Enabling a hold mode whose
+    // estimator is not running would leave it working from a state that never updates.
 #ifdef USE_ALTITUDE_HOLD
     setTaskEnabled(TASK_ALTHOLD, sensors(SENSOR_BARO) ||
-                                 sensors(SENSOR_RANGEFINDER) ||
+                                 featureIsEnabled(FEATURE_RANGEFINDER) ||
                                  featureIsEnabled(FEATURE_GPS));
 #endif
 
 #ifdef USE_POSITION_HOLD
-    setTaskEnabled(TASK_POSHOLD, featureIsEnabled(FEATURE_GPS) || sensors(SENSOR_OPTICALFLOW));
+    setTaskEnabled(TASK_POSHOLD, featureIsEnabled(FEATURE_GPS) ||
+                                 featureIsEnabled(FEATURE_OPTICALFLOW));
 #endif
 
 #ifdef USE_MAG
@@ -625,8 +630,20 @@ void tasksInit(void)
     setTaskEnabled(TASK_PITOT, pitotIsConfigured());
 #endif
 
-#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER)
-    setTaskEnabled(TASK_ALTITUDE, sensors(SENSOR_BARO) || featureIsEnabled(FEATURE_GPS) || sensors(SENSOR_RANGEFINDER));
+#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER) || defined(USE_OPTICALFLOW)
+    // Run the estimator if any measurement source is configured. Judged on the
+    // features, not on detection: this is evaluated once, so a source detected
+    // after tasksInit() would otherwise leave the estimator permanently off, and
+    // a configured source that never appears costs only a prediction step.
+    // Baro has no feature flag so it is judged by detection, which is safe because
+    // it is probed synchronously at boot with nothing to arrive late. SENSOR_GPS
+    // means "has a fix" (set at runtime in gps.c) rather than "hardware present".
+    // Optical flow belongs here because it is an XY source: a flow-only craft has no
+    // baro, GPS or rangefinder but still holds position.
+    setTaskEnabled(TASK_POSITION, sensors(SENSOR_BARO) ||
+                                  featureIsEnabled(FEATURE_GPS) ||
+                                  featureIsEnabled(FEATURE_RANGEFINDER) ||
+                                  featureIsEnabled(FEATURE_OPTICALFLOW));
 #endif
 
 #ifdef USE_DASHBOARD

--- a/src/main/flight/alt_hold_multirotor.c
+++ b/src/main/flight/alt_hold_multirotor.c
@@ -34,14 +34,21 @@
 #include "flight/failsafe.h"
 #include "flight/flight_plan_nav.h"
 #include "flight/position.h"
+#include "flight/position_estimator.h"
 #include "flight/position_nav.h"
 
 #include "rx/rx.h"
 #include "pg/autopilot.h"
+#include "scheduler/scheduler.h"
 
 #include "alt_hold.h"
 
-static const float taskIntervalSeconds = HZ_TO_INTERVAL(ALTHOLD_TASK_RATE_HZ); // i.e. 0.01 s
+// TASK_ALTHOLD is event driven off positionEstimatorUpdate(), so it runs as soon
+// as a new altitude estimate exists rather than at an arbitrary phase relative to
+// it. If the estimator is not running at all (TASK_POSITION disabled) this is the
+// interval after which the task falls back to periodic scheduling, so that mode
+// entry and exit are still serviced.
+#define ALTHOLD_FALLBACK_PERIOD_US (2 * TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ))
 
 typedef struct {
     bool isActive;
@@ -95,7 +102,7 @@ static void altHoldProcessTransitions(void) {
     }
 }
 
-static void altHoldUpdateTargetAltitude(void)
+static void altHoldUpdateTargetAltitude(timeUs_t taskIntervalUs)
 {
     // User can adjust the target altitude with throttle, but only when
     // - throttle is outside deadband, and
@@ -143,15 +150,15 @@ static void altHoldUpdateTargetAltitude(void)
     // the altitude target cannot be moved to a location that cannot be reached in 1s at maxClimbRate
     // this constrains the P and I response to user target changes, but not D of F responses
     if (fabsf(getAltitudeCmControl() - altHold.targetAltitudeCm) < maxClimbRate * 1.0f /* s */) {
-        altHold.targetAltitudeCm += altHold.targetVelocity * taskIntervalSeconds;
+        altHold.targetAltitudeCm += altHold.targetVelocity * US_TO_INTERVAL(taskIntervalUs);
     }
 }
 
-static void altHoldUpdate(void)
+static void altHoldUpdate(timeUs_t taskIntervalUs)
 {
-    
+
     if (altHoldConfig()->climbRate) {
-        altHoldUpdateTargetAltitude(); // check if the pilot has changed the target altitude using sticks
+        altHoldUpdateTargetAltitude(taskIntervalUs); // check if the pilot has changed the target altitude using sticks
     }
 
     float targetAltitudeCm = altHold.targetAltitudeCm; 
@@ -170,7 +177,19 @@ static void altHoldUpdate(void)
         }
     }
 
-    altitudeControl(targetAltitudeCm, taskIntervalSeconds, targetAltitudeVelocity, altHoldMaxClimbRate());
+    altitudeControl(targetAltitudeCm, taskIntervalUs, targetAltitudeVelocity, altHoldMaxClimbRate());
+}
+
+bool altHoldUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
+{
+    UNUSED(currentTimeUs);
+
+    if (positionEstimatorTakeUpdate(POS_EST_CONSUMER_ALTHOLD)) {
+        return true;
+    }
+
+    // No estimator running, so fall back to periodic scheduling
+    return currentDeltaTimeUs >= ALTHOLD_FALLBACK_PERIOD_US;
 }
 
 void updateAltHold(timeUs_t currentTimeUs) {
@@ -180,7 +199,8 @@ void updateAltHold(timeUs_t currentTimeUs) {
     altHoldProcessTransitions();
 
     if (altHold.isActive) {
-        altHoldUpdate();
+        // Event driven, so the interval between runs is the estimator's, not the nominal task period
+        altHoldUpdate(autopilotTaskIntervalUs(TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ)));
     }
 }
 

--- a/src/main/flight/alt_hold_multirotor.h
+++ b/src/main/flight/alt_hold_multirotor.h
@@ -27,6 +27,7 @@
 #define ALTHOLD_TASK_RATE_HZ 100         // hz
 
 void altHoldInit(void);
+bool altHoldUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);
 void updateAltHold(timeUs_t currentTimeUs);
 bool isAltHoldActive(void);
 

--- a/src/main/flight/alt_hold_wing.c
+++ b/src/main/flight/alt_hold_wing.c
@@ -47,6 +47,13 @@ void altHoldInit(void)
 {
 }
 
+bool altHoldUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
+{
+    UNUSED(currentTimeUs);
+    UNUSED(currentDeltaTimeUs);
+    return false;
+}
+
 void updateAltHold(timeUs_t currentTimeUs) {
     UNUSED(currentTimeUs);
 }

--- a/src/main/flight/alt_hold_wing.h
+++ b/src/main/flight/alt_hold_wing.h
@@ -27,6 +27,7 @@
 #define ALTHOLD_TASK_RATE_HZ 100         // hz
 
 void altHoldInit(void);
+bool altHoldUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);
 void updateAltHold(timeUs_t currentTimeUs);
 bool isAltHoldActive(void);
 

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -237,6 +237,26 @@ static autopilotState_t ap = {
     .wasSticksActive = false,
 };
 
+// TASK_ALTHOLD and TASK_POSHOLD are event driven off positionEstimatorUpdate(),
+// so their interval is whatever the estimator delivers rather than the nominal
+// task period, and every dt in the control loops has to be measured. The
+// measurement is bounded: the first run after a task is enabled, or one starved
+// behind a long-running peer, would otherwise hand the integrators a step of
+// arbitrary size.
+#define AP_TASK_INTERVAL_MIN_DIVIDER    4   // shortest accepted interval is nominal / 4
+#define AP_TASK_INTERVAL_MAX_MULTIPLIER 4   // longest accepted interval is nominal * 4
+
+timeUs_t autopilotTaskIntervalUs(timeUs_t nominalIntervalUs)
+{
+    timeDelta_t intervalUs = getTaskDeltaTimeUs(TASK_SELF);
+    if (intervalUs <= 0) {
+        intervalUs = nominalIntervalUs; // no measurement yet
+    }
+    return constrain(intervalUs,
+                     (timeDelta_t)(nominalIntervalUs / AP_TASK_INTERVAL_MIN_DIVIDER),
+                     (timeDelta_t)(nominalIntervalUs * AP_TASK_INTERVAL_MAX_MULTIPLIER));
+}
+
 static float posLpfDtS = 0.0f;  // interval the F filter gains are currently set for
 
 static float posPidLpfGain(float dtS)
@@ -255,9 +275,9 @@ static void initPidLpfs(void)
 }
 
 // The F filter steps once per loop, so its gain follows the real task interval:
-// TASK_POSHOLD is rescheduled to the flow sensor's rate, which need not be
-// POSHOLD_TASK_RATE_HZ. Retuned in place, without resetting the filter states,
-// whenever the measured interval moves.
+// TASK_POSHOLD is event driven off the position estimator, so it runs at the
+// estimator's rate, which need not be POSHOLD_TASK_RATE_HZ. Retuned in place,
+// without resetting the filter states, whenever the measured interval moves.
 static void updatePidLpfGains(float dtS)
 {
     if (dtS <= 0.0f || fabsf(dtS - posLpfDtS) < 0.05f * posLpfDtS) {
@@ -339,8 +359,9 @@ void autopilotClearAltHoldHoverThrottle(void)
     altHoldCapturedHoverPwm = 0;
 }
 
-void altitudeControl(float targetAltitudeCm, float taskIntervalS, float targetAltitudeVelCmS, float velLimitCmS)
+void altitudeControl(float targetAltitudeCm, timeUs_t taskIntervalUs, float targetAltitudeVelCmS, float velLimitCmS)
 {
+    const float taskIntervalS = US_TO_INTERVAL(taskIntervalUs);
     // PID controller on altitude error
     const float currentAltitudeCm = getAltitudeCmControl(); // un-filtered altitude from Kalman filter
     const float verticalAcceleration = getAltitudeAccelerationControl();
@@ -883,8 +904,7 @@ bool positionControl(void)
 {
 
     const positionEstimate3d_t *est = positionEstimatorGetEstimate();
-    const timeDelta_t posholdDtUs = getTaskDeltaTimeUs(TASK_SELF);
-    const float dt = (posholdDtUs > 0) ? (posholdDtUs * 1e-6f) : HZ_TO_INTERVAL(POSHOLD_TASK_RATE_HZ);
+    const float dt = US_TO_INTERVAL(autopilotTaskIntervalUs(TASK_PERIOD_HZ(POSHOLD_TASK_RATE_HZ)));
     updatePidLpfGains(dt);
 
     if (!est->isValidXY) {

--- a/src/main/flight/autopilot_multirotor.h
+++ b/src/main/flight/autopilot_multirotor.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #include "common/axis.h"
+#include "common/time.h"
 #include "common/vector.h"
 
 
@@ -35,7 +36,11 @@ void resetAltitudeControl(void);
 void setSticksActiveStatus(bool areSticksActive);
 void resetPositionControl(unsigned taskRateHz);
 bool positionControl(void);
-void altitudeControl(float targetAltitudeCm, float taskIntervalS, float targetAltitudeVelCmS, float velLimitCmS);
+void altitudeControl(float targetAltitudeCm, timeUs_t taskIntervalUs, float targetAltitudeVelCmS, float velLimitCmS);
+// Measured interval since the calling task last ran, bounded around its nominal
+// period. The autopilot control tasks are event driven, so their interval is
+// real rather than the nominal task period.
+timeUs_t autopilotTaskIntervalUs(timeUs_t nominalIntervalUs);
 void moveTargetLocation(const vector2_t *stepEF, unsigned taskRateHz, bool forceAbortNav);// for nav modes to update the target position
 void pitchForwardOverride(bool request);
 void autopilotForceLevelPark(bool request); // heading/mag fault: force angle-mode self-level, never position hold

--- a/src/main/flight/autopilot_wing.c
+++ b/src/main/flight/autopilot_wing.c
@@ -54,12 +54,17 @@ void autopilotInit(void)
 void resetAltitudeControl (void) {
 }
 
-void altitudeControl(float targetAltitudeCm, float taskIntervalS, float targetAltitudeVelCmS, float velLimitCmS)
+void altitudeControl(float targetAltitudeCm, timeUs_t taskIntervalUs, float targetAltitudeVelCmS, float velLimitCmS)
 {
     UNUSED(targetAltitudeCm);
-    UNUSED(taskIntervalS);
+    UNUSED(taskIntervalUs);
     UNUSED(targetAltitudeVelCmS);
     UNUSED(velLimitCmS);
+}
+
+timeUs_t autopilotTaskIntervalUs(timeUs_t nominalIntervalUs)
+{
+    return nominalIntervalUs;
 }
 
 bool positionControl(void)

--- a/src/main/flight/autopilot_wing.h
+++ b/src/main/flight/autopilot_wing.h
@@ -19,6 +19,7 @@
 
 #include <stdbool.h>
 #include "common/axis.h"
+#include "common/time.h"
 
 #ifdef USE_WING
 
@@ -28,7 +29,8 @@ void autopilotInit(void);
 void resetAltitudeControl(void);
 void resetPositionControl(unsigned taskRateHz);
 bool positionControl(void);
-void altitudeControl(float targetAltitudeCm, float taskIntervalS, float targetAltitudeVelCmS, float velLimitCmS);
+void altitudeControl(float targetAltitudeCm, timeUs_t taskIntervalUs, float targetAltitudeVelCmS, float velLimitCmS);
+timeUs_t autopilotTaskIntervalUs(timeUs_t nominalIntervalUs);
 
 bool isBelowLandingAltitude(void);
 float getAutopilotThrottle(void);

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -292,7 +292,7 @@ static void clearTargetStep(void)
 static void controlAltitude(void)
 {
     const float vzLim = 3.0f * fmaxf((float)gpsRescueConfig()->ascendRate, (float)gpsRescueConfig()->descendRate);
-    altitudeControl(rescueState.intent.targetAltitudeCm, gpsRescueTaskIntervalSeconds, rescueState.intent.targetAltitudeVelCmS, vzLim);
+    altitudeControl(rescueState.intent.targetAltitudeCm, HZ_TO_INTERVAL_US(TASK_GPS_RESCUE_RATE_HZ), rescueState.intent.targetAltitudeVelCmS, vzLim);
 }
 
 bool oneSecondPassed(timeUs_t currentTimeUs, timeUs_t *lastTimeUs) {

--- a/src/main/flight/pos_hold_multirotor.c
+++ b/src/main/flight/pos_hold_multirotor.c
@@ -35,9 +35,17 @@
 #include "flight/position.h"
 #include "flight/position_estimator.h"
 #include "rx/rx.h"
+#include "scheduler/scheduler.h"
 
 #include "pg/pos_hold.h"
 #include "pos_hold.h"
+
+// TASK_POSHOLD is event driven off positionEstimatorUpdate(), so the control law
+// sees each new position estimate immediately rather than up to a task period
+// later. If the estimator is not running at all (TASK_POSITION disabled) this is
+// the interval after which the task falls back to periodic scheduling, so that
+// mode entry and exit are still serviced.
+#define POSHOLD_FALLBACK_PERIOD_US (2 * TASK_PERIOD_HZ(POSHOLD_TASK_RATE_HZ))
 
 typedef struct posHoldState_s {
     bool isEnabled;
@@ -82,6 +90,18 @@ static bool sensorsOk(void)
     } else {
         return true; // if no heading is needed, we don't care about it (optical flow situation)
     }
+}
+
+bool posHoldUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
+{
+    UNUSED(currentTimeUs);
+
+    if (positionEstimatorTakeUpdate(POS_EST_CONSUMER_POSHOLD)) {
+        return true;
+    }
+
+    // No estimator running, so fall back to periodic scheduling
+    return currentDeltaTimeUs >= POSHOLD_FALLBACK_PERIOD_US;
 }
 
 void updatePosHold(timeUs_t currentTimeUs)

--- a/src/main/flight/pos_hold_multirotor.h
+++ b/src/main/flight/pos_hold_multirotor.h
@@ -25,6 +25,7 @@
 #define POSHOLD_TASK_RATE_HZ 100 // hz
 
 void posHoldInit(void);
+bool posHoldUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);
 void updatePosHold(timeUs_t currentTimeUs);
 bool isAutopilotInControl(void);
 

--- a/src/main/flight/pos_hold_wing.c
+++ b/src/main/flight/pos_hold_wing.c
@@ -43,6 +43,13 @@ void posHoldInit(void)
 {
 }
 
+bool posHoldUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
+{
+    UNUSED(currentTimeUs);
+    UNUSED(currentDeltaTimeUs);
+    return false;
+}
+
 void updatePosHold(timeUs_t currentTimeUs) {
     UNUSED(currentTimeUs);
 }

--- a/src/main/flight/pos_hold_wing.h
+++ b/src/main/flight/pos_hold_wing.h
@@ -26,6 +26,7 @@
 #define POSHOLD_TASK_RATE_HZ 100 // hz
 
 void posHoldInit(void);
+bool posHoldUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs);
 void updatePosHold(timeUs_t currentTimeUs);
 
 bool posHoldFailure(void);

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -60,7 +60,7 @@ static float filteredAltitudeDerivative = 0.0f;
 static float controlAltitudeCm = 0.0f;
 static float controlAltitudeDerivative = 0.0f;
 static float controlAltitudeAcceleration = 0.0f;
-#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER)
+#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER) || defined(USE_OPTICALFLOW)
 static bool wasArmed = false;
 #endif
 #ifdef USE_VARIO
@@ -69,7 +69,7 @@ static int16_t estimatedVario = 0;
 
 static void positionResetAltitudeState(void)
 {
-    const float sampleTimeS = HZ_TO_INTERVAL(TASK_ALTITUDE_RATE_HZ);
+    const float sampleTimeS = HZ_TO_INTERVAL(TASK_POSITION_RATE_HZ);
 
     const float altitudeCutoffHz = positionConfig()->altitude_lpf / 100.0f;
     const float altitudeGain = pt2FilterGain(altitudeCutoffHz, sampleTimeS);
@@ -90,7 +90,7 @@ static void positionResetAltitudeState(void)
 void positionInit(void)
 {
     positionResetAltitudeState();
-#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER)
+#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER) || defined(USE_OPTICALFLOW)
     wasArmed = ARMING_FLAG(ARMED);
 #endif
 
@@ -112,22 +112,11 @@ PG_RESET_TEMPLATE(positionConfig_t, positionConfig,
     .rangefinder_max_range_cm = 400,
 );
 
-#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER)
-void calculateEstimatedAltitude(void)
+#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER) || defined(USE_OPTICALFLOW)
+// The altitude presentation layer: display smoothing and vario, derived from the
+// Z axis of the estimate. A consumer of the estimator, not the reason it runs.
+static void updateAltitudeFromEstimate(void)
 {
-    const bool isArmed = ARMING_FLAG(ARMED);
-
-#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER)
-    if (isArmed != wasArmed) {
-        positionEstimatorResetZ();
-        positionResetAltitudeState();
-        wasArmed = isArmed;
-    }
-#endif
-
-    // Run the Kalman filter estimator (prediction + all sensor measurement updates)
-    positionEstimatorUpdate();
-
     // Get raw KF altitude estimate
     const float kfAltCm = positionEstimatorGetAltitudeCm();
     const float kfVelZCm = positionEstimatorGetVerticalVelocity();
@@ -164,13 +153,27 @@ void calculateEstimatedAltitude(void)
     DEBUG_SET(DEBUG_ALTITUDE, 7, lrintf(kfAccelZCm));
 
     DEBUG_SET(DEBUG_RTH, 1, lrintf(displayAltitudeCm));
-
-#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER)
-    wasArmed = isArmed;
-#endif
 }
 
-#endif // defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER)
+// TASK_POSITION: run the Kalman filter estimator (prediction plus all sensor
+// measurement updates), then refresh the layers derived from it. The estimate
+// spans all three axes and feeds altitude hold, position hold, nav and rescue,
+// so this is the fusion step for the whole craft, not an altitude calculation.
+void positionUpdate(void)
+{
+    const bool isArmed = ARMING_FLAG(ARMED);
+    if (isArmed != wasArmed) {
+        positionEstimatorResetZ();
+        positionResetAltitudeState();
+        wasArmed = isArmed;
+    }
+
+    positionEstimatorUpdate();
+
+    updateAltitudeFromEstimate();
+}
+
+#endif // defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER) || defined(USE_OPTICALFLOW)
 
 float getAltitudeCm(void)
 {

--- a/src/main/flight/position.h
+++ b/src/main/flight/position.h
@@ -22,7 +22,7 @@
 
 #include "common/time.h"
 
-#define TASK_ALTITUDE_RATE_HZ 100
+#define TASK_POSITION_RATE_HZ 100
 
 typedef enum {
     ALTITUDE_SOURCE_DEFAULT = 0,
@@ -48,7 +48,8 @@ float getAltitudeDerivative(void);
 float getAltitudeCmControl(void);
 float getAltitudeDerivativeControl(void);
 float getAltitudeAccelerationControl(void);
-void calculateEstimatedAltitude(void);
+// TASK_POSITION: runs the position estimator and everything derived from it.
+void positionUpdate(void);
 void positionInit(void);
 int32_t getEstimatedAltitudeCm(void);
 float getAltitudeAsl(void);

--- a/src/main/flight/position_estimator.c
+++ b/src/main/flight/position_estimator.c
@@ -420,6 +420,11 @@ static timeUs_t lastXYMeasurementUs = 0;
 static timeUs_t lastZMeasurementUs = 0;
 static unsigned debugAxis; // 0 for East, 1 for North; selected by gyro_filter_debug_axis
 
+// One bit per positionEstimatorConsumer_e, set by every positionEstimatorUpdate()
+// and cleared as each consumer takes the event. Drives the event-based scheduling
+// of TASK_ALTHOLD and TASK_POSHOLD.
+static uint8_t pendingUpdateMask = 0;
+
 static sensorCalEntry_t zCal[CAL_Z_COUNT];
 
 #ifdef USE_GPS
@@ -503,6 +508,7 @@ void positionEstimatorInit(void)
     xyEnabled = false;
     lastXYMeasurementUs = 0;
     lastZMeasurementUs = 0;
+    pendingUpdateMask = 0;
     debugAxis = (gyroConfig()->gyro_filter_debug_axis == FD_PITCH) ? 1 : 0; //  0 for East, 1 for North
 
 
@@ -1274,7 +1280,7 @@ static void crossCalibrateOffsets(sensorCalEntry_t *sources, int count, float kf
 void positionEstimatorUpdate(void)
 {
     const timeUs_t nowUs = micros();
-    const float dt = HZ_TO_INTERVAL(TASK_ALTITUDE_RATE_HZ);
+    const float dt = HZ_TO_INTERVAL(TASK_POSITION_RATE_HZ);
 
     const bool wantXY = positionEstimatorWantXYFusion();
     if (wantXY != xyEnabled) {
@@ -1366,6 +1372,19 @@ void positionEstimatorUpdate(void)
     const float xyVar = (kalmanGetPositionVariance(&kfEast) + kalmanGetPositionVariance(&kfNorth)) * 0.5f;
     estimate.trustXY = 1.0f / (1.0f + xyVar / 10000.0f);
     estimate.trustZ = 1.0f / (1.0f + kalmanGetPositionVariance(&kfUp) / 10000.0f);
+
+    // Publish the update last, so a consumer woken by it reads a complete estimate.
+    pendingUpdateMask = (1 << POS_EST_CONSUMER_COUNT) - 1;
+}
+
+bool positionEstimatorTakeUpdate(positionEstimatorConsumer_e consumer)
+{
+    const uint8_t bit = 1 << consumer;
+    if (pendingUpdateMask & bit) {
+        pendingUpdateMask &= ~bit;
+        return true;
+    }
+    return false;
 }
 
 const positionEstimate3d_t *positionEstimatorGetEstimate(void)

--- a/src/main/flight/position_estimator.h
+++ b/src/main/flight/position_estimator.h
@@ -39,8 +39,23 @@ typedef struct positionEstimate3d_s {
     bool isValidZ;             // true if at least one Z measurement source active
 } positionEstimate3d_t;
 
+// Consumers of the estimate that are scheduled by it. Each gets its own bit in
+// the pending-update mask so that one taking the event does not hide it from
+// the other.
+typedef enum {
+    POS_EST_CONSUMER_ALTHOLD = 0,
+    POS_EST_CONSUMER_POSHOLD,
+    POS_EST_CONSUMER_COUNT
+} positionEstimatorConsumer_e;
+
 void positionEstimatorInit(void);
 void positionEstimatorUpdate(void);
+
+// Event-driven scheduling hook: positionEstimatorUpdate() publishes one update
+// event per run, and each consumer takes it exactly once. Returns true if a new
+// estimate has been published since this consumer last took one, and clears the
+// consumer's flag.
+bool positionEstimatorTakeUpdate(positionEstimatorConsumer_e consumer);
 
 // Request XY fusion (normally automatic from armed state / sensors / modes).
 // May re-initialize kfEast/kfNorth when transitioning to enabled; disabling stops prediction only.

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -149,8 +149,8 @@ typedef enum {
 #ifdef USE_PITOT
     TASK_PITOT,
 #endif
-#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER)
-    TASK_ALTITUDE,
+#if defined(USE_BARO) || defined(USE_GPS) || defined(USE_RANGEFINDER) || defined(USE_OPTICALFLOW)
+    TASK_POSITION,
 #endif
 #ifdef USE_DASHBOARD
     TASK_DASHBOARD,

--- a/src/main/sensors/opticalflow.c
+++ b/src/main/sensors/opticalflow.c
@@ -106,9 +106,6 @@ static bool opticalflowDetect(opticalflowDev_t * dev, uint8_t opticalflowHardwar
             if (upt1OpticalflowDetect(dev)) {
                 opticalflowHardware = OPTICALFLOW_UPT1;
                 rescheduleTask(TASK_OPTICALFLOW, TASK_PERIOD_MS(dev->delayMs));
-#ifdef USE_POSITION_HOLD
-                rescheduleTask(TASK_POSHOLD, TASK_PERIOD_MS(dev->delayMs));
-#endif
             }
             break;
 #endif

--- a/src/test/unit/althold_unittest.cc
+++ b/src/test/unit/althold_unittest.cc
@@ -68,6 +68,8 @@ extern "C" {
     extern float testAltitudeAccelerationCmS;
     extern float testCosTiltAngle;
     extern throttleStatus_e testThrottleStatus;
+    extern bool testEstimatorUpdatePending;
+    extern timeDelta_t testTaskDeltaTimeUs;
 }
 
 #include "unittest_macros.h"
@@ -91,6 +93,8 @@ protected:
         testAltitudeAccelerationCmS = 0.0f;
         testCosTiltAngle = 1.0f;
         testThrottleStatus = THROTTLE_LOW;
+        testEstimatorUpdatePending = false;
+        testTaskDeltaTimeUs = TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ);
 
         autopilotConfig_t *apCfg = autopilotConfigMutable();
         apCfg->hoverThrottle = 1500;
@@ -167,14 +171,14 @@ TEST_F(AltholdControlUnittest, AltitudeControlRaisesThrottleWhenBelowTarget)
     testAltitudeCm = 0.0f;
     testAltitudeDerivativeCmS = 0.0f;
     testAltitudeAccelerationCmS = 0.0f;
-    altitudeControl(100.0f, 0.01f, 0.0f, 500.0f);
+    altitudeControl(100.0f, TASK_PERIOD_HZ(100), 0.0f, 500.0f);
     const float belowTargetThrottle = getAutopilotThrottle();
 
     resetAltitudeControl();
     testAltitudeCm = 200.0f;
     testAltitudeDerivativeCmS = 0.0f;
     testAltitudeAccelerationCmS = 0.0f;
-    altitudeControl(100.0f, 0.01f, 0.0f, 500.0f);
+    altitudeControl(100.0f, TASK_PERIOD_HZ(100), 0.0f, 500.0f);
     const float aboveTargetThrottle = getAutopilotThrottle();
 
     EXPECT_GT(belowTargetThrottle, aboveTargetThrottle);
@@ -192,14 +196,14 @@ TEST_F(AltholdControlUnittest, AltitudeControlLowersThrottleWhenAcceleratingUpwa
     testAltitudeCm = 100.0f;
     testAltitudeDerivativeCmS = 0.0f;
     testAltitudeAccelerationCmS = 0.0f;
-    altitudeControl(100.0f, 0.01f, 0.0f, 500.0f);
+    altitudeControl(100.0f, TASK_PERIOD_HZ(100), 0.0f, 500.0f);
     const float noAccelerationThrottle = getAutopilotThrottle();
 
     resetAltitudeControl();
     testAltitudeCm = 100.0f;
     testAltitudeDerivativeCmS = 0.0f;
     testAltitudeAccelerationCmS = 200.0f; // accelerating upward
-    altitudeControl(100.0f, 0.01f, 0.0f, 500.0f);
+    altitudeControl(100.0f, TASK_PERIOD_HZ(100), 0.0f, 500.0f);
     const float upwardAccelerationThrottle = getAutopilotThrottle();
 
     // altitudeKa is 50 * 0.006 = 0.3, so this is roughly 60 PWM of opposition.
@@ -211,11 +215,11 @@ TEST_F(AltholdControlUnittest, AltitudeControlRespectsVelocityLimit)
     testAltitudeCm = 0.0f;
     testAltitudeDerivativeCmS = 0.0f;
     testAltitudeAccelerationCmS = 0.0f;
-    altitudeControl(200.0f, 0.01f, 0.0f, 100.0f);
+    altitudeControl(200.0f, TASK_PERIOD_HZ(100), 0.0f, 100.0f);
     const float limitedThrottle = getAutopilotThrottle();
 
     resetAltitudeControl();
-    altitudeControl(800.0f, 0.01f, 0.0f, 1000.0f);
+    altitudeControl(800.0f, TASK_PERIOD_HZ(100), 0.0f, 1000.0f);
     const float highLimitThrottle = getAutopilotThrottle();
 
     EXPECT_GT(highLimitThrottle, limitedThrottle);
@@ -227,15 +231,80 @@ TEST_F(AltholdControlUnittest, AltitudeControlCompensatesForTilt)
     testAltitudeDerivativeCmS = 0.0f;
     testAltitudeAccelerationCmS = 0.0f;
     testCosTiltAngle = 1.0f;
-    altitudeControl(100.0f, 0.01f, 0.0f, 500.0f);
+    altitudeControl(100.0f, TASK_PERIOD_HZ(100), 0.0f, 500.0f);
     const float levelThrottle = getAutopilotThrottle();
 
     resetAltitudeControl();
     testCosTiltAngle = 0.5f;
-    altitudeControl(100.0f, 0.01f, 0.0f, 500.0f);
+    altitudeControl(100.0f, TASK_PERIOD_HZ(100), 0.0f, 500.0f);
     const float tiltedThrottle = getAutopilotThrottle();
 
     EXPECT_GT(tiltedThrottle, levelThrottle);
+}
+
+// TASK_ALTHOLD is event driven off positionEstimatorUpdate() rather than run on a
+// fixed period, so it starts as soon as a new altitude estimate exists.
+TEST_F(AltholdControlUnittest, AltHoldIsScheduledByEstimatorUpdates)
+{
+    // Nothing published and no time elapsed: nothing to do
+    EXPECT_FALSE(altHoldUpdateCheck(currentTimeUs, 0));
+
+    // A new estimate schedules the task, and only once
+    testEstimatorUpdatePending = true;
+    EXPECT_TRUE(altHoldUpdateCheck(currentTimeUs, 0));
+    EXPECT_FALSE(altHoldUpdateCheck(currentTimeUs, 0));
+
+    // With no estimator running, periodic scheduling still services transitions
+    EXPECT_FALSE(altHoldUpdateCheck(currentTimeUs, TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ)));
+    EXPECT_TRUE(altHoldUpdateCheck(currentTimeUs, 2 * TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ)));
+}
+
+// Event driven scheduling makes the task interval the estimator's, so dt has to
+// be measured. It is bounded, so a first run or a starved one cannot hand the
+// integrators an arbitrarily large step.
+TEST_F(AltholdControlUnittest, TaskIntervalIsMeasuredAndBounded)
+{
+    const timeUs_t nominalUs = TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ);
+
+    testTaskDeltaTimeUs = nominalUs;
+    EXPECT_EQ(autopilotTaskIntervalUs(nominalUs), nominalUs);
+
+    testTaskDeltaTimeUs = TASK_PERIOD_HZ(200);
+    EXPECT_EQ(autopilotTaskIntervalUs(nominalUs), (timeUs_t)5000);
+
+    testTaskDeltaTimeUs = TASK_PERIOD_HZ(50);
+    EXPECT_EQ(autopilotTaskIntervalUs(nominalUs), (timeUs_t)20000);
+
+    testTaskDeltaTimeUs = 0; // no measurement yet
+    EXPECT_EQ(autopilotTaskIntervalUs(nominalUs), nominalUs);
+
+    testTaskDeltaTimeUs = 10 * nominalUs;
+    EXPECT_EQ(autopilotTaskIntervalUs(nominalUs), 4 * nominalUs);
+
+    testTaskDeltaTimeUs = TASK_PERIOD_HZ(10000);
+    EXPECT_EQ(autopilotTaskIntervalUs(nominalUs), nominalUs / 4);
+}
+
+// The measured interval has to reach the control law: with the same altitude
+// error, a longer interval must integrate proportionally more.
+TEST_F(AltholdControlUnittest, AltHoldIntegratesOverTheMeasuredInterval)
+{
+    auto throttleAfterOneStep = [](timeDelta_t intervalUs) {
+        flightModeFlags &= ~ALT_HOLD_MODE;
+        updateAltHold(currentTimeUs);   // leave alt hold, clearing the integrator
+        testAltitudeCm = 0.0f;
+        testTaskDeltaTimeUs = intervalUs;
+        flightModeFlags |= ALT_HOLD_MODE;
+        updateAltHold(currentTimeUs);   // enter, capturing a target of 0 cm
+        testAltitudeCm = -100.0f;       // now 1 m below the target
+        updateAltHold(currentTimeUs);   // one control step at the given interval
+        return getAutopilotThrottle();
+    };
+
+    const float shortStep = throttleAfterOneStep(TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ));
+    const float longStep = throttleAfterOneStep(4 * TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ));
+
+    EXPECT_GT(longStep, shortStep);
 }
 
 // STUBS
@@ -292,6 +361,14 @@ extern "C" {
     void positionEstimatorEnableXY(bool /*enable*/) { }
     bool positionEstimatorIsValidXY(void) { return false; }
 
+    bool testEstimatorUpdatePending = false;
+    bool positionEstimatorTakeUpdate(positionEstimatorConsumer_e /*consumer*/)
+    {
+        const bool pending = testEstimatorUpdatePending;
+        testEstimatorUpdatePending = false;
+        return pending;
+    }
+
     void positionNavInit(void) { }
     void positionNavReset(void) { }
     void positionNavUpdate(float /*dt*/, const positionEstimate3d_t * /*est*/) { }
@@ -305,10 +382,14 @@ extern "C" {
         UNUSED(rxConfig);
     }
 
+    // The alt hold task is event driven, so its interval is whatever the position
+    // estimator delivers. Tests set this to check that dt is measured, not assumed.
+    timeDelta_t testTaskDeltaTimeUs = TASK_PERIOD_HZ(ALTHOLD_TASK_RATE_HZ);
+
     timeDelta_t getTaskDeltaTimeUs(taskId_e taskId)
     {
         UNUSED(taskId);
-        return TASK_PERIOD_HZ(100); // default poshold rate in tests
+        return testTaskDeltaTimeUs;
     }
 
     throttleStatus_e calculateThrottleStatus() { return testThrottleStatus; }


### PR DESCRIPTION
`TASK_POSHOLD` and `TASK_ALTHOLD` are now event driven off the position estimator, in the same way `TASK_RX` is driven off received frames, so the hold loops run as soon as new state exists rather than at an arbitrary phase against the task that produces it. Both ran at 100 Hz alongside the estimator's own 100 Hz task, with no phase relationship between them, so a control cycle could act on state up to a full 10 ms old.

While reframing this it became clear the estimator was in the wrong place, and that this had left a real gap in optical-flow-only setups. Both are addressed here.

## Event driven scheduling

`positionEstimatorUpdate()` publishes one update event per run, taken once per consumer via `positionEstimatorTakeUpdate()` — one bit each, so `ALTHOLD` taking the event does not hide it from `POSHOLD`. The two tasks gain `altHoldUpdateCheck` / `posHoldUpdateCheck` check functions, mirroring `rxUpdateCheck`. Each falls back to periodic scheduling after 2x its nominal period, so mode entry and exit are still serviced if the estimator is not
running at all.

## dt

With the interval now set by the estimator rather than a fixed period, every dt in these loops has to be measured. Alt hold's `static const float taskIntervalSeconds` was the one place still assuming a nominal period and is gone. Both loops take their interval from `autopilotTaskIntervalUs()`, which measures `getTaskDeltaTimeUs(TASK_SELF)` and bounds it to nominal/4 .. nominal*4 so a first run after a task is enabled, or one starved behind a long-running peer, cannot hand the integrators a step of arbitrary size.

This reaches alt hold's target-altitude integration and I term, and pos hold's `positionNavUpdate`, speed trend, sanity-fence timers, yaw ramp and F-filter gain retune. GPS rescue is unaffected — it passes its own interval into `altitudeControl()`.

Intervals are carried as `timeUs_t` and converted to seconds only at the point of use, via a new `US_TO_INTERVAL()` in `common/maths.h` alongside the existing `HZ_TO_INTERVAL` / `HZ_TO_INTERVAL_US`. `altitudeControl()` takes `timeUs_t` accordingly.

## TASK_ALTITUDE renamed to TASK_POSITION

The estimator fuses baro, GPS, rangefinder, optical flow and IMU into a full 3D ENU state that feeds altitude hold, position hold, nav and rescue — but it ran inside `calculateEstimatedAltitude()`, under a task named ALTITUDE, as though altitude were its purpose. The task is now `TASK_POSITION` running `positionUpdate()`, with the altitude display filter and vario demoted to a static consumer, `updateAltitudeFromEstimate()`. `TASK_ALTITUDE_RATE_HZ` becomes `TASK_POSITION_RATE_HZ`. The CLI `tasks` output shows `POSITION`.

## Optical-flow-only fix

`TASK_POSHOLD` was enabled on `GPS || opticalflow`, while the estimator task was enabled on `baro || GPS || rangefinder` and its file guard omitted `USE_OPTICALFLOW` entirely. On a flow-only craft position hold was therefore
enabled against a state that never updated, and on a flow-only target the estimator task did not exist at all.

Task enable conditions now key on features rather than sensor detection. Detection is evaluated once at `tasksInit()`, so keying on it means a source detected later leaves the estimator permanently off, whereas a feature enabled whose hardware never appears costs only a prediction step and reports the estimate invalid. Baro keeps its sensor bit as it has no feature flag and is probed synchronously at boot. `TASK_ALTHOLD` and `TASK_POSHOLD` follow the same
rule restricted to the axes each needs, so neither can be enabled without its estimator running.

## Behaviour changes

- CLI `tasks` lists `POSITION` where it previously listed `ALTITUDE`.
- A craft with rangefinder or optical flow hardware configured but the corresponding feature switched off no longer gets `ALTHOLD` / `POSHOLD` enabled from that source alone. This is the intended correction — those sources were not feeding the estimator anyway, since `TASK_RANGEFINDER` and `TASK_OPTICALFLOW` are themselves feature gated — but it differs from master for that configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified position estimation now supports altitude updates from barometer, GPS, rangefinder, and optical flow data.
  * Altitude hold and position hold respond to fresh estimator updates, with periodic fallback behavior when needed.
  * Improved handling of measured task intervals for more consistent altitude and position control.

* **Bug Fixes**
  * Improved altitude-state reset behavior during arming transitions.
  * Expanded optical-flow support for position-related flight features.

* **Tests**
  * Added coverage for estimator-triggered updates, timing limits, and interval-dependent control behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->