### PR TITLE
gps: accept ublox modules that respond with an unrecognized hw version or never answer MON-VER

### DIFF
--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6240,7 +6240,15 @@ RAM_CODE static void cliStatus(const char *cmdName, char *cmdline)
             }
 #ifdef USE_GPS_UBLOX
             if (gpsConfig()->provider == GPS_UBLOX) {
-                cliPrintf(", version =  %s", gpsData.platformVersion != UBX_VERSION_UNDEF ? ubloxVersionMap[gpsData.platformVersion].str : "unknown");
+                if (gpsData.platformVersion == UBX_VERSION_UNKNOWN_GENERATION) {
+                    if (gpsData.unknownHwVersion) {
+                        cliPrintf(", version =  unknown (0x%08x)", gpsData.unknownHwVersion);
+                    } else {
+                        cliPrintf(", version =  unknown (no MON-VER reply)");
+                    }
+                } else {
+                    cliPrintf(", version =  %s", gpsData.platformVersion != UBX_VERSION_UNDEF ? ubloxVersionMap[gpsData.platformVersion].str : "unknown");
+                }
             }
 #endif
         }
@@ -6892,7 +6900,15 @@ RAM_CODE static void cliEnv(const char *cmdName, char *cmdline)
         cliPrintNameValue("GPS_CONNECTED", gpsData.state >= GPS_STATE_CONFIGURE ? "ON" : "OFF");
         cliPrintNameValue("GPS_CONFIGURED", gpsData.state > GPS_STATE_CONFIGURE ? "ON" : "OFF");
 #ifdef USE_GPS_UBLOX
-        cliPrintNameValue("GPS_VERSION", gpsData.platformVersion != UBX_VERSION_UNDEF ? ubloxVersionMap[gpsData.platformVersion].str : "unknown");
+        if (gpsData.platformVersion == UBX_VERSION_UNKNOWN_GENERATION) {
+            if (gpsData.unknownHwVersion) {
+                cliPrintNameValuef("GPS_VERSION", "unknown (0x%08x)", gpsData.unknownHwVersion);
+            } else {
+                cliPrintNameValue("GPS_VERSION", "unknown (no MON-VER reply)");
+            }
+        } else {
+            cliPrintNameValue("GPS_VERSION", gpsData.platformVersion != UBX_VERSION_UNDEF ? ubloxVersionMap[gpsData.platformVersion].str : "unknown");
+        }
 #endif
     }
 #endif

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6083,6 +6083,21 @@ static const char * const nodeHealthNames[] = { "OK", "WARNING", "ERROR", "CRITI
 static const char * const nodeModeNames[] = { "OPERATIONAL", "INITIALISING", "MAINTENANCE", "UPDATING", "?", "?", "?", "OFFLINE" };
 #endif
 
+#if defined(USE_GPS) && defined(USE_GPS_UBLOX)
+// Shared by cliStatus() and cliEnv() so the two displays can't drift apart. buf must be at least 24 bytes.
+static const char *cliGpsUbloxVersionString(char *buf)
+{
+    if (gpsData.platformVersion == UBX_VERSION_UNKNOWN_GENERATION) {
+        if (gpsData.unknownHwVersionValid) {
+            tfp_sprintf(buf, "unknown (0x%08x)", gpsData.unknownHwVersion);
+            return buf;
+        }
+        return "unknown (no MON-VER reply)";
+    }
+    return gpsData.platformVersion != UBX_VERSION_UNDEF ? ubloxVersionMap[gpsData.platformVersion].str : "unknown";
+}
+#endif
+
 RAM_CODE static void cliStatus(const char *cmdName, char *cmdline)
 {
     UNUSED(cmdName);
@@ -6240,15 +6255,8 @@ RAM_CODE static void cliStatus(const char *cmdName, char *cmdline)
             }
 #ifdef USE_GPS_UBLOX
             if (gpsConfig()->provider == GPS_UBLOX) {
-                if (gpsData.platformVersion == UBX_VERSION_UNKNOWN_GENERATION) {
-                    if (gpsData.unknownHwVersion) {
-                        cliPrintf(", version =  unknown (0x%08x)", gpsData.unknownHwVersion);
-                    } else {
-                        cliPrintf(", version =  unknown (no MON-VER reply)");
-                    }
-                } else {
-                    cliPrintf(", version =  %s", gpsData.platformVersion != UBX_VERSION_UNDEF ? ubloxVersionMap[gpsData.platformVersion].str : "unknown");
-                }
+                char gpsVersionBuf[24];
+                cliPrintf(", version =  %s", cliGpsUbloxVersionString(gpsVersionBuf));
             }
 #endif
         }
