### PR TITLE
Send rescue yaw to autopilot

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1780,6 +1780,8 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_AP_POSITION_CUTOFF, "%d",    autopilotConfig()->positionCutoff);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_AP_STOP_THRESHOLD, "%d",     autopilotConfig()->stopThreshold);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_AP_MAX_ANGLE, "%d",          autopilotConfig()->maxAngle);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_AP_MAX_YAW_RATE, "%d",       autopilotConfig()->maxYawRate);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_AP_YAW_P, "%d",              autopilotConfig()->yawP);
 #endif // !USE_WING
 
 #ifdef USE_MAG

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -2104,8 +2104,10 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_AP_POSITION_A,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, positionA) },
     { PARAM_NAME_AP_POSITION_F,          VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, positionF) },
     { PARAM_NAME_AP_POSITION_CUTOFF,     VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 10, 50 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, positionCutoff) },
-    { PARAM_NAME_AP_STOP_THRESHOLD,      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 5, 50 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, stopThreshold) },
+    { PARAM_NAME_AP_STOP_THRESHOLD,      VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 5, 50 },      PG_AUTOPILOT, offsetof(autopilotConfig_t, stopThreshold) },
     { PARAM_NAME_AP_MAX_ANGLE,           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 10, 70 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, maxAngle) },
+    { PARAM_NAME_AP_MAX_YAW_RATE,        VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 10, 250 },    PG_AUTOPILOT, offsetof(autopilotConfig_t, maxYawRate) },
+    { PARAM_NAME_AP_YAW_P,               VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 200 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, yawP) },
 
     // Drag feedforward and velocity setpoint cap
     { PARAM_NAME_AP_VELOCITY_DRAG_COEFF, VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 100 },     PG_AUTOPILOT, offsetof(autopilotConfig_t, velocityDragCoeff) },

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -194,7 +194,6 @@
 #define PARAM_NAME_AP_THROTTLE_DEADBAND "ap_throttle_deadband"
 #define PARAM_NAME_AP_YAW_MODE "ap_yaw_mode"
 #define PARAM_NAME_AP_YAW_P "ap_yaw_p"
-#define PARAM_NAME_AP_YAW_D "ap_yaw_d"
 #define PARAM_NAME_AP_MAX_YAW_RATE "ap_max_yaw_rate"
 #define PARAM_NAME_AP_MIN_FORWARD_VELOCITY "ap_min_forward_velocity"
 

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -648,7 +648,7 @@ FAST_CODE void processRcCommand(void)
 
             if ((axis == FD_YAW) && autopilotYawControlActive()
                 && fabsf(rcCommand[FD_YAW]) < (float)autopilotConfig()->stickDeadband) {
-                // Autopilotyaw control inclusing GPS Rescue. A yaw stick deflection past
+                // Autopilotyaw control including GPS Rescue. A yaw stick deflection past
                 // the deadband hands yaw back to the pilot.
                 angleRate = autopilotGetYawRate();
                 rcDeflection[axis] = 0;

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -646,23 +646,10 @@ FAST_CODE void processRcCommand(void)
 
             float angleRate;
 
-#ifdef USE_GPS_RESCUE
-            if ((axis == FD_YAW) && FLIGHT_MODE(GPS_RESCUE_MODE)) {
-                // If GPS Rescue is active then override the setpointRate used in the
-                // pid controller with the value calculated from the desired heading logic.
-                angleRate = gpsRescueGetYawRate();
-                // Treat the stick input as centered to avoid any stick deflection base modifications (like acceleration limit)
-                rcDeflection[axis] = 0;
-                rcDeflectionAbs[axis] = 0;
-            } else
-#endif
             if ((axis == FD_YAW) && autopilotYawControlActive()
                 && fabsf(rcCommand[FD_YAW]) < (float)autopilotConfig()->stickDeadband) {
-                // Mission and position hold yaw control, injected the same way as GPS
-                // rescue; a yaw stick deflection past the deadband hands yaw back to the
-                // pilot. autopilotYawControlActive() is the single source of truth for
-                // whether a rate is on offer - every path that stands the controller
-                // down clears it.
+                // Autopilotyaw control inclusing GPS Rescue. A yaw stick deflection past
+                // the deadband hands yaw back to the pilot.
                 angleRate = autopilotGetYawRate();
                 rcDeflection[axis] = 0;
                 rcDeflectionAbs[axis] = 0;

--- a/src/main/fc/rc.c
+++ b/src/main/fc/rc.c
@@ -648,7 +648,7 @@ FAST_CODE void processRcCommand(void)
 
             if ((axis == FD_YAW) && autopilotYawControlActive()
                 && fabsf(rcCommand[FD_YAW]) < (float)autopilotConfig()->stickDeadband) {
-                // Autopilotyaw control including GPS Rescue. A yaw stick deflection past
+                // Autopilot yaw control including GPS Rescue. A yaw stick deflection past
                 // the deadband hands yaw back to the pilot.
                 angleRate = autopilotGetYawRate();
                 rcDeflection[axis] = 0;

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -640,11 +640,6 @@ void tasksInit(void)
     tasksUpdateModeGatedEnables();
 
 #ifdef USE_MAG
-    // Heading hold needs only a compass - it is deliberately not tied to position hold,
-    // whose task is gated on GPS or optical flow. MAG_MODE is rarely used, so the task
-    // only runs for pilots who have actually put the mode on a switch. Saving a mode
-    // change reboots, so this is re-evaluated whenever the aux config changes.
-    setTaskEnabled(TASK_MAGHOLD, sensors(SENSOR_MAG) && isModeActivationConditionPresent(BOXMAG));
     setTaskEnabled(TASK_COMPASS, sensors(SENSOR_MAG));
 #endif
 

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -640,6 +640,11 @@ void tasksInit(void)
     tasksUpdateModeGatedEnables();
 
 #ifdef USE_MAG
+    // Heading hold needs only a compass - it is deliberately not tied to position hold,
+    // whose task is gated on GPS or optical flow. MAG_MODE is rarely used, so the task
+    // only runs for pilots who have actually put the mode on a switch. Saving a mode
+    // change reboots, so this is re-evaluated whenever the aux config changes.
+    setTaskEnabled(TASK_MAGHOLD, sensors(SENSOR_MAG) && isModeActivationConditionPresent(BOXMAG));
     setTaskEnabled(TASK_COMPASS, sensors(SENSOR_MAG));
 #endif
 

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -127,12 +127,16 @@
 #define NAV_ERROR_DISTANCE_LIMIT 500.0f // 5m
 #define POSITION_I_LIMIT      2000.0f // TO DO: test and set to a useful value, this is 20m
 
-#define AP_YAW_P_SCALE         0.01f
+#define AP_YAW_P_SCALE         0.06f
 #define AP_YAW_RAMP_TIME_S     1.0f
+
+static int16_t apYawDisableReason;
+static float apExternalYawTargetDeg;
+
 
 static pidCoefficient_t xyPid;
 static float xyKDrag;
-
+static float yawKp;
 static float altitudeKp;
 static float altitudeKi;
 static float altitudeKd;
@@ -304,7 +308,7 @@ void autopilotInit(void)
     altitudeKd = cfg->altitudeD * ALTITUDE_D_SCALE;
     altitudeKa = cfg->altitudeA * ALTITUDE_A_SCALE;
     altitudeKf = cfg->altitudeF * ALTITUDE_F_SCALE;
-
+    yawKp = cfg->yawP * AP_YAW_P_SCALE;
     xyPid.Kp = cfg->positionP * XY_DISTANCE_SCALE;
     xyPid.Ki = cfg->positionI * XY_DISTANCE_I_SCALE;
     xyPid.Kd = cfg->positionD * XY_VELOCITY_SCALE;
@@ -324,6 +328,7 @@ void autopilotInit(void)
     forceLevelPark = false;
     apNavHeadingOverrideValid = false;
     disableYawControl();
+    apYawDisableReason = 0;
     apYawRateLimitDps = 0.0f;
     positionNavInit();
 }
@@ -445,6 +450,11 @@ void moveTargetLocation(const vector2_t *stepEF, unsigned taskRateHz, bool force
     }
 }
 
+void autopilotSetYawTarget(float headingDeg)
+{
+    apExternalYawTargetDeg = headingDeg;
+}
+
 void pitchForwardOverride(bool request)
 {
     forcePitchForward = request;
@@ -508,7 +518,6 @@ void initPositionHold(void)
     vector2Zero(&previousTargetVelocity);
     // nb: we do not reset the distanceError integral, to hold its opposition to wind between quick stick inputs
 }
-
 // Re-anchor the hold at the craft's current position — what a pilot cycling
 // the mode switch achieves, callable from recovery paths (sensor dropout
 // recovery, the one-shot sanity retry). Enters through the normal braking
@@ -634,9 +643,11 @@ bool autopilotYawControlActive(void)
     // period after the pilot switched the mode off, injecting a stale yaw rate on the
     // first frame they expect the stick back.
     return apYawActive
-        && (FLIGHT_MODE(AUTOPILOT_MODE) || FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(MAG_MODE));
+        && (FLIGHT_MODE(AUTOPILOT_MODE)
+            || FLIGHT_MODE(POS_HOLD_MODE)
+            || FLIGHT_MODE(MAG_MODE)
+            || FLIGHT_MODE(GPS_RESCUE_MODE));
 }
