### PR TITLE
dshot_bitbang: skip the frame instead of waiting for the ESC reply

### DIFF
--- a/src/platform/APM32/dshot_bitbang.c
+++ b/src/platform/APM32/dshot_bitbang.c
@@ -367,13 +367,13 @@ static void bbFindPacerTimer(void)
     }
 }
 
-static timeDelta_t bbTelemetryTimeoutUs;
-
 static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocolType)
 {
     uint32_t timerclock = timerClock(bbPort->timhw);
 
     uint32_t outputFreq = getDshotBaseFrequency(dshotProtocolType);
+    // Written per port group, so the last group wins; harmless only because
+    // all groups share one protocol. Make it per port if that ever ends.
     dshotFrameUs = 1000000 * 17 * 3 / outputFreq;
     bbPort->outputARR = timerclock / outputFreq - 1;
 
@@ -381,11 +381,7 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
     uint32_t inputFreq = outputFreq * 5 * 2 * DSHOT_BITBANG_TELEMETRY_OVER_SAMPLE / 24;
     bbPort->inputARR = timerclock / inputFreq - 1;
 
-    // Backstop for bbTelemetryWait(): capture window plus 25% margin.
-    // DShot600: ~62 us -> ~78 us, DShot300: ~124 us -> ~155 us.
-    // Called per port group, so the last group wins; harmless only because all
-    // groups share one protocol. Make this and dshotFrameUs per port if that ends.
-    bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
+    bbSetCaptureTimeout(bbPort, inputFreq);
 }
 
 //
@@ -475,51 +471,6 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
     return true;
 }
 
-static bool bbTelemetryWait(void)
-{
-    // The capture must not be cut short: the window is only a few microseconds
-    // longer than the ESC reply (~62 us against ~58 us at DShot600), so aborting
-    // it leaves bbSwitchToOutput() driving the line push-pull against a still
-    // transmitting ESC. That contention couples into the 3.3 V rail and has been
-    // seen to corrupt I2C barometers on AIO boards (#15533).
-    //
-    // The window is timer paced and always completes, so bbTelemetryTimeoutUs is
-    // a backstop for a stalled DMA only.
-    bool telemetryPending;
-    bool telemetryWait = false;
-    const timeUs_t startTimeUs = micros();
-
-    do {
-        telemetryPending = false;
-        for (int i = 0; i < usedMotorPorts; i++) {
-            telemetryPending |= bbPorts[i].telemetryPending;
-        }
-
-        telemetryWait |= telemetryPending;
-
-        if (cmpTimeUs(micros(), startTimeUs) > bbTelemetryTimeoutUs) {
-            // Leave the stream for bbUpdateComplete() to reinitialise, as it does
-            // on every cycle; stopping it here would additionally race
-            // bbDMAIrqHandler() on the pacer TMRx DMA request enables, which are
-            // shared with the other port group. The buffers may hold a partial
-            // frame, so skip them rather than decode a bad-but-valid GCR frame.
-            for (int i = 0; i < usedMotorPorts; i++) {
-                if (bbPorts[i].telemetryPending) {
-                    bbPorts[i].telemetryAborted = true;
-                }
-            }
-            // Count timeouts only. Spinning here is normal - the capture window
-            // legitimately overlaps the next update on high loop rates - so
-            // counting every wait would leave debug[2] permanently nonzero
-            // instead of flagging a stalled capture.
-            DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);  //!< Reception Timeout Count
-            break;
-        }
-    } while (telemetryPending);
-
-    return telemetryWait;
-}
-
 static void bbUpdateInit(void)
 {
     for (int i = 0; i < usedMotorPorts; i++) {
@@ -542,9 +493,9 @@ static bool bbDecodeTelemetry(void)
         }
 #endif
         for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < dshotMotorCount; motorIndex++) {
-            if (bbMotors[motorIndex].bbPort->telemetryAborted) {
-                // Aborted reception; already counted in debug[2] by bbTelemetryWait().
-                // Don't bump debug[1] (missing-edge) - an abort is not a missing edge.
+            if (bbMotors[motorIndex].bbPort->captureState != BB_CAPTURE_COMPLETE) {
+                // Already counted in debug[2] by bbTelemetryWait(). Don't bump
+                // debug[1] (missing-edge) - the frame is unfinished, not late.
                 continue;
             }
 #ifdef APM32F4
@@ -576,10 +527,6 @@ static bool bbDecodeTelemetry(void)
         }
 
         dshotTelemetryState.rawValueState = DSHOT_RAW_VALUE_STATE_NOT_PROCESSED;
-
-        for (int i = 0; i < usedMotorPorts; i++) {
-            bbPorts[i].telemetryAborted = false;
-        }
     }
 #endif
 