@@ -6900,15 +6908,8 @@ RAM_CODE static void cliEnv(const char *cmdName, char *cmdline)
         cliPrintNameValue("GPS_CONNECTED", gpsData.state >= GPS_STATE_CONFIGURE ? "ON" : "OFF");
         cliPrintNameValue("GPS_CONFIGURED", gpsData.state > GPS_STATE_CONFIGURE ? "ON" : "OFF");
 #ifdef USE_GPS_UBLOX
-        if (gpsData.platformVersion == UBX_VERSION_UNKNOWN_GENERATION) {
-            if (gpsData.unknownHwVersion) {
-                cliPrintNameValuef("GPS_VERSION", "unknown (0x%08x)", gpsData.unknownHwVersion);
-            } else {
-                cliPrintNameValue("GPS_VERSION", "unknown (no MON-VER reply)");
-            }
-        } else {
-            cliPrintNameValue("GPS_VERSION", gpsData.platformVersion != UBX_VERSION_UNDEF ? ubloxVersionMap[gpsData.platformVersion].str : "unknown");
-        }
+        char gpsVersionBuf[24];
+        cliPrintNameValue("GPS_VERSION", cliGpsUbloxVersionString(gpsVersionBuf));
 #endif
     }
 #endif

--- a/src/main/cli/cli.c
+++ b/src/main/cli/cli.c
@@ -6908,8 +6908,10 @@ RAM_CODE static void cliEnv(const char *cmdName, char *cmdline)
         cliPrintNameValue("GPS_CONNECTED", gpsData.state >= GPS_STATE_CONFIGURE ? "ON" : "OFF");
         cliPrintNameValue("GPS_CONFIGURED", gpsData.state > GPS_STATE_CONFIGURE ? "ON" : "OFF");
 #ifdef USE_GPS_UBLOX
-        char gpsVersionBuf[24];
-        cliPrintNameValue("GPS_VERSION", cliGpsUbloxVersionString(gpsVersionBuf));
+        if (gpsConfig()->provider == GPS_UBLOX) {
+            char gpsVersionBuf[24];
+            cliPrintNameValue("GPS_VERSION", cliGpsUbloxVersionString(gpsVersionBuf));
+        }
 #endif
     }
 #endif

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -407,6 +407,10 @@ void gpsInit(void)
 #endif
     gpsData.updateRateHz = 10; // initialise at 10hz
     gpsData.platformVersion = UBX_VERSION_UNDEF;
+#ifdef USE_GPS_UBLOX
+    gpsData.unknownHwVersion = 0;
+    gpsData.ubloxValidFrameReceived = false;
+#endif
 
 #ifdef USE_DASHBOARD
     gpsData.errors = 0;
@@ -485,6 +489,10 @@ struct ubloxVersion_s ubloxVersionMap[] = {
     [UBX_VERSION_M8] = { 0x00080000, "M8" },
     [UBX_VERSION_M9] = { 0x00190000, "M9" },
     [UBX_VERSION_M10] = { 0x000A0000, "M10" },
+    // Sentinel entry, never matched by ubloxParseVersion() (hw == ~0, same trick as UBX_VERSION_UNDEF).
+    // platformVersion is set to this value explicitly by the MON-VER handler below when a module
+    // responds with a hw code that isn't in this table, so the raw code isn't lost here.
+    [UBX_VERSION_UNKNOWN_GENERATION] = { ~0, "unknown" },
 };
 
 static uint8_t ubloxAddValSet(ubxMessage_t * tx_buffer, ubxValGetSetBytes_e key, const uint8_t * payload, const uint8_t offset)