-
 static void disableYawControl(void)
 {
     apYawActive = false;
@@ -679,67 +690,62 @@ static bool bearingToTargetDeg(const positionEstimate3d_t *est, float *headingDe
     return true;
 }
 
-// Mission yaw: while navigation is flying a leg, steer the nose to the ground
-// course (VELOCITY), the bearing to the active target (BEARING), or course
-// falling back to bearing when too slow for a reliable course (HYBRID).
-// P on wrapped heading error with a short engage ramp and gyro damping,
-// clamped to ap_max_yaw_rate and any YAW_RATE mission cap; rc.c injects the
-// resulting rate as the yaw setpoint, exactly as GPS rescue injects its own.
+// Yaw control priority is GPS Rescue, active navigation, then heading hold.
+// GPS Rescue supplies its own target heading. Active navigation chooses a
+// heading according to ap_yaw_mode. POS_HOLD and MAG_MODE hold the
+// heading captured on engagement. 
+// Yaw control priority is GPS Rescue, active navigation, then heading hold.
+// GPS Rescue supplies its own target heading. Active navigation chooses a
+// heading according to ap_yaw_mode. POS_HOLD and MAG_MODE instead hold the
+// heading captured on engagement.
 static void updateYawControl(float dt, const positionEstimate3d_t *est)
 {
-const autopilotConfig_t *cfg = autopilotConfig();
+    const autopilotConfig_t *cfg = autopilotConfig();
 
-DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 7, apYawDisableReason);
+    DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 7, apYawDisableReason);
 
-// Nothing holds a heading on the bench. disarm() clears ARMED but leaves the flight
-// mode flags alone, so POS_HOLD_MODE stays set until processRxModes() next runs and
-// this task can be scheduled in between; without this the controller would capture a
-// heading and offer a rate while disarmed. Standing down also drops the captured
-// heading, so arming re-captures rather than resuming an old one.
-if (!ARMING_FLAG(ARMED)) {
-    disableYawControl();
-    apYawDisableReason = 4;
-    return;
-}
+    // Nothing holds a heading on the bench. disarm() clears ARMED but leaves the flight
+    // mode flags alone, so POS_HOLD_MODE stays set until processRxModes() next runs and
+    // this task can be scheduled in between; without this the controller would capture a
+    // heading and offer a rate while disarmed. Standing down also drops the captured
+    // heading, so arming re-captures rather than resuming an old one.
+    if (!ARMING_FLAG(ARMED)) {
+        disableYawControl();
+        apYawDisableReason = 4;
+        return;
+    }
 
-// Nothing holds a heading on the bench. disarm() clears ARMED but leaves the flight
-// mode flags alone, so POS_HOLD_MODE stays set until processRxModes() next runs and
-// this task can be scheduled in between; without this the controller would capture a
-// heading and offer a rate while disarmed. Standing down also drops the captured
-// heading, so arming re-captures rather than resuming an old one.
-if (!ARMING_FLAG(ARMED)) {
-    disableYawControl();
-    apYawDisableReason = 4;
-    return;
-}
+    const bool rescueYawActive = FLIGHT_MODE(GPS_RESCUE_MODE);
+    const bool navYawActive = FLIGHT_MODE(AUTOPILOT_MODE) && ap.navActive;
+    const bool holdYawActive = FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(MAG_MODE);
 
-const bool rescueYawActive = FLIGHT_MODE(GPS_RESCUE_MODE);
-const bool navYawActive = FLIGHT_MODE(AUTOPILOT_MODE) && ap.navActive;
-const bool holdYawActive = FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(MAG_MODE);
+    if (!rescueYawActive && !navYawActive && !holdYawActive) {
+        disableYawControl();
+        apYawDisableReason = 6;
+        return;
+    }
 
-if (!rescueYawActive && !navYawActive && !holdYawActive) {
-    disableYawControl();
-    apYawDisableReason = 6;
-    return;
-}
+    // Every path below steers to a compass heading, so one the IMU trusts is a hard
+    // requirement: a calibrated compass, or a GPS course it has gained confidence in.
+    // Without it the controller would hold an arbitrary direction. Same requirement
+    // GPS rescue applies.
+    if (!imuIsHeadingValid()) {
+        disableYawControl();
+        apYawDisableReason = 5;
+        return;
+    }
 
-// Every path below steers to a compass heading, so one the IMU trusts is a hard
-// requirement: a calibrated compass, or a GPS course it has gained confidence in.
-// Without it the controller would hold an arbitrary direction. Same requirement
-// GPS rescue applies.
-if (!imuIsHeadingValid()) {
-    disableYawControl();
-    apYawDisableReason = 5;
-    return;
-}
     const float headingDeg = attitude.values.yaw * 0.1f;
-
     float desiredHeadingDeg = 0.0f;