@@ -636,6 +583,12 @@ static void bbUpdateComplete(void)
 
     for (int i = 0; i < usedMotorPorts; i++) {
         bbPort_t *bbPort = &bbPorts[i];
+
+        if (bbPort->captureState == BB_CAPTURE_IN_FLIGHT) {
+            // The ESC is still replying. Leave the capture alone and send
+            // this port's frame on the next cycle.
+            continue;
+        }
 #ifdef USE_DSHOT_CACHE_MGMT
         SCB_CleanDCache_by_Addr(bbPort->portOutputBuffer, MOTOR_DSHOT_BUF_CACHE_ALIGN_BYTES);
 #endif

--- a/src/platform/AT32/dshot_bitbang.c
+++ b/src/platform/AT32/dshot_bitbang.c
@@ -354,13 +354,13 @@ static void bbFindPacerTimer(void)
     }
 }
 
-static timeDelta_t bbTelemetryTimeoutUs;
-
 static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocolType)
 {
     uint32_t timerclock = timerClock(bbPort->timhw);
 
     uint32_t outputFreq = getDshotBaseFrequency(dshotProtocolType);
+    // Written per port group, so the last group wins; harmless only because
+    // all groups share one protocol. Make it per port if that ever ends.
     dshotFrameUs = 1000000 * 17 * 3 / outputFreq;
     bbPort->outputARR = timerclock / outputFreq - 1;
 
@@ -368,11 +368,7 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
     uint32_t inputFreq = outputFreq * 5 * 2 * DSHOT_BITBANG_TELEMETRY_OVER_SAMPLE / 24;
     bbPort->inputARR = timerclock / inputFreq - 1;
 
-    // Backstop for bbTelemetryWait(): capture window plus 25% margin.
-    // DShot600: ~62 us -> ~78 us, DShot300: ~124 us -> ~155 us.
-    // Called per port group, so the last group wins; harmless only because all
-    // groups share one protocol. Make this and dshotFrameUs per port if that ends.
-    bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
+    bbSetCaptureTimeout(bbPort, inputFreq);
 }
 
 //
@@ -456,51 +452,6 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
     return true;
 }
 