@@ -1047,6 +1055,21 @@ static void gpsConfigureUblox(void)
         messageCounter = 0;
         gpsData.state_ts = gpsData.now;
 
+        // We've spent a full dwell (GPS_BAUDRATE_TEST_COUNT retries) at this baud rate without a
+        // MON-VER reply. If a checksum-valid UBX frame nonetheless arrived at this same rate
+        // (ubloxValidFrameReceived - set for any class/id, not just MON-VER), the module is
+        // provably alive and correctly framed right here; it just doesn't implement the MON-VER
+        // poll. Accept it as a module of unknown generation instead of hopping to another baud
+        // rate - since userBaudRateIndex (the configured Ports-tab baud) is always tried first,
+        // this typically resolves in one ~1s dwell instead of a full multi-rate sweep. The next
+        // pass through this state takes the `platformVersion > UBX_VERSION_UNDEF` branch above
+        // and proceeds normally.
+        if (gpsData.ubloxValidFrameReceived) {
+            gpsData.platformVersion = UBX_VERSION_UNKNOWN_GENERATION;
+            gpsData.unknownHwVersion = 0; // no MON-VER reply was ever received, so no hw code to report
+            return;
+        }
+
         // failed to connect at that rate after five attempts
         // try other GPS baudrates, starting at 9600 and moving up
         if (gpsData.tempBaudRateIndex == 0) {
@@ -1056,6 +1079,9 @@ static void gpsConfigureUblox(void)
         }
         // set the FC baud rate to the new temp baud rate
         serialSetBaudRate(gpsPort, baudRates[gpsInitData[gpsData.tempBaudRateIndex].baudrateIndex]);
+        // Only relevant to the check above: a frame received at the baud rate we're leaving
+        // must not be mistaken for proof the *new* rate is correct.
+        gpsData.ubloxValidFrameReceived = false;
         initBaudRateCycleCount++;
 
         break;
@@ -2575,10 +2601,25 @@ static bool UBLOX_parse_gps(void)
 #ifdef USE_DASHBOARD
         *dashboardGpsPacketLogCurrentChar = DASHBOARD_LOG_UBLOX_MONVER;
 #endif
-        gpsData.platformVersion = ubloxParseVersion(strtoul(ubxRcvMsgPayload.ubxMonVer.hwVersion, NULL, 16));
-        gpsData.ubloxM7orAbove = gpsData.platformVersion >= UBX_VERSION_M7;
-        gpsData.ubloxM8orAbove = gpsData.platformVersion >= UBX_VERSION_M8;
-        gpsData.ubloxM9orAbove = gpsData.platformVersion >= UBX_VERSION_M9;
+        {
+            const uint32_t ubloxHwVersion = strtoul(ubxRcvMsgPayload.ubxMonVer.hwVersion, NULL, 16);
+            gpsData.platformVersion = ubloxParseVersion(ubloxHwVersion);
+            if (gpsData.platformVersion == UBX_VERSION_UNDEF) {
+                // The module answered MON-VER (so it's genuinely there and speaking UBX), it's just
+                // a hw code this firmware doesn't recognize yet (e.g. a clone chipset). Without this,
+                // platformVersion would stay UBX_VERSION_UNDEF forever and GPS_STATE_DETECT_BAUD would
+                // never advance (see the `platformVersion > UBX_VERSION_UNDEF` gate above), even though
+                // the module is fully functional. Treat it as a valid module of unknown generation and
+                // keep the raw code around for `status` / `get GPS_VERSION` to display.
+                gpsData.platformVersion = UBX_VERSION_UNKNOWN_GENERATION;
+                gpsData.unknownHwVersion = ubloxHwVersion;
+            }
+        }
+        // Exclude UBX_VERSION_UNKNOWN_GENERATION from these checks: it sorts after UBX_VERSION_M10 so a bare
+        // `>=` would wrongly claim M7/M8/M9+ capabilities for a module of unconfirmed generation.
+        gpsData.ubloxM7orAbove = gpsData.platformVersion >= UBX_VERSION_M7 && gpsData.platformVersion <= UBX_VERSION_M10;
+        gpsData.ubloxM8orAbove = gpsData.platformVersion >= UBX_VERSION_M8 && gpsData.platformVersion <= UBX_VERSION_M10;
+        gpsData.ubloxM9orAbove = gpsData.platformVersion >= UBX_VERSION_M9 && gpsData.platformVersion <= UBX_VERSION_M10;
         break;
     case CLSMSG(CLASS_NAV, MSG_NAV_POSLLH):
 #ifdef USE_DASHBOARD