-    if (navYawActive) {
+
+    if (rescueYawActive) {
+        apYawHoldHeadingValid = false; // capture current heading when hold resumes
+        desiredHeadingDeg = apExternalYawTargetDeg;
+    } else if (navYawActive) {
+        apYawHoldHeadingValid = false; // capture current heading when hold resumes
         bool haveDesiredHeading = false;
+
         if (apNavHeadingOverrideValid) {
-            // Mission pre-turn blend: point the nose onto the next leg regardless of
-            // the configured yaw mode, so it is already there as the gate is crossed.
             desiredHeadingDeg = apNavHeadingOverrideDeg;
             haveDesiredHeading = true;
         } else {
@@ -754,13 +760,14 @@ if (!imuIsHeadingValid()) {
                 haveDesiredHeading = courseHeadingDeg(est, &desiredHeadingDeg)
                     || bearingToTargetDeg(est, &desiredHeadingDeg);
                 break;
-            default: // YAW_MODE_FIXED, YAW_MODE_DAMPENER (wing only)
+            default:
                 break;
             }
         }
 
         if (!haveDesiredHeading) {
             disableYawControl();
+            apYawDisableReason = 7;
             return;
         }
     } else {
@@ -768,32 +775,35 @@ if (!imuIsHeadingValid()) {
         // rc.c flies the stick instead of our rate, so track the heading rather than
         // accumulating an error to fight on release - the hold resumes wherever the
         // pilot leaves the nose.
-        if (!apYawHoldHeadingValid || fabsf(rcCommand[FD_YAW]) >= (float)cfg->stickDeadband) {
+        const bool sticksMoving = fabsf(rcCommand[FD_YAW]) >= (float)cfg->stickDeadband;
+
+        if (!apYawHoldHeadingValid || sticksMoving) {
             apYawHoldHeadingDeg = headingDeg;
             apYawHoldHeadingValid = true;
         }
+
         desiredHeadingDeg = apYawHoldHeadingDeg;
     }
 
-    apYawAttenuator = fminf(apYawAttenuator + dt / AP_YAW_RAMP_TIME_S, 1.0f);
+apYawAttenuator = fminf(apYawAttenuator + dt / AP_YAW_RAMP_TIME_S, 1.0f);
 
-    // The yaw rate setpoint (and gyro) is CCW-positive while compass headings
-    // are CW-positive, so the heading error enters the setpoint frame negated:
-    // desired ahead of heading (a right turn) demands a negative rate.
-    float errorDeg = headingDeg - desiredHeadingDeg;
-    errorDeg = fmodf(errorDeg + 540.0f, 360.0f) - 180.0f;
+// The yaw rate setpoint (and gyro) is CCW-positive while compass headings
+// are CW-positive, so the heading error enters the setpoint frame negated:
+// desired ahead of heading (a right turn) demands a negative rate.
+float errorDeg = headingDeg - desiredHeadingDeg;
+errorDeg = fmodf(errorDeg + 540.0f, 360.0f) - 180.0f;
 
-    float yawRateDps = errorDeg * cfg->yawP * AP_YAW_P_SCALE;
-    yawRateDps *= apYawAttenuator;
+const float yawP = errorDeg * yawKp;
+float yawRateDps = yawP * apYawAttenuator;
 
-    float maxRateDps = (float)cfg->maxYawRate;
-    if (apYawRateLimitDps > 0.0f) {
-        maxRateDps = fminf(maxRateDps, apYawRateLimitDps);
-    }
-    yawRateDps = constrainf(yawRateDps, -maxRateDps, maxRateDps);
+float maxRateDps = (float)cfg->maxYawRate;
+if (apYawRateLimitDps > 0.0f) {
+    maxRateDps = fminf(maxRateDps, apYawRateLimitDps);
+}
+yawRateDps = constrainf(yawRateDps, -maxRateDps, maxRateDps);
 
-    apYawRateDps = yawRateDps * GET_DIRECTION(rcControlsConfig()->yaw_control_reversed);
-    apYawActive = true;
+apYawRateDps = yawRateDps * GET_DIRECTION(rcControlsConfig()->yaw_control_reversed);
+apYawActive = true;
 
 DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 0, lrintf(headingDeg * 10.0f));
 DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 1, lrintf(desiredHeadingDeg * 10.0f));
@@ -813,25 +823,7 @@ void updateHeadingHold(timeUs_t currentTimeUs)
 
     if (FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(GPS_RESCUE_MODE)) {
         return;
-    }    
-
-    const float dt = US_TO_INTERVAL(autopilotTaskIntervalUs(TASK_PERIOD_HZ(HEADING_HOLD_TASK_RATE_HZ)));
-    updateYawControl(dt, positionEstimatorGetEstimate());
-}
-
-// TASK_MAGHOLD. Heading hold with no position control behind it: the MAG_MODE switch on
-// its own, which needs only a compass. positionControl() already drives the yaw
-// controller whenever position hold or a rescue is running, so stand aside then -
-// running updateYawControl() twice in a cycle would double the engage ramp and the gyro
-// damping. When nothing wants yaw control this stands it down, every cycle.
-void updateHeadingHold(timeUs_t currentTimeUs)
-{
-    UNUSED(currentTimeUs);
-
-    if (FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(GPS_RESCUE_MODE)) {
-        return;
     }
-
     const float dt = US_TO_INTERVAL(autopilotTaskIntervalUs(TASK_PERIOD_HZ(HEADING_HOLD_TASK_RATE_HZ)));
     updateYawControl(dt, positionEstimatorGetEstimate());
 }
@@ -1022,10 +1014,12 @@ bool positionControl(void)
 
     if (!est->isValidXY) {
         disableYawControl();
+            apYawDisableReason = 8;
         return false;
     }
     if (abortNavRequested) {
         disableYawControl();
+            apYawDisableReason = 9;
         handlepositionControlFailure();
         return false; // Return failure and show pos hold fail message in OSD
     }
@@ -1034,11 +1028,13 @@ bool positionControl(void)
         // fly sideways, so drop to angle-mode self-level (altitude hold, a
         // separate mode, keeps holding height) until a mode-switch cycle clears it.
         disableYawControl();
+            apYawDisableReason = 10;
         handlepositionControlFailure();
         return false;
     }
     if (forcePitchForward) {
         disableYawControl();
+                    apYawDisableReason = 11;
         autopilotAngle[AI_ROLL]  = 0.0f;
         autopilotAngle[AI_PITCH] = 35.0f;
         DEBUG_SET(DEBUG_AUTOPILOT_PID, 7, 200);   //!< Status Flags

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -1010,12 +1010,12 @@ bool positionControl(void)
 
     if (!est->isValidXY) {
         disableYawControl();
-            apYawDisableReason = 8;
+        apYawDisableReason = 8;
         return false;
     }
     if (abortNavRequested) {
         disableYawControl();
-            apYawDisableReason = 9;
+        apYawDisableReason = 9;
         handlepositionControlFailure();
         return false; // Return failure and show pos hold fail message in OSD
     }
@@ -1024,13 +1024,13 @@ bool positionControl(void)
         // fly sideways, so drop to angle-mode self-level (altitude hold, a
         // separate mode, keeps holding height) until a mode-switch cycle clears it.
         disableYawControl();
-            apYawDisableReason = 10;
+        apYawDisableReason = 10;
         handlepositionControlFailure();
         return false;
     }
     if (forcePitchForward) {
         disableYawControl();
-                    apYawDisableReason = 11;
+        apYawDisableReason = 11;
         autopilotAngle[AI_ROLL]  = 0.0f;
         autopilotAngle[AI_PITCH] = 35.0f;
         DEBUG_SET(DEBUG_AUTOPILOT_PID, 7, 200);   //!< Status Flags

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -542,6 +542,7 @@ void resetPositionControl(unsigned taskRateHz)
     ap.sticksActive = false;
     ap.wasSticksActive = false;
     disableYawControl();
+    apYawDisableReason = 1;
     apYawCourseValid = false;
     wasAngleSaturated = false;
     // Initialise the nav system
@@ -578,6 +579,7 @@ static bool sanityViolationExpired(void)
         return true;
     }
     disableYawControl();
+    apYawDisableReason = 2;
     autopilotAngle[AI_ROLL]  = 0.0f; // Level out
     autopilotAngle[AI_PITCH] = 0.0f;
     handlepositionControlFailure();
@@ -616,6 +618,7 @@ void autopilotSetYawRateLimit(float rateLimitDps)
 void autopilotDisableYawControl(void)
 {
     disableYawControl();
+    apYawDisableReason = 3;
 }
 
 float autopilotGetYawRate(void)
@@ -639,7 +642,7 @@ static void disableYawControl(void)
     apYawActive = false;
     apYawAttenuator = 0.0f;
     apYawRateDps = 0.0f;
-    DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 3, 0);  //!< Yaw Rate Setpoint [unit:0.1dps]
+
     // Re-capture the hold heading on re-engagement rather than snapping back to a
     // heading the craft may have left long ago.
     apYawHoldHeadingValid = false;
