### PR TITLE
telemetry/mavlink: run telemetry on the MAVLink RX port without a provider slot

### DIFF
--- a/src/main/telemetry/mavlink.c
+++ b/src/main/telemetry/mavlink.c
@@ -1526,9 +1526,21 @@ static void processMAVLinkTelemetry(void)
     }
 }
 
+// A MAVLink receiver link is bidirectional, so telemetry rides on the RX port
+// without a provider slot, as CRSF does; a configured provider still wins.
+static bool mavlinkTelemetryOnRxPort(void)
+{
+#ifdef USE_SERIALRX_MAVLINK
+    if (telemetryPort == SERIAL_PORT_NONE && rxRuntimeState.serialrxProvider == SERIALRX_MAVLINK) {
+        return true;
+    }
+#endif
+    return telemetryPort != SERIAL_PORT_NONE && telemetryCheckRxPortShared(telemetryPort, rxRuntimeState.serialrxProvider);
+}
+
 void checkMAVLinkTelemetryState(void)
 {
-    if (telemetryPort != SERIAL_PORT_NONE && telemetryCheckRxPortShared(telemetryPort, rxRuntimeState.serialrxProvider)) {
+    if (mavlinkTelemetryOnRxPort()) {
         if (!mavlinkTelemetryEnabled && telemetrySharedPort != NULL) {
             mavlinkPort = telemetrySharedPort;
             lastArmingDisableFlags = 0;


### PR DESCRIPTION
A MAVLink receiver link is bidirectional, but telemetry only started when a MAVLink telemetry provider was also configured on the same UART. CRSF has always implied telemetry from the RX alone, so switching between the two providers meant adding or removing a MAVLink provider slot by hand each time.

With no MAVLink provider configured, telemetry now attaches to the open RX port whenever the serial RX provider is MAVLink. A configured provider keeps its existing behaviour, whether on the RX UART or a dedicated one. Telemetry remains gated by the TELEMETRY feature, as for CRSF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MAVLink telemetry can now use the serial receiver port when no dedicated telemetry port is configured.
  * Shared receiver-port handling now supports MAVLink serial RX setups, improving telemetry compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->