### PR TITLE
dshot_bitbang: recover from a DMA transfer error instead of hanging

### DIFF
--- a/src/platform/APM32/dshot_bitbang.c
+++ b/src/platform/APM32/dshot_bitbang.c
@@ -283,8 +283,9 @@ FAST_IRQ_HANDLER void bbDMAIrqHandler(dmaChannelDescriptor_t *descriptor)
 
     bbTIM_DMACmd(bbPort->timhw->tim, bbPort->dmaSource, DISABLE);
 
-    if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TEIF)) {
-        while (1) {};
+    if (bbDMAHandleTransferError(bbPort, descriptor)) {
+        dbgPinLo(0);
+        return;
     }
 
     DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);

--- a/src/platform/AT32/dshot_bitbang.c
+++ b/src/platform/AT32/dshot_bitbang.c
@@ -270,8 +270,9 @@ FAST_IRQ_HANDLER void bbDMAIrqHandler(dmaChannelDescriptor_t *descriptor)
 
     bbTIM_DMACmd(bbPort->timhw->tim, bbPort->dmaSource, FALSE);
 
-    if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TEIF)) {
-        while (1) {};
+    if (bbDMAHandleTransferError(bbPort, descriptor)) {
+        dbgPinLo(0);
+        return;
     }
 
     DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);

--- a/src/platform/STM32/dshot_bitbang.c
+++ b/src/platform/STM32/dshot_bitbang.c
@@ -320,8 +320,9 @@ FAST_IRQ_HANDLER void bbDMAIrqHandler(dmaChannelDescriptor_t *descriptor)
 
     bbTIM_DMACmd(bbPort->timhw->tim, bbPort->dmaSource, DISABLE);
 
-    if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TEIF)) {
-        while (1) {};
+    if (bbDMAHandleTransferError(bbPort, descriptor)) {
+        dbgPinLo(0);
+        return;
     }
 
     DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);

--- a/src/platform/X32/dshot_bitbang.c
+++ b/src/platform/X32/dshot_bitbang.c
@@ -281,8 +281,9 @@ FAST_IRQ_HANDLER void bbDMAIrqHandler(dmaChannelDescriptor_t *descriptor)
 
     bbTIM_DMACmd(bbPort->timhw->tim, bbPort->dmaSource, DISABLE);
 
-    if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TEIF)) {
-        while (1) {};
+    if (bbDMAHandleTransferError(bbPort, descriptor)) {
+        dbgPinLo(0);
+        return;
     }
 
     DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);

--- a/src/platform/common/stm32/dshot_bitbang_impl.h
+++ b/src/platform/common/stm32/dshot_bitbang_impl.h
@@ -214,6 +214,7 @@ typedef struct bbPort_s {
 #ifdef DEBUG_COUNT_INTERRUPT
     uint32_t outputIrq;
     uint32_t inputIrq;
+    uint32_t errorIrq;
 #endif
     resourceOwner_t resourceOwner;
 } bbPort_t;
@@ -316,6 +317,8 @@ static inline bool bbDMAWaitStopped(dmaResource_t *dmaResource)
 
     return false;
 }
+
+bool bbDMAHandleTransferError(bbPort_t *bbPort, dmaChannelDescriptor_t *descriptor);
 
 void bbDshotRequestTelemetry(unsigned motorIndex);
 bool bbDshotIsMotorIdle(unsigned motorIndex);

--- a/src/platform/common/stm32/dshot_bitbang_shared.c
+++ b/src/platform/common/stm32/dshot_bitbang_shared.c
@@ -19,6 +19,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "drivers/dma.h"
+
+#include "platform/dma.h"
+
 #include "dshot_bitbang_impl.h"
 
 FAST_DATA_ZERO_INIT bbPacer_t bbPacers[MAX_MOTOR_PACERS];  // TIM1 or TIM8
@@ -30,6 +34,41 @@ FAST_DATA_ZERO_INIT int usedMotorPorts;
 FAST_DATA_ZERO_INIT bbMotor_t bbMotors[MAX_SUPPORTED_MOTORS];
 
 dshotBitbangStatus_e bbStatus;