@@ -684,37 +687,39 @@ static bool bearingToTargetDeg(const positionEstimate3d_t *est, float *headingDe
 // resulting rate as the yaw setpoint, exactly as GPS rescue injects its own.
 static void updateYawControl(float dt, const positionEstimate3d_t *est)
 {
-    const autopilotConfig_t *cfg = autopilotConfig();
+const autopilotConfig_t *cfg = autopilotConfig();
 
-    // Nothing holds a heading on the bench. disarm() clears ARMED but leaves the flight
-    // mode flags alone, so POS_HOLD_MODE stays set until processRxModes() next runs and
-    // this task can be scheduled in between; without this the controller would capture a
-    // heading and offer a rate while disarmed. Standing down also drops the captured
-    // heading, so arming re-captures rather than resuming an old one.
-    if (!ARMING_FLAG(ARMED)) {
-        disableYawControl();
-        return;
-    }
+DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 7, apYawDisableReason);
 
-    // Every path below steers to a compass heading, so one the IMU trusts is a hard
-    // requirement: a calibrated compass, or a GPS course it has gained confidence in.
-    // Without it the controller would hold an arbitrary direction. Same requirement
-    // GPS rescue applies.
-    if (!imuIsHeadingValid()) {
-        disableYawControl();
-        return;
-    }
+// Nothing holds a heading on the bench. disarm() clears ARMED but leaves the flight
+// mode flags alone, so POS_HOLD_MODE stays set until processRxModes() next runs and
+// this task can be scheduled in between; without this the controller would capture a
+// heading and offer a rate while disarmed. Standing down also drops the captured
+// heading, so arming re-captures rather than resuming an old one.
+if (!ARMING_FLAG(ARMED)) {
+    disableYawControl();
+    apYawDisableReason = 4;
+    return;
+}
 
-    // A mission steers the nose per ap_yaw_mode while a leg is being flown. Position
-    // hold and MAG_MODE have no leg to follow, so they hold the heading they had on
-    // engagement. MAG_MODE is heading hold alone - no position control involved.
-    const bool navYawActive = FLIGHT_MODE(AUTOPILOT_MODE) && ap.navActive;
-    const bool holdYawActive = FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(MAG_MODE);
-    if (!navYawActive && !holdYawActive) {
-        disableYawControl();
-        return;
-    }
+// Every path below steers to a compass heading, so one the IMU trusts is a hard
+// requirement: a calibrated compass, or a GPS course it has gained confidence in.
+// Without it the controller would hold an arbitrary direction. Same requirement
+// GPS rescue applies.
+if (!imuIsHeadingValid()) {
+    disableYawControl();
+    apYawDisableReason = 5;
+    return;
+}
+const bool rescueYawActive = FLIGHT_MODE(GPS_RESCUE_MODE);
+const bool navYawActive = FLIGHT_MODE(AUTOPILOT_MODE) && ap.navActive;
+const bool holdYawActive = FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(MAG_MODE);
 
+if (!rescueYawActive && !navYawActive && !holdYawActive) {
+    disableYawControl();
+    apYawDisableReason = 6;
+    return;
+}
     const float headingDeg = attitude.values.yaw * 0.1f;
 
     float desiredHeadingDeg = 0.0f;
@@ -778,10 +783,11 @@ static void updateYawControl(float dt, const positionEstimate3d_t *est)
     apYawRateDps = yawRateDps * GET_DIRECTION(rcControlsConfig()->yaw_control_reversed);
     apYawActive = true;
 
-    DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 0, lrintf(headingDeg * 10.0f));         //!< Aircraft Heading [unit:0.1deg]
-    DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 1, lrintf(desiredHeadingDeg * 10.0f));  //!< Target Heading [unit:0.1deg]
-    DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 2, lrintf(errorDeg * 10.0f));           //!< Heading Error [unit:0.1deg]
-    DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 3, lrintf(apYawRateDps * 10.0f));       //!< Yaw Rate Setpoint [unit:0.1dps]
+DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 0, lrintf(headingDeg * 10.0f));
+DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 1, lrintf(desiredHeadingDeg * 10.0f));
+DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 2, lrintf(errorDeg * 10.0f));
+DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 3, lrintf(apYawRateDps * 10.0f));
+DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 4, lrintf(yawP * 10.0f));
 }
 
 // TASK_MAGHOLD. Heading hold with no position control behind it: the MAG_MODE switch on
@@ -795,7 +801,7 @@ void updateHeadingHold(timeUs_t currentTimeUs)
 
     if (FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(GPS_RESCUE_MODE)) {
         return;
-    }
+    }    
 
     const float dt = US_TO_INTERVAL(autopilotTaskIntervalUs(TASK_PERIOD_HZ(HEADING_HOLD_TASK_RATE_HZ)));
     updateYawControl(dt, positionEstimatorGetEstimate());

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -693,10 +693,6 @@ static bool bearingToTargetDeg(const positionEstimate3d_t *est, float *headingDe
 // Yaw control priority is GPS Rescue, active navigation, then heading hold.
 // GPS Rescue supplies its own target heading. Active navigation chooses a
 // heading according to ap_yaw_mode. POS_HOLD and MAG_MODE hold the
-// heading captured on engagement. 
-// Yaw control priority is GPS Rescue, active navigation, then heading hold.
-// GPS Rescue supplies its own target heading. Active navigation chooses a
-// heading according to ap_yaw_mode. POS_HOLD and MAG_MODE instead hold the
 // heading captured on engagement.
 static void updateYawControl(float dt, const positionEstimate3d_t *est)
 {
@@ -785,31 +781,31 @@ static void updateYawControl(float dt, const positionEstimate3d_t *est)
         desiredHeadingDeg = apYawHoldHeadingDeg;
     }
 
-apYawAttenuator = fminf(apYawAttenuator + dt / AP_YAW_RAMP_TIME_S, 1.0f);
+    apYawAttenuator = fminf(apYawAttenuator + dt / AP_YAW_RAMP_TIME_S, 1.0f);
 
-// The yaw rate setpoint (and gyro) is CCW-positive while compass headings
-// are CW-positive, so the heading error enters the setpoint frame negated:
-// desired ahead of heading (a right turn) demands a negative rate.
-float errorDeg = headingDeg - desiredHeadingDeg;
-errorDeg = fmodf(errorDeg + 540.0f, 360.0f) - 180.0f;
+    // The yaw rate setpoint (and gyro) is CCW-positive while compass headings
+    // are CW-positive, so the heading error enters the setpoint frame negated:
+    // desired ahead of heading (a right turn) demands a negative rate.
+    float errorDeg = headingDeg - desiredHeadingDeg;
+    errorDeg = fmodf(errorDeg + 540.0f, 360.0f) - 180.0f;
 
-const float yawP = errorDeg * yawKp;
-float yawRateDps = yawP * apYawAttenuator;
+    const float yawP = errorDeg * yawKp;
+    float yawRateDps = yawP * apYawAttenuator;
 
-float maxRateDps = (float)cfg->maxYawRate;
-if (apYawRateLimitDps > 0.0f) {
-    maxRateDps = fminf(maxRateDps, apYawRateLimitDps);
-}
-yawRateDps = constrainf(yawRateDps, -maxRateDps, maxRateDps);
+    float maxRateDps = (float)cfg->maxYawRate;
+    if (apYawRateLimitDps > 0.0f) {
+        maxRateDps = fminf(maxRateDps, apYawRateLimitDps);
+    }
+    yawRateDps = constrainf(yawRateDps, -maxRateDps, maxRateDps);
 
-apYawRateDps = yawRateDps * GET_DIRECTION(rcControlsConfig()->yaw_control_reversed);
-apYawActive = true;
+    apYawRateDps = yawRateDps * GET_DIRECTION(rcControlsConfig()->yaw_control_reversed);
+    apYawActive = true;
 
-DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 0, lrintf(headingDeg * 10.0f));
-DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 1, lrintf(desiredHeadingDeg * 10.0f));
-DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 2, lrintf(errorDeg * 10.0f));
-DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 3, lrintf(apYawRateDps * 10.0f));
-DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 4, lrintf(yawP * 10.0f));
+    DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 0, lrintf(headingDeg * 10.0f));
+    DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 1, lrintf(desiredHeadingDeg * 10.0f));
+    DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 2, lrintf(errorDeg * 10.0f));
+    DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 3, lrintf(apYawRateDps * 10.0f));
+    DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 4, lrintf(yawP * 10.0f));
 }
 
 // TASK_MAGHOLD. Heading hold with no position control behind it: the MAG_MODE switch on

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -702,6 +702,17 @@ if (!ARMING_FLAG(ARMED)) {
     return;
 }
 
+// Nothing holds a heading on the bench. disarm() clears ARMED but leaves the flight
+// mode flags alone, so POS_HOLD_MODE stays set until processRxModes() next runs and
+// this task can be scheduled in between; without this the controller would capture a
+// heading and offer a rate while disarmed. Standing down also drops the captured
+// heading, so arming re-captures rather than resuming an old one.
+if (!ARMING_FLAG(ARMED)) {
+    disableYawControl();
+    apYawDisableReason = 4;
+    return;
+}
+
 const bool rescueYawActive = FLIGHT_MODE(GPS_RESCUE_MODE);
 const bool navYawActive = FLIGHT_MODE(AUTOPILOT_MODE) && ap.navActive;
 const bool holdYawActive = FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(MAG_MODE);