@@ -2831,6 +2872,11 @@ static bool gpsNewFrameUBLOX(uint8_t data)
     case UBX_PARSE_CHECKSUM_B:
         if (ubxRcvMsgChecksumB == data) {
             // Checksum B also matches, successfully received a new full packet!
+            // Independent of which message this is, a checksum-valid frame proves the module is a
+            // live UBX speaker. GPS_STATE_DETECT_BAUD uses this to give up waiting on a MON-VER
+            // reply that may never come (some modules never implement that poll) instead of
+            // cycling baud rates forever.
+            gpsData.ubloxValidFrameReceived = true;
 #ifdef USE_DASHBOARD
             dashboardGpsPacketCount++;  // Packet counter used by dashboard device.
             shiftPacketLog();           // Make space for message handling to add the message type char to the dashboard device packet log.

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -409,8 +409,12 @@ void gpsInit(void)
     gpsData.platformVersion = UBX_VERSION_UNDEF;
 #ifdef USE_GPS_UBLOX
     gpsData.unknownHwVersion = 0;
+    gpsData.unknownHwVersionValid = false;
     gpsData.ubloxValidFrameReceived = false;
 #endif
+    gpsData.ubloxM7orAbove = false;
+    gpsData.ubloxM8orAbove = false;
+    gpsData.ubloxM9orAbove = false;
 
 #ifdef USE_DASHBOARD
     gpsData.errors = 0;
@@ -1066,7 +1070,13 @@ static void gpsConfigureUblox(void)
         // and proceeds normally.
         if (gpsData.ubloxValidFrameReceived) {
             gpsData.platformVersion = UBX_VERSION_UNKNOWN_GENERATION;
-            gpsData.unknownHwVersion = 0; // no MON-VER reply was ever received, so no hw code to report
+            gpsData.unknownHwVersion = 0;
+            gpsData.unknownHwVersionValid = false; // no MON-VER reply was ever received, so no hw code to report
+            // A module reconnecting here (e.g. after GPS_STATE_LOST_COMMUNICATION) could otherwise
+            // inherit stale capability flags left over from a previously connected, recognized module.
+            gpsData.ubloxM7orAbove = false;
+            gpsData.ubloxM8orAbove = false;
+            gpsData.ubloxM9orAbove = false;
             return;
         }
 
@@ -2613,6 +2623,12 @@ static bool UBLOX_parse_gps(void)
                 // keep the raw code around for `status` / `get GPS_VERSION` to display.
                 gpsData.platformVersion = UBX_VERSION_UNKNOWN_GENERATION;
                 gpsData.unknownHwVersion = ubloxHwVersion;
+                gpsData.unknownHwVersionValid = true;
+            } else {
+                // Recognized module: clear any unknown-hw-code state left over from a previous
+                // module on this port (e.g. swapped without a full reboot).
+                gpsData.unknownHwVersion = 0;
+                gpsData.unknownHwVersionValid = false;
             }
         }
         // Exclude UBX_VERSION_UNKNOWN_GENERATION from these checks: it sorts after UBX_VERSION_M10 so a bare

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -1597,6 +1597,11 @@ void gpsUpdate(timeUs_t currentTimeUs)
         // previously we would attempt a different baud rate here if gps auto-baud was enabled.  that code has been removed.
         gpsSol.numSat = 0;
         DISABLE_STATE(GPS_FIX);
