### PR TITLE
dma: parenthesise the flag argument of DMA_CLEAR_FLAG and DMA_GET_FLAG_STATUS

### DIFF
--- a/src/platform/APM32/include/platform/dma.h
+++ b/src/platform/APM32/include/platform/dma.h
@@ -72,8 +72,19 @@
                                                                     handler(&dmaDescriptors[index]); \
                                                             }
 
-#define DMA_CLEAR_FLAG(d, flag) if (d->flagsShift > 31) ((DMA_TypeDef*)(d)->dma)->HIFCLR = (flag << (d->flagsShift - 32)); else ((DMA_TypeDef*)(d)->dma)->LIFCLR = (flag << d->flagsShift)
-#define DMA_GET_FLAG_STATUS(d, flag) (d->flagsShift > 31 ? ((DMA_TypeDef*)(d)->dma)->HINTSTS & (flag << (d->flagsShift - 32)): ((DMA_TypeDef*)(d)->dma)->LINTSTS & (flag << d->flagsShift))
+// (flag) and (d) are parenthesised deliberately. Callers pass OR-ed masks, and
+// without the parentheses `A | B` binds as `A | (B << flagsShift)`: only the last
+// flag lands on this stream and the rest write ones into bits 0-5, which are
+// stream 0's flags in the low register and stream 4's in the high one.
+#define DMA_CLEAR_FLAG(d, flag) \
+    do { \
+        if ((d)->flagsShift > 31) { \
+            ((DMA_TypeDef*)(d)->dma)->HIFCLR = ((flag) << ((d)->flagsShift - 32)); \
+        } else { \
+            ((DMA_TypeDef*)(d)->dma)->LIFCLR = ((flag) << (d)->flagsShift); \
+        } \
+    } while (0)
+#define DMA_GET_FLAG_STATUS(d, flag) ((d)->flagsShift > 31 ? ((DMA_TypeDef*)(d)->dma)->HINTSTS & ((flag) << ((d)->flagsShift - 32)): ((DMA_TypeDef*)(d)->dma)->LINTSTS & ((flag) << (d)->flagsShift))
 
 #define xDDL_EX_DMA_DeInit(dmaResource) DDL_EX_DMA_DeInit((DMA_ARCH_TYPE *)(dmaResource))
 #define xDDL_EX_DMA_Init(dmaResource, initstruct) DDL_EX_DMA_Init((DMA_ARCH_TYPE *)(dmaResource), initstruct)

--- a/src/platform/AT32/include/platform/dma.h
+++ b/src/platform/AT32/include/platform/dma.h
@@ -75,8 +75,12 @@ uint32_t dmaGetChannel(const uint8_t channel);
                                                                             handler(&dmaDescriptors[index]); \
                                                                     }
 
-#define DMA_CLEAR_FLAG(d, flag) ((dma_type*)(d)->dma)->clr = (flag << d->flagsShift)
-#define DMA_GET_FLAG_STATUS(d, flag) (((dma_type*)(d)->dma)->sts & (flag << d->flagsShift))
+// (flag) and (d) are parenthesised deliberately. Callers pass OR-ed masks, and
+// without the parentheses `A | B` binds as `A | (B << flagsShift)`: only the last
+// flag lands on this channel and the rest write ones into the low bits, which are
+// the first channel's flags.
+#define DMA_CLEAR_FLAG(d, flag) ((dma_type*)(d)->dma)->clr = ((flag) << (d)->flagsShift)
+#define DMA_GET_FLAG_STATUS(d, flag) (((dma_type*)(d)->dma)->sts & ((flag) << (d)->flagsShift))
 #define DMA_IT_GLOB         ((uint32_t)0x00000001) // channel global interput flag
 #define DMA_IT_TCIF         ((uint32_t)0x00000002) // channel full transport flag
 #define DMA_IT_HTIF         ((uint32_t)0x00000004) // channel half transport flag

--- a/src/platform/STM32/include/platform/dma.h
+++ b/src/platform/STM32/include/platform/dma.h
@@ -82,8 +82,19 @@
                                                                     handler(&dmaDescriptors[index]); \
                                                             }
 
-#define DMA_CLEAR_FLAG(d, flag) if (d->flagsShift > 31) ((DMA_TypeDef*)(d)->dma)->HIFCR = (flag << (d->flagsShift - 32)); else ((DMA_TypeDef*)(d)->dma)->LIFCR = (flag << d->flagsShift)
-#define DMA_GET_FLAG_STATUS(d, flag) (d->flagsShift > 31 ? ((DMA_TypeDef*)(d)->dma)->HISR & (flag << (d->flagsShift - 32)): ((DMA_TypeDef*)(d)->dma)->LISR & (flag << d->flagsShift))
+// (flag) and (d) are parenthesised deliberately. Callers pass OR-ed masks, and
+// without the parentheses `A | B` binds as `A | (B << flagsShift)`: only the last
+// flag lands on this stream and the rest write ones into bits 0-5, which are
+// stream 0's flags in the low register and stream 4's in the high one.
+#define DMA_CLEAR_FLAG(d, flag) \
+    do { \
+        if ((d)->flagsShift > 31) { \
+            ((DMA_TypeDef*)(d)->dma)->HIFCR = ((flag) << ((d)->flagsShift - 32)); \
+        } else { \
+            ((DMA_TypeDef*)(d)->dma)->LIFCR = ((flag) << (d)->flagsShift); \
+        } \
+    } while (0)
+#define DMA_GET_FLAG_STATUS(d, flag) ((d)->flagsShift > 31 ? ((DMA_TypeDef*)(d)->dma)->HISR & ((flag) << ((d)->flagsShift - 32)): ((DMA_TypeDef*)(d)->dma)->LISR & ((flag) << (d)->flagsShift))
 
 #define DMA_IT_TCIF         ((uint32_t)0x00000020)
 #define DMA_IT_HTIF         ((uint32_t)0x00000010)