+
+// Deal with a DMA transfer error, if that is what this IRQ was. Returns true when
+// it was, in which case the caller must return without doing any direction work.
+//
+// The stream aborted partway, so its registers no longer describe a usable
+// transfer. The caller has already stopped the stream and the pacer request, so
+// clear the error and mark the port as an input: the next bbUpdateComplete() then
+// runs bbSwitchToOutput(), which reloads the cached register set and reconfigures
+// the pin. Spinning here instead, as this used to, took the flight controller down
+// with it - there is no watchdog to recover an ISR that never returns, so one
+// transfer error meant losing the craft.
+//
+// telemetryPending is left alone if a capture was running: the port then waits out
+// its telemetry timeout before being handed back, by which point the ESC has
+// certainly stopped replying and bbSwitchToOutput() cannot drive the line against
+// it (#15533).
+bool bbDMAHandleTransferError(bbPort_t *bbPort, dmaChannelDescriptor_t *descriptor)
+{
+    if (!DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TEIF)) {
+        return false;
+    }
+
+#ifdef DEBUG_COUNT_INTERRUPT
+    bbPort->errorIrq++;
+#endif
+    bbPort->direction = DSHOT_BITBANG_DIRECTION_INPUT;
+
+    // Cleared one at a time: DMA_CLEAR_FLAG() does not parenthesise its flag
+    // argument before shifting it, so an OR-ed mask shifts only the last term and
+    // writes ones into other streams' bits.
+    DMA_CLEAR_FLAG(descriptor, DMA_IT_TEIF);
+    DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
+
+    return true;
+}
 
 void bbDshotRequestTelemetry(unsigned motorIndex)
 {


### PR DESCRIPTION
## Problem

`bbDMAIrqHandler()` answers a DMA transfer error with an infinite loop:

```c
if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TEIF)) {
    while (1) {};
}
```

No IWDG is enabled on these targets, so nothing recovers an ISR that never returns. A single DMA transfer error on a motor stream takes the whole flight controller down — in flight, that is the aircraft. The trap reads like bring-up code, where stopping dead in the debugger was the point.

It is present in the STM32, APM32, AT32 and X32 copies.

## Fix

Recover, following what `motor_DMA_IRQHandler()` already does for the non-bitbang DShot path (`src/platform/X32/pwm_output_dshot_x32.c`): the stream and the pacer request are stopped just above, so clear the error and return.

The stream aborted partway, so its registers no longer describe a usable transfer. The port is therefore marked as an input, so the next `bbUpdateComplete()` runs `bbSwitchToOutput()`, which reloads the whole cached register set and reconfigures the pin.

`telemetryPending` is deliberately left alone when a capture was running. Clearing it would hand the port straight back and let `bbSwitchToOutput()` drive the line push-pull while the ESC may still be replying — the contention behind #15533. Leaving it makes the port wait out its telemetry timeout first, by which point the reply window has certainly elapsed.

The recovery lives in `src/platform/common/stm32/dshot_bitbang_shared.c`, which STM32, APM32, AT32 and X32 all already build, so no makefile changes and no fourfold copy. Each platform's `bbDMAIrqHandler()` carries only:

```c
if (bbDMAHandleTransferError(bbPort, descriptor)) {
    dbgPinLo(0);
    return;
}
```

`errorIrq` joins `inputIrq`/`outputIrq` under `DEBUG_COUNT_INTERRUPT`, so the fault stays countable on the bench now that it no longer announces itself by hanging.

## A macro defect found on the way

The two flags are cleared in **separate** `DMA_CLEAR_FLAG()` calls rather than as one OR-ed mask, because the macro does not parenthesise its argument before shifting it:

```c
#define DMA_CLEAR_FLAG(d, flag) ... ->LIFCR = (flag << d->flagsShift)
```

`DMA_CLEAR_FLAG(d, DMA_IT_TEIF | DMA_IT_TCIF)` therefore parses as `DMA_IT_TEIF | (DMA_IT_TCIF << flagsShift)` — only the last term lands on the right stream, and the others write ones into stream 0's flag bits, clearing another peripheral's pending flags. Confirmed in the disassembly: the first attempt compiled to `orr.w r2, r2, #8` against a shifted TCIF mask; with the calls split it compiles to two correctly shifted stores.

The same shape is at `dma.h:85` and `:335` (STM32), `:75` (APM32) and `:78` (AT32). X32's variants parenthesise and are safe. **Existing OR-ed callers have the same defect** — `bus_spi_stdperiph.c:148`, `bus_spi_at32bsp.c` and others pass `DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_TCIF`. Fixing the macro is the right repair and would correct those too, but it changes behaviour in the SPI drivers, so it wants its own PR rather than being buried here.

## On the non-telemetry path

An earlier revision of this description claimed that F4/F7/H7 without bidirectional DShot never reloads `NDTR` and so would not recover. That was wrong, and I have removed it.

Every family already has what it needs to restart the transfer:

- **F4/F7/H7** — re-enabling the stream reloads `NDTR` from the previously programmed value in hardware (RM0090 §10.3.10: reloaded "when the stream is enabled again by setting EN bit to '1'"). This is what makes the plain `bbDMA_Cmd(ENABLE)` in the non-telemetry path work at all, frame after frame — and bitbang without bidirectional DShot is the default on F7/H7, so that path is very well exercised.
- **G4 and X32** — `bbUpdateComplete()` calls `bbSwitchToOutput()` unconditionally on the non-telemetry path, with a comment saying why.
- **H5/C5/N6** — `bbDMA_Cmd(ENABLE)` reloads the cached registers itself.

So marking the port as an input is what drives recovery on the telemetry path, where the cached registers are the wrong ones for the next frame, and is inert elsewhere because those paths already restart the transfer correctly.

## Testing

Builds clean with no warnings on STM32F405 (stdperiph), STM32F722 and STM32H743 (LL), STM32G474, APM32F405, AT32F435M and X32M7B. `make test` passes.

Verified in the STM32F405 disassembly that the infinite loop is gone and the error branch increments `errorIrq`, sets `direction`, writes both `*IFCR` clears with the correct per-stream shift, and returns.

**Not flight tested**, and not easily testable in normal operation — a transfer error is a fault path that should never be reached. The change is a strict improvement over hanging regardless of whether the recovery is ever exercised.

Related: #15533, #15678.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented DShot output from becoming permanently unresponsive after a DMA transfer error.
  * Added automatic recovery so affected ports return to normal operation during the next update cycle.
  * Improved DMA error handling across supported APM32, AT32, STM32, and X32 platforms.

* **Diagnostics**
  * Added optional tracking for DMA transfer-error interrupts to support troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->