+#ifdef USE_GPS_UBLOX
+        // Defensive: a frame received before the disconnect must not be mistaken for evidence
+        // that a module is still present once we start a fresh detection cycle.
+        gpsData.ubloxValidFrameReceived = false;
+#endif
         gpsSetState(GPS_STATE_DETECT_BAUD);
         break;
 

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -322,7 +322,8 @@ typedef struct gpsData_s {
 #ifdef USE_GPS_UBLOX
     uint32_t lastNavSolTs;          // time stamp of last UBCX message.  Used to calculate message delta
     ubloxVersion_e platformVersion; // module platform version, mapped from reported hardware version
-    uint32_t unknownHwVersion;      // raw MON-VER hw code when platformVersion == UBX_VERSION_UNKNOWN_GENERATION; 0 if no MON-VER reply was ever received
+    uint32_t unknownHwVersion;      // raw MON-VER hw code when platformVersion == UBX_VERSION_UNKNOWN_GENERATION and unknownHwVersionValid is true; meaningless otherwise
+    bool unknownHwVersionValid;     // true if unknownHwVersion was actually populated from a MON-VER reply (distinguishes a genuine hw code of 0 from "no MON-VER reply was ever received")
     bool ubloxValidFrameReceived;   // set when any checksum-valid UBX frame (any class/id) is received at the current candidate baud rate; cleared each time GPS_STATE_DETECT_BAUD moves to a different baud
 #endif
 } gpsData_t;

--- a/src/main/io/gps.h
+++ b/src/main/io/gps.h
@@ -47,6 +47,7 @@ typedef enum {
     UBX_VERSION_M8,
     UBX_VERSION_M9,
     UBX_VERSION_M10,
+    UBX_VERSION_UNKNOWN_GENERATION, // module responded to MON-VER but reported a hw code not in ubloxVersionMap (e.g. clone chipset)
     UBX_VERSION_COUNT
 } ubloxVersion_e;
 
@@ -321,6 +322,8 @@ typedef struct gpsData_s {
 #ifdef USE_GPS_UBLOX
     uint32_t lastNavSolTs;          // time stamp of last UBCX message.  Used to calculate message delta
     ubloxVersion_e platformVersion; // module platform version, mapped from reported hardware version
+    uint32_t unknownHwVersion;      // raw MON-VER hw code when platformVersion == UBX_VERSION_UNKNOWN_GENERATION; 0 if no MON-VER reply was ever received
+    bool ubloxValidFrameReceived;   // set when any checksum-valid UBX frame (any class/id) is received at the current candidate baud rate; cleared each time GPS_STATE_DETECT_BAUD moves to a different baud
 #endif
 } gpsData_t;
 


### PR DESCRIPTION
## The bug

`ubloxParseVersion()` in `src/main/io/gps.c` only recognizes 6 hardcoded hw
version codes (M5-M10, `ubloxVersionMap`). Any module that reports a code
outside that table — or one that never replies to a `MON-VER` poll at all —
leaves `gpsData.platformVersion` permanently at `UBX_VERSION_UNDEF`.

`GPS_STATE_DETECT_BAUD` only advances once `platformVersion > UBX_VERSION_UNDEF`,
so the state machine loops on baud detection forever and never reaches
`GPS_STATE_RECEIVING_DATA` — even though the module is fully functional and
`NAV_PVT` frames are being parsed and updating `gpsSol`/`STATE(GPS_FIX)` the
whole time, independently of this stuck state machine.