@@ -332,8 +343,12 @@ uint32_t dmaGetChannel(const uint8_t channel);
                                                                             handler(&dmaDescriptors[index]); \
                                                                     }
 
-#define DMA_CLEAR_FLAG(d, flag) ((DMA_TypeDef*)(d)->dma)->IFCR = (flag << d->flagsShift)
-#define DMA_GET_FLAG_STATUS(d, flag) (((DMA_TypeDef*)(d)->dma)->ISR & (flag << d->flagsShift))
+// (flag) and (d) are parenthesised deliberately. Callers pass OR-ed masks, and
+// without the parentheses `A | B` binds as `A | (B << flagsShift)`: only the last
+// flag lands on this channel and the rest write ones into the low bits, which are
+// the first channel's flags.
+#define DMA_CLEAR_FLAG(d, flag) ((DMA_TypeDef*)(d)->dma)->IFCR = ((flag) << (d)->flagsShift)
+#define DMA_GET_FLAG_STATUS(d, flag) (((DMA_TypeDef*)(d)->dma)->ISR & ((flag) << (d)->flagsShift))
 
 #define DMA_IT_TCIF         ((uint32_t)0x00000002)
 #define DMA_IT_HTIF         ((uint32_t)0x00000004)


### PR DESCRIPTION
## Problem

The flag macros shift their `flag` argument without parenthesising it:

```c
#define DMA_CLEAR_FLAG(d, flag) ... ->LIFCR = (flag << d->flagsShift)
```

`<<` binds tighter than `|`, so a call passing an OR-ed mask expands with the wrong precedence: `A | B` parses as `A | (B << flagsShift)`. Only the last flag reaches this stream; every other term is written **unshifted**, into bits 0–5 — stream 0's flags in the low register, stream 4's in the high one. The channel-based controllers have the same defect against their first channel.

Almost every call site passes an OR-ed mask, so this is live, not theoretical:

```c
pwm_output_dshot.c:205    DMA_CLEAR_FLAG(d, FEIF | DMEIF | TEIF | HTIF | TCIF)
bus_spi_stdperiph.c:148   DMA_CLEAR_FLAG(d, HTIF | TEIF | TCIF)
```

For a stream with `flagsShift = 22`:

| call site | writes today | should write |
|---|---|---|
| DShot DMA IRQ | `0x0800001D` | `0x0F400000` |
| SPI DMA | `0x08000018` | `0x0E000000` |

So the DShot handler clears its own `TCIF`, leaves its own `FEIF`/`DMEIF`/`TEIF`/`HTIF` set, and clears **stream 0's** four error flags instead — on every motor update. The SPI drivers do the same on every transfer, from `bus_spi_stdperiph.c`, `bus_spi_ll.c`, `bus_spi_hal2.c`, `bus_spi_apm32.c` and `bus_spi_at32bsp.c`.

Two consequences, both live today:

- Streams 0 and 4 of each controller have their error flags silently cleared by their neighbours, so a real transfer error there can vanish before its own handler looks.
- The clearing streams never clear the error flags they meant to, leaving `HTIF`/`FEIF`/`DMEIF`/`TEIF` set — which RM0090's stream configuration procedure requires be cleared before the stream is re-enabled.

## Fix

Parenthesise `(flag)` and `(d)`, and wrap the two statement-form macros in `do { } while (0)` so a future `if (x) DMA_CLEAR_FLAG(...); else ...` cannot bind to the macro's own `else`. No call site does that today, but the macro invites it.

The channel-based STM32/AT32 variants need only the parentheses. The `CFCR`/`CSR` variants (H5/C5/N6) and X32's function-call variants already parenthesise and are unchanged.

No call sites are touched — they were all written expecting the corrected semantics.

## Sequencing

**#15679 should land first.** This makes genuine transfer errors on streams 0 and 4 visible again, and on master `bbDMAIrqHandler()` still answers `DMA_IT_TEIF` with `while (1) {};`. Fixing the macro without that in place turns a previously-masked error into a hang. #15679 replaces the trap with recovery.

## Testing

Builds clean with no warnings on STM32F405 (stdperiph), STM32F722 and STM32H743 (LL), STM32G474 and STM32H563, APM32F405, AT32F435M and X32M7B — covering all four macro families including the two that were already correct. `make test` passes.

Verified in the STM32F405 disassembly that `motor_DMA_IRQHandler()` now builds the mask as `movs r3, #0x3d` / `lsls r3, r2` and stores it to `LIFCR`/`HIFCR`, instead of OR-ing unshifted bits into a shifted `TCIF`.

**Not flight tested.** The change is confined to how existing masks are shifted; the risk is that a driver somewhere was relying, accidentally, on a neighbour clearing its flags — which is the bug being fixed, but is worth a bench check on a board with SPI and DShot both active.

Related: #15678, #15679.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected DMA flag handling when multiple flags are combined, ensuring all selected flags are evaluated and cleared correctly.
  * Fixed DMA status checks involving combined flags and channel or stream offsets.
  * Improved consistency of DMA flag operations across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->