@@ -719,15 +730,6 @@ if (!rescueYawActive && !navYawActive && !holdYawActive) {
 if (!imuIsHeadingValid()) {
     disableYawControl();
     apYawDisableReason = 5;
-    return;
-}
-const bool rescueYawActive = FLIGHT_MODE(GPS_RESCUE_MODE);
-const bool navYawActive = FLIGHT_MODE(AUTOPILOT_MODE) && ap.navActive;
-const bool holdYawActive = FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(MAG_MODE);
-
-if (!rescueYawActive && !navYawActive && !holdYawActive) {
-    disableYawControl();
-    apYawDisableReason = 6;
     return;
 }
     const float headingDeg = attitude.values.yaw * 0.1f;
@@ -827,12 +829,6 @@ void updateHeadingHold(timeUs_t currentTimeUs)
     UNUSED(currentTimeUs);
 
     if (FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(GPS_RESCUE_MODE)) {
-        return;
-    }
-
-    if (!ARMING_FLAG(ARMED)) {
-        // No holding a heading on the bench; re-capture on arming instead.
-        disableYawControl();
         return;
     }
 

--- a/src/main/flight/autopilot_multirotor.c
+++ b/src/main/flight/autopilot_multirotor.c
@@ -702,6 +702,16 @@ if (!ARMING_FLAG(ARMED)) {
     return;
 }
 
+const bool rescueYawActive = FLIGHT_MODE(GPS_RESCUE_MODE);
+const bool navYawActive = FLIGHT_MODE(AUTOPILOT_MODE) && ap.navActive;
+const bool holdYawActive = FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(MAG_MODE);
+
+if (!rescueYawActive && !navYawActive && !holdYawActive) {
+    disableYawControl();
+    apYawDisableReason = 6;
+    return;
+}
+
 // Every path below steers to a compass heading, so one the IMU trusts is a hard
 // requirement: a calibrated compass, or a GPS course it has gained confidence in.
 // Without it the controller would hold an arbitrary direction. Same requirement
@@ -802,6 +812,29 @@ void updateHeadingHold(timeUs_t currentTimeUs)
     if (FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(GPS_RESCUE_MODE)) {
         return;
     }    
+
+    const float dt = US_TO_INTERVAL(autopilotTaskIntervalUs(TASK_PERIOD_HZ(HEADING_HOLD_TASK_RATE_HZ)));
+    updateYawControl(dt, positionEstimatorGetEstimate());
+}
+
+// TASK_MAGHOLD. Heading hold with no position control behind it: the MAG_MODE switch on
+// its own, which needs only a compass. positionControl() already drives the yaw
+// controller whenever position hold or a rescue is running, so stand aside then -
+// running updateYawControl() twice in a cycle would double the engage ramp and the gyro
+// damping. When nothing wants yaw control this stands it down, every cycle.
+void updateHeadingHold(timeUs_t currentTimeUs)
+{
+    UNUSED(currentTimeUs);
+
+    if (FLIGHT_MODE(POS_HOLD_MODE) || FLIGHT_MODE(GPS_RESCUE_MODE)) {
+        return;
+    }
+
+    if (!ARMING_FLAG(ARMED)) {
+        // No holding a heading on the bench; re-capture on arming instead.
+        disableYawControl();
+        return;
+    }
 
     const float dt = US_TO_INTERVAL(autopilotTaskIntervalUs(TASK_PERIOD_HZ(HEADING_HOLD_TASK_RATE_HZ)));
     updateYawControl(dt, positionEstimatorGetEstimate());

--- a/src/main/flight/autopilot_multirotor.h
+++ b/src/main/flight/autopilot_multirotor.h
@@ -60,7 +60,6 @@ bool autopilotYawControlActive(void);
 void autopilotSetYawRateLimit(float rateLimitDps); // deg/s, 0 = no mission cap
 void autopilotDisableYawControl(void);
 
-#define HEADING_HOLD_TASK_RATE_HZ 100 // hz
-void updateHeadingHold(timeUs_t currentTimeUs);
+#define HEADING_HOLD_TASK_RATE_HZ 100 // Hz
 
 #endif // !USE_WING

--- a/src/main/flight/autopilot_multirotor.h
+++ b/src/main/flight/autopilot_multirotor.h
@@ -52,6 +52,7 @@ void autopilotCaptureHoverThrottleForAltHold(void);
 void autopilotClearAltHoldHoverThrottle(void);
 bool isBelowLandingAltitude(void);
 float getAutopilotThrottle(void);
+void autopilotSetYawTarget(float headingDeg);
 
 // Mission yaw control: rate injected as the yaw setpoint by rc.c while a
 // navigation leg is being flown (see updateYawControl in autopilot_multirotor.c)

--- a/src/main/flight/autopilot_multirotor.h
+++ b/src/main/flight/autopilot_multirotor.h
@@ -60,6 +60,7 @@ bool autopilotYawControlActive(void);
 void autopilotSetYawRateLimit(float rateLimitDps); // deg/s, 0 = no mission cap
 void autopilotDisableYawControl(void);
 
-#define HEADING_HOLD_TASK_RATE_HZ 100 // Hz
+#define HEADING_HOLD_TASK_RATE_HZ 100 // hz
+void updateHeadingHold(timeUs_t currentTimeUs);
 
 #endif // !USE_WING

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -94,6 +94,7 @@ typedef struct {
     int8_t secondsFailing;
     float yawAttenuator;
     float targetVelocityCmS;
+    float targetHeadingDeg;
     float xyStartAttenuator;
     float proximityAttenuator;
     vector2_t stepEF; // distance to move the craft along the path each iteration
@@ -132,7 +133,6 @@ rescueState_s rescueState;
 #if !ENABLE_RESCUE_PLAN
 static const float gpsRescueTaskIntervalSeconds = HZ_TO_INTERVAL(TASK_GPS_RESCUE_RATE_HZ); // i.e. 0.01s
 #endif
-static float rescueYawRate = 0.0f;
 
 
 
@@ -187,35 +187,35 @@ static void sensorUpdate(void)
     rescueState.sensor.isHeadingOK = imuIsHeadingValid();
     rescueState.sensor.gpsHealthy = gpsIsHealthy();
 
-rescueState.sensor.currentAltitudeCm = getAltitudeCmControl();
+    rescueState.sensor.currentAltitudeCm = getAltitudeCmControl();
 
-rescueState.sensor.positionXYAvailable = positionEstimatorIsValidXY();
-if (rescueState.sensor.positionXYAvailable) {
-    const positionEstimate3d_t *est = positionEstimatorGetEstimate();
-    rescueState.sensor.currentPositionV  = *(const vector2_t *)&est->position.v;
-    rescueState.sensor.currentVelocityV  = *(const vector2_t *)&est->velocity.v;
-    rescueState.sensor.previousPositionV = rescueState.sensor.currentPositionV;
-}
-    rescueState.sensor.distanceToHomeCm = vector2Norm(&rescueState.sensor.currentPositionV);
-    rescueState.sensor.velocityCmS =vector2Norm(&rescueState.sensor.currentVelocityV); // only for debugs
-
-    rescueState.sensor.aircraftHeadingDeg = DECIDEGREES_TO_DEGREES(attitude.values.yaw); // for debugs only
-
-    if (rescueState.sensor.distanceToHomeCm > GPS_RESCUE_ACCEPT_RADIUS) {
-        const float headingRad = DECIDEGREES_TO_RADIANS(attitude.values.yaw);
-        vector2_t headingV;
-
-        headingV.v[EF_NORTH] = cosf(headingRad);
-        headingV.v[EF_EAST]  = sinf(headingRad);
-
-        const float dotProduct = vector2Dot(&headingV, &rescueState.sensor.currentPositionV);
-        const float crossProduct = vector2Cross(&headingV, &rescueState.sensor.currentPositionV);
-
-        rescueState.sensor.errorAngleDeg = RADIANS_TO_DEGREES(atan2f(-crossProduct, -dotProduct));
-    } else {
-        rescueState.sensor.errorAngleDeg = 0.0f;
+    rescueState.sensor.positionXYAvailable = positionEstimatorIsValidXY();
+    if (rescueState.sensor.positionXYAvailable) {
+        const positionEstimate3d_t *est = positionEstimatorGetEstimate();
+        rescueState.sensor.currentPositionV  = *(const vector2_t *)&est->position.v;
+        rescueState.sensor.currentVelocityV  = *(const vector2_t *)&est->velocity.v;
+        rescueState.sensor.previousPositionV = rescueState.sensor.currentPositionV;
     }
 
+    rescueState.sensor.distanceToHomeCm = vector2Norm(&rescueState.sensor.currentPositionV);
+    rescueState.sensor.velocityCmS = vector2Norm(&rescueState.sensor.currentVelocityV); // only for debugs
+
+rescueState.sensor.aircraftHeadingDeg = DECIDEGREES_TO_DEGREES(attitude.values.yaw); // for debugs only
+if (rescueState.sensor.distanceToHomeCm > GPS_RESCUE_ACCEPT_RADIUS) {
+    rescueState.intent.targetHeadingDeg = RADIANS_TO_DEGREES(atan2f(
+        -rescueState.sensor.currentPositionV.v[EF_EAST],
+        -rescueState.sensor.currentPositionV.v[EF_NORTH]));
+
+    if (rescueState.intent.targetHeadingDeg < 0.0f) {
+        rescueState.intent.targetHeadingDeg += 360.0f;
+    }
+}
+
+rescueState.sensor.errorAngleDeg =
+    rescueState.sensor.aircraftHeadingDeg - rescueState.intent.targetHeadingDeg;
+rescueState.sensor.errorAngleDeg =
+    fmodf(rescueState.sensor.errorAngleDeg + 540.0f, 360.0f) - 180.0f;
+    
     DEBUG_SET(DEBUG_ATTITUDE, 0, lrintf(rescueState.sensor.aircraftHeadingDeg));  //!< Aircraft Heading [unit:deg]
     DEBUG_SET(DEBUG_ATTITUDE, 2, lrintf(rescueState.sensor.velocityCmS));         //!< Ground Speed [unit:cm/s]
 
@@ -232,8 +232,8 @@ if (rescueState.sensor.positionXYAvailable) {
     const float currentAltitudeCm = getAltitudeCm();
     DEBUG_SET(DEBUG_GPS_RESCUE_TRACKING, 0, lrintf(rescueState.sensor.velocityCmS));         //!< Ground Speed [unit:cm/s]
     DEBUG_SET(DEBUG_GPS_RESCUE_TRACKING, 2, lrintf(currentAltitudeCm));                      //!< Current Altitude [unit:cm]
-    DEBUG_SET(DEBUG_GPS_RESCUE_TRACKING, 4, lrintf(rescueState.sensor.aircraftHeadingDeg));  //!< Aircraft Heading [unit:deg]
-    DEBUG_SET(DEBUG_GPS_RESCUE_TRACKING, 5, lrintf(rescueState.sensor.errorAngleDeg));       //!< Heading Error [unit:deg]
+    DEBUG_SET(DEBUG_GPS_RESCUE_TRACKING, 4, lrintf(rescueState.intent.targetHeadingDeg));    //!< Target Heading [unit:deg]
+    DEBUG_SET(DEBUG_GPS_RESCUE_TRACKING, 5, lrintf(rescueState.sensor.aircraftHeadingDeg));  //!< Aircraft Heading [unit:deg]
 }
 
 #if !ENABLE_RESCUE_PLAN
@@ -246,6 +246,7 @@ static void updateYawStartupAttenuator(void)
         }
     }
 }