Because `GPS_STATE_RECEIVING_DATA` is also what gates `SENSOR_GPS` (set in
`gpsHandleFrameComplete()`), this silently breaks three separate things that
all read the same flag:
- The Betaflight Configurator's GPS satellite icon (`MSP_STATUS` sensor
  bitmask, `msp.c` line ~1142: `sensors(SENSOR_GPS) << 3`)
- Every GPS OSD element — they're never even registered as active
  (`osd_elements.c`: `if (sensors(SENSOR_GPS)) { osdAddActiveElement(...) }`)
- GPS Rescue's `gpsHealthy` gate (`gps_rescue_multirotor.c`:
  `rescueState.sensor.gpsHealthy = gpsIsHealthy()`)

Meanwhile `status`/CLI and raw position/sat count/distance-to-home look
completely correct the whole time, which is why this is easy to misdiagnose
as a display-only bug rather than a stuck state machine.

## The fix

Two additive cases, both promoting `platformVersion` to a new
`UBX_VERSION_UNKNOWN_GENERATION` enum value (sorted after `UBX_VERSION_M10`,
so it can't be confused with a real module):

1. **MON-VER reply received, hw code not recognized** — promote instead of
   leaving it at `UBX_VERSION_UNDEF`. The raw hw code is kept in the new
   `gpsData.unknownHwVersion` field so `status` / `get GPS_VERSION` can show
   `unknown (0x########)` instead of just `unknown`.

2. **No MON-VER reply ever received, but the module is otherwise proven
   alive** — a new `gpsData.ubloxValidFrameReceived` flag is set in
   `gpsNewFrameUBLOX()` the moment *any* checksum-valid UBX frame is
   received at the current candidate baud rate, regardless of message
   class/id, and cleared each time `GPS_STATE_DETECT_BAUD` moves to a
   different baud. If that flag is set once the current baud's dwell
   completes without a `MON-VER` reply, accept the module right there as
   `UBX_VERSION_UNKNOWN_GENERATION` instead of hopping to another baud
   rate. Since the configured Ports-tab baud is always tried first, this
   typically resolves within a single ~1s dwell rather than a multi-cycle
   sweep across every candidate rate (an earlier version of this fix
   required a fixed number of full sweeps before giving up, which could
   take up to ~30s — tightened to per-baud-dwell after real-flight testing
   showed the longer wait was unnecessary). `status` shows
   `unknown (no MON-VER reply)` in this case. Some "ublox-compatible" GNSS
   chipsets stream valid NAV output but never implement the `MON-VER`
   poll/response at all — this was the actual real-world case hit during
   testing (see below).

Recognized M5-M10 modules are completely unaffected: `ubloxM7orAbove` /
`ubloxM8orAbove` / `ubloxM9orAbove` gain an explicit upper bound
(`&& platformVersion <= UBX_VERSION_M10`) purely so the new enum value
(which numerically sorts after M10) can't be misclassified as a
high-generation module by the existing `>=` comparisons.

## Files changed

- `src/main/io/gps.h` — new `UBX_VERSION_UNKNOWN_GENERATION` enum value,
  new `unknownHwVersion` / `ubloxValidFrameReceived` fields on `gpsData_t`.
- `src/main/io/gps.c` — `ubloxVersionMap` sentinel entry, the two
  promotion paths described above, and the `ubloxValidFrameReceived`
  per-baud dwell/clear logic in `gpsConfigureUblox()`.
- `src/main/cli/cli.c` — `status` and `get GPS_VERSION` display the new
  states distinctly (`unknown (0x########)` vs `unknown (no MON-VER reply)`).

Full diff: see `0001-gps-accept-ublox-modules-that-respond-with-an-unreco.patch`
in this folder, or `git log` on the `fix/gps-ublox-unrecognized-module`
branch in the source checkout.

## Hardware testing performed

Target: HGLRC F405 V2 (`HGLRCF405V2`), Betaflight 2026.6.1, GPS = Flash
Hobby T10-5883 (ublox-compatible chipset + QMC5883L compass) on UART4.

1. **Baseline reproduction (unpatched 2026.6.1):** confirmed
   `GPS: NOT CONNECTED, UART4 57600 (set to AUTO), NOT CONFIGURED, version =
   unknown` exactly as reported, indefinitely (watched for 100+ seconds
   across a full cold power cycle, `MON-VER` never answered at any of the
   6 candidate baud rates).
2. **Confirmed wiring/module were not the problem independently:** real 3D
   fix with up to 22 satellites, valid lat/lon/altitude, all visible via
   `status`'s low-level `UBLOX_parse_gps()` path throughout — proving the
   module and wiring were fine the whole time, it was purely the
   `MON-VER`-gated state machine that was stuck.
3. **Patched build (initial multi-cycle version):** `status` resolved to
   `GPS: connected, UART4 115200 (set to AUTO), configured, version =
   unknown (no MON-VER reply)` within ~7 seconds of power-on. After
   tightening to per-baud-dwell detection (see fix description above),
   re-confirmed this now resolves within ~1-8 seconds, still stable
   indefinitely — verified through numerous **full cold power cycles**
   (unplug/replug, not just a CLI `save`-reboot) across several separate
   testing sessions over multiple days, zero flapping observed at any
   point, RX link solid throughout (RX rate ~246-247), no CPU/gyro
   regression (CPU ~42-50%, gyro ~7900-7924Hz, same as baseline).
4. **`GPS_FIX_HOME` / GPS Rescue's `gpsHealthy` gate — exercised end-to-end
   with real arms, not just via MSP polling:** flown across multiple real
   flights (HDZero DVR-recorded) with `failsafe_procedure = GPS-RESCUE`
   configured and GPS Rescue's mode range active. `rescueState.sensor.
   gpsHealthy` — the specific thing this bug broke — held healthy
   throughout every flight, with real 3D fixes and satellite counts
   observed ranging 12-40. The original bug's exact symptom (GPS OSD
   elements never appearing / Configurator icon missing) did not recur
   once across any flight or power cycle during this testing period.
   Separately observed the remaining `rescueState.isAvailable`
   prerequisites (`isHeadingOK` in particular, via a since-diagnosed and
   unrelated compass/heading issue on this specific test aircraft) gate
   rescue availability independently of `gpsHealthy` — useful real-world
   confirmation that those conditions are genuinely independent,
   pre-existing requirements and not something this change conflates with
   the flag it fixes.
5. **Visual OSD/goggles confirmation:** confirmed via DVR footage across
   multiple flights that GPS OSD elements (satellite count, home
   direction/distance, GPS coordinates) populate and update live and
   continuously throughout flight — direct visual proof that the
   `SENSOR_GPS` flag this fixes is what the OSD element registration in
   `osd_elements.c` was waiting on, not just inferred from MSP/CLI state.
6. **Regression safety:** not tested against a genuine recognized M5-M10
   module (none available on hand) — argued instead from the diff itself:
   the M5-M10 path in `ubloxParseVersion()` is completely untouched, and
   the only change to shared code (`ubloxM7orAbove` etc.) is a numerically
   inert upper bound for any value ≤ `UBX_VERSION_M10`.

## Multi-target build verification

`src/main/io/gps.c` is shared across all Betaflight targets, not
HGLRC-specific. Confirmed clean builds (no warnings related to this
change) for:

- `HGLRCF405V2` (the tested board)
- `MATEKF405STD`
- `SPEEDYBEEF4`
- `AT32F435G` (generic target, different MCU family entirely — AT32 vs
  STM32F4 — confirming the change isn't accidentally MCU-family-specific)

All four `.hex` files are in `binaries/` in this folder. **These are
unofficial community test builds, not official Betaflight releases** —
label them as such if sharing with anyone else with a similarly
unrecognized clone GPS module.

## The actual chipset (T10-5883 / T10-5583)

Identified via product listings (not a datasheet, so treat as reasonably
confident rather than certain): the Flash Hobby T10-5883 used for testing
is built around a **"BT-16CYJ"** GNSS chip — this is *not* genuine u-blox
silicon.

This matters because of a naming collision worth flagging explicitly: the
"T10" family (T10-5883, and the T10-5583 SKU, which a product listing
directly confirms uses the same BT-16CYJ chip and is almost certainly the
same or near-identical hardware under a different reseller's naming) looks
deliberately similar to the **genuine u-blox "M10" family** already
recognized by Betaflight's table — Matek M10-5883 (MAX-M10S), Matek
M10Q-5883 (SAM-M10Q-00B), MicoAir M10G-5883 (u-blox M10050), Foxeer
M10Q-5883, HGLRC M100-5883. Those all use real u-blox chips and should
already work fine. "T10" vs "M10", both with a "-5883" QMC5883L-compass
suffix, is an easy mix-up — worth being explicit about in the PR itself so
reviewers (and anyone hitting this) don't assume "T10" is just a M10 typo.

I was **not** able to independently confirm other differently-branded
modules using the exact same BT-16CYJ chip — web search only turned up the
T10-5583/T10-5883 SKUs themselves. Given how this market works (many
small brands rebrand the same OEM factory board under different SKUs), it
would not be surprising if other "T10-xxxx" or unbranded AliExpress
GPS+compass combos share this chip, but that's a plausibility, not a
verified list — don't state it as fact in the PR without a source.

## Related upstream issues

- [betaflight/betaflight#13542](https://github.com/betaflight/betaflight/issues/13542) —
  "GOKU GM10 UBLOX GPS Issue": satellites & 3D fix acquired in the GPS tab,
  but GPS icon doesn't show and no OSD GPS data, UBLOX-only (NMEA works
  around it). Closed only because the reporter replaced the GPS module —
  i.e. worked around, not fixed. This is the closest match to the exact
  mechanism fixed here.
- [betaflight/betaflight#10040](https://github.com/betaflight/betaflight/issues/10040) —
  "GPS indicates its fixed but Betaflight shows nothing" — same symptom
  class (MATEKF405STD, incidentally one of the extra targets built above).
- [betaflight/betaflight#2442](https://github.com/betaflight/betaflight/issues/2442) —
  older report of the same category (ublox module confirmed working via
  passthrough/u-center, but Configurator never recognizes it).
- [betaflight/betaflight#14242](https://github.com/betaflight/betaflight/issues/14242) —
  different but related class of "ublox stopped detecting on a HGLRC
  board" regression, still open — worth a mention/cross-link but not the
  same root cause (this one is about the module falling back to NMEA-only
  entirely, not a stuck detection state machine).

## What's NOT done yet (before this should go upstream)

- No test against a real recognized M5-M10 module (regression argued from
  the diff only, not hardware-verified) — still open, no such module on
  hand.
- No unit test added. `src/test/unit/gps_conversion_unittest.cc` exists
  but only covers coordinate conversion, not `ubloxParseVersion()` or the
  state machine — a test for the two new promotion paths would strengthen
  this PR and doesn't currently exist anywhere.
- No changelog entry added (`docs/` or issue template requirements —
  check `CONTRIBUTING.md` for current expectations before opening).

Closed out since the last update: `rescueState.isAvailable`/`gpsHealthy`
end-to-end with a real arm, and visual OSD/goggles confirmation — both
now verified across multiple real flights, see "Hardware testing
performed" above.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1eA7zPcmamEzP2vbvuAzg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved GPS module detection for devices with unrecognized hardware versions.
  - Supports GPS modules that provide valid data but do not respond to version queries.
  - Status and environment output now displays unknown hardware identifiers when available.
  - Clearly reports when no version response is received.

- **Bug Fixes**
  - Prevented unknown GPS generations from being incorrectly assigned known-generation capabilities.
  - Limited GPS version reporting in environment output to u-blox GPS modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->