-static bool bbTelemetryWait(void)
-{
-    // The capture must not be cut short: the window is only a few microseconds
-    // longer than the ESC reply (~62 us against ~58 us at DShot600), so aborting
-    // it leaves bbSwitchToOutput() driving the line push-pull against a still
-    // transmitting ESC. That contention couples into the 3.3 V rail and has been
-    // seen to corrupt I2C barometers on AIO boards (#15533).
-    //
-    // The window is timer paced and always completes, so bbTelemetryTimeoutUs is
-    // a backstop for a stalled DMA only.
-    bool telemetryPending;
-    bool telemetryWait = false;
-    const timeUs_t startTimeUs = micros();
-
-    do {
-        telemetryPending = false;
-        for (int i = 0; i < usedMotorPorts; i++) {
-            telemetryPending |= bbPorts[i].telemetryPending;
-        }
-
-        telemetryWait |= telemetryPending;
-
-        if (cmpTimeUs(micros(), startTimeUs) > bbTelemetryTimeoutUs) {
-            // Leave the stream for bbUpdateComplete() to reinitialise, as it does
-            // on every cycle; stopping it here would additionally race
-            // bbDMAIrqHandler() on the pacer TMRx DMA request enables, which are
-            // shared with the other port group. The buffers may hold a partial
-            // frame, so skip them rather than decode a bad-but-valid GCR frame.
-            for (int i = 0; i < usedMotorPorts; i++) {
-                if (bbPorts[i].telemetryPending) {
-                    bbPorts[i].telemetryAborted = true;
-                }
-            }
-            // Count timeouts only. Spinning here is normal - the capture window
-            // legitimately overlaps the next update on high loop rates - so
-            // counting every wait would leave debug[2] permanently nonzero
-            // instead of flagging a stalled capture.
-            DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);  //!< Reception Timeout Count
-            break;
-        }
-    } while (telemetryPending);
-
-    return telemetryWait;
-}
-
 static void bbUpdateInit(void)
 {
     for (int i = 0; i < usedMotorPorts; i++) {
@@ -523,9 +474,9 @@ static bool bbDecodeTelemetry(void)
         }
 #endif
         for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < dshotMotorCount; motorIndex++) {
-            if (bbMotors[motorIndex].bbPort->telemetryAborted) {
-                // Aborted reception; already counted in debug[2] by bbTelemetryWait().
-                // Don't bump debug[1] (missing-edge) - an abort is not a missing edge.
+            if (bbMotors[motorIndex].bbPort->captureState != BB_CAPTURE_COMPLETE) {
+                // Already counted in debug[2] by bbTelemetryWait(). Don't bump
+                // debug[1] (missing-edge) - the frame is unfinished, not late.
                 continue;
             }
 
@@ -557,10 +508,6 @@ static bool bbDecodeTelemetry(void)
         }
 
         dshotTelemetryState.rawValueState = DSHOT_RAW_VALUE_STATE_NOT_PROCESSED;
-
-        for (int i = 0; i < usedMotorPorts; i++) {
-            bbPorts[i].telemetryAborted = false;
-        }
     }
 #endif
 
@@ -631,6 +578,12 @@ static void bbUpdateComplete(void)
 
     for (int i = 0; i < usedMotorPorts; i++) {
         bbPort_t *bbPort = &bbPorts[i];
+
+        if (bbPort->captureState == BB_CAPTURE_IN_FLIGHT) {
+            // The ESC is still replying. Leave the capture alone and send
+            // this port's frame on the next cycle.
+            continue;
+        }
 
 #ifdef USE_DSHOT_TELEMETRY
         if (useDshotTelemetry) {

--- a/src/platform/STM32/dshot_bitbang.c
+++ b/src/platform/STM32/dshot_bitbang.c
@@ -404,13 +404,13 @@ static void bbFindPacerTimer(void)
     }
 }
 
-static timeDelta_t bbTelemetryTimeoutUs;
-
 static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocolType)
 {
     uint32_t timerclock = timerClock(bbPort->timhw);
 
     uint32_t outputFreq = getDshotBaseFrequency(dshotProtocolType);
+    // Written per port group, so the last group wins; harmless only because
+    // all groups share one protocol. Make it per port if that ever ends.
     dshotFrameUs = 1000000 * 17 * 3 / outputFreq;
     bbPort->outputARR = timerclock / outputFreq - 1;
 
@@ -418,11 +418,7 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
     uint32_t inputFreq = outputFreq * 5 * 2 * DSHOT_BITBANG_TELEMETRY_OVER_SAMPLE / 24;
     bbPort->inputARR = timerclock / inputFreq - 1;
 
-    // Backstop for bbTelemetryWait(): capture window plus 25% margin.
-    // DShot600: ~62 us -> ~78 us, DShot300: ~124 us -> ~155 us.
-    // Called per port group, so the last group wins; harmless only because all
-    // groups share one protocol. Make this and dshotFrameUs per port if that ends.
-    bbTelemetryTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
+    bbSetCaptureTimeout(bbPort, inputFreq);
 }
 
 //