+
 static void updateVelocityStartupAttenuator(void)
 {
     if (rescueState.intent.xyStartAttenuator < 1.0f) {
@@ -256,17 +257,14 @@ static void updateVelocityStartupAttenuator(void)
     }
 }
 
-
 static void controlYaw(void)
 {
-    float yawRateTemp = rescueState.sensor.errorAngleDeg * rescueState.intent.yawAttenuator * gpsRescueConfig()->yawP * 0.1f;
-    yawRateTemp = constrainf(yawRateTemp, -GPS_RESCUE_MAX_YAW_RATE, GPS_RESCUE_MAX_YAW_RATE);
-    yawRateTemp *= GET_DIRECTION(rcControlsConfig()->yaw_control_reversed);
-    // rescueYaw is the yaw rate in deg/s to correct the heading error
-    rescueYawRate = yawRateTemp;
-    DEBUG_SET(DEBUG_GPS_RESCUE_HEADING, 7, rescueYawRate);  //!< Yaw Rate Correction [unit:dps]
-}
+    const float targetHeadingDeg =
+        rescueState.sensor.aircraftHeadingDeg -
+        rescueState.sensor.errorAngleDeg * rescueState.intent.yawAttenuator;
 
+    autopilotSetYawTarget(targetHeadingDeg);
+}
 static void calculateTargetStep(void)
 {
     if (rescueState.sensor.distanceToHomeCm > GPS_RESCUE_ACCEPT_RADIUS) {
@@ -500,7 +498,6 @@ static void descend(void)
     float verticalVelAttenuator = scaleRangef(constrainf(rescueState.intent.targetAltitudeCm, 1000, 5000), 1000, 5000, 0.6f, 3.0f);
 
     rescueState.intent.targetAltitudeVelCmS = verticalVelMax * verticalVelAttenuator;
-    rescueYawRate = 0.0f; // keep yaw rate zero in case we float past the home point
 }
 static bool descendIfNeeded(void)
 {
@@ -542,15 +539,15 @@ void initRescueValues(void)
         }
     }
     rescueState.intent.targetAltitudeCm = rescueState.sensor.currentAltitudeCm;  // Initial target altitude is current filtered altitude
-
-    rescueState.sensor.errorAngleDeg = 0.0f;       // Prevent yaw adjustments
-    rescueYawRate = 0.0f;                          // No yaw until climb is complete
-    rescueState.intent.targetVelocityCmS = 0.0f;   // Zero initial velocity
+    autopilotSetYawTarget(DECIDEGREES_TO_DEGREES(attitude.values.yaw));
+    rescueState.sensor.errorAngleDeg = 0.0f;
+    rescueState.intent.targetVelocityCmS = 0.0f; // Zero initial velocity
     clearTargetStep();
     rescueState.intent.targetAltitudeVelCmS = 0.0f;
     rescueState.sensor.velocityCmS = 0.0f;
-    rescueState.intent.yawAttenuator = 0.0f;       // For a smooth start to the yaw
-    rescueState.intent.xyStartAttenuator = 0.0f;        // For a slower start to gaining velocity
+
+    rescueState.intent.yawAttenuator = 0.0f; // For a smooth start to the yaw
+    rescueState.intent.xyStartAttenuator = 0.0f; // For a smooth start to gaining velocity
 
     resetAltitudeControl(); // Initialise altitude in autopilot multirotor
 }
@@ -592,7 +589,7 @@ void gpsRescueUpdate(void) // called from core.c at TASK_GPS_RESCUE_RATE_HZ
             if (rescueState.sensor.distanceToHomeCm < GPS_RESCUE_ACCEPT_RADIUS && isBelowLandingAltitude()) {
                 rescueState.phase = RESCUE_DO_NOTHING;
             } else {
-                initRescueValues(); // fix the target location
+                initRescueValues(); // fix the target location, velocity to zero
                 returnAltitudeLow = rescueState.sensor.currentAltitudeCm < rescueState.intent.returnAltitudeCm;
                 rescueState.phase = RESCUE_ATTAIN_ALT;
             }
