### PR TITLE
dma: fix the flag mask in DMA_CLEAR_FLAG, and recover from a bitbang DMA error

### DIFF
--- a/src/platform/APM32/dshot_bitbang.c
+++ b/src/platform/APM32/dshot_bitbang.c
@@ -283,11 +283,10 @@ FAST_IRQ_HANDLER void bbDMAIrqHandler(dmaChannelDescriptor_t *descriptor)
 
     bbTIM_DMACmd(bbPort->timhw->tim, bbPort->dmaSource, DISABLE);
 
-    if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TEIF)) {
-        while (1) {};
+    if (bbDMAServiceFlags(bbPort, descriptor)) {
+        dbgPinLo(0);
+        return;
     }
-
-    DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
 
 #ifdef USE_DSHOT_TELEMETRY
     if (useDshotTelemetry) {
@@ -639,6 +638,17 @@ static void bbUpdateComplete(void)
 #ifdef USE_DSHOT_CACHE_MGMT
         SCB_CleanDCache_by_Addr(bbPort->portOutputBuffer, MOTOR_DSHOT_BUF_CACHE_ALIGN_BYTES);
 #endif
+
+        if (bbPort->reinitRequired) {
+            // A DMA transfer error left the stream's registers describing a
+            // partial transfer. Reload them before enabling it again; if the
+            // stream will not stop, leave the flag up and retry next cycle.
+            if (!bbSwitchToOutput(bbPort)) {
+                continue;
+            }
+            bbPort->inputActive = false;
+            bbPort->reinitRequired = false;
+        }
 
 #ifdef USE_DSHOT_TELEMETRY
         if (useDshotTelemetry) {

--- a/src/platform/APM32/include/platform/dma.h
+++ b/src/platform/APM32/include/platform/dma.h
@@ -72,8 +72,19 @@
                                                                     handler(&dmaDescriptors[index]); \
                                                             }
 
-#define DMA_CLEAR_FLAG(d, flag) if (d->flagsShift > 31) ((DMA_TypeDef*)(d)->dma)->HIFCLR = (flag << (d->flagsShift - 32)); else ((DMA_TypeDef*)(d)->dma)->LIFCLR = (flag << d->flagsShift)
-#define DMA_GET_FLAG_STATUS(d, flag) (d->flagsShift > 31 ? ((DMA_TypeDef*)(d)->dma)->HINTSTS & (flag << (d->flagsShift - 32)): ((DMA_TypeDef*)(d)->dma)->LINTSTS & (flag << d->flagsShift))
+// (flag) and (d) are parenthesised deliberately. Callers pass OR-ed masks, and
+// without the parentheses `A | B` binds as `A | (B << flagsShift)`: only the last
+// flag lands on this stream and the rest write ones into bits 0-5, which are
+// stream 0's flags in the low register and stream 4's in the high one.
+#define DMA_CLEAR_FLAG(d, flag) \
+    do { \
+        if ((d)->flagsShift > 31) { \
+            ((DMA_TypeDef*)(d)->dma)->HIFCLR = ((flag) << ((d)->flagsShift - 32)); \
+        } else { \
+            ((DMA_TypeDef*)(d)->dma)->LIFCLR = ((flag) << (d)->flagsShift); \
+        } \
+    } while (0)
+#define DMA_GET_FLAG_STATUS(d, flag) ((d)->flagsShift > 31 ? ((DMA_TypeDef*)(d)->dma)->HINTSTS & ((flag) << ((d)->flagsShift - 32)): ((DMA_TypeDef*)(d)->dma)->LINTSTS & ((flag) << (d)->flagsShift))
 
 #define xDDL_EX_DMA_DeInit(dmaResource) DDL_EX_DMA_DeInit((DMA_ARCH_TYPE *)(dmaResource))
 #define xDDL_EX_DMA_Init(dmaResource, initstruct) DDL_EX_DMA_Init((DMA_ARCH_TYPE *)(dmaResource), initstruct)

--- a/src/platform/AT32/dshot_bitbang.c
+++ b/src/platform/AT32/dshot_bitbang.c
@@ -270,11 +270,10 @@ FAST_IRQ_HANDLER void bbDMAIrqHandler(dmaChannelDescriptor_t *descriptor)
 
     bbTIM_DMACmd(bbPort->timhw->tim, bbPort->dmaSource, FALSE);
 
-    if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TEIF)) {
-        while (1) {};
+    if (bbDMAServiceFlags(bbPort, descriptor)) {
+        dbgPinLo(0);
+        return;
     }
-
-    DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
 
 #ifdef USE_DSHOT_TELEMETRY
     if (useDshotTelemetry) {
@@ -631,6 +630,17 @@ static void bbUpdateComplete(void)
 
     for (int i = 0; i < usedMotorPorts; i++) {
         bbPort_t *bbPort = &bbPorts[i];
+
+        if (bbPort->reinitRequired) {
+            // A DMA transfer error left the stream's registers describing a
+            // partial transfer. Reload them before enabling it again; if the
+            // stream will not stop, leave the flag up and retry next cycle.
+            if (!bbSwitchToOutput(bbPort)) {
+                continue;
+            }
+            bbPort->inputActive = false;
+            bbPort->reinitRequired = false;
+        }
 
 #ifdef USE_DSHOT_TELEMETRY
         if (useDshotTelemetry) {

--- a/src/platform/AT32/include/platform/dma.h
+++ b/src/platform/AT32/include/platform/dma.h
@@ -75,8 +75,12 @@ uint32_t dmaGetChannel(const uint8_t channel);
                                                                             handler(&dmaDescriptors[index]); \
                                                                     }
 
-#define DMA_CLEAR_FLAG(d, flag) ((dma_type*)(d)->dma)->clr = (flag << d->flagsShift)
-#define DMA_GET_FLAG_STATUS(d, flag) (((dma_type*)(d)->dma)->sts & (flag << d->flagsShift))
+// (flag) and (d) are parenthesised deliberately. Callers pass OR-ed masks, and
+// without the parentheses `A | B` binds as `A | (B << flagsShift)`: only the last
+// flag lands on this channel and the rest write ones into the low bits, which are
+// the first channel's flags.
+#define DMA_CLEAR_FLAG(d, flag) ((dma_type*)(d)->dma)->clr = ((flag) << (d)->flagsShift)
+#define DMA_GET_FLAG_STATUS(d, flag) (((dma_type*)(d)->dma)->sts & ((flag) << (d)->flagsShift))
 #define DMA_IT_GLOB         ((uint32_t)0x00000001) // channel global interput flag
 #define DMA_IT_TCIF         ((uint32_t)0x00000002) // channel full transport flag
 #define DMA_IT_HTIF         ((uint32_t)0x00000004) // channel half transport flag

--- a/src/platform/STM32/dshot_bitbang.c
+++ b/src/platform/STM32/dshot_bitbang.c
@@ -320,11 +320,10 @@ FAST_IRQ_HANDLER void bbDMAIrqHandler(dmaChannelDescriptor_t *descriptor)
 
     bbTIM_DMACmd(bbPort->timhw->tim, bbPort->dmaSource, DISABLE);
 
-    if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TEIF)) {
-        while (1) {};
+    if (bbDMAServiceFlags(bbPort, descriptor)) {
+        dbgPinLo(0);
+        return;
     }
-
-    DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
 
 #ifdef USE_DSHOT_TELEMETRY
     if (useDshotTelemetry) {
@@ -679,6 +678,17 @@ static void bbUpdateComplete(void)
 #ifdef USE_DSHOT_CACHE_MGMT
         SCB_CleanDCache_by_Addr(bbPort->portOutputBuffer, MOTOR_DSHOT_BUF_CACHE_ALIGN_BYTES);
 #endif
+
+        if (bbPort->reinitRequired) {
+            // A DMA transfer error left the stream's registers describing a
+            // partial transfer. Reload them before enabling it again; if the
+            // stream will not stop, leave the flag up and retry next cycle.
+            if (!bbSwitchToOutput(bbPort)) {
+                continue;
+            }
+            bbPort->inputActive = false;
+            bbPort->reinitRequired = false;
+        }
 
 #ifdef USE_DSHOT_TELEMETRY
         if (useDshotTelemetry) {

--- a/src/platform/STM32/include/platform/dma.h
+++ b/src/platform/STM32/include/platform/dma.h
@@ -82,8 +82,19 @@
                                                                     handler(&dmaDescriptors[index]); \
                                                             }
 
-#define DMA_CLEAR_FLAG(d, flag) if (d->flagsShift > 31) ((DMA_TypeDef*)(d)->dma)->HIFCR = (flag << (d->flagsShift - 32)); else ((DMA_TypeDef*)(d)->dma)->LIFCR = (flag << d->flagsShift)
-#define DMA_GET_FLAG_STATUS(d, flag) (d->flagsShift > 31 ? ((DMA_TypeDef*)(d)->dma)->HISR & (flag << (d->flagsShift - 32)): ((DMA_TypeDef*)(d)->dma)->LISR & (flag << d->flagsShift))
+// (flag) and (d) are parenthesised deliberately. Callers pass OR-ed masks, and
+// without the parentheses `A | B` binds as `A | (B << flagsShift)`: only the last
+// flag lands on this stream and the rest write ones into bits 0-5, which are
+// stream 0's flags in the low register and stream 4's in the high one.
+#define DMA_CLEAR_FLAG(d, flag) \
+    do { \
+        if ((d)->flagsShift > 31) { \
+            ((DMA_TypeDef*)(d)->dma)->HIFCR = ((flag) << ((d)->flagsShift - 32)); \
+        } else { \
+            ((DMA_TypeDef*)(d)->dma)->LIFCR = ((flag) << (d)->flagsShift); \
+        } \
+    } while (0)
+#define DMA_GET_FLAG_STATUS(d, flag) ((d)->flagsShift > 31 ? ((DMA_TypeDef*)(d)->dma)->HISR & ((flag) << ((d)->flagsShift - 32)): ((DMA_TypeDef*)(d)->dma)->LISR & ((flag) << (d)->flagsShift))
 
 #define DMA_IT_TCIF         ((uint32_t)0x00000020)
 #define DMA_IT_HTIF         ((uint32_t)0x00000010)
@@ -332,8 +343,12 @@ uint32_t dmaGetChannel(const uint8_t channel);
                                                                             handler(&dmaDescriptors[index]); \
                                                                     }
 
-#define DMA_CLEAR_FLAG(d, flag) ((DMA_TypeDef*)(d)->dma)->IFCR = (flag << d->flagsShift)
-#define DMA_GET_FLAG_STATUS(d, flag) (((DMA_TypeDef*)(d)->dma)->ISR & (flag << d->flagsShift))
+// (flag) and (d) are parenthesised deliberately. Callers pass OR-ed masks, and
+// without the parentheses `A | B` binds as `A | (B << flagsShift)`: only the last
+// flag lands on this channel and the rest write ones into the low bits, which are
+// the first channel's flags.
+#define DMA_CLEAR_FLAG(d, flag) ((DMA_TypeDef*)(d)->dma)->IFCR = ((flag) << (d)->flagsShift)
+#define DMA_GET_FLAG_STATUS(d, flag) (((DMA_TypeDef*)(d)->dma)->ISR & ((flag) << (d)->flagsShift))
 
 #define DMA_IT_TCIF         ((uint32_t)0x00000002)
 #define DMA_IT_HTIF         ((uint32_t)0x00000004)

--- a/src/platform/X32/dshot_bitbang.c
+++ b/src/platform/X32/dshot_bitbang.c
@@ -281,11 +281,10 @@ FAST_IRQ_HANDLER void bbDMAIrqHandler(dmaChannelDescriptor_t *descriptor)
 
     bbTIM_DMACmd(bbPort->timhw->tim, bbPort->dmaSource, DISABLE);
 
-    if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TEIF)) {
-        while (1) {};
+    if (bbDMAServiceFlags(bbPort, descriptor)) {
+        dbgPinLo(0);
+        return;
     }
-
-    DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
 
 #ifdef USE_DSHOT_TELEMETRY
     if (useDshotTelemetry) {
@@ -612,6 +611,17 @@ static void bbUpdateComplete(void)
 #ifdef USE_DSHOT_CACHE_MGMT
         X32_CLEAN_DCACHE_BY_ADDR(bbPort->portOutputBuffer, MOTOR_DSHOT_BUF_CACHE_ALIGN_BYTES);
 #endif
+
+        if (bbPort->reinitRequired) {
+            // A DMA transfer error left the stream's registers describing a
+            // partial transfer. Reload them before enabling it again; if the
+            // stream will not stop, leave the flag up and retry next cycle.
+            if (!bbSwitchToOutput(bbPort)) {
+                continue;
+            }
+            bbPort->inputActive = false;
+            bbPort->reinitRequired = false;
+        }
 
 #ifdef USE_DSHOT_TELEMETRY
         if (useDshotTelemetry) {

--- a/src/platform/common/stm32/dshot_bitbang_impl.h
+++ b/src/platform/common/stm32/dshot_bitbang_impl.h
@@ -211,9 +211,16 @@ typedef struct bbPort_s {
     bool telemetryAborted;
 
     // Misc
+
+    // Set by bbDMAServiceFlags() when a DMA transfer error left the stream's
+    // registers unusable; cleared by bbUpdateComplete() once bbSwitchToOutput()
+    // has reloaded them. Written from the DMA ISR, read from the PID task.
+    volatile bool reinitRequired;
+
 #ifdef DEBUG_COUNT_INTERRUPT
     uint32_t outputIrq;
     uint32_t inputIrq;
+    uint32_t errorIrq;
 #endif
     resourceOwner_t resourceOwner;
 } bbPort_t;
@@ -315,6 +322,69 @@ static inline bool bbDMAWaitStopped(dmaResource_t *dmaResource)
     }
 
     return false;
+}
+
+// Every status bit a bitbang stream can leave set. A completed frame always
+// leaves HTIF behind - the flag is set by hardware whether or not HTIE is on,
+// and bbDMA_ITConfig() only enables TC - and RM0090 requires a clear status
+// before the stream is started again (DMA_SxCR, EN bit: "Before setting EN bit
+// to '1' to start a new transfer, the event flags corresponding to the stream
+// in DMA_LISR or DMA_HISR register must be cleared"). ST's own HAL does the
+// same, writing IFCR = 0x3F << StreamIndex immediately before enabling.
+//
+// The mask resolves to 0x3D on the stream-based controllers (F4/F7/H7/APM32F4),
+// 0x0E on the channel-based ones (G4/AT32), TCF|HTF|DTEF on H5/C5/N6 GPDMA and
+// 0x13 on X32. Note that AT32 aliases DMA_IT_DMEIF onto DMA_IT_HTIF and X32
+// aliases both DMA_IT_DMEIF and DMA_IT_FEIF onto DMA_IT_TEIF, so which branch
+// those two take is incidental - the resulting mask is the same either way.
+// Requires platform/dma.h ahead of this header, as all includers have.
+#if defined(DMA_IT_FEIF) && defined(DMA_IT_DMEIF)
+#define BB_DMA_FLAGS (DMA_IT_TCIF | DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_DMEIF | DMA_IT_FEIF)
+#else
+#define BB_DMA_FLAGS (DMA_IT_TCIF | DMA_IT_HTIF | DMA_IT_TEIF)
+#endif
+
+// Clear the stream's status flags, and report whether the transfer failed.
+// Returns true on a transfer error, in which case the port has been flagged for
+// reinitialisation and the caller must return without doing any direction work.
+//
+// Only TEIF is tested, because only TEIF means the stream aborted. DMEIF cannot
+// be set on these streams - they run with the FIFO enabled, so direct mode is
+// never used - and escalating FEIF to a port reinitialisation would drop a motor
+// frame for a condition the transfer survives. So the rest are cleared, not
+// acted on.
+//
+// On a transfer error the stream aborted partway and its registers no longer
+// describe a usable transfer. The caller has already stopped the stream and the
+// pacer request, so raise reinitRequired: the next bbUpdateComplete() runs
+// bbSwitchToOutput(), which reloads the cached register set and reconfigures the
+// pin. Spinning here instead, as this used to, took the flight controller down
+// with it - nothing recovers an ISR that never returns on any target except
+// STM32N657, where OBL arms an IWDG that BF refreshes from TASK_SERIAL, and even
+// there it is a reset seconds later.
+//
+// direction is deliberately left alone: it says where the pin and the DMA are
+// actually pointed, and on H5/C5/N6 bbDMA_Cmd(ENABLE) picks the cached register
+// set from it. telemetryPending is left alone too, so a port that was capturing
+// spins out bbTelemetryTimeoutUs in bbTelemetryWait() before being handed back.
+// By then the ESC has certainly stopped replying, and bbSwitchToOutput() cannot
+// drive the line against it (#15533).
+static inline bool bbDMAServiceFlags(bbPort_t *bbPort, dmaChannelDescriptor_t *descriptor)
+{
+    const bool transferError = DMA_GET_FLAG_STATUS(descriptor, DMA_IT_TEIF) != 0;
+
+    DMA_CLEAR_FLAG(descriptor, BB_DMA_FLAGS);
+
+    if (!transferError) {
+        return false;
+    }
+
+#ifdef DEBUG_COUNT_INTERRUPT
+    bbPort->errorIrq++;
+#endif
+    bbPort->reinitRequired = true;
+
+    return true;
 }
 
 void bbDshotRequestTelemetry(unsigned motorIndex);

--- a/src/platform/common/stm32/dshot_bitbang_shared.c
+++ b/src/platform/common/stm32/dshot_bitbang_shared.c
@@ -19,6 +19,10 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "drivers/dma.h"
+
+#include "platform/dma.h"
+
 #include "dshot_bitbang_impl.h"
 
 FAST_DATA_ZERO_INIT bbPacer_t bbPacers[MAX_MOTOR_PACERS];  // TIM1 or TIM8


### PR DESCRIPTION
Two independent DMA faults. Neither touches the telemetry timing path.

## 1. `DMA_CLEAR_FLAG()` shifted only the last flag of an OR-ed mask

The macro did not parenthesise its flag argument, so `A | B` parsed as `A | (B << flagsShift)`: only the last flag reached the intended stream, and the rest were written unshifted into bits 0-5 — stream 0's flags in the low register, stream 4's in the high one. Nearly every caller passes an OR-ed mask.

For a stream with `flagsShift` 22 the F4 DShot DMA handler wrote `0x0800001D` instead of `0x0F400000`: it cleared its own TCIF, left its own FEIF/DMEIF/TEIF/HTIF set, and cleared stream 0's four flags instead — on every motor update. The SPI drivers do the same on every transfer, from `bus_spi_stdperiph.c`, `bus_spi_ll.c`, `bus_spi_hal2.c`, `bus_spi_apm32.c` and `bus_spi_at32bsp.c`. So streams 0 and 4 of each controller have had their flags silently scrubbed by their neighbours, while the clearing streams never cleared the ones they meant to.

Parenthesises `(flag)` and `(d)`, and wraps the two statement-form macros in `do/while(0)` so a future `if (x) DMA_CLEAR_FLAG(...); else ...` cannot bind to the macro's own `else`. No call sites change — they were all written expecting the corrected semantics. X32 already parenthesised and is unchanged.

`DMA_GET_FLAG_STATUS()` had the same missing parentheses, but no STM32, APM32 or AT32 caller passes it an OR-ed mask, so that half is hardening rather than a live fix. The `CFCR`/`CSR` and X32 variants were already correct.

## 2. `bbDMAIrqHandler()` hung on a transfer error

It answered `DMA_IT_TEIF` with `while (1) {};`. Nothing recovers an ISR that never returns — no watchdog is armed on any of these targets except STM32N657, where OBL arms an IWDG that BF refreshes from `TASK_SERIAL`, and even there it is a reset seconds later. So one DMA transfer error on a motor stream took the flight controller down mid-flight. The trap dates from bring-up, where hanging in the debugger was the point.

It now recovers, as `motor_DMA_IRQHandler()` already does for the non-bitbang path: the stream and the pacer request are stopped just above, so clear the flags and return with `bbPort->reinitRequired` raised. `bbUpdateComplete()` then runs `bbSwitchToOutput()` before enabling the stream — reloading the cached register set and reconfiguring the pin — and retries next cycle if the stream will not stop.

### Why a new field and not `bbPort->direction`

`direction` records where the pin and the DMA are actually pointed, and `bbUpdateComplete()` only acts on `direction == INPUT` when telemetry is in use — except on G4, AT32 and X32, which call `bbSwitchToOutput()` unconditionally. Signalling the reinit by faking `direction = INPUT` from the ISR would therefore have been ignored on the non-bidirectional path on F4, F7, H7, H5, C5, N6 and APM32F4.

Worse than ignored on H5/C5/N6: there `bbDMA_Cmd(ENABLE)` selects the cached register set *from* `direction` (`STM32/dshot_bitbang_ll.c:262-276`, single-shot GPDMA does not auto-rearm). A port left at INPUT would load the input configuration over the output one on every subsequent frame and stop driving the motors permanently. `dshot_bitbang = AUTO` activates bitbang on those MCUs regardless of `dshot_bidir`, so that is the default configuration there. `reinitRequired` keeps the two meanings separate.

`telemetryPending` is left alone, so a port that was capturing spins out `bbTelemetryTimeoutUs` in `bbTelemetryWait()` before being handed back and cannot be driven against an ESC that is still replying (#15533). One cycle is lost, then it self-heals.

### Flag clearing

With the mask fixed the handler clears the whole set in one call, so it now clears every status bit the stream can leave set rather than only TCIF. A completed frame always leaves HTIF behind — the flag is set by hardware whether or not HTIE is enabled, and `bbDMA_ITConfig()` only enables TC — and RM0090 requires a clear status before the stream is started again (`DMA_SxCR`, EN bit: *"Before setting EN bit to '1' to start a new transfer, the event flags corresponding to the stream in DMA_LISR or DMA_HISR register must be cleared"*). ST's own HAL does the same, writing `IFCR = 0x3F << StreamIndex` immediately before enabling.

`BB_DMA_FLAGS` and the handler live in `dshot_bitbang_impl.h` — the mask as a macro, the handler as a `static inline` beside `bbDMAWaitStopped()` — so it stays inside the ITCM-resident ISR on H7 and N6 rather than calling out to flash. Each platform copy of `bbDMAIrqHandler()` carries only the call. `errorIrq` joins `inputIrq`/`outputIrq` under `DEBUG_COUNT_INTERRUPT`, so the fault is inspectable in a debugger now that it no longer announces itself by hanging.

## Verification

Clean rebuild (`obj/` wiped), 0 compiler warnings on all ten targets:

| | |
|---|---|
| Builds | STM32F405, F722, H743, G474, H563, C562, N657, APM32F405, AT32F435M, X32M7B |
| `make test` | pass |
| `BB_DMA_FLAGS` | asserted per platform at compile time: `0x3D` on F4/F7/H7/APM32F4, `0x0E` on G4/AT32, `0x700` (TCF 8, HTF 9, DTEF 10) on H5/C5/N6 GPDMA, `0x13` on X32 |
| Placement | `bbDMAServiceFlags()` inlines away — no symbol in any ELF; `bbDMAIrqHandler()` resolves into `.tcm_code` on H743 and into RAM on N657 |

N657 emits one pre-existing linker warning (`LOAD segment with RWX permissions`); confirmed present on `master` too.

**Not flight tested.**

## Known and not addressed here

- A DMA error on an *output* frame leaves `telemetryPending` false, so the next cycle's `bbDecodeTelemetry()` re-decodes the stale `portInputBuffer` and counts one duplicate eRPM. `telemetryAborted` cannot be reused — it is consumed by the decode in the same cycle it is set, and the error IRQ races that decode. Needs a skip-next-decode flag; not worth it for a fault this exceptional.
- `errorIrq` is debugger-inspectable only. All four `DEBUG_DSHOT_TELEMETRY_COUNTS` slots are in use, so surfacing it needs a new debug mode.
- `pwm_output_dshot.c` clears the full mask only under `#if defined(STM32F4)`; on F7/H7/G4 it still clears TCIF only and then re-enables the stream with HTIF set — the same RM0090 issue this PR fixes for bitbang. Same in `pwm_output_dshot_hal.c` and `APM32/pwm_output_dshot_apm32.c`. Separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DShot output recovery after DMA transfer errors, reducing hangs and allowing affected frames to retry safely.
  - Corrected DMA status handling for combined flag values across supported hardware platforms.
  - Improved handling of incomplete telemetry captures to prevent invalid or premature processing.
  - Added broader DMA error detection and cleanup, including additional error conditions where supported.
  - Prevented interrupted transfers from leaving the output stream in an inconsistent state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