@@ -511,51 +507,6 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
     return true;
 }
 
-static bool bbTelemetryWait(void)
-{
-    // The capture must not be cut short: the window is only a few microseconds
-    // longer than the ESC reply (~62 us against ~58 us at DShot600), so aborting
-    // it leaves bbSwitchToOutput() driving the line push-pull against a still
-    // transmitting ESC. That contention couples into the 3.3 V rail and has been
-    // seen to corrupt I2C barometers on AIO boards (#15533).
-    //
-    // The window is timer paced and always completes, so bbTelemetryTimeoutUs is
-    // a backstop for a stalled DMA only.
-    bool telemetryPending;
-    bool telemetryWait = false;
-    const timeUs_t startTimeUs = micros();
-
-    do {
-        telemetryPending = false;
-        for (int i = 0; i < usedMotorPorts; i++) {
-            telemetryPending |= bbPorts[i].telemetryPending;
-        }
-
-        telemetryWait |= telemetryPending;
-
-        if (cmpTimeUs(micros(), startTimeUs) > bbTelemetryTimeoutUs) {
-            // Leave the stream for bbUpdateComplete() to reinitialise, as it does
-            // on every cycle; stopping it here would additionally race
-            // bbDMAIrqHandler() on the pacer TIMx->DIER, which is shared with the
-            // other port group. The buffers may hold a partial frame, so skip
-            // them rather than decode a bad-but-valid GCR frame.
-            for (int i = 0; i < usedMotorPorts; i++) {
-                if (bbPorts[i].telemetryPending) {
-                    bbPorts[i].telemetryAborted = true;
-                }
-            }
-            // Count timeouts only. Spinning here is normal - the capture window
-            // legitimately overlaps the next update on high loop rates - so
-            // counting every wait would leave debug[2] permanently nonzero
-            // instead of flagging a stalled capture.
-            DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);  //!< Reception Timeout Count
-            break;
-        }
-    } while (telemetryPending);
-
-    return telemetryWait;
-}
-
 static void bbUpdateInit(void)
 {
     for (int i = 0; i < usedMotorPorts; i++) {
@@ -578,9 +529,9 @@ static bool bbDecodeTelemetry(void)
         }
 #endif
         for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < dshotMotorCount; motorIndex++) {
-            if (bbMotors[motorIndex].bbPort->telemetryAborted) {
-                // Aborted reception; already counted in debug[2] by bbTelemetryWait().
-                // Don't bump debug[1] (missing-edge) - an abort is not a missing edge.
+            if (bbMotors[motorIndex].bbPort->captureState != BB_CAPTURE_COMPLETE) {
+                // Already counted in debug[2] by bbTelemetryWait(). Don't bump
+                // debug[1] (missing-edge) - the frame is unfinished, not late.
                 continue;
             }
 #ifdef STM32F4
@@ -617,10 +568,6 @@ static bool bbDecodeTelemetry(void)
         }
 
         dshotTelemetryState.rawValueState = DSHOT_RAW_VALUE_STATE_NOT_PROCESSED;
-
-        for (int i = 0; i < usedMotorPorts; i++) {
-            bbPorts[i].telemetryAborted = false;
-        }
     }
 #endif
 