@@ -619,7 +616,6 @@ void gpsRescueUpdate(void) // called from core.c at TASK_GPS_RESCUE_RATE_HZ
     case RESCUE_PITCH_FORWARD:
         if (!rescueState.sensor.isHeadingOK) { // sanity check allows 15s for this to be true
             clearTargetStep();
-            rescueYawRate = 0.0f;
             rescueState.intent.targetVelocityCmS = 0.0f;
             pitchForwardOverride(true); // instructs autopilot to apply forward pitch angle to recover IMU
         } else {
@@ -643,8 +639,8 @@ void gpsRescueUpdate(void) // called from core.c at TASK_GPS_RESCUE_RATE_HZ
         break;
 
     case RESCUE_FLY_HOME:
-        updateVelocityStartupAttenuator(); // starts slowing down at twice descend distance
-        if (!descendIfNeeded()) {
+        updateVelocityStartupAttenuator(); // was inited to zero, climbs to 1 over one second
+        if (!descendIfNeeded()) { // if close enough to home, skip this iteration and enter descent mode
             updateTargetVelocity();
             calculateTargetStep();
             controlYaw();
@@ -655,7 +651,7 @@ void gpsRescueUpdate(void) // called from core.c at TASK_GPS_RESCUE_RATE_HZ
         updateVelocityStartupAttenuator();
         updateTargetVelocity();
         calculateTargetStep();
-        descend(); // sets a negative targetAltitudeVelocity
+        descend(); // sets a negative targetAltitudeVelocity, holds last heading
         if (isBelowLandingAltitude()) {
             rescueState.phase = RESCUE_LANDING;
             rescueState.intent.secondsFailing = 0; // reset sanity timer for landing
@@ -665,19 +661,18 @@ void gpsRescueUpdate(void) // called from core.c at TASK_GPS_RESCUE_RATE_HZ
     case RESCUE_LANDING:
         descend();
         clearTargetStep();
-        // same as Descent mode
+        // same as Descent mode, target altitude keeps going down
         break;
 
     case RESCUE_EMERG_DESCENT:
         descend();
         vector2Zero(&rescueState.intent.stepEF);
-        moveTargetLocation(&rescueState.intent.stepEF, TASK_GPS_RESCUE_RATE_HZ, true); // stop position control
+        moveTargetLocation(&rescueState.intent.stepEF, TASK_GPS_RESCUE_RATE_HZ, true); // stop position control with force abort
         break;
 
     case RESCUE_DO_NOTHING:
         clearTargetStep();
         rescueState.intent.targetAltitudeVelCmS = 0.0f;
-        rescueYawRate = 0.0f;
         // altitude control with no change in height or heading, position control at zero target velocity
         break;
 
@@ -715,11 +710,6 @@ void gpsRescueUpdate(void)
     checkGPSRescueIsAvailable();
 }
 #endif // !ENABLE_RESCUE_PLAN
-
-float gpsRescueGetYawRate(void)
-{
-    return rescueYawRate; // the control yaw value for rc.c to be used while flightMode gps_rescue is active.
-}
 
 float gpsRescueGetMaxAltitudeCm(void)
 {

--- a/src/main/flight/gps_rescue_multirotor.c
+++ b/src/main/flight/gps_rescue_multirotor.c
@@ -200,22 +200,22 @@ static void sensorUpdate(void)
     rescueState.sensor.distanceToHomeCm = vector2Norm(&rescueState.sensor.currentPositionV);
     rescueState.sensor.velocityCmS = vector2Norm(&rescueState.sensor.currentVelocityV); // only for debugs
 
-rescueState.sensor.aircraftHeadingDeg = DECIDEGREES_TO_DEGREES(attitude.values.yaw); // for debugs only
-if (rescueState.sensor.distanceToHomeCm > GPS_RESCUE_ACCEPT_RADIUS) {
-    rescueState.intent.targetHeadingDeg = RADIANS_TO_DEGREES(atan2f(
-        -rescueState.sensor.currentPositionV.v[EF_EAST],
-        -rescueState.sensor.currentPositionV.v[EF_NORTH]));
-
-    if (rescueState.intent.targetHeadingDeg < 0.0f) {
-        rescueState.intent.targetHeadingDeg += 360.0f;
-    }
-}
-
-rescueState.sensor.errorAngleDeg =
-    rescueState.sensor.aircraftHeadingDeg - rescueState.intent.targetHeadingDeg;
-rescueState.sensor.errorAngleDeg =
-    fmodf(rescueState.sensor.errorAngleDeg + 540.0f, 360.0f) - 180.0f;
+    rescueState.sensor.aircraftHeadingDeg = DECIDEGREES_TO_DEGREES(attitude.values.yaw); // for debugs only
+    if (rescueState.sensor.distanceToHomeCm > GPS_RESCUE_ACCEPT_RADIUS) {
+        rescueState.intent.targetHeadingDeg = RADIANS_TO_DEGREES(atan2f(
+            -rescueState.sensor.currentPositionV.v[EF_EAST],
+            -rescueState.sensor.currentPositionV.v[EF_NORTH]));
     
+        if (rescueState.intent.targetHeadingDeg < 0.0f) {
+            rescueState.intent.targetHeadingDeg += 360.0f;
+        }
+    }
+
+    rescueState.sensor.errorAngleDeg =
+        rescueState.sensor.aircraftHeadingDeg - rescueState.intent.targetHeadingDeg;
+    rescueState.sensor.errorAngleDeg =
+    fmodf(rescueState.sensor.errorAngleDeg + 540.0f, 360.0f) - 180.0f;
+
     DEBUG_SET(DEBUG_ATTITUDE, 0, lrintf(rescueState.sensor.aircraftHeadingDeg));  //!< Aircraft Heading [unit:deg]
     DEBUG_SET(DEBUG_ATTITUDE, 2, lrintf(rescueState.sensor.velocityCmS));         //!< Ground Speed [unit:cm/s]
 

--- a/src/main/flight/gps_rescue_multirotor.h
+++ b/src/main/flight/gps_rescue_multirotor.h
@@ -43,7 +43,6 @@ typedef enum {
 
 void gpsRescueInit(void);
 void gpsRescueUpdate(void);
-float gpsRescueGetYawRate(void);
 float gpsRescueGetMaxAltitudeCm(void);
 bool gpsRescueIsConfigured(void);
 bool gpsRescueIsAvailable(void);

--- a/src/main/flight/gps_rescue_wing.c
+++ b/src/main/flight/gps_rescue_wing.c
@@ -63,10 +63,6 @@ void gpsRescueUpdate(void)
 {
 }
 
-float gpsRescueGetYawRate(void)
-{
-    return 0.0f; // the control yaw value for rc.c to be used while flightMode gps_rescue is active.
-}
 
 bool gpsRescueIsConfigured(void)
 {

--- a/src/main/flight/gps_rescue_wing.h
+++ b/src/main/flight/gps_rescue_wing.h
@@ -31,7 +31,6 @@ extern float gpsRescueAngle[RP_AXIS_COUNT]; // NOTE: ANGLES ARE IN CENTIDEGREES
 
 void gpsRescueInit(void);
 void gpsRescueUpdate(void);
-float gpsRescueGetYawRate(void);
 bool gpsRescueIsConfigured(void);
 bool gpsRescueIsAvailable(void);
 bool gpsRescueIsHeadingOK(void);

--- a/src/main/flight/pos_hold_multirotor.c
+++ b/src/main/flight/pos_hold_multirotor.c
@@ -73,25 +73,21 @@ static void posHoldCheckSticks(void)
 
 static bool sensorsOk(void)
 {
-    // Optical flow position hold is heading-agnostic: the same yaw is used
-    // to project flow into ENU and to rotate the correction back to body
-    // frame, so a heading error cancels. GPS-assisted hold is not: GPS
-    // provides absolute ENU measurements and a bad yaw in the body-frame
-    // correction rotation will cause a flyaway.
-    // Use the runtime GPS state (fix present + config allows GPS) rather than
-    // the configured source alone, so AUTO mode with no GPS hardware correctly
-
     if (!positionEstimatorIsValidXY()) {
-        return false; // always need valid XY data, can be optical only
+        DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 6, 1);
+        return false;
     }
 
     if (positionEstimatorIsHeadingRequired()) {
-        return imuIsHeadingValid(); // if heading is essential (ie no optical flow), pass or fail based on whether or not heading exists.
-    } else {
-        return true; // if no heading is needed, we don't care about it (optical flow situation)
+        if (!imuIsHeadingValid()) {
+            DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 6, 2);
+            return false;
+        }
     }
-}
 
+    DEBUG_SET(DEBUG_AUTOPILOT_HEADING, 6, 0);
+    return true;
+}
 bool posHoldUpdateCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs)
 {
     UNUSED(currentTimeUs);

--- a/src/main/pg/autopilot.c
+++ b/src/main/pg/autopilot.c
@@ -28,7 +28,7 @@
 
 #include "autopilot.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig, PG_AUTOPILOT, 14);
+PG_REGISTER_WITH_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig, PG_AUTOPILOT, 13);
 
 PG_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig,
     .landingAltitudeM = 4,

--- a/src/main/pg/autopilot.c
+++ b/src/main/pg/autopilot.c
@@ -28,7 +28,7 @@
 
 #include "autopilot.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig, PG_AUTOPILOT, 13);
+PG_REGISTER_WITH_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig, PG_AUTOPILOT, 14);
 
 PG_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig,
     .landingAltitudeM = 4,

--- a/src/main/pg/autopilot.c
+++ b/src/main/pg/autopilot.c
@@ -28,7 +28,7 @@
 
 #include "autopilot.h"
 
-PG_REGISTER_WITH_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig, PG_AUTOPILOT, 12);
+PG_REGISTER_WITH_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig, PG_AUTOPILOT, 13);
 
 PG_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig,
     .landingAltitudeM = 4,
