### PR TITLE
fix(gps): bound the baud scan to stop UART re-initialisation

### DIFF
--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -347,14 +347,7 @@ static void uartSetBaudRate(serialPort_t *instance, uint32_t baudRate)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
     uartDevice_t *uartDevice = container_of(uartPort, uartDevice_t, port);
-    const portMode_e mode = uartSanitizeMode(uartDevice, uartPort->port.mode, uartPort->port.options);
-
-    // skip the full USART and DMA teardown in uartReconfigure() when nothing would change
-    if ((baudRate == uartPort->port.baudRate) && (mode == uartPort->port.mode)) {
-        return;
-    }
-
-    uartPort->port.mode = mode;
+    uartPort->port.mode = uartSanitizeMode(uartDevice, uartPort->port.mode, uartPort->port.options);
     uartPort->port.baudRate = baudRate;
     uartReconfigure(uartPort);
 }

--- a/src/main/drivers/serial_uart.c
+++ b/src/main/drivers/serial_uart.c
@@ -347,7 +347,14 @@ static void uartSetBaudRate(serialPort_t *instance, uint32_t baudRate)
 {
     uartPort_t *uartPort = (uartPort_t *)instance;
     uartDevice_t *uartDevice = container_of(uartPort, uartDevice_t, port);
-    uartPort->port.mode = uartSanitizeMode(uartDevice, uartPort->port.mode, uartPort->port.options);
+    const portMode_e mode = uartSanitizeMode(uartDevice, uartPort->port.mode, uartPort->port.options);
+
+    // skip the full USART and DMA teardown in uartReconfigure() when nothing would change
+    if ((baudRate == uartPort->port.baudRate) && (mode == uartPort->port.mode)) {
+        return;
+    }
+
+    uartPort->port.mode = mode;
     uartPort->port.baudRate = baudRate;
     uartReconfigure(uartPort);
 }

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -95,7 +95,7 @@ GPS_svinfo_t GPS_svinfo[GPS_SV_MAXSATS_M8N];
 #define GPS_CONFIG_CHANGE_INTERVAL 110       // Time to wait, in ms, between CONFIG steps
 #define GPS_BAUDRATE_TEST_COUNT 3      // Number of times to repeat the test message when setting baudrate
 // bound the baud scan - each step re-inits the UART, and a port with no module never stops (#13946)
-#define GPS_BAUD_SWEEP_CYCLE_LIMIT 2
+#define GPS_BAUD_SWEEP_CYCLE_LIMIT 2    // in whole passes, so the backoff always starts on the configured baud rate
 #define GPS_BAUD_SWEEP_BACKOFF_MS 30000
 #define GPS_RECV_TIME_MAX 25           // Max permitted time, in us, for the NMEA Receive Data process
 #define GPS_UBLOX_RECV_TIME_MAX 15     // Max permitted time, in us, for the UBLOX Receive Data process

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -353,8 +353,7 @@ typedef enum {
     UBLOX_CONFIG_COMPLETE   // 22. Config finished, start receiving data
 } ubloxStatePosition_e;
 
-baudRate_e initBaudRateIndex;
-size_t initBaudRateCycleCount;
+static size_t initBaudRateCycleCount;
 static uint32_t lastBaudStepMs;
 #endif // USE_GPS_UBLOX
 
@@ -434,7 +433,6 @@ void gpsInit(void)
     }
 
     // set the user's intended baud rate
-    initBaudRateIndex = BAUD_COUNT;
     initBaudRateCycleCount = 0;
     lastBaudStepMs = millis();
     gpsData.userBaudRateIndex = DEFAULT_BAUD_RATE_INDEX;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -1025,6 +1025,8 @@ static void gpsConfigureUblox(void)
             serialPrint(gpsPort, gpsInitData[gpsData.userBaudRateIndex].ubx);
             // use this baud rate for re-connections
             gpsData.tempBaudRateIndex = gpsData.userBaudRateIndex;
+            // the link is proven, so a later dropout gets the full-speed sweep again
+            initBaudRateCycleCount = 0;
             // we're done here, let's move the the next state
             gpsSetState(GPS_STATE_CHANGE_BAUD);
             return;

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -94,6 +94,9 @@ GPS_svinfo_t GPS_svinfo[GPS_SV_MAXSATS_M8N];
 #define GPS_CONFIG_BAUD_CHANGE_INTERVAL 330  // Time to wait, in ms, between 'test this baud rate' messages
 #define GPS_CONFIG_CHANGE_INTERVAL 110       // Time to wait, in ms, between CONFIG steps
 #define GPS_BAUDRATE_TEST_COUNT 3      // Number of times to repeat the test message when setting baudrate