@@ -676,6 +623,13 @@ static void bbUpdateComplete(void)
 
     for (int i = 0; i < usedMotorPorts; i++) {
         bbPort_t *bbPort = &bbPorts[i];
+
+        if (bbPort->captureState == BB_CAPTURE_IN_FLIGHT) {
+            // The ESC is still replying. Leave the capture alone and send
+            // this port's frame on the next cycle.
+            continue;
+        }
+
 #ifdef USE_DSHOT_CACHE_MGMT
         SCB_CleanDCache_by_Addr(bbPort->portOutputBuffer, MOTOR_DSHOT_BUF_CACHE_ALIGN_BYTES);
 #endif

--- a/src/platform/X32/dshot_bitbang.c
+++ b/src/platform/X32/dshot_bitbang.c
@@ -56,9 +56,6 @@
 // 2 - Count of reception not complete in time
 // 3 - Number of high bits before telemetry start
 
-// Maximum time to wait for telemetry reception to complete
-#define DSHOT_TELEMETRY_TIMEOUT 2000
-
 // For MCUs that use MPU to control DMA coherency, there might be a performance hit
 // on manipulating input buffer content especially if it is read multiple times,
 // as the buffer region is attributed as not cachable.
@@ -373,12 +370,16 @@ static void bbTimebaseSetup(bbPort_t *bbPort, motorProtocolTypes_e dshotProtocol
     uint32_t timerclock = timerClock(bbPort->timhw);
 
     uint32_t outputFreq = getDshotBaseFrequency(dshotProtocolType);
+    // Written per port group, so the last group wins; harmless only because
+    // all groups share one protocol. Make it per port if that ever ends.
     dshotFrameUs = 1000000 * 17 * 3 / outputFreq;
     bbPort->outputARR = timerclock / outputFreq - 1;
 
     // XXX Explain this formula
     uint32_t inputFreq = outputFreq * 5 * 2 * DSHOT_BITBANG_TELEMETRY_OVER_SAMPLE / 24;
     bbPort->inputARR = timerclock / inputFreq - 1;
+
+    bbSetCaptureTimeout(bbPort, inputFreq);
 }
 
 //
@@ -470,33 +471,6 @@ static bool bbMotorConfig(IO_t io, uint8_t motorIndex, motorProtocolTypes_e pwmP
     return true;
 }
 
-static bool bbTelemetryWait(void)
-{
-    // Wait for telemetry reception to complete
-    bool telemetryPending;
-    bool telemetryWait = false;
-    const timeUs_t startTimeUs = micros();
-
-    do {
-        telemetryPending = false;
-        for (int i = 0; i < usedMotorPorts; i++) {
-            telemetryPending |= bbPorts[i].telemetryPending;
-        }
-
-        telemetryWait |= telemetryPending;
-
-        if (cmpTimeUs(micros(), startTimeUs) > DSHOT_TELEMETRY_TIMEOUT) {
-            break;
-        }
-    } while (telemetryPending);
-
-    if (telemetryWait) {
-        DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);  //!< Reception Timeout Count
-    }
-
-    return telemetryWait;
-}
-
 static void bbUpdateInit(void)
 {
     for (int i = 0; i < usedMotorPorts; i++) {
@@ -519,6 +493,11 @@ static bool bbDecodeTelemetry(void)
         }
 #endif
         for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < dshotMotorCount; motorIndex++) {
+            if (bbMotors[motorIndex].bbPort->captureState != BB_CAPTURE_COMPLETE) {
+                // Already counted in debug[2] by bbTelemetryWait(). Don't bump
+                // debug[1] (missing-edge) - the frame is unfinished, not late.
+                continue;
+            }
 #ifdef USE_DSHOT_BITBAND
             uint32_t rawValue = decode_bb_bitband(
                 bbMotors[motorIndex].bbPort->portInputBuffer,
@@ -609,6 +588,12 @@ static void bbUpdateComplete(void)
 
     for (int i = 0; i < usedMotorPorts; i++) {
         bbPort_t *bbPort = &bbPorts[i];
+
+        if (bbPort->captureState == BB_CAPTURE_IN_FLIGHT) {
+            // The ESC is still replying. Leave the capture alone and send
+            // this port's frame on the next cycle.
+            continue;
+        }
 #ifdef USE_DSHOT_CACHE_MGMT
         X32_CLEAN_DCACHE_BY_ADDR(bbPort->portOutputBuffer, MOTOR_DSHOT_BUF_CACHE_ALIGN_BYTES);
 #endif

--- a/src/platform/common/stm32/dshot_bitbang_impl.h
+++ b/src/platform/common/stm32/dshot_bitbang_impl.h
@@ -148,6 +148,13 @@ typedef struct tmr_base_init_s {
 
 #endif
 
+// Where a port's ESC reply capture stood when bbTelemetryWait() last sampled it.
+typedef enum {
+    BB_CAPTURE_COMPLETE = 0,  // buffer holds a finished frame: decode it, send the next
+    BB_CAPTURE_IN_FLIGHT,     // still filling: skip both the decode and the frame
+    BB_CAPTURE_STALLED,       // overdue: the buffer is unusable, but take the port back
+} bbCaptureState_e;
+
 // Per GPIO port and timer channel
 
 typedef struct bbPort_s {
@@ -207,8 +214,11 @@ typedef struct bbPort_s {
     uint16_t *portInputBuffer;
     uint32_t portInputCount;
     bool inputActive;
+    // Set by the DMA IRQ handler: an ESC reply capture is running on this port.
     volatile bool telemetryPending;
-    bool telemetryAborted;
+    bbCaptureState_e captureState;
+    timeUs_t captureDeadlineUs;
+    timeDelta_t captureTimeoutUs;
 
     // Misc
 #ifdef DEBUG_COUNT_INTERRUPT
@@ -316,6 +326,9 @@ static inline bool bbDMAWaitStopped(dmaResource_t *dmaResource)
 
     return false;
 }
+
+void bbSetCaptureTimeout(bbPort_t *bbPort, uint32_t inputFreq);
+bool bbTelemetryWait(void);
 
 void bbDshotRequestTelemetry(unsigned motorIndex);
 bool bbDshotIsMotorIdle(unsigned motorIndex);

--- a/src/platform/common/stm32/dshot_bitbang_shared.c
+++ b/src/platform/common/stm32/dshot_bitbang_shared.c
@@ -19,6 +19,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "build/debug.h"
+
+#include "drivers/time.h"
+
 #include "dshot_bitbang_impl.h"
 
 FAST_DATA_ZERO_INIT bbPacer_t bbPacers[MAX_MOTOR_PACERS];  // TIM1 or TIM8
@@ -30,6 +34,77 @@ FAST_DATA_ZERO_INIT int usedMotorPorts;
 FAST_DATA_ZERO_INIT bbMotor_t bbMotors[MAX_SUPPORTED_MOTORS];
 
 dshotBitbangStatus_e bbStatus;
+
+// Derive how long a port may sit in BB_CAPTURE_IN_FLIGHT: the capture window plus
+// a 25% margin. DShot600: ~62 us -> ~78 us, DShot300: ~124 us -> ~155 us.
+void bbSetCaptureTimeout(bbPort_t *bbPort, uint32_t inputFreq)
+{
+    bbPort->captureTimeoutUs = (timeDelta_t)(DSHOT_BB_PORT_IP_BUF_LENGTH * 1000000 / inputFreq) * 5 / 4;
+}
+
+// Record, without blocking, where each port's ESC reply capture stands.
+//
+// The capture must not be cut short: the window is only a few microseconds longer
+// than the reply (~62 us against ~58 us at DShot600), so stopping it early leaves
+// bbSwitchToOutput() driving the line push-pull against a still transmitting ESC.
+// That contention couples into the 3.3 V rail and has been seen to corrupt I2C
+// barometers on AIO boards (#15533).
+//
+// Waiting for it here is not an option either. This runs in the PID task, and at
+// loop rates where the round trip does not fit inside one cycle - DShot300 at
+// 8 kHz needs ~182 us against a 125 us period - the spin cost tens of microseconds
+// every cycle and starved TASK_RX (#15332).
+//
+// So do neither: a port still capturing keeps its capture, and skips this cycle's
+// motor frame and telemetry decode instead. Both resume on the next cycle, and the
+// ESC holds its last commanded value meanwhile - which is what it does between
+// DShot frames anyway.
+//
+// A capture overdue past captureTimeoutUs is wedged rather than busy, so the port
+// is handed back to bbUpdateComplete() to have its stream reinitialised; without
+// that the group would never send another motor frame. Its buffer stays off limits
+// to the decode either way. The deadline cannot fire on a live capture, since it is
+// armed at the first update the capture overlaps and by then at most one window
+// remains.
+bool bbTelemetryWait(void)
+{
+    const timeUs_t currentTimeUs = micros();
+    bool captureIncomplete = false;
+
+    for (int i = 0; i < usedMotorPorts; i++) {
+        bbPort_t *bbPort = &bbPorts[i];
+
+        if (!bbPort->telemetryPending) {
+            bbPort->captureState = BB_CAPTURE_COMPLETE;
+            continue;
+        }
+
+        // Not signalled complete, so the buffer is not filled, either way below.
+        captureIncomplete = true;
+
+        if (bbPort->captureState != BB_CAPTURE_IN_FLIGHT) {
+            // First update this capture has overlapped.
+            bbPort->captureState = BB_CAPTURE_IN_FLIGHT;
+            bbPort->captureDeadlineUs = currentTimeUs + bbPort->captureTimeoutUs;
+        } else if (cmpTimeUs(currentTimeUs, bbPort->captureDeadlineUs) > 0) {
+            // Overdue. Release the frame but keep telemetryPending: the IRQ owns
+            // that flag, and leaving it set is what stops the next cycle reading
+            // the torn buffer as if a fresh capture had landed in it. Once the
+            // released frame goes out the IRQ drives the flag again as usual; if
+            // it does not, this re-arms and retries.
+            bbPort->captureState = BB_CAPTURE_STALLED;
+        }
+    }
+
+    if (captureIncomplete) {
+        // A nonzero count means the ESC round trip does not fit in the loop period,
+        // so motor frames are being dropped. Lower the loop rate or raise the DShot
+        // speed to clear it.
+        DEBUG_SET(DEBUG_DSHOT_TELEMETRY_COUNTS, 2, debug[2] + 1);  //!< Reception Not Complete Count
+    }
+
+    return captureIncomplete;
+}
 
 void bbDshotRequestTelemetry(unsigned motorIndex)
 {


### PR DESCRIPTION
## Problem

`bbTelemetryWait()` runs in the PID task and spins until the ESC reply capture completes. Where the DShot round trip does not fit inside one loop period, that spin is unbounded work in the REALTIME chain.

On an F405 (TIM1/TIM8 pacer at 168 MHz, 140-sample input buffer, 51-state output frame):

| Protocol | output frame | capture window | round trip | available at 8 kHz |
|---|---|---|---|---|
| DShot600 | 28 us | 62 us | ~92 us | ~122 us — ~30 us of margin |
| DShot300 | 57 us | 124 us | **~182 us** | ~122 us — **spins ~57 us every cycle** |
| DShot150 | 113 us | 248 us | ~363 us | ~122 us — spins to the backstop |

At DShot300/8 kHz that is ~46% of the loop period spent spinning, and because the capture always completes well inside the 155 us backstop, `debug[2]` stays at zero — the existing instrumentation cannot see it. It surfaces as task lateness and RC drops.

This is the starvation #15332 removed the wait for. #15538 had to restore the wait, because aborting the capture mid-frame left `bbSwitchToOutput()` driving the line push-pull into a still transmitting ESC, and that contention corrupted I2C barometers on AIO boards (#15533). So the two fixes each solve one half and reopen the other.

## Approach

The constraints only conflict if the cycle insists on transmitting. It doesn't have to.

A port whose capture is still running **keeps it, and skips this cycle's motor frame and telemetry decode**. Both resume on the next cycle. The capture is never cut short, the PID task never blocks, and the ESC holds its last commanded value in the gap — which is what it does between DShot frames anyway.

The cost, stated plainly: a port updates at the rate its round trip allows rather than the loop rate. In the DShot300-at-8 kHz case above that is 4 kHz instead of 8 kHz for motor frames and telemetry alike; the RPM filter smooths over it. DShot600 at 8 kHz never defers, so the common F405 setup is unchanged.

## Stall backstop

Dropping the timeout outright would be a regression: a wedged capture leaves `telemetryPending` latched, and that port group would stop sending motor frames permanently. The old timeout at least let `bbUpdateComplete()` force the stream back to output.

So #15538's derived timeout stays, repurposed from a spin bound to a non-blocking deadline. A capture still pending past its full window plus 25% is wedged rather than busy, so the port is released and `bbUpdateComplete()` reinitialises the stream. The deadline cannot fire on a live capture: it is armed at the first update the capture overlaps, and at most one full window remains at that point. It is now stored per port, which also retires the "last group wins" caveat it used to carry.

`telemetryAborted` becomes a three-state `captureState`, sampled once per cycle:

| state | decode | motor frame |
|---|---|---|
| `BB_CAPTURE_COMPLETE` | yes | yes |
| `BB_CAPTURE_IN_FLIGHT` | no | no |
| `BB_CAPTURE_STALLED` | no | yes |

Naming the three states is what lets a wedged port keep transmitting while its torn buffer stays off limits to the decode — one boolean could not express that.

## Shared, not copied

`bbTelemetryWait()` and the timeout derivation live in `src/platform/common/stm32/dshot_bitbang_shared.c`, which STM32, APM32, AT32 and X32 all already build, so no makefile changes. The platform copies keep only two one-line state checks each.

Net effect on the platform files is a **reduction**: −208 lines against +141, with the policy in one place instead of four near-identical copies.

## Debug field

`debug[2]` of `DEBUG_DSHOT_TELEMETRY_COUNTS` now counts cycles where reception was not complete, which is what the field has always been documented as ("Count of reception not complete in time"). No configurator or blackbox-log-viewer change is needed. A nonzero value is now actionable: motor frames are being dropped because the round trip does not fit the loop period — lower the loop rate or raise the DShot speed.

## Scope

STM32, APM32, AT32 and X32. X32 had never received #15538, so it also picks up the decode skip it was missing and no longer decodes a torn buffer. PICO has a no-op telemetry wait and is unaffected.

## Testing

Builds clean with no warnings on STM32F405 (stdperiph), STM32F722 and STM32H743 (LL), STM32G474 (exercises the non-telemetry switch path), APM32F405, AT32F435M, and X32M7B (the only build without `USE_DMA_REGISTER_CACHE`). `make test` passes.

Also checked that the blocking DShot command path cannot be affected: its 1000 us inter-repeat delay exceeds every capture window, so no port is ever in flight there and no command repeat is skipped.

**Not yet flight tested.** The timing argument above needs a bench check on an F405 with bidirectional DShot before this is merged. `debug[2]` in `DEBUG_DSHOT_TELEMETRY_COUNTS` is the field to watch, along with task lateness on TASK_RX.

Related: #15332, #15533, #15538, #15539, #15679.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * DShot telemetry capture is now handled without blocking while waiting for ESC responses.
  * Motor frames and telemetry decoding are deferred for ports with incomplete captures, preserving responsiveness.
  * Capture timeouts are managed independently for each port, improving handling of delayed or stalled ESC responses.
* **Reliability**
  * Stalled captures are automatically detected and recovered on subsequent cycles, helping maintain consistent motor and telemetry updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->