@@ -74,8 +74,8 @@ PG_RESET_TEMPLATE(autopilotConfig_t, autopilotConfig,
 
     // Yaw control parameters
     .yawMode = YAW_MODE_VELOCITY,     // Default: follow velocity
-    .yawP = 50,                       // 0.5 P gain
-    .maxYawRate = 30,                 // 30 deg/s max
+    .yawP = 30,                       // 1.8 P gain
+    .maxYawRate = 150,                 // 150 deg/s max
     .minForwardVelocity = 300,        // 3.0 m/s minimum forward velocity (GPS course reliability / stall prevention)
 
     // Velocity buildup (acceleration from stationary)

--- a/src/main/pg/autopilot.h
+++ b/src/main/pg/autopilot.h
@@ -90,8 +90,8 @@ typedef struct autopilotConfig_s {
 
     // Yaw control parameters
     uint8_t yawMode;                  // autopilotYawMode_e (default YAW_MODE_VELOCITY)
-    uint8_t yawP;                     // scaled by 100 (e.g., 50 = 0.5, default 50)
-    uint8_t maxYawRate;               // deg/s, maximum yaw rate (default 150)
+    uint8_t yawP;                     //heading error P gain, scaled by AP_YAW_P_SCALE
+    uint8_t maxYawRate;               // deg/s, maximum yaw rate
 
     uint16_t minForwardVelocity;      // cm/s, minimum forward velocity: GPS course reliability (multirotor) / stall prevention (wing)
 

--- a/src/main/pg/autopilot.h
+++ b/src/main/pg/autopilot.h
@@ -90,8 +90,9 @@ typedef struct autopilotConfig_s {
 
     // Yaw control parameters
     uint8_t yawMode;                  // autopilotYawMode_e (default YAW_MODE_VELOCITY)
-    uint16_t yawP;                    // scaled by 100 (e.g., 50 = 0.5, default 50)
-    uint16_t maxYawRate;              // deg/s, maximum yaw rate (default 30)
+    uint8_t yawP;                     // scaled by 100 (e.g., 50 = 0.5, default 50)
+    uint8_t maxYawRate;               // deg/s, maximum yaw rate (default 150)
+
     uint16_t minForwardVelocity;      // cm/s, minimum forward velocity: GPS course reliability (multirotor) / stall prevention (wing)
 
     // Velocity buildup (acceleration from stationary)

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -1197,8 +1197,8 @@ TEST_F(PosHoldTest, YawControlStandsDownWhileDisarmedWithPosHoldStillLatched)
     initAndSettleAt(0, 0, 0);
 
     autopilotConfig_t *cfg = autopilotConfigMutable();
-    cfg->yawP = 50;
-    cfg->maxYawRate = 30;
+    cfg->yawP = 30;
+    cfg->maxYawRate = 150;
     cfg->stickDeadband = 50;
 
     armingFlags = ARMED;

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -1159,7 +1159,7 @@ TEST_F(PosHoldTest, YawControlGoesInactiveWithTheModeNotTheNextTick)
     // non-zero or the hold re-captures every tick, mirroring rc.c declining to inject.
     autopilotConfig_t *cfg = autopilotConfigMutable();
     cfg->yawP = 30;
-    cfg->maxYawRate = 30;
+    cfg->maxYawRate = 150;
     cfg->stickDeadband = 50;
 
     armingFlags = ARMED;

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -176,12 +176,15 @@ static void initAndSettleAt(float eastCm, float northCm, int16_t yawDecidegrees)
     cfg->hoverThrottle = 1500;
     cfg->throttleMin   = 1000;
     cfg->throttleMax   = 2000;
-    cfg->altitudeP = 50;
-    cfg->altitudeI = 50;
-    cfg->altitudeD = 50;
-    cfg->altitudeA = 50;
-    cfg->altitudeF = 0;
+    cfg->altitudeP = 30;
+    cfg->altitudeI = 30;
+    cfg->altitudeD = 30;
+    cfg->altitudeA = 30;
+    cfg->altitudeF = 30;
     cfg->landingAltitudeM = 5;
+    cfg->yawP = 30;
+    cfg->maxYawRate =150;
+cfg->stickDeadband = 50;
 
     autopilotInit();
     resetPositionControl(100);
@@ -936,7 +939,7 @@ TEST_F(AutopilotYawTest, VelocityModeProportionalBelowClamp)
 
     settleYaw();
     EXPECT_TRUE(autopilotYawControlActive());
-    EXPECT_NEAR(autopilotGetYawRate(), 11.0f, 1.0f);
+    EXPECT_NEAR(autopilotGetYawRate(), 30.0f, 1.0f);
 }
 
 TEST_F(AutopilotYawTest, BearingModeYawsTowardTarget)
@@ -988,11 +991,10 @@ TEST_F(AutopilotYawTest, EngageRampsRateIn)
     engageNavLeg(YAW_MODE_VELOCITY);
     testEstimate.velocity.x = 300.0f;
 
-    // A quarter of the 1 s ramp: attenuated well below the clamp.
-    runIterations(25);
+// A tenth of the 1 s ramp: 90 deg error * 1.8 Kp * 0.1 = 16.2 deg/s.
+    runIterations(10);
     EXPECT_TRUE(autopilotYawControlActive());
-    EXPECT_GT(autopilotGetYawRate(), -15.0f);
-    EXPECT_LT(autopilotGetYawRate(), 0.0f);
+    EXPECT_NEAR(autopilotGetYawRate(), -16.2f, 1.0f);
 }
 
 // -- Nav mode --

--- a/src/test/unit/poshold_unittest.cc
+++ b/src/test/unit/poshold_unittest.cc
@@ -1158,7 +1158,7 @@ TEST_F(PosHoldTest, YawControlGoesInactiveWithTheModeNotTheNextTick)
     // without defaults here, so the yaw law needs its own setup. stickDeadband must be
     // non-zero or the hold re-captures every tick, mirroring rc.c declining to inject.
     autopilotConfig_t *cfg = autopilotConfigMutable();
-    cfg->yawP = 50;
+    cfg->yawP = 30;
     cfg->maxYawRate = 30;
     cfg->stickDeadband = 50;
 


### PR DESCRIPTION
This PR follows on from @SteveCEvans PR #15672 which provided a path by which  legacy GPS rescue could use `updateYawControl()`to yaw  the craft to a specified target heading.
The PR removes the legacy GPS Rescue yaw control code, calling `autopilotSetYawTarget` instead.
While doing this it became clear that we needed cli access to `ap_yawP` and `ap_max_yaw rate when buiding without Flight_Plan.  Also both those parameters  needed to be higher or you waited too long for a rescue to rotate.

Since there were a lot of possible places to disable yaw  control, each is written to apYawDisableReason  and then intoAUTOPILOT_HEADING, 7.

Also moves most of the GPS Rescue debugs to autopilot multirotor, so that they log the same things in both a FlightPlan and a legacy Rescue (some status and sanity flags can't be directly translated.

Has been flight tested in position hold and with legacy GPS  Rescue

Also now we send a velocity vector request to autopilot multirotor, which now has a gps velocity handler that integrates to position at autopilot looptime. This could be used for similar purposes, but the other velocity request handlers - eg nav and sticks - do not integrate the velocity to a position target. It works accurately for GPS Rescue because the target velocity itself is calculated from craft position relative to home, each time GPS Rescue runs; instead of sending a new 'position' as a 'carrot' to which the quad flies, and from which  velocity is derived, it's cleaner I think to send the velocity vector itself. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPS Rescue now uses autopilot heading control and velocity-based guidance for smoother recovery behavior.
  * Added configurable maximum yaw rate and proportional gain settings.
  * Added autopilot yaw targets and expanded yaw-control status information in debug telemetry.

* **Improvements**
  * Updated default yaw-control tuning, including a higher maximum yaw rate.
  * Refined yaw behavior and transitions during GPS Rescue, navigation, and heading hold.
  * Improved position-hold diagnostics for invalid navigation or heading data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->