+// bound the baud scan - each step re-inits the UART, and a port with no module never stops (#13946)
+#define GPS_BAUD_SWEEP_CYCLE_LIMIT 2
+#define GPS_BAUD_SWEEP_BACKOFF_MS 30000
 #define GPS_RECV_TIME_MAX 25           // Max permitted time, in us, for the NMEA Receive Data process
 #define GPS_UBLOX_RECV_TIME_MAX 15     // Max permitted time, in us, for the UBLOX Receive Data process
 #define GPS_FRAME_PROCESS_TIME_US 10    // Estimated ceiling for time required to process a frame, in us, for the Receive Data process
@@ -351,6 +354,7 @@ typedef enum {
 
 baudRate_e initBaudRateIndex;
 size_t initBaudRateCycleCount;
+static uint32_t lastBaudStepMs;
 #endif // USE_GPS_UBLOX
 
 gpsData_t gpsData;
@@ -431,6 +435,7 @@ void gpsInit(void)
     // set the user's intended baud rate
     initBaudRateIndex = BAUD_COUNT;
     initBaudRateCycleCount = 0;
+    lastBaudStepMs = millis();
     gpsData.userBaudRateIndex = DEFAULT_BAUD_RATE_INDEX;
     for (unsigned i = 0; i < ARRAYLEN(gpsInitData); i++) {
         if (gpsInitData[i].baudrateIndex == gpsConfig()->gps_baud) {
@@ -1046,6 +1051,13 @@ static void gpsConfigureUblox(void)
         }
         messageCounter = 0;
         gpsData.state_ts = gpsData.now;
+
+        // let the opening passes run unthrottled, then stop re-initialising the UART every step
+        if ((initBaudRateCycleCount >= GPS_BAUD_SWEEP_CYCLE_LIMIT * ARRAYLEN(gpsInitData))
+            && (cmp32(gpsData.now, lastBaudStepMs) < GPS_BAUD_SWEEP_BACKOFF_MS)) {
+            break;
+        }
+        lastBaudStepMs = gpsData.now;
 
         // failed to connect at that rate after five attempts
         // try other GPS baudrates, starting at 9600 and moving up

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -124,6 +124,7 @@ static const gpsInitData_t gpsInitData[] = {
 };
 
 #define DEFAULT_BAUD_RATE_INDEX 0
+#define GPS_BAUD_SWEEP_STEP_LIMIT (GPS_BAUD_SWEEP_CYCLE_LIMIT * ARRAYLEN(gpsInitData))
 
 #ifdef USE_GPS_UBLOX
 #define MAX_VALSET_SIZE 128
@@ -1055,7 +1056,7 @@ static void gpsConfigureUblox(void)
         gpsData.state_ts = gpsData.now;
 
         // let the opening passes run unthrottled, then stop re-initialising the UART every step
-        if ((initBaudRateCycleCount >= GPS_BAUD_SWEEP_CYCLE_LIMIT * ARRAYLEN(gpsInitData))
+        if ((initBaudRateCycleCount >= GPS_BAUD_SWEEP_STEP_LIMIT)
             && (cmp32(gpsData.now, lastBaudStepMs) < GPS_BAUD_SWEEP_BACKOFF_MS)) {
             break;
         }
@@ -1070,7 +1071,8 @@ static void gpsConfigureUblox(void)
         }
         // set the FC baud rate to the new temp baud rate
         serialSetBaudRate(gpsPort, baudRates[gpsInitData[gpsData.tempBaudRateIndex].baudrateIndex]);
-        initBaudRateCycleCount++;
+        // stop counting once backed off, so debug[2] can't overflow
+        initBaudRateCycleCount = MIN(initBaudRateCycleCount + 1, GPS_BAUD_SWEEP_STEP_LIMIT);
 
         break;
 

--- a/src/main/io/gps.c
+++ b/src/main/io/gps.c
@@ -400,6 +400,14 @@ static void gpsSetState(gpsState_e state)
     gpsData.ackState = UBLOX_ACK_IDLE;
 }
 
+// skip the USART and DMA teardown in uartReconfigure() when the port is already at this rate (#13946)
+static void gpsSetBaudRate(uint32_t baudRate)
+{
+    if (serialGetBaudRate(gpsPort) != baudRate) {
+        serialSetBaudRate(gpsPort, baudRate);
+    }
+}
+
 void gpsInit(void)
 {
     gpsDataIntervalSeconds = 0.1f;
@@ -962,7 +970,7 @@ static void gpsConfigureNmea(void)
 #if !defined(GPS_NMEA_TX_ONLY)
         if (gpsData.state_position < 1) {
             // set the FC's baud rate to the user's configured baud rate
-            serialSetBaudRate(gpsPort, baudRates[gpsInitData[gpsData.userBaudRateIndex].baudrateIndex]);
+            gpsSetBaudRate(baudRates[gpsInitData[gpsData.userBaudRateIndex].baudrateIndex]);
             gpsData.state_position++;
         } else if (gpsData.state_position < 2) {
             // send NMEA custom commands to select which messages being sent, data rate etc
@@ -1068,7 +1076,7 @@ static void gpsConfigureUblox(void)
             gpsData.tempBaudRateIndex--;
         }
         // set the FC baud rate to the new temp baud rate
-        serialSetBaudRate(gpsPort, baudRates[gpsInitData[gpsData.tempBaudRateIndex].baudrateIndex]);
+        gpsSetBaudRate(baudRates[gpsInitData[gpsData.tempBaudRateIndex].baudrateIndex]);
         // stop counting once backed off, so debug[2] can't overflow
         initBaudRateCycleCount = MIN(initBaudRateCycleCount + 1, GPS_BAUD_SWEEP_STEP_LIMIT);
 
@@ -1082,7 +1090,7 @@ static void gpsConfigureUblox(void)
             return;
         }
         // set the FC's serial port to the configured rate
-        serialSetBaudRate(gpsPort, baudRates[gpsInitData[gpsData.userBaudRateIndex].baudrateIndex]);
+        gpsSetBaudRate(baudRates[gpsInitData[gpsData.userBaudRateIndex].baudrateIndex]);
         DEBUG_SET(DEBUG_GPS_CONNECTION, 3, baudRates[gpsInitData[gpsData.userBaudRateIndex].baudrateIndex] / 100);  //!< Baud Rate / 100, Else Nav Message Age In Milliseconds
         // then start sending configuration settings
         gpsSetState(GPS_STATE_CONFIGURE);


### PR DESCRIPTION
## Problem

**TL;DR: This fixes an issue with the FC crashing in-flight if GPS is assigned to a UART but missing/not communicating properly.**
Such as documented in #13946 and https://yarosfpv.com/en/blog/betaflight-gps-crash

## Details

`GPS_STATE_DETECT_BAUD` has exactly one exit: a parsed MON-VER reply.
With no module answering it never takes it, and steps the baud rate ~once a second forever. Every step is a full `uartReconfigure()`.

| GPS state | `uartReconfigure()` calls |
|---|---|
| connected and working | ~2, at boot |
| configured, not talking | **~1/s, forever (~3600/hour)** |

This is the one thing unique to the configuration in #13946, and it is the amplifier that turns a rare reconfigure race into a frozen FC.
The backport commit on 2025.12-maintenance names it directly:

> GPS baud-rate scanning calls uartSetBaudRate every 2.5 s, repeatedly arming TXEIE/TCIE on the pinless port.

## Fix

Two changes, both small:

1. `gps.c` - after 2 full passes over the baud table with no reply, require 30 s between further steps. The opening passes are untouched, so discovery is bit-for-bit what it was; polling continues throughout at no reconfigure cost.
2. `serial_uart.c` - `uartSetBaudRate()` returns early when neither the rate nor the sanitized mode would change. Needed separately because the NMEA path never sweeps; it re-asserts the same rate on every lost-comms cycle.

## Why it can't regress detection

The bound only engages after every rate has been tried twice over (~12 s). A module that answers, answers well before that. The only degradation is a module that appears mid-flight at a different baud than configured, which now takes up to ~3 min instead of ~6 s; one appearing at the configured rate is still found immediately.

## Testing

Builds clean, but needs extensive testing on bench and in-flight.

## AI disclosure

Claude Code was used to analyze the issue and suggest a fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPS serial communication reliability by avoiding unnecessary baud-rate resets.
  * GPS detection and configuration now apply baud-rate changes only when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->